### PR TITLE
feat: add account-kit to docs during ci

### DIFF
--- a/.github/actions/sparse-checkout-docs/action.yml
+++ b/.github/actions/sparse-checkout-docs/action.yml
@@ -1,0 +1,21 @@
+name: "Add aa-sdk docs to fern"
+description: "Checks out aa-sdk repository with sparse checkout and copies docs to fern/docs/account-kit"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Sparse Checkout Repository
+      uses: actions/checkout@v4
+      with:
+        repository: alchemyplatform/aa-sdk
+        path: aa-sdk
+        sparse-checkout: |
+          docs/
+        sparse-checkout-cone-mode: true
+
+    - name: Copy docs to workspace and insert into fern
+      shell: bash
+      run: |
+        mkdir -p fern/docs/account-kit
+        cp -r aa-sdk/docs/* fern/docs/account-kit
+        fern/docs/account-kit/scripts/insert-docs.sh

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -13,20 +13,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Sparse Checkout aa-sdk
-        uses: actions/checkout@v4
-        with:
-          repository: alchemyplatform/aa-sdk
-          path: aa-sdk
-          sparse-checkout: |
-            docs/
-          sparse-checkout-cone-mode: true
-
-      - name: Copy aa-sdk docs to workspace
-        run: |
-          mkdir -p fern/docs/account-kit
-          cp -r aa-sdk/docs/* fern/docs/account-kit
-          fern/docs/account-kit/scripts/insert-docs.sh
+      - name: Add aa-sdk docs to fern
+        uses: ./.github/actions/sparse-checkout-docs
 
       - name: Set Build Comment to In Progress
         uses: actions/github-script@v7

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -16,6 +16,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Add aa-sdk docs to fern
+        uses: ./.github/actions/sparse-checkout-docs
+
       - name: Publish Documentation
         uses: ./.github/actions/publish-fern
         id: publish


### PR DESCRIPTION
## Description

Account Kit docs live separately in [this repo](https://github.com/alchemyplatform/aa-sdk/). This PR checks out that repo and adds the contents of their docs to this site during CI.

## Changes Made

- Create composite action for checking out aa-sdk and adding its docs content to fern
- Apply the composite action to preview/publish docs

## Testing
Just check the preview comment lol

- [x] I have tested these changes locally
- [x] I have run the validation scripts (`pnpm run validate`)
- [x] I have checked that the documentation builds correctly
