### PR TITLE
chore: add warnings to not diretly edit files in /build

### DIFF
--- a/build/api-specs/alchemy/json-rpc/bundler.json
+++ b/build/api-specs/alchemy/json-rpc/bundler.json
@@ -1,4 +1,5 @@
 {
+  "x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
   "$schema": "https://meta.open-rpc.org/",
   "openrpc": "1.2.4",
   "info": {

--- a/build/api-specs/alchemy/json-rpc/debug.json
+++ b/build/api-specs/alchemy/json-rpc/debug.json
@@ -1,4 +1,5 @@
 {
+  "x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
   "$schema": "https://meta.open-rpc.org/",
   "openrpc": "1.2.4",
   "info": {

--- a/build/api-specs/alchemy/json-rpc/gas-manager-coverage.json
+++ b/build/api-specs/alchemy/json-rpc/gas-manager-coverage.json
@@ -1,4 +1,5 @@
 {
+  "x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
   "$schema": "https://meta.open-rpc.org/",
   "openrpc": "1.2.4",
   "info": {

--- a/build/api-specs/alchemy/json-rpc/gas-optimized-txns.json
+++ b/build/api-specs/alchemy/json-rpc/gas-optimized-txns.json
@@ -1,4 +1,5 @@
 {
+  "x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
   "$schema": "https://meta.open-rpc.org/",
   "openrpc": "1.2.4",
   "info": {

--- a/build/api-specs/alchemy/json-rpc/private-api.json
+++ b/build/api-specs/alchemy/json-rpc/private-api.json
@@ -1,4 +1,5 @@
 {
+  "x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
   "$schema": "https://meta.open-rpc.org/",
   "openrpc": "1.2.4",
   "info": {

--- a/build/api-specs/alchemy/json-rpc/token-api.json
+++ b/build/api-specs/alchemy/json-rpc/token-api.json
@@ -1,4 +1,5 @@
 {
+  "x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
   "$schema": "https://meta.open-rpc.org/",
   "openrpc": "1.2.4",
   "info": {

--- a/build/api-specs/alchemy/json-rpc/trace.json
+++ b/build/api-specs/alchemy/json-rpc/trace.json
@@ -1,4 +1,5 @@
 {
+  "x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
   "$schema": "https://meta.open-rpc.org/",
   "openrpc": "1.2.4",
   "info": {

--- a/build/api-specs/alchemy/json-rpc/transaction-simulation.json
+++ b/build/api-specs/alchemy/json-rpc/transaction-simulation.json
@@ -1,4 +1,5 @@
 {
+  "x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
   "$schema": "https://meta.open-rpc.org/",
   "openrpc": "1.2.4",
   "info": {

--- a/build/api-specs/alchemy/json-rpc/transactions-receipt.json
+++ b/build/api-specs/alchemy/json-rpc/transactions-receipt.json
@@ -1,4 +1,5 @@
 {
+  "x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
   "$schema": "https://meta.open-rpc.org/",
   "openrpc": "1.2.4",
   "info": {

--- a/build/api-specs/alchemy/json-rpc/transfers.json
+++ b/build/api-specs/alchemy/json-rpc/transfers.json
@@ -1,4 +1,5 @@
 {
+  "x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
   "$schema": "https://meta.open-rpc.org/",
   "openrpc": "1.2.4",
   "info": {

--- a/build/api-specs/alchemy/json-rpc/userop-sim.json
+++ b/build/api-specs/alchemy/json-rpc/userop-sim.json
@@ -1,4 +1,5 @@
 {
+  "x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
   "$schema": "https://meta.open-rpc.org/",
   "openrpc": "1.2.4",
   "info": {

--- a/build/api-specs/alchemy/rest/accounts.json
+++ b/build/api-specs/alchemy/rest/accounts.json
@@ -1,4 +1,5 @@
 {
+  "x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
   "openapi": "3.1.0",
   "info": {
     "title": "👤 Smart Wallets",

--- a/build/api-specs/alchemy/rest/blocks.json
+++ b/build/api-specs/alchemy/rest/blocks.json
@@ -1,4 +1,5 @@
 {
+  "x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
   "openapi": "3.1.0",
   "info": {
     "title": "⛓️ Block Timestamp API",

--- a/build/api-specs/alchemy/rest/nft.json
+++ b/build/api-specs/alchemy/rest/nft.json
@@ -1,4 +1,5 @@
 {
+  "x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
   "openapi": "3.1.0",
   "info": {
     "title": "🎨 NFT API",

--- a/build/api-specs/alchemy/rest/notify.json
+++ b/build/api-specs/alchemy/rest/notify.json
@@ -1,4 +1,5 @@
 {
+  "x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
   "openapi": "3.1.0",
   "info": {
     "title": "🔔 Webhooks",

--- a/build/api-specs/alchemy/rest/prices.json
+++ b/build/api-specs/alchemy/rest/prices.json
@@ -1,4 +1,5 @@
 {
+  "x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
   "openapi": "3.1.0",
   "info": {
     "title": "📈 Prices API",

--- a/build/api-specs/alchemy/rest/transactions.json
+++ b/build/api-specs/alchemy/rest/transactions.json
@@ -1,4 +1,5 @@
 {
+  "x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
   "openapi": "3.1.0",
   "info": {
     "title": "📈 Prices API",

--- a/build/api-specs/chains/abstract.json
+++ b/build/api-specs/chains/abstract.json
@@ -1,4 +1,5 @@
 {
+  "x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
   "$schema": "https://meta.open-rpc.org/",
   "openrpc": "1.2.4",
   "info": {

--- a/build/api-specs/chains/apechain.json
+++ b/build/api-specs/chains/apechain.json
@@ -1,4 +1,5 @@
 {
+  "x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
   "$schema": "https://meta.open-rpc.org/",
   "openrpc": "1.2.4",
   "info": {

--- a/build/api-specs/chains/arbitrum-nova.json
+++ b/build/api-specs/chains/arbitrum-nova.json
@@ -1,4 +1,5 @@
 {
+  "x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
   "$schema": "https://meta.open-rpc.org/",
   "openrpc": "1.2.4",
   "info": {

--- a/build/api-specs/chains/arbitrum.json
+++ b/build/api-specs/chains/arbitrum.json
@@ -1,4 +1,5 @@
 {
+  "x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
   "$schema": "https://meta.open-rpc.org/",
   "openrpc": "1.2.4",
   "info": {

--- a/build/api-specs/chains/astar.json
+++ b/build/api-specs/chains/astar.json
@@ -1,4 +1,5 @@
 {
+  "x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
   "$schema": "https://meta.open-rpc.org/",
   "openrpc": "1.2.4",
   "info": {

--- a/build/api-specs/chains/avalanche.json
+++ b/build/api-specs/chains/avalanche.json
@@ -1,4 +1,5 @@
 {
+  "x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
   "$schema": "https://meta.open-rpc.org/",
   "openrpc": "1.2.4",
   "info": {

--- a/build/api-specs/chains/base.json
+++ b/build/api-specs/chains/base.json
@@ -1,4 +1,5 @@
 {
+  "x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
   "$schema": "https://meta.open-rpc.org/",
   "openrpc": "1.2.4",
   "info": {

--- a/build/api-specs/chains/berachain.json
+++ b/build/api-specs/chains/berachain.json
@@ -1,4 +1,5 @@
 {
+  "x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
   "$schema": "https://meta.open-rpc.org/",
   "openrpc": "1.2.4",
   "info": {

--- a/build/api-specs/chains/blast.json
+++ b/build/api-specs/chains/blast.json
@@ -1,4 +1,5 @@
 {
+  "x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
   "$schema": "https://meta.open-rpc.org/",
   "openrpc": "1.2.4",
   "info": {

--- a/build/api-specs/chains/bsc.json
+++ b/build/api-specs/chains/bsc.json
@@ -1,4 +1,5 @@
 {
+  "x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
   "$schema": "https://meta.open-rpc.org/",
   "openrpc": "1.2.4",
   "info": {

--- a/build/api-specs/chains/crossfi.json
+++ b/build/api-specs/chains/crossfi.json
@@ -1,4 +1,5 @@
 {
+  "x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
   "$schema": "https://meta.open-rpc.org/",
   "openrpc": "1.2.4",
   "info": {

--- a/build/api-specs/chains/eth.json
+++ b/build/api-specs/chains/eth.json
@@ -1,4 +1,5 @@
 {
+  "x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
   "$schema": "https://meta.open-rpc.org/",
   "openrpc": "1.2.4",
   "info": {

--- a/build/api-specs/chains/flow.json
+++ b/build/api-specs/chains/flow.json
@@ -1,4 +1,5 @@
 {
+  "x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
   "$schema": "https://meta.open-rpc.org/",
   "openrpc": "1.2.4",
   "info": {

--- a/build/api-specs/chains/geist.json
+++ b/build/api-specs/chains/geist.json
@@ -1,4 +1,5 @@
 {
+  "x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
   "$schema": "https://meta.open-rpc.org/",
   "openrpc": "1.2.4",
   "info": {

--- a/build/api-specs/chains/gnosis.json
+++ b/build/api-specs/chains/gnosis.json
@@ -1,4 +1,5 @@
 {
+  "x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
   "$schema": "https://meta.open-rpc.org/",
   "openrpc": "1.2.4",
   "info": {

--- a/build/api-specs/chains/ink.json
+++ b/build/api-specs/chains/ink.json
@@ -1,4 +1,5 @@
 {
+  "x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
   "$schema": "https://meta.open-rpc.org/",
   "openrpc": "1.2.4",
   "info": {

--- a/build/api-specs/chains/lens.json
+++ b/build/api-specs/chains/lens.json
@@ -1,4 +1,5 @@
 {
+  "x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
   "$schema": "https://meta.open-rpc.org/",
   "openrpc": "1.2.4",
   "info": {

--- a/build/api-specs/chains/linea.json
+++ b/build/api-specs/chains/linea.json
@@ -1,4 +1,5 @@
 {
+  "x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
   "$schema": "https://meta.open-rpc.org/",
   "openrpc": "1.2.4",
   "info": {

--- a/build/api-specs/chains/lumia.json
+++ b/build/api-specs/chains/lumia.json
@@ -1,4 +1,5 @@
 {
+  "x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
   "$schema": "https://meta.open-rpc.org/",
   "openrpc": "1.2.4",
   "info": {

--- a/build/api-specs/chains/mantle.json
+++ b/build/api-specs/chains/mantle.json
@@ -1,4 +1,5 @@
 {
+  "x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
   "$schema": "https://meta.open-rpc.org/",
   "openrpc": "1.2.4",
   "info": {

--- a/build/api-specs/chains/metis.json
+++ b/build/api-specs/chains/metis.json
@@ -1,4 +1,5 @@
 {
+  "x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
   "$schema": "https://meta.open-rpc.org/",
   "openrpc": "1.2.4",
   "info": {

--- a/build/api-specs/chains/opBNB.json
+++ b/build/api-specs/chains/opBNB.json
@@ -1,4 +1,5 @@
 {
+  "x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
   "$schema": "https://meta.open-rpc.org/",
   "openrpc": "1.2.4",
   "info": {

--- a/build/api-specs/chains/optimism.json
+++ b/build/api-specs/chains/optimism.json
@@ -1,4 +1,5 @@
 {
+  "x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
   "$schema": "https://meta.open-rpc.org/",
   "openrpc": "1.2.4",
   "info": {

--- a/build/api-specs/chains/polygon-zkevm.json
+++ b/build/api-specs/chains/polygon-zkevm.json
@@ -1,4 +1,5 @@
 {
+  "x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
   "$schema": "https://meta.open-rpc.org/",
   "openrpc": "1.2.4",
   "info": {

--- a/build/api-specs/chains/polygon.json
+++ b/build/api-specs/chains/polygon.json
@@ -1,4 +1,5 @@
 {
+  "x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
   "$schema": "https://meta.open-rpc.org/",
   "openrpc": "1.2.4",
   "info": {

--- a/build/api-specs/chains/rootstock.json
+++ b/build/api-specs/chains/rootstock.json
@@ -1,4 +1,5 @@
 {
+  "x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
   "$schema": "https://meta.open-rpc.org/",
   "openrpc": "1.2.4",
   "info": {

--- a/build/api-specs/chains/scroll.json
+++ b/build/api-specs/chains/scroll.json
@@ -1,4 +1,5 @@
 {
+  "x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
   "$schema": "https://meta.open-rpc.org/",
   "openrpc": "1.2.4",
   "info": {

--- a/build/api-specs/chains/shape.json
+++ b/build/api-specs/chains/shape.json
@@ -1,4 +1,5 @@
 {
+  "x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
   "$schema": "https://meta.open-rpc.org/",
   "openrpc": "1.2.4",
   "info": {

--- a/build/api-specs/chains/solana.json
+++ b/build/api-specs/chains/solana.json
@@ -1,4 +1,5 @@
 {
+  "x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
   "$schema": "https://meta.open-rpc.org/",
   "openrpc": "1.2.4",
   "info": {

--- a/build/api-specs/chains/soneium.json
+++ b/build/api-specs/chains/soneium.json
@@ -1,4 +1,5 @@
 {
+  "x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
   "$schema": "https://meta.open-rpc.org/",
   "openrpc": "1.2.4",
   "info": {

--- a/build/api-specs/chains/sonic.json
+++ b/build/api-specs/chains/sonic.json
@@ -1,4 +1,5 @@
 {
+  "x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
   "$schema": "https://meta.open-rpc.org/",
   "openrpc": "1.2.4",
   "info": {

--- a/build/api-specs/chains/starknet.json
+++ b/build/api-specs/chains/starknet.json
@@ -1,4 +1,5 @@
 {
+  "x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
   "$schema": "https://meta.open-rpc.org/",
   "openrpc": "1.2.4",
   "info": {

--- a/build/api-specs/chains/unichain.json
+++ b/build/api-specs/chains/unichain.json
@@ -1,4 +1,5 @@
 {
+  "x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
   "$schema": "https://meta.open-rpc.org/",
   "openrpc": "1.2.4",
   "info": {

--- a/build/api-specs/chains/worldchain.json
+++ b/build/api-specs/chains/worldchain.json
@@ -1,4 +1,5 @@
 {
+  "x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
   "$schema": "https://meta.open-rpc.org/",
   "openrpc": "1.2.4",
   "info": {

--- a/build/api-specs/chains/zetachain.json
+++ b/build/api-specs/chains/zetachain.json
@@ -1,4 +1,5 @@
 {
+  "x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
   "$schema": "https://meta.open-rpc.org/",
   "openrpc": "1.2.4",
   "info": {

--- a/build/api-specs/chains/zksync.json
+++ b/build/api-specs/chains/zksync.json
@@ -1,4 +1,5 @@
 {
+  "x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
   "$schema": "https://meta.open-rpc.org/",
   "openrpc": "1.2.4",
   "info": {

--- a/scripts/generate-open-api.sh
+++ b/scripts/generate-open-api.sh
@@ -43,8 +43,12 @@ for file in src/openapi/*; do
         fi
       else
         # Run both bundle and lint when validate-only is false
-        if ! pnpm exec redocly bundle "$file" --dereferenced --output "$filename" --ext json --remove-unused-components || \
-           ! pnpm exec redocly lint "$filename" --format json; then
+        if ! pnpm exec redocly bundle "$file" --dereferenced --output "$filename" --ext json --remove-unused-components; then
+          exit 1
+        fi
+        # Add warning message to the JSON file
+        jq '{"x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually"} + .' "$filename" > "$filename.tmp" && mv "$filename.tmp" "$filename" || exit 1
+        if ! pnpm exec redocly lint "$filename" --format json; then
           exit 1
         fi
       fi

--- a/src/utils/generateRpcSpecs.ts
+++ b/src/utils/generateRpcSpecs.ts
@@ -31,6 +31,8 @@ export const generateChainRpcSpec = async (
   const base = getOpenRpcBase(schemaDir);
 
   const doc: OpenrpcDocument = {
+    "x-generated-warning":
+      "⚠️ This file is auto-generated. Do not edit manually",
     $schema: "https://meta.open-rpc.org/",
     openrpc: "1.2.4",
     ...base,
@@ -65,6 +67,8 @@ export const generateAlchemyRpcSpec = async (
   const base = getOpenRpcBase(schemaDir);
 
   const doc: OpenrpcDocument = {
+    "x-generated-warning":
+      "⚠️ This file is auto-generated. Do not edit manually",
     $schema: "https://meta.open-rpc.org/",
     openrpc: "1.2.4",
     ...base,


### PR DESCRIPTION
## Description

Files in the /build dir are auto-generated and should not be edited directly. This adds lines in each spec specifying that to prevent people from changing them directly.


## Changes Made

- Add x-generate-warning to open rpc specs at generate time
- Add x-generate-warning to open api specs after generation

## Testing

<!-- Describe the tests that you ran to verify your changes -->

- [x] I have tested these changes locally
- [x] I have run the validation scripts (`pnpm run validate`)
- [x] I have checked that the documentation builds correctly
