### PR TITLE
chore: change default local dev port to 3020

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Start the development server:
 pnpm dev
 ```
 
-This will start a local server with live reloading. Visit `http://localhost:3000` to view the documentation.
+This will start a local server with live reloading. Visit `http://localhost:3020` to view the documentation.
 
 ### Building API Specs
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "API Specs and content files for Alchemy's documentation",
   "license": "MIT",
   "scripts": {
-    "dev": "fern docs dev",
+    "dev": "fern docs dev --port 3020",
     "check-links": "fern docs broken-links",
     "fern:check": "fern check",
     "fern:preview": "fern generate --docs --preview",


### PR DESCRIPTION
## Description

3000 is the default port for Nextjs apps. It can be annoying running multiple projects locally if they all take the same port, so I usually recommend assigning an arbitrary port to avoid conflicts.


## Changes Made

- Change local dev port from 3000 to 3020

## Testing

<!-- Describe the tests that you ran to verify your changes -->

- [x] I have tested these changes locally
- [x] I have run the validation scripts (`pnpm run validate`)
- [x] I have checked that the documentation builds correctly
