### PR TITLE
Add chains supported for `debug_` methods

### DIFF
--- a/src/openrpc/alchemy/debug/base.yaml
+++ b/src/openrpc/alchemy/debug/base.yaml
@@ -4,7 +4,225 @@ info:
   description: A specification of the standard JSON-RPC methods for Debug API.
   version: 0.0.0
 servers:
-  - url: https://eth-mainnet.g.alchemy.com/v2/
-    name: Mainnet
-  - url: https://eth-sepolia.g.alchemy.com/v2/
-    name: Sepolia
+  [
+    { "url": "https://eth-mainnet.g.alchemy.com/v2/", "name": "Mainnet" },
+    { "url": "https://eth-sepolia.g.alchemy.com/v2/", "name": "Sepolia" },
+    { "url": "https://eth-holesky.g.alchemy.com/v2/", "name": "Holesky" },
+    {
+      "url": "https://opt-mainnet.g.alchemy.com/v2/",
+      "name": "Optimism Mainnet",
+    },
+    {
+      "url": "https://opt-sepolia.g.alchemy.com/v2/",
+      "name": "Optimism Sepolia",
+    },
+    {
+      "url": "https://polygon-mainnet.g.alchemy.com/v2/",
+      "name": "Polygon Mainnet",
+    },
+    { "url": "https://polygon-amoy.g.alchemy.com/v2/", "name": "Polygon Amoy" },
+    {
+      "url": "https://polygonzkevm-mainnet.g.alchemy.com/v2/",
+      "name": "Polygon zkEVM Mainnet",
+    },
+    {
+      "url": "https://polygonzkevm-cardona.g.alchemy.com/v2/",
+      "name": "Polygon zkEVM Cardona",
+    },
+    {
+      "url": "https://apechain-mainnet.g.alchemy.com/v2/",
+      "name": "ApeChain Mainnet",
+    },
+    {
+      "url": "https://apechain-curtis.g.alchemy.com/v2/",
+      "name": "ApeChain Curtis",
+    },
+    {
+      "url": "https://arb-mainnet.g.alchemy.com/v2/",
+      "name": "Arbitrum Mainnet",
+    },
+    {
+      "url": "https://arb-sepolia.g.alchemy.com/v2/",
+      "name": "Arbitrum Sepolia",
+    },
+    {
+      "url": "https://astar-mainnet.g.alchemy.com/v2/",
+      "name": "Astar Mainnet",
+    },
+    {
+      "url": "https://avax-mainnet.g.alchemy.com/v2/",
+      "name": "Avalanche Mainnet",
+    },
+    { "url": "https://avax-fuji.g.alchemy.com/v2/", "name": "Avalanche Fuji" },
+    {
+      "url": "https://arbnova-mainnet.g.alchemy.com/v2/",
+      "name": "Arbitrum Nova Mainnet",
+    },
+    {
+      "url": "https://abstract-mainnet.g.alchemy.com/v2/",
+      "name": "Abstract Mainnet",
+    },
+    {
+      "url": "https://abstract-testnet.g.alchemy.com/v2/",
+      "name": "Abstract Testnet",
+    },
+    { "url": "https://base-mainnet.g.alchemy.com/v2/", "name": "Base Mainnet" },
+    { "url": "https://base-sepolia.g.alchemy.com/v2/", "name": "Base Sepolia" },
+    {
+      "url": "https://berachain-mainnet.g.alchemy.com/v2/",
+      "name": "Berachain Mainnet",
+    },
+    { "url": "https://bob-mainnet.g.alchemy.com/v2/", "name": "BOB Mainnet" },
+    {
+      "url": "https://blast-sepolia.g.alchemy.com/v2/",
+      "name": "Blast Sepolia",
+    },
+    { "url": "https://bnb-mainnet.g.alchemy.com/v2/", "name": "BNB Mainnet" },
+    { "url": "https://celo-mainnet.g.alchemy.com/v2/", "name": "Celo Mainnet" },
+    {
+      "url": "https://crossfi-mainnet.g.alchemy.com/v2/",
+      "name": "CrossFi Mainnet",
+    },
+    {
+      "url": "https://crossfi-testnet.g.alchemy.com/v2/",
+      "name": "CrossFi Testnet",
+    },
+    {
+      "url": "https://degen-mainnet.g.alchemy.com/v2/",
+      "name": "Degen Mainnet",
+    },
+    {
+      "url": "https://fantom-testnet.g.alchemy.com/v2/",
+      "name": "Fantom Testnet",
+    },
+    { "url": "https://flow-mainnet.g.alchemy.com/v2/", "name": "Flow Mainnet" },
+    {
+      "url": "https://geist-mainnet.g.alchemy.com/v2/",
+      "name": "Geist Mainnet",
+    },
+    { "url": "https://geist-polter.g.alchemy.com/v2/", "name": "Geist Polter" },
+    {
+      "url": "https://gnosis-chiado.g.alchemy.com/v2/",
+      "name": "Gnosis Chiado",
+    },
+    { "url": "https://k2-testnet.g.alchemy.com/v2/", "name": "K2 Testnet" },
+    {
+      "url": "https://kinto-mainnet.g.alchemy.com/v2/",
+      "name": "Kinto Mainnet",
+    },
+    {
+      "url": "https://spotlight-mainnet.g.alchemy.com/v2/",
+      "name": "Spotlight Mainnet",
+    },
+    {
+      "url": "https://spotlight-sepolia.g.alchemy.com/v2/",
+      "name": "Spotlight Sepolia",
+    },
+    { "url": "https://xmtp-testnet.g.alchemy.com/v2/", "name": "XMTP Testnet" },
+    {
+      "url": "https://chiliz-mainnet.g.alchemy.com/v2/",
+      "name": "Chiliz Mainnet",
+    },
+    { "url": "https://chiliz-spicy.g.alchemy.com/v2/", "name": "Chiliz Spicy" },
+    { "url": "https://ink-mainnet.g.alchemy.com/v2/", "name": "Ink Mainnet" },
+    { "url": "https://ink-sepolia.g.alchemy.com/v2/", "name": "Ink Sepolia" },
+    {
+      "url": "https://metis-mainnet.g.alchemy.com/v2/",
+      "name": "Metis Mainnet",
+    },
+    {
+      "url": "https://moonbeam-mainnet.g.alchemy.com/v2/",
+      "name": "Moonbeam Mainnet",
+    },
+    {
+      "url": "https://monad-testnet.g.alchemy.com/v2/",
+      "name": "Monad Testnet",
+    },
+    { "url": "https://lens-mainnet.g.alchemy.com/v2/", "name": "Lens Mainnet" },
+    { "url": "https://lens-sepolia.g.alchemy.com/v2/", "name": "Lens Sepolia" },
+    {
+      "url": "https://linea-mainnet.g.alchemy.com/v2/",
+      "name": "Linea Mainnet",
+    },
+    {
+      "url": "https://opbnb-mainnet.g.alchemy.com/v2/",
+      "name": "opBNB Mainnet",
+    },
+    {
+      "url": "https://openloot-sepolia.g.alchemy.com/v2/",
+      "name": "OpenLoot Sepolia",
+    },
+    {
+      "url": "https://rootstock-mainnet.g.alchemy.com/v2/",
+      "name": "Rootstock Mainnet",
+    },
+    {
+      "url": "https://rootstock-testnet.g.alchemy.com/v2/",
+      "name": "Rootstock Testnet",
+    },
+    {
+      "url": "https://ronin-mainnet.g.alchemy.com/v2/",
+      "name": "Ronin Mainnet",
+    },
+    { "url": "https://ronin-saigon.g.alchemy.com/v2/", "name": "Ronin Saigon" },
+    { "url": "https://sei-mainnet.g.alchemy.com/v2/", "name": "Sei Mainnet" },
+    { "url": "https://sei-testnet.g.alchemy.com/v2/", "name": "Sei Testnet" },
+    {
+      "url": "https://scroll-mainnet.g.alchemy.com/v2/",
+      "name": "Scroll Mainnet",
+    },
+    {
+      "url": "https://scroll-sepolia.g.alchemy.com/v2/",
+      "name": "Scroll Sepolia",
+    },
+    {
+      "url": "https://shape-mainnet.g.alchemy.com/v2/",
+      "name": "Shape Mainnet",
+    },
+    {
+      "url": "https://soneium-mainnet.g.alchemy.com/v2/",
+      "name": "Soneium Mainnet",
+    },
+    {
+      "url": "https://soneium-minato.g.alchemy.com/v2/",
+      "name": "Soneium Minato",
+    },
+    { "url": "https://sonic-blaze.g.alchemy.com/v2/", "name": "Sonic Blaze" },
+    {
+      "url": "https://superseed-mainnet.g.alchemy.com/v2/",
+      "name": "Superseed Mainnet",
+    },
+    { "url": "https://tea-sepolia.g.alchemy.com/v2/", "name": "Tea Sepolia" },
+    {
+      "url": "https://unichain-mainnet.g.alchemy.com/v2/",
+      "name": "Unichain Mainnet",
+    },
+    {
+      "url": "https://unichain-sepolia.g.alchemy.com/v2/",
+      "name": "Unichain Sepolia",
+    },
+    {
+      "url": "https://worldchain-mainnet.g.alchemy.com/v2/",
+      "name": "Worldchain Mainnet",
+    },
+    {
+      "url": "https://worldchain-sepolia.g.alchemy.com/v2/",
+      "name": "Worldchain Sepolia",
+    },
+    {
+      "url": "https://zetachain-mainnet.g.alchemy.com/v2/",
+      "name": "ZetaChain Mainnet",
+    },
+    {
+      "url": "https://zetachain-testnet.g.alchemy.com/v2/",
+      "name": "ZetaChain Testnet",
+    },
+    {
+      "url": "https://zksync-mainnet.g.alchemy.com/v2/",
+      "name": "zkSync Mainnet",
+    },
+    {
+      "url": "https://zksync-sepolia.g.alchemy.com/v2/",
+      "name": "zkSync Sepolia",
+    },
+  ]


### PR DESCRIPTION
Added supported chains, verified by Imply, to Top 4 debug_ methods:

`debug_traceBlockByNumber`
`debug_traceBlockByHash`
`debug_traceTransaction`
`debug_traceCall`

Used this Imply query as source of truth: https://alchemy.implycloud.com/p/1f0ab80e-9f33-4dce-911f-56f1997ba004/pivot/d/612f468d4ecb4dfb7b/Alchemy_Api_Logs