### PR TITLE
docs: re-add fern schema to docs.yml

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://schema.buildwithfern.dev/docs-yml.json
+
 instances:
   - url: https://alchemy.docs.buildwithfern.com
 


### PR DESCRIPTION
## Description

I could have sworn this schema was placed here to provide Intellisense validation with yaml extensions. But it fell off somehow. This re-adds it.

## Related Issues

<!-- Link to any related issues or Asana tasks this PR addresses (e.g., "Fixes #123") -->

## Changes Made

-  re-add fern schema to docs.yml

## Testing

<!-- Describe the tests that you ran to verify your changes -->

- [x] I have tested these changes locally
- [x] I have run the validation scripts (`pnpm run validate`)
- [x] I have checked that the documentation builds correctly
