### PR TITLE
add portfolio apis to docs

### DIFF
--- a/build/api-specs/alchemy/rest/portfolio.json
+++ b/build/api-specs/alchemy/rest/portfolio.json
@@ -15,9 +15,16 @@
       "post": {
         "summary": "Tokens By Wallet",
         "description": "Fetches fungible tokens (native and ERC-20) for multiple wallet addresses and networks. Returns a list of tokens with balances, prices, and metadata for each wallet/network combination. This endpoint is supported on Ethereum, Solana, and 30+ EVM chains. See the full list of supported networks [here](https://dashboard.alchemy.com/chains?service=token-api&utm_source=readme&utm_medium=link&utm_campaign=docs_method_chains_link_v1_tokens).\n",
-        "tags": ["📚 Portfolio APIs"],
+        "tags": [
+          "Portfolio API Endpoints"
+        ],
         "x-readme": {
-          "samples-languages": ["javascript", "curl", "python", "go"]
+          "samples-languages": [
+            "javascript",
+            "curl",
+            "python",
+            "go"
+          ]
         },
         "parameters": [
           {
@@ -68,7 +75,10 @@
                           "description": "<style>\n  .custom-style {\n    color: #048FF4;\n  }\n</style>\nNetwork identifier (e.g., eth-mainnet). Find more network enums <span class=\"custom-style\"><a href=\"https://dashboard.alchemy.com/chains\" target=\"_blank\">here</a></span>\n"
                         }
                       },
-                      "required": ["address", "networks"]
+                      "required": [
+                        "address",
+                        "networks"
+                      ]
                     }
                   },
                   "withMetadata": {
@@ -88,7 +98,9 @@
                     "default": true
                   }
                 },
-                "required": ["addresses"]
+                "required": [
+                  "addresses"
+                ]
               }
             }
           }
@@ -198,7 +210,10 @@
                                 }
                               },
                               "error": {
-                                "type": ["string", "null"],
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "description": "Error message if applicable."
                               }
                             },
@@ -219,7 +234,9 @@
                       }
                     }
                   },
-                  "required": ["data"]
+                  "required": [
+                    "data"
+                  ]
                 }
               }
             }
@@ -239,11 +256,15 @@
                           "description": "Detailed error message."
                         }
                       },
-                      "required": ["message"],
+                      "required": [
+                        "message"
+                      ],
                       "description": "Error details."
                     }
                   },
-                  "required": ["error"]
+                  "required": [
+                    "error"
+                  ]
                 }
               }
             }
@@ -263,11 +284,15 @@
                           "description": "Detailed error message."
                         }
                       },
-                      "required": ["message"],
+                      "required": [
+                        "message"
+                      ],
                       "description": "Error details."
                     }
                   },
-                  "required": ["error"]
+                  "required": [
+                    "error"
+                  ]
                 }
               }
             }
@@ -280,9 +305,16 @@
       "post": {
         "summary": "Token Balances By Wallet",
         "description": "Fetches fungible tokens (native and ERC-20) for multiple wallet addresses and networks. Returns a list of tokens with balances for each wallet/network combination. This endpoint is supported on Ethereum, Solana, and 30+ EVM chains. See the full list of supported networks [here](https://dashboard.alchemy.com/chains?service=token-api&utm_source=readme&utm_medium=link&utm_campaign=docs_method_chains_link_v1_tokens)\n",
-        "tags": ["📚 Portfolio APIs"],
+        "tags": [
+          "Portfolio API Endpoints"
+        ],
         "x-readme": {
-          "samples-languages": ["javascript", "curl", "python", "go"]
+          "samples-languages": [
+            "javascript",
+            "curl",
+            "python",
+            "go"
+          ]
         },
         "parameters": [
           {
@@ -333,7 +365,10 @@
                           "description": "<style>\n  .custom-style {\n    color: #048FF4;\n  }\n</style>\nNetwork identifier (e.g., eth-mainnet). Find more network enums <span class=\"custom-style\"><a href=\"https://dashboard.alchemy.com/chains\" target=\"_blank\">here</a></span>\n"
                         }
                       },
-                      "required": ["address", "networks"]
+                      "required": [
+                        "address",
+                        "networks"
+                      ]
                     }
                   },
                   "includeNativeTokens": {
@@ -343,7 +378,9 @@
                     "default": true
                   }
                 },
-                "required": ["addresses"]
+                "required": [
+                  "addresses"
+                ]
               }
             }
           }
@@ -388,7 +425,9 @@
                       }
                     }
                   },
-                  "required": ["data"]
+                  "required": [
+                    "data"
+                  ]
                 }
               }
             }
@@ -408,11 +447,15 @@
                           "description": "Detailed error message."
                         }
                       },
-                      "required": ["message"],
+                      "required": [
+                        "message"
+                      ],
                       "description": "Error details."
                     }
                   },
-                  "required": ["error"]
+                  "required": [
+                    "error"
+                  ]
                 }
               }
             }
@@ -432,11 +475,15 @@
                           "description": "Detailed error message."
                         }
                       },
-                      "required": ["message"],
+                      "required": [
+                        "message"
+                      ],
                       "description": "Error details."
                     }
                   },
-                  "required": ["error"]
+                  "required": [
+                    "error"
+                  ]
                 }
               }
             }
@@ -449,9 +496,16 @@
       "post": {
         "summary": "NFTs By Wallet",
         "description": "Fetches NFTs for multiple wallet addresses and networks. Returns a list of NFTs and metadata for each wallet/network combination. This endpoint is supported on Ethereum and many L2s, including Polygon, Arbitrum, Optimism, Base, World Chain and more. See the full list of supported networks [here](https://dashboard.alchemy.com/chains?service=token-api&utm_source=readme&utm_medium=link&utm_campaign=docs_method_chains_link_v1_tokens).\n",
-        "tags": ["📚 Portfolio APIs"],
+        "tags": [
+          "Portfolio API Endpoints"
+        ],
         "x-readme": {
-          "samples-languages": ["javascript", "curl", "python", "go"]
+          "samples-languages": [
+            "javascript",
+            "curl",
+            "python",
+            "go"
+          ]
         },
         "parameters": [
           {
@@ -540,7 +594,10 @@
                           "type": "array",
                           "items": {
                             "type": "string",
-                            "enum": ["SPAM", "AIRDROPS"],
+                            "enum": [
+                              "SPAM",
+                              "AIRDROPS"
+                            ],
                             "default": "SPAM"
                           }
                         },
@@ -548,16 +605,27 @@
                           "type": "array",
                           "items": {
                             "type": "string",
-                            "enum": ["SPAM", "AIRDROPS"],
+                            "enum": [
+                              "SPAM",
+                              "AIRDROPS"
+                            ],
                             "default": "SPAM"
                           }
                         },
                         "spamConfidenceLevel": {
                           "type": "string",
-                          "enum": ["VERY_HIGH", "HIGH", "MEDIUM", "LOW"]
+                          "enum": [
+                            "VERY_HIGH",
+                            "HIGH",
+                            "MEDIUM",
+                            "LOW"
+                          ]
                         }
                       },
-                      "required": ["address", "networks"]
+                      "required": [
+                        "address",
+                        "networks"
+                      ]
                     }
                   },
                   "withMetadata": {
@@ -573,7 +641,9 @@
                     "default": 100
                   }
                 },
-                "required": ["addresses"]
+                "required": [
+                  "addresses"
+                ]
               }
             }
           }
@@ -589,21 +659,266 @@
                     "data": {
                       "type": "object",
                       "description": "List of nfts by address with appropriate metadata.",
-                      "ownedNfts": {
-                        "type": "array",
-                        "items": {
-                          "$ref": "#/components/schemas/NFTResponseItem"
+                      "properties": {
+                        "ownedNfts": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "description": "The object that represents an NFT and has all data corresponding to that NFT",
+                            "properties": {
+                              "network": {
+                                "type": "string",
+                                "description": "Network identifier."
+                              },
+                              "address": {
+                                "type": "string",
+                                "description": "Wallet address."
+                              },
+                              "contract": {
+                                "type": "object",
+                                "description": "The contract object that has details of a contract",
+                                "properties": {
+                                  "address": {
+                                    "description": "Address of the held contract",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string",
+                                    "description": "String - NFT contract name."
+                                  },
+                                  "symbol": {
+                                    "type": "string",
+                                    "description": "String - NFT contract symbol abbreviation."
+                                  },
+                                  "totalSupply": {
+                                    "type": "string",
+                                    "description": "String - Total number of NFTs in a given NFT collection."
+                                  },
+                                  "tokenType": {
+                                    "type": "string",
+                                    "enum": [
+                                      "ERC721",
+                                      "ERC1155",
+                                      "NO_SUPPORTED_NFT_STANDARD",
+                                      "NOT_A_CONTRACT"
+                                    ],
+                                    "description": "String - For valid NFTs, 'ERC721' or 'ERC1155.' For invalid NFTs, a descriptive reason such as 'NO_SUPPORTED_NFT_STANDARD' if the input contract address doesn't support a known NFT standard, or 'NOT_A_CONTRACT' if there is no contract deployed at the input address."
+                                  },
+                                  "contractDeployer": {
+                                    "type": "string",
+                                    "description": "String - Address that deployed the smart contract"
+                                  },
+                                  "deployedBlockNumber": {
+                                    "type": "number",
+                                    "description": "Number - The Block Number when the deployment transaction is successfully mined"
+                                  },
+                                  "openseaMetadata": {
+                                    "type": "object",
+                                    "description": "Note that the OpenSea metadata object is currently only available on ETH and Polygon Mainnet. Please reach out to us at support@alchemy.com if you would like to access this data on other networks.",
+                                    "properties": {
+                                      "floorPrice": {
+                                        "type": "number",
+                                        "description": "NFT floor price"
+                                      },
+                                      "collectionName": {
+                                        "type": "string",
+                                        "description": "OpenSea collection name"
+                                      },
+                                      "safelistRequestStatus": {
+                                        "type": "string",
+                                        "description": "Collection approval status within OpenSea. For more info, see the Opensea docs at docs.opensea.io/reference/collection-model"
+                                      },
+                                      "imageUrl": {
+                                        "type": "string",
+                                        "description": "OpenSea CDN image URL"
+                                      },
+                                      "description": {
+                                        "type": "string",
+                                        "description": "OpenSea collection description"
+                                      },
+                                      "externalUrl": {
+                                        "type": "string",
+                                        "description": "Collection homepage"
+                                      },
+                                      "twitterUsername": {
+                                        "type": "string",
+                                        "description": "The twitter username of the collection"
+                                      },
+                                      "discordUrl": {
+                                        "type": "string",
+                                        "description": "The discord URL of the collection"
+                                      },
+                                      "lastIngestedAt": {
+                                        "type": "string",
+                                        "description": "The timestamp when the collection was last ingested by us"
+                                      }
+                                    }
+                                  },
+                                  "isSpam": {
+                                    "type": "string",
+                                    "description": "\"true\" if contract is spam, else \"false\". **Only available on paid tiers.**"
+                                  },
+                                  "spamClassifications": {
+                                    "description": "List of reasons why a contract was classified as spam. **Only available on paid tiers.**",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "tokenId": {
+                                "type": "string",
+                                "default": "44"
+                              },
+                              "tokenType": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string",
+                                "description": "String - Name of the NFT asset."
+                              },
+                              "description": {
+                                "type": "string",
+                                "description": "String - Brief human-readable description"
+                              },
+                              "image": {
+                                "type": "object",
+                                "description": "Details of the image corresponding to this contract",
+                                "properties": {
+                                  "cachedUrl": {
+                                    "type": "string",
+                                    "description": "The Url of the image stored in Alchemy cache"
+                                  },
+                                  "thumbnailUrl": {
+                                    "type": "string",
+                                    "description": "The Url that has the thumbnail version of the NFT"
+                                  },
+                                  "pngUrl": {
+                                    "type": "string",
+                                    "description": "The Url that has the NFT image in png"
+                                  },
+                                  "contentType": {
+                                    "type": "string",
+                                    "description": "The Url of the image stored in Alchemy cache"
+                                  },
+                                  "size": {
+                                    "type": "integer",
+                                    "description": "The size of the media asset in bytes."
+                                  },
+                                  "originalUrl": {
+                                    "type": "string",
+                                    "description": "The original Url of the image coming straight from the smart contract"
+                                  }
+                                }
+                              },
+                              "raw": {
+                                "type": "object",
+                                "description": "Raw details of the NFT like its tokenUri and metadata info obtained directly from the smart contract",
+                                "properties": {
+                                  "tokenUri": {
+                                    "type": "string",
+                                    "description": "String - Uri representing the location of the NFT's original metadata blob. This is a backup for you to parse when the metadata field is not automatically populated."
+                                  },
+                                  "metadata": {
+                                    "type": "object",
+                                    "description": "Relevant metadata for NFT contract. This is useful for viewing image url, traits, etc. without having to follow the metadata url in tokenUri to parse manually.",
+                                    "properties": {
+                                      "image": {
+                                        "type": "string",
+                                        "description": "String - URL to the NFT asset image. Can be standard URLs pointing to images on conventional servers, IPFS, or Arweave. Most types of images (SVGs, PNGs, JPEGs, etc.) are supported by NFT marketplaces."
+                                      },
+                                      "name": {
+                                        "type": "string",
+                                        "description": "String - Name of the NFT asset."
+                                      },
+                                      "description": {
+                                        "type": "string",
+                                        "description": "String - Human-readable description of the NFT asset. (Markdown is supported/rendered on OpenSea and other NFT platforms)"
+                                      },
+                                      "attributes": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "value": {
+                                              "type": "string"
+                                            },
+                                            "trait_type": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        },
+                                        "description": "Object - Traits/attributes/characteristics for each NFT asset."
+                                      }
+                                    }
+                                  },
+                                  "error": {
+                                    "type": "string",
+                                    "description": "String - A string describing a particular reason that we were unable to fetch complete metadata for the NFT."
+                                  }
+                                }
+                              },
+                              "collection": {
+                                "type": "object",
+                                "description": "The collection object that has details of a collection",
+                                "properties": {
+                                  "name": {
+                                    "type": "string",
+                                    "description": "String - Collection name"
+                                  },
+                                  "slug": {
+                                    "type": "string",
+                                    "description": "String - OpenSea collection slug"
+                                  },
+                                  "externalUrl": {
+                                    "type": "string",
+                                    "description": "String - URL for the external site of the collection"
+                                  },
+                                  "bannerImageUrl": {
+                                    "type": "string",
+                                    "description": "String - Banner image URL for the collection"
+                                  }
+                                }
+                              },
+                              "tokenUri": {
+                                "type": "string",
+                                "description": "String - Uri representing the location of the NFT's original metadata blob. This is a backup for you to parse when the metadata field is not automatically populated."
+                              },
+                              "timeLastUpdated": {
+                                "type": "string",
+                                "description": "String - ISO timestamp of the last cache refresh for the information returned in the metadata field."
+                              },
+                              "acquiredAt": {
+                                "type": "object",
+                                "description": "Only present if the request specified `orderBy=transferTime`.",
+                                "properties": {
+                                  "blockTimestamp": {
+                                    "type": "string",
+                                    "description": "Block timestamp of the block where the NFT was most recently acquired."
+                                  },
+                                  "blockNumber": {
+                                    "type": "string",
+                                    "description": "Block number of the block where the NFT was most recently acquired."
+                                  }
+                                }
+                              }
+                            }
+                          }
                         },
                         "totalCount": {
-                          "$ref": "../nft/nft.yaml#/components/schemas/totalNFTCount"
+                          "type": "integer",
+                          "description": "Integer - Total number of NFTs (distinct `tokenIds`) owned by the given address."
                         },
                         "pageKey": {
-                          "$ref": "../nft/nft.yaml#/components/schemas/pageKey"
+                          "type": "string"
                         }
                       }
                     }
                   },
-                  "required": ["data"]
+                  "required": [
+                    "data"
+                  ]
                 }
               }
             }
@@ -623,11 +938,15 @@
                           "description": "Detailed error message."
                         }
                       },
-                      "required": ["message"],
+                      "required": [
+                        "message"
+                      ],
                       "description": "Error details."
                     }
                   },
-                  "required": ["error"]
+                  "required": [
+                    "error"
+                  ]
                 }
               }
             }
@@ -647,11 +966,15 @@
                           "description": "Detailed error message."
                         }
                       },
-                      "required": ["message"],
+                      "required": [
+                        "message"
+                      ],
                       "description": "Error details."
                     }
                   },
-                  "required": ["error"]
+                  "required": [
+                    "error"
+                  ]
                 }
               }
             }
@@ -664,9 +987,16 @@
       "post": {
         "summary": "NFT Collections By Wallet",
         "description": "Fetches NFT collections (contracts) for multiple wallet addresses and networks. Returns a list of collections and metadata for each wallet/network combination. This endpoint is supported on Ethereum and many L2s, including Polygon, Arbitrum, Optimism, Base, World Chain and more. See the full list of supported networks [here](https://dashboard.alchemy.com/chains?service=token-api&utm_source=readme&utm_medium=link&utm_campaign=docs_method_chains_link_v1_tokens).\n",
-        "tags": ["📚 Portfolio APIs"],
+        "tags": [
+          "Portfolio API Endpoints"
+        ],
         "x-readme": {
-          "samples-languages": ["javascript", "curl", "python", "go"]
+          "samples-languages": [
+            "javascript",
+            "curl",
+            "python",
+            "go"
+          ]
         },
         "parameters": [
           {
@@ -717,7 +1047,10 @@
                           "description": "<style>\n  .custom-style {\n    color: #048FF4;\n  }\n</style>\nNetwork identifier (e.g., eth-mainnet). Find more network enums <span class=\"custom-style\"><a href=\"https://dashboard.alchemy.com/chains\" target=\"_blank\">here</a></span>\n"
                         }
                       },
-                      "required": ["address", "networks"]
+                      "required": [
+                        "address",
+                        "networks"
+                      ]
                     }
                   },
                   "withMetadata": {
@@ -726,7 +1059,9 @@
                     "default": true
                   }
                 },
-                "required": ["addresses"]
+                "required": [
+                  "addresses"
+                ]
               }
             }
           }
@@ -742,21 +1077,266 @@
                     "data": {
                       "type": "object",
                       "description": "List of nfts by address with appropriate metadata.",
-                      "ownedNfts": {
-                        "type": "array",
-                        "items": {
-                          "$ref": "#/components/schemas/NFTResponseItem"
+                      "properties": {
+                        "ownedNfts": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "description": "The object that represents an NFT and has all data corresponding to that NFT",
+                            "properties": {
+                              "network": {
+                                "type": "string",
+                                "description": "Network identifier."
+                              },
+                              "address": {
+                                "type": "string",
+                                "description": "Wallet address."
+                              },
+                              "contract": {
+                                "type": "object",
+                                "description": "The contract object that has details of a contract",
+                                "properties": {
+                                  "address": {
+                                    "description": "Address of the held contract",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string",
+                                    "description": "String - NFT contract name."
+                                  },
+                                  "symbol": {
+                                    "type": "string",
+                                    "description": "String - NFT contract symbol abbreviation."
+                                  },
+                                  "totalSupply": {
+                                    "type": "string",
+                                    "description": "String - Total number of NFTs in a given NFT collection."
+                                  },
+                                  "tokenType": {
+                                    "type": "string",
+                                    "enum": [
+                                      "ERC721",
+                                      "ERC1155",
+                                      "NO_SUPPORTED_NFT_STANDARD",
+                                      "NOT_A_CONTRACT"
+                                    ],
+                                    "description": "String - For valid NFTs, 'ERC721' or 'ERC1155.' For invalid NFTs, a descriptive reason such as 'NO_SUPPORTED_NFT_STANDARD' if the input contract address doesn't support a known NFT standard, or 'NOT_A_CONTRACT' if there is no contract deployed at the input address."
+                                  },
+                                  "contractDeployer": {
+                                    "type": "string",
+                                    "description": "String - Address that deployed the smart contract"
+                                  },
+                                  "deployedBlockNumber": {
+                                    "type": "number",
+                                    "description": "Number - The Block Number when the deployment transaction is successfully mined"
+                                  },
+                                  "openseaMetadata": {
+                                    "type": "object",
+                                    "description": "Note that the OpenSea metadata object is currently only available on ETH and Polygon Mainnet. Please reach out to us at support@alchemy.com if you would like to access this data on other networks.",
+                                    "properties": {
+                                      "floorPrice": {
+                                        "type": "number",
+                                        "description": "NFT floor price"
+                                      },
+                                      "collectionName": {
+                                        "type": "string",
+                                        "description": "OpenSea collection name"
+                                      },
+                                      "safelistRequestStatus": {
+                                        "type": "string",
+                                        "description": "Collection approval status within OpenSea. For more info, see the Opensea docs at docs.opensea.io/reference/collection-model"
+                                      },
+                                      "imageUrl": {
+                                        "type": "string",
+                                        "description": "OpenSea CDN image URL"
+                                      },
+                                      "description": {
+                                        "type": "string",
+                                        "description": "OpenSea collection description"
+                                      },
+                                      "externalUrl": {
+                                        "type": "string",
+                                        "description": "Collection homepage"
+                                      },
+                                      "twitterUsername": {
+                                        "type": "string",
+                                        "description": "The twitter username of the collection"
+                                      },
+                                      "discordUrl": {
+                                        "type": "string",
+                                        "description": "The discord URL of the collection"
+                                      },
+                                      "lastIngestedAt": {
+                                        "type": "string",
+                                        "description": "The timestamp when the collection was last ingested by us"
+                                      }
+                                    }
+                                  },
+                                  "isSpam": {
+                                    "type": "string",
+                                    "description": "\"true\" if contract is spam, else \"false\". **Only available on paid tiers.**"
+                                  },
+                                  "spamClassifications": {
+                                    "description": "List of reasons why a contract was classified as spam. **Only available on paid tiers.**",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "tokenId": {
+                                "type": "string",
+                                "default": "44"
+                              },
+                              "tokenType": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string",
+                                "description": "String - Name of the NFT asset."
+                              },
+                              "description": {
+                                "type": "string",
+                                "description": "String - Brief human-readable description"
+                              },
+                              "image": {
+                                "type": "object",
+                                "description": "Details of the image corresponding to this contract",
+                                "properties": {
+                                  "cachedUrl": {
+                                    "type": "string",
+                                    "description": "The Url of the image stored in Alchemy cache"
+                                  },
+                                  "thumbnailUrl": {
+                                    "type": "string",
+                                    "description": "The Url that has the thumbnail version of the NFT"
+                                  },
+                                  "pngUrl": {
+                                    "type": "string",
+                                    "description": "The Url that has the NFT image in png"
+                                  },
+                                  "contentType": {
+                                    "type": "string",
+                                    "description": "The Url of the image stored in Alchemy cache"
+                                  },
+                                  "size": {
+                                    "type": "integer",
+                                    "description": "The size of the media asset in bytes."
+                                  },
+                                  "originalUrl": {
+                                    "type": "string",
+                                    "description": "The original Url of the image coming straight from the smart contract"
+                                  }
+                                }
+                              },
+                              "raw": {
+                                "type": "object",
+                                "description": "Raw details of the NFT like its tokenUri and metadata info obtained directly from the smart contract",
+                                "properties": {
+                                  "tokenUri": {
+                                    "type": "string",
+                                    "description": "String - Uri representing the location of the NFT's original metadata blob. This is a backup for you to parse when the metadata field is not automatically populated."
+                                  },
+                                  "metadata": {
+                                    "type": "object",
+                                    "description": "Relevant metadata for NFT contract. This is useful for viewing image url, traits, etc. without having to follow the metadata url in tokenUri to parse manually.",
+                                    "properties": {
+                                      "image": {
+                                        "type": "string",
+                                        "description": "String - URL to the NFT asset image. Can be standard URLs pointing to images on conventional servers, IPFS, or Arweave. Most types of images (SVGs, PNGs, JPEGs, etc.) are supported by NFT marketplaces."
+                                      },
+                                      "name": {
+                                        "type": "string",
+                                        "description": "String - Name of the NFT asset."
+                                      },
+                                      "description": {
+                                        "type": "string",
+                                        "description": "String - Human-readable description of the NFT asset. (Markdown is supported/rendered on OpenSea and other NFT platforms)"
+                                      },
+                                      "attributes": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "value": {
+                                              "type": "string"
+                                            },
+                                            "trait_type": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        },
+                                        "description": "Object - Traits/attributes/characteristics for each NFT asset."
+                                      }
+                                    }
+                                  },
+                                  "error": {
+                                    "type": "string",
+                                    "description": "String - A string describing a particular reason that we were unable to fetch complete metadata for the NFT."
+                                  }
+                                }
+                              },
+                              "collection": {
+                                "type": "object",
+                                "description": "The collection object that has details of a collection",
+                                "properties": {
+                                  "name": {
+                                    "type": "string",
+                                    "description": "String - Collection name"
+                                  },
+                                  "slug": {
+                                    "type": "string",
+                                    "description": "String - OpenSea collection slug"
+                                  },
+                                  "externalUrl": {
+                                    "type": "string",
+                                    "description": "String - URL for the external site of the collection"
+                                  },
+                                  "bannerImageUrl": {
+                                    "type": "string",
+                                    "description": "String - Banner image URL for the collection"
+                                  }
+                                }
+                              },
+                              "tokenUri": {
+                                "type": "string",
+                                "description": "String - Uri representing the location of the NFT's original metadata blob. This is a backup for you to parse when the metadata field is not automatically populated."
+                              },
+                              "timeLastUpdated": {
+                                "type": "string",
+                                "description": "String - ISO timestamp of the last cache refresh for the information returned in the metadata field."
+                              },
+                              "acquiredAt": {
+                                "type": "object",
+                                "description": "Only present if the request specified `orderBy=transferTime`.",
+                                "properties": {
+                                  "blockTimestamp": {
+                                    "type": "string",
+                                    "description": "Block timestamp of the block where the NFT was most recently acquired."
+                                  },
+                                  "blockNumber": {
+                                    "type": "string",
+                                    "description": "Block number of the block where the NFT was most recently acquired."
+                                  }
+                                }
+                              }
+                            }
+                          }
                         },
                         "totalCount": {
-                          "$ref": "../nft/nft.yaml#/components/schemas/totalNFTCount"
+                          "type": "integer",
+                          "description": "Integer - Total number of NFTs (distinct `tokenIds`) owned by the given address."
                         },
                         "pageKey": {
-                          "$ref": "../nft/nft.yaml#/components/schemas/pageKey"
+                          "type": "string"
                         }
                       }
                     }
                   },
-                  "required": ["data"]
+                  "required": [
+                    "data"
+                  ]
                 }
               }
             }
@@ -776,11 +1356,15 @@
                           "description": "Detailed error message."
                         }
                       },
-                      "required": ["message"],
+                      "required": [
+                        "message"
+                      ],
                       "description": "Error details."
                     }
                   },
-                  "required": ["error"]
+                  "required": [
+                    "error"
+                  ]
                 }
               }
             }
@@ -800,11 +1384,15 @@
                           "description": "Detailed error message."
                         }
                       },
-                      "required": ["message"],
+                      "required": [
+                        "message"
+                      ],
                       "description": "Error details."
                     }
                   },
-                  "required": ["error"]
+                  "required": [
+                    "error"
+                  ]
                 }
               }
             }
@@ -817,9 +1405,16 @@
       "post": {
         "summary": "Transactions By Wallet",
         "description": "Fetches all historical transactions (internal & external) for multiple wallet addresses and networks. Returns a list of transaction objects with metadata and log information. This endpoint will be supported on Ethereum, Solana, and 30+ EVM chains (Beta: currently limited to Ethereum and Base with a limit of 1 address)\n",
-        "tags": ["📚 Portfolio APIs"],
+        "tags": [
+          "Portfolio API Endpoints"
+        ],
         "x-readme": {
-          "samples-languages": ["javascript", "curl", "python", "go"]
+          "samples-languages": [
+            "javascript",
+            "curl",
+            "python",
+            "go"
+          ]
         },
         "parameters": [
           {
@@ -858,7 +1453,10 @@
                           "type": "array",
                           "minItems": 1,
                           "maxItems": 2,
-                          "default": ["eth-mainnet", "base-mainnet"],
+                          "default": [
+                            "eth-mainnet",
+                            "base-mainnet"
+                          ],
                           "items": {
                             "type": "string",
                             "default": "eth-mainnet"
@@ -866,7 +1464,10 @@
                           "description": "<style>\n  .custom-style {\n    color: #048FF4;\n  }\n</style>\n(In BETA and only accepts ETH & BASE mainnets). Network identifier (e.g., eth-mainnet). Find more network enums <span class=\"custom-style\"><a href=\"https://dashboard.alchemy.com/chains\" target=\"_blank\">here</a></span>\n"
                         }
                       },
-                      "required": ["address", "networks"]
+                      "required": [
+                        "address",
+                        "networks"
+                      ]
                     }
                   },
                   "before": {
@@ -883,7 +1484,9 @@
                     "default": 25
                   }
                 },
-                "required": ["addresses"]
+                "required": [
+                  "addresses"
+                ]
               }
             }
           }
@@ -1055,7 +1658,9 @@
                       }
                     }
                   },
-                  "required": ["transactions"]
+                  "required": [
+                    "transactions"
+                  ]
                 }
               }
             }
@@ -1075,11 +1680,15 @@
                           "description": "Detailed error message."
                         }
                       },
-                      "required": ["message"],
+                      "required": [
+                        "message"
+                      ],
                       "description": "Error details."
                     }
                   },
-                  "required": ["error"]
+                  "required": [
+                    "error"
+                  ]
                 }
               }
             }
@@ -1099,1019 +1708,21 @@
                           "description": "Detailed error message."
                         }
                       },
-                      "required": ["message"],
+                      "required": [
+                        "message"
+                      ],
                       "description": "Error details."
                     }
                   },
-                  "required": ["error"]
+                  "required": [
+                    "error"
+                  ]
                 }
               }
             }
           }
         },
         "operationId": "get-transaction-history-by-address"
-      }
-    },
-    "/{apiKey}/assets/nfts": {
-      "post": {
-        "summary": "Placeholder for NFT API",
-        "description": "Placeholder for the NFT API - in order to update this you'll need to move it back and forth.\n",
-        "tags": ["🎨 NFT API"],
-        "x-readme": {
-          "samples-languages": ["javascript", "curl", "python", "go"]
-        },
-        "parameters": [
-          {
-            "name": "apiKey",
-            "in": "path",
-            "schema": {
-              "type": "string",
-              "default": "docs-demo",
-              "description": "<style>\n  .custom-style {\n    color: #048FF4;\n  }\n</style>\nFor higher throughput, <span class=\"custom-style\"><a href=\"https://alchemy.com/?a=docs-demo\" target=\"_blank\">create your own API key</a></span>\n"
-            },
-            "required": true
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "addresses": {
-                    "type": "array",
-                    "minItems": 1,
-                    "maxItems": 2,
-                    "description": "Array of address and networks pairs (limit 2 pairs, max 5 networks each). Networks should match network enums.\n",
-                    "items": {
-                      "type": "array",
-                      "properties": {
-                        "address": {
-                          "type": "string",
-                          "description": "Wallet address.",
-                          "example": "0x1E6E8695FAb3Eb382534915eA8d7Cc1D1994B152",
-                          "default": "0x1E6E8695FAb3Eb382534915eA8d7Cc1D1994B152"
-                        },
-                        "networks": {
-                          "type": "array",
-                          "minItems": 1,
-                          "maxItems": 5,
-                          "default": [
-                            "eth-mainnet",
-                            "base-mainnet",
-                            "matic-mainnet"
-                          ],
-                          "items": {
-                            "type": "string",
-                            "default": "eth-mainnet"
-                          },
-                          "description": "<style>\n  .custom-style {\n    color: #048FF4;\n  }\n</style>\nNetwork identifier (e.g., eth-mainnet). Find more network enums <span class=\"custom-style\"><a href=\"https://dashboard.alchemy.com/chains\" target=\"_blank\">here</a></span>\n"
-                        }
-                      },
-                      "required": ["address", "networks"]
-                    }
-                  }
-                },
-                "required": ["addresses"]
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful response!",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "description": "List of token price data.",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "symbol": {
-                            "type": "string",
-                            "description": "Token symbol."
-                          },
-                          "prices": {
-                            "type": "array",
-                            "description": "List of price information.",
-                            "items": {
-                              "type": "object",
-                              "properties": {
-                                "currency": {
-                                  "type": "string",
-                                  "description": "Currency code (e.g., USD)."
-                                },
-                                "value": {
-                                  "type": "string",
-                                  "description": "Price value as a string."
-                                },
-                                "lastUpdatedAt": {
-                                  "type": "string",
-                                  "format": "date-time",
-                                  "description": "Time when the price was last updated."
-                                }
-                              },
-                              "required": ["currency", "value", "lastUpdatedAt"]
-                            }
-                          },
-                          "error": {
-                            "type": "string",
-                            "nullable": true,
-                            "description": "Error message if applicable."
-                          }
-                        },
-                        "required": ["symbol", "prices", "error"]
-                      }
-                    }
-                  },
-                  "required": ["data"]
-                }
-              }
-            }
-          }
-        },
-        "operationId": "get-nfts-by-address-placeholder"
-      }
-    },
-    "/{apiKey}/assets/tokens": {
-      "post": {
-        "summary": "Placeholder for Tokens API",
-        "description": "Placeholder for the Prices API - in order to update this you'll need to move it back and forth.\n",
-        "tags": ["🪙 Token API"],
-        "x-readme": {
-          "samples-languages": ["javascript", "curl", "python", "go"]
-        },
-        "parameters": [
-          {
-            "name": "apiKey",
-            "in": "path",
-            "schema": {
-              "type": "string",
-              "default": "docs-demo",
-              "description": "<style>\n  .custom-style {\n    color: #048FF4;\n  }\n</style>\nFor higher throughput, <span class=\"custom-style\"><a href=\"https://alchemy.com/?a=docs-demo\" target=\"_blank\">create your own API key</a></span>\n"
-            },
-            "required": true
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "addresses": {
-                    "type": "array",
-                    "minItems": 1,
-                    "maxItems": 2,
-                    "description": "Array of address and networks pairs (limit 2 pairs, max 5 networks each). Networks should match network enums.\n",
-                    "items": {
-                      "type": "array",
-                      "properties": {
-                        "address": {
-                          "type": "string",
-                          "description": "Wallet address.",
-                          "example": "0x1E6E8695FAb3Eb382534915eA8d7Cc1D1994B152",
-                          "default": "0x1E6E8695FAb3Eb382534915eA8d7Cc1D1994B152"
-                        },
-                        "networks": {
-                          "type": "array",
-                          "minItems": 1,
-                          "maxItems": 5,
-                          "default": [
-                            "eth-mainnet",
-                            "base-mainnet",
-                            "matic-mainnet"
-                          ],
-                          "items": {
-                            "type": "string",
-                            "default": "eth-mainnet"
-                          },
-                          "description": "<style>\n  .custom-style {\n    color: #048FF4;\n  }\n</style>\nNetwork identifier (e.g., eth-mainnet). Find more network enums <span class=\"custom-style\"><a href=\"https://dashboard.alchemy.com/chains\" target=\"_blank\">here</a></span>\n"
-                        }
-                      },
-                      "required": ["address", "networks"]
-                    }
-                  }
-                },
-                "required": ["addresses"]
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful response!",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "description": "List of token price data.",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "symbol": {
-                            "type": "string",
-                            "description": "Token symbol."
-                          },
-                          "prices": {
-                            "type": "array",
-                            "description": "List of price information.",
-                            "items": {
-                              "type": "object",
-                              "properties": {
-                                "currency": {
-                                  "type": "string",
-                                  "description": "Currency code (e.g., USD)."
-                                },
-                                "value": {
-                                  "type": "string",
-                                  "description": "Price value as a string."
-                                },
-                                "lastUpdatedAt": {
-                                  "type": "string",
-                                  "format": "date-time",
-                                  "description": "Time when the price was last updated."
-                                }
-                              },
-                              "required": ["currency", "value", "lastUpdatedAt"]
-                            }
-                          },
-                          "error": {
-                            "type": "string",
-                            "nullable": true,
-                            "description": "Error message if applicable."
-                          }
-                        },
-                        "required": ["symbol", "prices", "error"]
-                      }
-                    }
-                  },
-                  "required": ["data"]
-                }
-              }
-            }
-          }
-        },
-        "operationId": "get-tokens-by-address-placeholder"
-      }
-    },
-    "/{apiKey}/assets/prices": {
-      "post": {
-        "summary": "Placeholder for Prices API",
-        "description": "Placeholder for the Prices API - in order to update this you'll need to move it back and forth.\n",
-        "tags": ["📈 Prices API"],
-        "x-readme": {
-          "samples-languages": ["javascript", "curl", "python", "go"]
-        },
-        "parameters": [
-          {
-            "name": "apiKey",
-            "in": "path",
-            "schema": {
-              "type": "string",
-              "default": "docs-demo",
-              "description": "<style>\n  .custom-style {\n    color: #048FF4;\n  }\n</style>\nFor higher throughput, <span class=\"custom-style\"><a href=\"https://alchemy.com/?a=docs-demo\" target=\"_blank\">create your own API key</a></span>\n"
-            },
-            "required": true
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "addresses": {
-                    "type": "array",
-                    "minItems": 1,
-                    "maxItems": 2,
-                    "description": "Array of address and networks pairs (limit 2 pairs, max 5 networks each). Networks should match network enums.\n",
-                    "items": {
-                      "type": "array",
-                      "properties": {
-                        "address": {
-                          "type": "string",
-                          "description": "Wallet address.",
-                          "example": "0x1E6E8695FAb3Eb382534915eA8d7Cc1D1994B152",
-                          "default": "0x1E6E8695FAb3Eb382534915eA8d7Cc1D1994B152"
-                        },
-                        "networks": {
-                          "type": "array",
-                          "minItems": 1,
-                          "maxItems": 5,
-                          "default": [
-                            "eth-mainnet",
-                            "base-mainnet",
-                            "matic-mainnet"
-                          ],
-                          "items": {
-                            "type": "string",
-                            "default": "eth-mainnet"
-                          },
-                          "description": "<style>\n  .custom-style {\n    color: #048FF4;\n  }\n</style>\nNetwork identifier (e.g., eth-mainnet). Find more network enums <span class=\"custom-style\"><a href=\"https://dashboard.alchemy.com/chains\" target=\"_blank\">here</a></span>\n"
-                        }
-                      },
-                      "required": ["address", "networks"]
-                    }
-                  }
-                },
-                "required": ["addresses"]
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful response!",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "description": "List of token price data.",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "symbol": {
-                            "type": "string",
-                            "description": "Token symbol."
-                          },
-                          "prices": {
-                            "type": "array",
-                            "description": "List of price information.",
-                            "items": {
-                              "type": "object",
-                              "properties": {
-                                "currency": {
-                                  "type": "string",
-                                  "description": "Currency code (e.g., USD)."
-                                },
-                                "value": {
-                                  "type": "string",
-                                  "description": "Price value as a string."
-                                },
-                                "lastUpdatedAt": {
-                                  "type": "string",
-                                  "format": "date-time",
-                                  "description": "Time when the price was last updated."
-                                }
-                              },
-                              "required": ["currency", "value", "lastUpdatedAt"]
-                            }
-                          },
-                          "error": {
-                            "type": "string",
-                            "nullable": true,
-                            "description": "Error message if applicable."
-                          }
-                        },
-                        "required": ["symbol", "prices", "error"]
-                      }
-                    }
-                  },
-                  "required": ["data"]
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request: Invalid input (e.g., malformed JSON).",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "object",
-                      "properties": {
-                        "message": {
-                          "type": "string",
-                          "description": "Detailed error message."
-                        }
-                      },
-                      "required": ["message"],
-                      "description": "Error details."
-                    }
-                  },
-                  "required": ["error"]
-                }
-              }
-            }
-          },
-          "429": {
-            "description": "Too Many Requests: Rate limit exceeded.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "object",
-                      "properties": {
-                        "message": {
-                          "type": "string",
-                          "description": "Detailed error message."
-                        }
-                      },
-                      "required": ["message"],
-                      "description": "Error details."
-                    }
-                  },
-                  "required": ["error"]
-                }
-              }
-            }
-          }
-        },
-        "operationId": "get-tokens-prices-by-address-placeholder"
-      }
-    },
-    "/{apiKey}/assets/transfers": {
-      "post": {
-        "summary": "Placeholder for Transfers API",
-        "description": "Placeholder for the Transfers API - in order to update this you'll need to move it back and forth.\n",
-        "tags": ["💸 Transfers API"],
-        "x-readme": {
-          "samples-languages": ["javascript", "curl", "python", "go"]
-        },
-        "parameters": [
-          {
-            "name": "apiKey",
-            "in": "path",
-            "schema": {
-              "type": "string",
-              "default": "docs-demo",
-              "description": "<style>\n  .custom-style {\n    color: #048FF4;\n  }\n</style>\nFor higher throughput, <span class=\"custom-style\"><a href=\"https://alchemy.com/?a=docs-demo\" target=\"_blank\">create your own API key</a></span>\n"
-            },
-            "required": true
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "addresses": {
-                    "type": "array",
-                    "minItems": 1,
-                    "maxItems": 2,
-                    "description": "Array of address and networks pairs (limit 2 pairs, max 5 networks each). Networks should match network enums.\n",
-                    "items": {
-                      "type": "array",
-                      "properties": {
-                        "address": {
-                          "type": "string",
-                          "description": "Wallet address.",
-                          "example": "0x1E6E8695FAb3Eb382534915eA8d7Cc1D1994B152",
-                          "default": "0x1E6E8695FAb3Eb382534915eA8d7Cc1D1994B152"
-                        },
-                        "networks": {
-                          "type": "array",
-                          "minItems": 1,
-                          "maxItems": 5,
-                          "default": [
-                            "eth-mainnet",
-                            "base-mainnet",
-                            "matic-mainnet"
-                          ],
-                          "items": {
-                            "type": "string",
-                            "default": "eth-mainnet"
-                          },
-                          "description": "<style>\n  .custom-style {\n    color: #048FF4;\n  }\n</style>\nNetwork identifier (e.g., eth-mainnet). Find more network enums <span class=\"custom-style\"><a href=\"https://dashboard.alchemy.com/chains\" target=\"_blank\">here</a></span>\n"
-                        }
-                      },
-                      "required": ["address", "networks"]
-                    }
-                  }
-                },
-                "required": ["addresses"]
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful response!",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "description": "List of token price data.",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "symbol": {
-                            "type": "string",
-                            "description": "Token symbol."
-                          },
-                          "prices": {
-                            "type": "array",
-                            "description": "List of price information.",
-                            "items": {
-                              "type": "object",
-                              "properties": {
-                                "currency": {
-                                  "type": "string",
-                                  "description": "Currency code (e.g., USD)."
-                                },
-                                "value": {
-                                  "type": "string",
-                                  "description": "Price value as a string."
-                                },
-                                "lastUpdatedAt": {
-                                  "type": "string",
-                                  "format": "date-time",
-                                  "description": "Time when the price was last updated."
-                                }
-                              },
-                              "required": ["currency", "value", "lastUpdatedAt"]
-                            }
-                          },
-                          "error": {
-                            "type": "string",
-                            "nullable": true,
-                            "description": "Error message if applicable."
-                          }
-                        },
-                        "required": ["symbol", "prices", "error"]
-                      }
-                    }
-                  },
-                  "required": ["data"]
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request: Invalid input (e.g., malformed JSON).",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "object",
-                      "properties": {
-                        "message": {
-                          "type": "string",
-                          "description": "Detailed error message."
-                        }
-                      },
-                      "required": ["message"],
-                      "description": "Error details."
-                    }
-                  },
-                  "required": ["error"]
-                }
-              }
-            }
-          },
-          "429": {
-            "description": "Too Many Requests: Rate limit exceeded.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "object",
-                      "properties": {
-                        "message": {
-                          "type": "string",
-                          "description": "Detailed error message."
-                        }
-                      },
-                      "required": ["message"],
-                      "description": "Error details."
-                    }
-                  },
-                  "required": ["error"]
-                }
-              }
-            }
-          }
-        },
-        "operationId": "get-transfers-by-address-placeholder"
-      }
-    },
-    "/{apiKey}/utility/blocks/by-timestamp": {
-      "get": {
-        "summary": "Blocks by Timestamp",
-        "description": "Fetches the first block before or after a given timestamp. Returns the block's number and on-chain timestamp.",
-        "tags": ["🛠️ Utility APIs"],
-        "x-readme": {
-          "samples-languages": ["javascript", "curl", "python", "go"]
-        },
-        "parameters": [
-          {
-            "name": "apiKey",
-            "in": "path",
-            "schema": {
-              "type": "string",
-              "default": "docs-demo",
-              "description": "<style>\n  .custom-style {\n    color: #048FF4;\n  }\n</style>\nFor higher throughput, <span class=\"custom-style\"><a href=\"https://alchemy.com/?a=docs-demo\" target=\"_blank\">create your own API key</a></span>\n"
-            },
-            "required": true
-          },
-          {
-            "name": "networks",
-            "description": "<style>\n  .custom-style {\n    color: #048FF4;\n  }\n</style>\nArray of networks to query on. The response will be an array with one block per network. Find network enums <span class=\"custom-style\"><a href=\"https://dashboard.alchemy.com/chains\" target=\"_blank\">here</a></span>\n",
-            "schema": {
-              "type": "array",
-              "minItems": 1,
-              "maxItems": 3,
-              "items": {
-                "type": "string",
-                "default": "eth-mainnet"
-              }
-            },
-            "in": "query",
-            "required": true
-          },
-          {
-            "name": "timestamp",
-            "description": "Unix or ISO timestamp",
-            "schema": {
-              "type": "string",
-              "default": "2025-02-28T19:38:57Z"
-            },
-            "required": true,
-            "in": "query"
-          },
-          {
-            "name": "direction",
-            "required": true,
-            "description": "Return the first block \"BEFORE\" or \"AFTER\" the provided timestamp",
-            "schema": {
-              "type": "string",
-              "enum": ["BEFORE", "AFTER"],
-              "default": "AFTER"
-            },
-            "in": "query"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "description": "List of blocks",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "network": {
-                            "type": "string",
-                            "description": "Network identifier"
-                          },
-                          "block": {
-                            "type": "object",
-                            "properties": {
-                              "number": {
-                                "type": "integer",
-                                "description": "Block number"
-                              },
-                              "timestamp": {
-                                "type": "string",
-                                "description": "ISO timestamp of the block"
-                              }
-                            },
-                            "required": ["number", "timestamp"]
-                          }
-                        },
-                        "required": ["network", "block"]
-                      }
-                    }
-                  },
-                  "required": ["data"]
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request: Malformed request or missing parameters.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "object",
-                      "properties": {
-                        "message": {
-                          "type": "string",
-                          "description": "Detailed error message."
-                        }
-                      },
-                      "required": ["message"],
-                      "description": "Error details."
-                    }
-                  },
-                  "required": ["error"]
-                }
-              }
-            }
-          },
-          "429": {
-            "description": "Too Many Requests: Rate limit exceeded.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "object",
-                      "properties": {
-                        "message": {
-                          "type": "string",
-                          "description": "Detailed error message."
-                        }
-                      },
-                      "required": ["message"],
-                      "description": "Error details."
-                    }
-                  },
-                  "required": ["error"]
-                }
-              }
-            }
-          }
-        },
-        "operationId": "blocks-by-timestamp"
-      }
-    },
-    "/{apiKey}/subgraphs": {
-      "post": {
-        "summary": "Placeholder for Subgraphs",
-        "description": "Placeholder for the Subgraphs - in order to update this you'll need to move it back and forth.\n",
-        "tags": ["🍊 Subgraphs"],
-        "x-readme": {
-          "samples-languages": ["javascript", "curl", "python", "go"]
-        },
-        "parameters": [
-          {
-            "name": "apiKey",
-            "in": "path",
-            "schema": {
-              "type": "string",
-              "default": "docs-demo",
-              "description": "<style>\n  .custom-style {\n    color: #048FF4;\n  }\n</style>\nFor higher throughput, <span class=\"custom-style\"><a href=\"https://alchemy.com/?a=docs-demo\" target=\"_blank\">create your own API key</a></span>\n"
-            },
-            "required": true
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "addresses": {
-                    "type": "array",
-                    "minItems": 1,
-                    "maxItems": 2,
-                    "description": "Array of address and networks pairs (limit 2 pairs, max 5 networks each). Networks should match network enums.\n",
-                    "items": {
-                      "type": "array",
-                      "properties": {
-                        "address": {
-                          "type": "string",
-                          "description": "Wallet address.",
-                          "example": "0x1E6E8695FAb3Eb382534915eA8d7Cc1D1994B152",
-                          "default": "0x1E6E8695FAb3Eb382534915eA8d7Cc1D1994B152"
-                        },
-                        "networks": {
-                          "type": "array",
-                          "minItems": 1,
-                          "maxItems": 5,
-                          "default": [
-                            "eth-mainnet",
-                            "base-mainnet",
-                            "matic-mainnet"
-                          ],
-                          "items": {
-                            "type": "string",
-                            "default": "eth-mainnet"
-                          },
-                          "description": "<style>\n  .custom-style {\n    color: #048FF4;\n  }\n</style>\nNetwork identifier (e.g., eth-mainnet). Find more network enums <span class=\"custom-style\"><a href=\"https://dashboard.alchemy.com/chains\" target=\"_blank\">here</a></span>\n"
-                        }
-                      },
-                      "required": ["address", "networks"]
-                    }
-                  }
-                },
-                "required": ["addresses"]
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful response!",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "description": "List of token price data.",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "symbol": {
-                            "type": "string",
-                            "description": "Token symbol."
-                          },
-                          "prices": {
-                            "type": "array",
-                            "description": "List of price information.",
-                            "items": {
-                              "type": "object",
-                              "properties": {
-                                "currency": {
-                                  "type": "string",
-                                  "description": "Currency code (e.g., USD)."
-                                },
-                                "value": {
-                                  "type": "string",
-                                  "description": "Price value as a string."
-                                },
-                                "lastUpdatedAt": {
-                                  "type": "string",
-                                  "format": "date-time",
-                                  "description": "Time when the price was last updated."
-                                }
-                              },
-                              "required": ["currency", "value", "lastUpdatedAt"]
-                            }
-                          },
-                          "error": {
-                            "type": "string",
-                            "nullable": true,
-                            "description": "Error message if applicable."
-                          }
-                        },
-                        "required": ["symbol", "prices", "error"]
-                      }
-                    }
-                  },
-                  "required": ["data"]
-                }
-              }
-            }
-          }
-        },
-        "operationId": "subgraphs-placeholder"
-      }
-    },
-    "/{apiKey}/assets/webhooks": {
-      "post": {
-        "summary": "Placeholder for Webhooks",
-        "description": "Placeholder for the Webhooks - in order to update this you'll need to move it back and forth.\n",
-        "tags": ["🔔 Webhooks"],
-        "x-readme": {
-          "samples-languages": ["javascript", "curl", "python", "go"]
-        },
-        "parameters": [
-          {
-            "name": "apiKey",
-            "in": "path",
-            "schema": {
-              "type": "string",
-              "default": "docs-demo",
-              "description": "<style>\n  .custom-style {\n    color: #048FF4;\n  }\n</style>\nFor higher throughput, <span class=\"custom-style\"><a href=\"https://alchemy.com/?a=docs-demo\" target=\"_blank\">create your own API key</a></span>\n"
-            },
-            "required": true
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "addresses": {
-                    "type": "array",
-                    "minItems": 1,
-                    "maxItems": 2,
-                    "description": "Array of address and networks pairs (limit 2 pairs, max 5 networks each). Networks should match network enums.\n",
-                    "items": {
-                      "type": "array",
-                      "properties": {
-                        "address": {
-                          "type": "string",
-                          "description": "Wallet address.",
-                          "example": "0x1E6E8695FAb3Eb382534915eA8d7Cc1D1994B152",
-                          "default": "0x1E6E8695FAb3Eb382534915eA8d7Cc1D1994B152"
-                        },
-                        "networks": {
-                          "type": "array",
-                          "minItems": 1,
-                          "maxItems": 5,
-                          "default": [
-                            "eth-mainnet",
-                            "base-mainnet",
-                            "matic-mainnet"
-                          ],
-                          "items": {
-                            "type": "string",
-                            "default": "eth-mainnet"
-                          },
-                          "description": "<style>\n  .custom-style {\n    color: #048FF4;\n  }\n</style>\nNetwork identifier (e.g., eth-mainnet). Find more network enums <span class=\"custom-style\"><a href=\"https://dashboard.alchemy.com/chains\" target=\"_blank\">here</a></span>\n"
-                        }
-                      },
-                      "required": ["address", "networks"]
-                    }
-                  }
-                },
-                "required": ["addresses"]
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful response!",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "description": "List of token price data.",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "symbol": {
-                            "type": "string",
-                            "description": "Token symbol."
-                          },
-                          "prices": {
-                            "type": "array",
-                            "description": "List of price information.",
-                            "items": {
-                              "type": "object",
-                              "properties": {
-                                "currency": {
-                                  "type": "string",
-                                  "description": "Currency code (e.g., USD)."
-                                },
-                                "value": {
-                                  "type": "string",
-                                  "description": "Price value as a string."
-                                },
-                                "lastUpdatedAt": {
-                                  "type": "string",
-                                  "format": "date-time",
-                                  "description": "Time when the price was last updated."
-                                }
-                              },
-                              "required": ["currency", "value", "lastUpdatedAt"]
-                            }
-                          },
-                          "error": {
-                            "type": "string",
-                            "nullable": true,
-                            "description": "Error message if applicable."
-                          }
-                        },
-                        "required": ["symbol", "prices", "error"]
-                      }
-                    }
-                  },
-                  "required": ["data"]
-                }
-              }
-            }
-          }
-        },
-        "operationId": "webhooks-placeholder"
       }
     }
   },
@@ -2138,7 +1749,11 @@
                   "type": "array",
                   "minItems": 1,
                   "maxItems": 5,
-                  "default": ["eth-mainnet", "base-mainnet", "matic-mainnet"],
+                  "default": [
+                    "eth-mainnet",
+                    "base-mainnet",
+                    "matic-mainnet"
+                  ],
                   "items": {
                     "type": "string",
                     "default": "eth-mainnet"
@@ -2146,11 +1761,16 @@
                   "description": "<style>\n  .custom-style {\n    color: #048FF4;\n  }\n</style>\nNetwork identifier (e.g., eth-mainnet). Find more network enums <span class=\"custom-style\"><a href=\"https://dashboard.alchemy.com/chains\" target=\"_blank\">here</a></span>\n"
                 }
               },
-              "required": ["address", "networks"]
+              "required": [
+                "address",
+                "networks"
+              ]
             }
           }
         },
-        "required": ["addresses"]
+        "required": [
+          "addresses"
+        ]
       },
       "ByAddressRequestWith1AddressAnd2Networks": {
         "type": "object",
@@ -2173,7 +1793,10 @@
                   "type": "array",
                   "minItems": 1,
                   "maxItems": 2,
-                  "default": ["eth-mainnet", "base-mainnet"],
+                  "default": [
+                    "eth-mainnet",
+                    "base-mainnet"
+                  ],
                   "items": {
                     "type": "string",
                     "default": "eth-mainnet"
@@ -2181,7 +1804,10 @@
                   "description": "<style>\n  .custom-style {\n    color: #048FF4;\n  }\n</style>\n(In BETA and only accepts ETH & BASE mainnets). Network identifier (e.g., eth-mainnet). Find more network enums <span class=\"custom-style\"><a href=\"https://dashboard.alchemy.com/chains\" target=\"_blank\">here</a></span>\n"
                 }
               },
-              "required": ["address", "networks"]
+              "required": [
+                "address",
+                "networks"
+              ]
             }
           },
           "before": {
@@ -2198,7 +1824,9 @@
             "default": 25
           }
         },
-        "required": ["addresses"]
+        "required": [
+          "addresses"
+        ]
       },
       "ByAddressRequestWith3PairsAnd20Networks": {
         "type": "object",
@@ -2221,7 +1849,11 @@
                   "type": "array",
                   "minItems": 1,
                   "maxItems": 20,
-                  "default": ["eth-mainnet", "base-mainnet", "matic-mainnet"],
+                  "default": [
+                    "eth-mainnet",
+                    "base-mainnet",
+                    "matic-mainnet"
+                  ],
                   "items": {
                     "type": "string",
                     "default": "eth-mainnet"
@@ -2229,7 +1861,10 @@
                   "description": "<style>\n  .custom-style {\n    color: #048FF4;\n  }\n</style>\nNetwork identifier (e.g., eth-mainnet). Find more network enums <span class=\"custom-style\"><a href=\"https://dashboard.alchemy.com/chains\" target=\"_blank\">here</a></span>\n"
                 }
               },
-              "required": ["address", "networks"]
+              "required": [
+                "address",
+                "networks"
+              ]
             }
           },
           "includeNativeTokens": {
@@ -2239,7 +1874,9 @@
             "default": true
           }
         },
-        "required": ["addresses"]
+        "required": [
+          "addresses"
+        ]
       },
       "ByAddressRequestWithOptions": {
         "type": "object",
@@ -2262,7 +1899,11 @@
                   "type": "array",
                   "minItems": 1,
                   "maxItems": 5,
-                  "default": ["eth-mainnet", "base-mainnet", "matic-mainnet"],
+                  "default": [
+                    "eth-mainnet",
+                    "base-mainnet",
+                    "matic-mainnet"
+                  ],
                   "items": {
                     "type": "string",
                     "default": "eth-mainnet"
@@ -2270,7 +1911,10 @@
                   "description": "<style>\n  .custom-style {\n    color: #048FF4;\n  }\n</style>\nNetwork identifier (e.g., eth-mainnet). Find more network enums <span class=\"custom-style\"><a href=\"https://dashboard.alchemy.com/chains\" target=\"_blank\">here</a></span>\n"
                 }
               },
-              "required": ["address", "networks"]
+              "required": [
+                "address",
+                "networks"
+              ]
             }
           },
           "withMetadata": {
@@ -2290,7 +1934,9 @@
             "default": true
           }
         },
-        "required": ["addresses"]
+        "required": [
+          "addresses"
+        ]
       },
       "ByAddressRequestWithNFTOptionsAndPaging": {
         "type": "object",
@@ -2313,7 +1959,11 @@
                   "type": "array",
                   "minItems": 1,
                   "maxItems": 5,
-                  "default": ["eth-mainnet", "base-mainnet", "matic-mainnet"],
+                  "default": [
+                    "eth-mainnet",
+                    "base-mainnet",
+                    "matic-mainnet"
+                  ],
                   "items": {
                     "type": "string",
                     "enum": [
@@ -2359,7 +2009,10 @@
                   "type": "array",
                   "items": {
                     "type": "string",
-                    "enum": ["SPAM", "AIRDROPS"],
+                    "enum": [
+                      "SPAM",
+                      "AIRDROPS"
+                    ],
                     "default": "SPAM"
                   }
                 },
@@ -2367,16 +2020,27 @@
                   "type": "array",
                   "items": {
                     "type": "string",
-                    "enum": ["SPAM", "AIRDROPS"],
+                    "enum": [
+                      "SPAM",
+                      "AIRDROPS"
+                    ],
                     "default": "SPAM"
                   }
                 },
                 "spamConfidenceLevel": {
                   "type": "string",
-                  "enum": ["VERY_HIGH", "HIGH", "MEDIUM", "LOW"]
+                  "enum": [
+                    "VERY_HIGH",
+                    "HIGH",
+                    "MEDIUM",
+                    "LOW"
+                  ]
                 }
               },
-              "required": ["address", "networks"]
+              "required": [
+                "address",
+                "networks"
+              ]
             }
           },
           "withMetadata": {
@@ -2392,7 +2056,9 @@
             "default": 100
           }
         },
-        "required": ["addresses"]
+        "required": [
+          "addresses"
+        ]
       },
       "ByAddressRequestWithNFTOptions": {
         "type": "object",
@@ -2415,7 +2081,11 @@
                   "type": "array",
                   "minItems": 1,
                   "maxItems": 5,
-                  "default": ["eth-mainnet", "base-mainnet", "matic-mainnet"],
+                  "default": [
+                    "eth-mainnet",
+                    "base-mainnet",
+                    "matic-mainnet"
+                  ],
                   "items": {
                     "type": "string",
                     "default": "eth-mainnet"
@@ -2423,7 +2093,10 @@
                   "description": "<style>\n  .custom-style {\n    color: #048FF4;\n  }\n</style>\nNetwork identifier (e.g., eth-mainnet). Find more network enums <span class=\"custom-style\"><a href=\"https://dashboard.alchemy.com/chains\" target=\"_blank\">here</a></span>\n"
                 }
               },
-              "required": ["address", "networks"]
+              "required": [
+                "address",
+                "networks"
+              ]
             }
           },
           "withMetadata": {
@@ -2432,7 +2105,9 @@
             "default": true
           }
         },
-        "required": ["addresses"]
+        "required": [
+          "addresses"
+        ]
       },
       "AddressItemForNFTOwnership": {
         "type": "array",
@@ -2447,7 +2122,11 @@
             "type": "array",
             "minItems": 1,
             "maxItems": 5,
-            "default": ["eth-mainnet", "base-mainnet", "matic-mainnet"],
+            "default": [
+              "eth-mainnet",
+              "base-mainnet",
+              "matic-mainnet"
+            ],
             "items": {
               "type": "string",
               "enum": [
@@ -2493,7 +2172,10 @@
             "type": "array",
             "items": {
               "type": "string",
-              "enum": ["SPAM", "AIRDROPS"],
+              "enum": [
+                "SPAM",
+                "AIRDROPS"
+              ],
               "default": "SPAM"
             }
           },
@@ -2501,16 +2183,27 @@
             "type": "array",
             "items": {
               "type": "string",
-              "enum": ["SPAM", "AIRDROPS"],
+              "enum": [
+                "SPAM",
+                "AIRDROPS"
+              ],
               "default": "SPAM"
             }
           },
           "spamConfidenceLevel": {
             "type": "string",
-            "enum": ["VERY_HIGH", "HIGH", "MEDIUM", "LOW"]
+            "enum": [
+              "VERY_HIGH",
+              "HIGH",
+              "MEDIUM",
+              "LOW"
+            ]
           }
         },
-        "required": ["address", "networks"]
+        "required": [
+          "address",
+          "networks"
+        ]
       },
       "TokensResponse": {
         "type": "object",
@@ -2604,22 +2297,41 @@
                             "description": "Time when the price was last updated."
                           }
                         },
-                        "required": ["currency", "value", "lastUpdatedAt"]
+                        "required": [
+                          "currency",
+                          "value",
+                          "lastUpdatedAt"
+                        ]
                       }
                     },
                     "error": {
-                      "type": ["string", "null"],
+                      "type": [
+                        "string",
+                        "null"
+                      ],
                       "description": "Error message if applicable."
                     }
                   },
-                  "required": ["network", "address", "prices", "error"]
+                  "required": [
+                    "network",
+                    "address",
+                    "prices",
+                    "error"
+                  ]
                 }
               },
-              "required": ["network", "address", "tokenAddress", "tokenBalance"]
+              "required": [
+                "network",
+                "address",
+                "tokenAddress",
+                "tokenBalance"
+              ]
             }
           }
         },
-        "required": ["data"]
+        "required": [
+          "data"
+        ]
       },
       "TokensResponseItem": {
         "type": "object",
@@ -2707,18 +2419,35 @@
                       "description": "Time when the price was last updated."
                     }
                   },
-                  "required": ["currency", "value", "lastUpdatedAt"]
+                  "required": [
+                    "currency",
+                    "value",
+                    "lastUpdatedAt"
+                  ]
                 }
               },
               "error": {
-                "type": ["string", "null"],
+                "type": [
+                  "string",
+                  "null"
+                ],
                 "description": "Error message if applicable."
               }
             },
-            "required": ["network", "address", "prices", "error"]
+            "required": [
+              "network",
+              "address",
+              "prices",
+              "error"
+            ]
           }
         },
-        "required": ["network", "address", "tokenAddress", "tokenBalance"]
+        "required": [
+          "network",
+          "address",
+          "tokenAddress",
+          "tokenBalance"
+        ]
       },
       "TokenBalancesResponse": {
         "type": "object",
@@ -2746,11 +2475,285 @@
                   "description": "Balance of that particular token."
                 }
               },
-              "required": ["network", "address", "tokenAddress", "tokenBalance"]
+              "required": [
+                "network",
+                "address",
+                "tokenAddress",
+                "tokenBalance"
+              ]
             }
           }
         },
-        "required": ["data"]
+        "required": [
+          "data"
+        ]
+      },
+      "NFTByOwnerResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "description": "List of nfts by address with appropriate metadata.",
+            "properties": {
+              "ownedNfts": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "description": "The object that represents an NFT and has all data corresponding to that NFT",
+                  "properties": {
+                    "network": {
+                      "type": "string",
+                      "description": "Network identifier."
+                    },
+                    "address": {
+                      "type": "string",
+                      "description": "Wallet address."
+                    },
+                    "contract": {
+                      "type": "object",
+                      "description": "The contract object that has details of a contract",
+                      "properties": {
+                        "address": {
+                          "description": "Address of the held contract",
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "String - NFT contract name."
+                        },
+                        "symbol": {
+                          "type": "string",
+                          "description": "String - NFT contract symbol abbreviation."
+                        },
+                        "totalSupply": {
+                          "type": "string",
+                          "description": "String - Total number of NFTs in a given NFT collection."
+                        },
+                        "tokenType": {
+                          "type": "string",
+                          "enum": [
+                            "ERC721",
+                            "ERC1155",
+                            "NO_SUPPORTED_NFT_STANDARD",
+                            "NOT_A_CONTRACT"
+                          ],
+                          "description": "String - For valid NFTs, 'ERC721' or 'ERC1155.' For invalid NFTs, a descriptive reason such as 'NO_SUPPORTED_NFT_STANDARD' if the input contract address doesn't support a known NFT standard, or 'NOT_A_CONTRACT' if there is no contract deployed at the input address."
+                        },
+                        "contractDeployer": {
+                          "type": "string",
+                          "description": "String - Address that deployed the smart contract"
+                        },
+                        "deployedBlockNumber": {
+                          "type": "number",
+                          "description": "Number - The Block Number when the deployment transaction is successfully mined"
+                        },
+                        "openseaMetadata": {
+                          "type": "object",
+                          "description": "Note that the OpenSea metadata object is currently only available on ETH and Polygon Mainnet. Please reach out to us at support@alchemy.com if you would like to access this data on other networks.",
+                          "properties": {
+                            "floorPrice": {
+                              "type": "number",
+                              "description": "NFT floor price"
+                            },
+                            "collectionName": {
+                              "type": "string",
+                              "description": "OpenSea collection name"
+                            },
+                            "safelistRequestStatus": {
+                              "type": "string",
+                              "description": "Collection approval status within OpenSea. For more info, see the Opensea docs at docs.opensea.io/reference/collection-model"
+                            },
+                            "imageUrl": {
+                              "type": "string",
+                              "description": "OpenSea CDN image URL"
+                            },
+                            "description": {
+                              "type": "string",
+                              "description": "OpenSea collection description"
+                            },
+                            "externalUrl": {
+                              "type": "string",
+                              "description": "Collection homepage"
+                            },
+                            "twitterUsername": {
+                              "type": "string",
+                              "description": "The twitter username of the collection"
+                            },
+                            "discordUrl": {
+                              "type": "string",
+                              "description": "The discord URL of the collection"
+                            },
+                            "lastIngestedAt": {
+                              "type": "string",
+                              "description": "The timestamp when the collection was last ingested by us"
+                            }
+                          }
+                        },
+                        "isSpam": {
+                          "type": "string",
+                          "description": "\"true\" if contract is spam, else \"false\". **Only available on paid tiers.**"
+                        },
+                        "spamClassifications": {
+                          "description": "List of reasons why a contract was classified as spam. **Only available on paid tiers.**",
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "tokenId": {
+                      "type": "string",
+                      "default": "44"
+                    },
+                    "tokenType": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "String - Name of the NFT asset."
+                    },
+                    "description": {
+                      "type": "string",
+                      "description": "String - Brief human-readable description"
+                    },
+                    "image": {
+                      "type": "object",
+                      "description": "Details of the image corresponding to this contract",
+                      "properties": {
+                        "cachedUrl": {
+                          "type": "string",
+                          "description": "The Url of the image stored in Alchemy cache"
+                        },
+                        "thumbnailUrl": {
+                          "type": "string",
+                          "description": "The Url that has the thumbnail version of the NFT"
+                        },
+                        "pngUrl": {
+                          "type": "string",
+                          "description": "The Url that has the NFT image in png"
+                        },
+                        "contentType": {
+                          "type": "string",
+                          "description": "The Url of the image stored in Alchemy cache"
+                        },
+                        "size": {
+                          "type": "integer",
+                          "description": "The size of the media asset in bytes."
+                        },
+                        "originalUrl": {
+                          "type": "string",
+                          "description": "The original Url of the image coming straight from the smart contract"
+                        }
+                      }
+                    },
+                    "raw": {
+                      "type": "object",
+                      "description": "Raw details of the NFT like its tokenUri and metadata info obtained directly from the smart contract",
+                      "properties": {
+                        "tokenUri": {
+                          "type": "string",
+                          "description": "String - Uri representing the location of the NFT's original metadata blob. This is a backup for you to parse when the metadata field is not automatically populated."
+                        },
+                        "metadata": {
+                          "type": "object",
+                          "description": "Relevant metadata for NFT contract. This is useful for viewing image url, traits, etc. without having to follow the metadata url in tokenUri to parse manually.",
+                          "properties": {
+                            "image": {
+                              "type": "string",
+                              "description": "String - URL to the NFT asset image. Can be standard URLs pointing to images on conventional servers, IPFS, or Arweave. Most types of images (SVGs, PNGs, JPEGs, etc.) are supported by NFT marketplaces."
+                            },
+                            "name": {
+                              "type": "string",
+                              "description": "String - Name of the NFT asset."
+                            },
+                            "description": {
+                              "type": "string",
+                              "description": "String - Human-readable description of the NFT asset. (Markdown is supported/rendered on OpenSea and other NFT platforms)"
+                            },
+                            "attributes": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "value": {
+                                    "type": "string"
+                                  },
+                                  "trait_type": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "description": "Object - Traits/attributes/characteristics for each NFT asset."
+                            }
+                          }
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "String - A string describing a particular reason that we were unable to fetch complete metadata for the NFT."
+                        }
+                      }
+                    },
+                    "collection": {
+                      "type": "object",
+                      "description": "The collection object that has details of a collection",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "description": "String - Collection name"
+                        },
+                        "slug": {
+                          "type": "string",
+                          "description": "String - OpenSea collection slug"
+                        },
+                        "externalUrl": {
+                          "type": "string",
+                          "description": "String - URL for the external site of the collection"
+                        },
+                        "bannerImageUrl": {
+                          "type": "string",
+                          "description": "String - Banner image URL for the collection"
+                        }
+                      }
+                    },
+                    "tokenUri": {
+                      "type": "string",
+                      "description": "String - Uri representing the location of the NFT's original metadata blob. This is a backup for you to parse when the metadata field is not automatically populated."
+                    },
+                    "timeLastUpdated": {
+                      "type": "string",
+                      "description": "String - ISO timestamp of the last cache refresh for the information returned in the metadata field."
+                    },
+                    "acquiredAt": {
+                      "type": "object",
+                      "description": "Only present if the request specified `orderBy=transferTime`.",
+                      "properties": {
+                        "blockTimestamp": {
+                          "type": "string",
+                          "description": "Block timestamp of the block where the NFT was most recently acquired."
+                        },
+                        "blockNumber": {
+                          "type": "string",
+                          "description": "Block number of the block where the NFT was most recently acquired."
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "totalCount": {
+                "type": "integer",
+                "description": "Integer - Total number of NFTs (distinct `tokenIds`) owned by the given address."
+              },
+              "pageKey": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "required": [
+          "data"
+        ]
       },
       "NFTResponseItem": {
         "type": "object",
@@ -3157,7 +3160,9 @@
             }
           }
         },
-        "required": ["transactions"]
+        "required": [
+          "transactions"
+        ]
       },
       "TransactionHistoryResponseItem": {
         "type": "object",
@@ -3334,20 +3339,32 @@
                         "description": "Time when the price was last updated."
                       }
                     },
-                    "required": ["currency", "value", "lastUpdatedAt"]
+                    "required": [
+                      "currency",
+                      "value",
+                      "lastUpdatedAt"
+                    ]
                   }
                 },
                 "error": {
-                  "type": "string",
-                  "nullable": true,
+                  "type": [
+                    "string",
+                    "null"
+                  ],
                   "description": "Error message if applicable."
                 }
               },
-              "required": ["symbol", "prices", "error"]
+              "required": [
+                "symbol",
+                "prices",
+                "error"
+              ]
             }
           }
         },
-        "required": ["data"]
+        "required": [
+          "data"
+        ]
       },
       "TokenPriceResponseItem": {
         "type": "object",
@@ -3376,68 +3393,26 @@
                   "description": "Time when the price was last updated."
                 }
               },
-              "required": ["currency", "value", "lastUpdatedAt"]
+              "required": [
+                "currency",
+                "value",
+                "lastUpdatedAt"
+              ]
             }
           },
           "error": {
-            "type": "string",
-            "nullable": true,
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Error message if applicable."
           }
         },
-        "required": ["symbol", "prices", "error"]
-      },
-      "AddressPricesResponse": {
-        "type": "object",
-        "properties": {
-          "data": {
-            "type": "array",
-            "description": "List of token prices by address.",
-            "items": {
-              "type": "object",
-              "properties": {
-                "network": {
-                  "type": "string",
-                  "description": "Network identifier."
-                },
-                "address": {
-                  "type": "string",
-                  "description": "Token contract address."
-                },
-                "prices": {
-                  "type": "array",
-                  "description": "List of price information.",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "currency": {
-                        "type": "string",
-                        "description": "Currency code (e.g., USD)."
-                      },
-                      "value": {
-                        "type": "string",
-                        "description": "Price value as a string."
-                      },
-                      "lastUpdatedAt": {
-                        "type": "string",
-                        "format": "date-time",
-                        "description": "Time when the price was last updated."
-                      }
-                    },
-                    "required": ["currency", "value", "lastUpdatedAt"]
-                  }
-                },
-                "error": {
-                  "type": "string",
-                  "nullable": true,
-                  "description": "Error message if applicable."
-                }
-              },
-              "required": ["network", "address", "prices", "error"]
-            }
-          }
-        },
-        "required": ["data"]
+        "required": [
+          "symbol",
+          "prices",
+          "error"
+        ]
       },
       "AddressPriceResponseItem": {
         "type": "object",
@@ -3470,171 +3445,27 @@
                   "description": "Time when the price was last updated."
                 }
               },
-              "required": ["currency", "value", "lastUpdatedAt"]
+              "required": [
+                "currency",
+                "value",
+                "lastUpdatedAt"
+              ]
             }
           },
           "error": {
-            "type": "string",
-            "nullable": true,
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Error message if applicable."
           }
         },
-        "required": ["network", "address", "prices", "error"]
-      },
-      "HistoricalPricesResponse": {
-        "type": "object",
-        "description": "Response containing historical price data. It will either include `symbol` or both `network` and `address` based on the request.\n",
-        "properties": {
-          "data": {
-            "oneOf": [
-              {
-                "type": "object",
-                "properties": {
-                  "symbol": {
-                    "type": "string",
-                    "description": "Token symbol.",
-                    "example": "ETH",
-                    "default": "ETH"
-                  },
-                  "prices": {
-                    "type": "array",
-                    "description": "List of historical price data points.",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "value": {
-                          "type": "string",
-                          "description": "Price value as a string.",
-                          "example": "1900.00"
-                        },
-                        "timestamp": {
-                          "type": "string",
-                          "format": "date-time",
-                          "description": "Timestamp of the price data point.",
-                          "example": "2024-01-01T00:00:00Z"
-                        }
-                      },
-                      "required": ["value", "timestamp"]
-                    }
-                  }
-                },
-                "required": ["symbol", "prices"]
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "network": {
-                    "type": "string",
-                    "description": "Network identifier.",
-                    "example": "eth-mainnet",
-                    "default": "eth-mainnet"
-                  },
-                  "address": {
-                    "type": "string",
-                    "description": "Token contract address.",
-                    "example": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
-                    "default": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
-                  },
-                  "prices": {
-                    "type": "array",
-                    "description": "List of historical price data points.",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "value": {
-                          "type": "string",
-                          "description": "Price value as a string.",
-                          "example": "1900.00"
-                        },
-                        "timestamp": {
-                          "type": "string",
-                          "format": "date-time",
-                          "description": "Timestamp of the price data point.",
-                          "example": "2024-01-01T00:00:00Z"
-                        }
-                      },
-                      "required": ["value", "timestamp"]
-                    }
-                  }
-                },
-                "required": ["network", "address", "prices"]
-              }
-            ]
-          }
-        },
-        "required": ["data"]
-      },
-      "HistoricalPricesBySymbol": {
-        "type": "object",
-        "properties": {
-          "symbol": {
-            "type": "string",
-            "description": "Token symbol.",
-            "example": "ETH",
-            "default": "ETH"
-          },
-          "prices": {
-            "type": "array",
-            "description": "List of historical price data points.",
-            "items": {
-              "type": "object",
-              "properties": {
-                "value": {
-                  "type": "string",
-                  "description": "Price value as a string.",
-                  "example": "1900.00"
-                },
-                "timestamp": {
-                  "type": "string",
-                  "format": "date-time",
-                  "description": "Timestamp of the price data point.",
-                  "example": "2024-01-01T00:00:00Z"
-                }
-              },
-              "required": ["value", "timestamp"]
-            }
-          }
-        },
-        "required": ["symbol", "prices"]
-      },
-      "HistoricalPricesByAddress": {
-        "type": "object",
-        "properties": {
-          "network": {
-            "type": "string",
-            "description": "Network identifier.",
-            "example": "eth-mainnet",
-            "default": "eth-mainnet"
-          },
-          "address": {
-            "type": "string",
-            "description": "Token contract address.",
-            "example": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
-            "default": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
-          },
-          "prices": {
-            "type": "array",
-            "description": "List of historical price data points.",
-            "items": {
-              "type": "object",
-              "properties": {
-                "value": {
-                  "type": "string",
-                  "description": "Price value as a string.",
-                  "example": "1900.00"
-                },
-                "timestamp": {
-                  "type": "string",
-                  "format": "date-time",
-                  "description": "Timestamp of the price data point.",
-                  "example": "2024-01-01T00:00:00Z"
-                }
-              },
-              "required": ["value", "timestamp"]
-            }
-          }
-        },
-        "required": ["network", "address", "prices"]
+        "required": [
+          "network",
+          "address",
+          "prices",
+          "error"
+        ]
       },
       "BlockTimestampResponse": {
         "type": "object",
@@ -3661,14 +3492,22 @@
                       "description": "ISO timestamp of the block"
                     }
                   },
-                  "required": ["number", "timestamp"]
+                  "required": [
+                    "number",
+                    "timestamp"
+                  ]
                 }
               },
-              "required": ["network", "block"]
+              "required": [
+                "network",
+                "block"
+              ]
             }
           }
         },
-        "required": ["data"]
+        "required": [
+          "data"
+        ]
       },
       "alchemy_getTokenMetadata": {
         "allOf": [
@@ -3705,308 +3544,6 @@
             }
           }
         ]
-      },
-      "totalSupply": {
-        "type": "string",
-        "description": "String - Total number of NFTs in a given NFT collection."
-      },
-      "tokenType_response": {
-        "type": "string",
-        "enum": [
-          "ERC721",
-          "ERC1155",
-          "NO_SUPPORTED_NFT_STANDARD",
-          "NOT_A_CONTRACT"
-        ],
-        "description": "String - For valid NFTs, 'ERC721' or 'ERC1155.' For invalid NFTs, a descriptive reason such as 'NO_SUPPORTED_NFT_STANDARD' if the input contract address doesn't support a known NFT standard, or 'NOT_A_CONTRACT' if there is no contract deployed at the input address."
-      },
-      "opensea": {
-        "type": "object",
-        "description": "Note that the OpenSea metadata object is currently only available on ETH and Polygon Mainnet. Please reach out to us at support@alchemy.com if you would like to access this data on other networks.",
-        "properties": {
-          "floorPrice": {
-            "type": "number",
-            "description": "NFT floor price"
-          },
-          "collectionName": {
-            "type": "string",
-            "description": "OpenSea collection name"
-          },
-          "safelistRequestStatus": {
-            "type": "string",
-            "description": "Collection approval status within OpenSea. For more info, see the Opensea docs at docs.opensea.io/reference/collection-model"
-          },
-          "imageUrl": {
-            "type": "string",
-            "description": "OpenSea CDN image URL"
-          },
-          "description": {
-            "type": "string",
-            "description": "OpenSea collection description"
-          },
-          "externalUrl": {
-            "type": "string",
-            "description": "Collection homepage"
-          },
-          "twitterUsername": {
-            "type": "string",
-            "description": "The twitter username of the collection"
-          },
-          "discordUrl": {
-            "type": "string",
-            "description": "The discord URL of the collection"
-          },
-          "lastIngestedAt": {
-            "type": "string",
-            "description": "The timestamp when the collection was last ingested by us"
-          }
-        }
-      },
-      "contractv3": {
-        "type": "object",
-        "description": "The contract object that has details of a contract",
-        "properties": {
-          "address": {
-            "description": "Address of the held contract",
-            "type": "string"
-          },
-          "name": {
-            "type": "string",
-            "description": "String - NFT contract name."
-          },
-          "symbol": {
-            "type": "string",
-            "description": "String - NFT contract symbol abbreviation."
-          },
-          "totalSupply": {
-            "type": "string",
-            "description": "String - Total number of NFTs in a given NFT collection."
-          },
-          "tokenType": {
-            "type": "string",
-            "enum": [
-              "ERC721",
-              "ERC1155",
-              "NO_SUPPORTED_NFT_STANDARD",
-              "NOT_A_CONTRACT"
-            ],
-            "description": "String - For valid NFTs, 'ERC721' or 'ERC1155.' For invalid NFTs, a descriptive reason such as 'NO_SUPPORTED_NFT_STANDARD' if the input contract address doesn't support a known NFT standard, or 'NOT_A_CONTRACT' if there is no contract deployed at the input address."
-          },
-          "contractDeployer": {
-            "type": "string",
-            "description": "String - Address that deployed the smart contract"
-          },
-          "deployedBlockNumber": {
-            "type": "number",
-            "description": "Number - The Block Number when the deployment transaction is successfully mined"
-          },
-          "openseaMetadata": {
-            "type": "object",
-            "description": "Note that the OpenSea metadata object is currently only available on ETH and Polygon Mainnet. Please reach out to us at support@alchemy.com if you would like to access this data on other networks.",
-            "properties": {
-              "floorPrice": {
-                "type": "number",
-                "description": "NFT floor price"
-              },
-              "collectionName": {
-                "type": "string",
-                "description": "OpenSea collection name"
-              },
-              "safelistRequestStatus": {
-                "type": "string",
-                "description": "Collection approval status within OpenSea. For more info, see the Opensea docs at docs.opensea.io/reference/collection-model"
-              },
-              "imageUrl": {
-                "type": "string",
-                "description": "OpenSea CDN image URL"
-              },
-              "description": {
-                "type": "string",
-                "description": "OpenSea collection description"
-              },
-              "externalUrl": {
-                "type": "string",
-                "description": "Collection homepage"
-              },
-              "twitterUsername": {
-                "type": "string",
-                "description": "The twitter username of the collection"
-              },
-              "discordUrl": {
-                "type": "string",
-                "description": "The discord URL of the collection"
-              },
-              "lastIngestedAt": {
-                "type": "string",
-                "description": "The timestamp when the collection was last ingested by us"
-              }
-            }
-          },
-          "isSpam": {
-            "type": "string",
-            "description": "\"true\" if contract is spam, else \"false\". **Only available on paid tiers.**"
-          },
-          "spamClassifications": {
-            "description": "List of reasons why a contract was classified as spam. **Only available on paid tiers.**",
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        }
-      },
-      "tokenIdV3": {
-        "type": "string",
-        "default": "44"
-      },
-      "tokenType": {
-        "type": "string"
-      },
-      "imagev3": {
-        "type": "object",
-        "description": "Details of the image corresponding to this contract",
-        "properties": {
-          "cachedUrl": {
-            "type": "string",
-            "description": "The Url of the image stored in Alchemy cache"
-          },
-          "thumbnailUrl": {
-            "type": "string",
-            "description": "The Url that has the thumbnail version of the NFT"
-          },
-          "pngUrl": {
-            "type": "string",
-            "description": "The Url that has the NFT image in png"
-          },
-          "contentType": {
-            "type": "string",
-            "description": "The Url of the image stored in Alchemy cache"
-          },
-          "size": {
-            "type": "integer",
-            "description": "The size of the media asset in bytes."
-          },
-          "originalUrl": {
-            "type": "string",
-            "description": "The original Url of the image coming straight from the smart contract"
-          }
-        }
-      },
-      "metadatav3": {
-        "type": "object",
-        "description": "Relevant metadata for NFT contract. This is useful for viewing image url, traits, etc. without having to follow the metadata url in tokenUri to parse manually.",
-        "properties": {
-          "image": {
-            "type": "string",
-            "description": "String - URL to the NFT asset image. Can be standard URLs pointing to images on conventional servers, IPFS, or Arweave. Most types of images (SVGs, PNGs, JPEGs, etc.) are supported by NFT marketplaces."
-          },
-          "name": {
-            "type": "string",
-            "description": "String - Name of the NFT asset."
-          },
-          "description": {
-            "type": "string",
-            "description": "String - Human-readable description of the NFT asset. (Markdown is supported/rendered on OpenSea and other NFT platforms)"
-          },
-          "attributes": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "value": {
-                  "type": "string"
-                },
-                "trait_type": {
-                  "type": "string"
-                }
-              }
-            },
-            "description": "Object - Traits/attributes/characteristics for each NFT asset."
-          }
-        }
-      },
-      "rawv3": {
-        "type": "object",
-        "description": "Raw details of the NFT like its tokenUri and metadata info obtained directly from the smart contract",
-        "properties": {
-          "tokenUri": {
-            "type": "string",
-            "description": "String - Uri representing the location of the NFT's original metadata blob. This is a backup for you to parse when the metadata field is not automatically populated."
-          },
-          "metadata": {
-            "type": "object",
-            "description": "Relevant metadata for NFT contract. This is useful for viewing image url, traits, etc. without having to follow the metadata url in tokenUri to parse manually.",
-            "properties": {
-              "image": {
-                "type": "string",
-                "description": "String - URL to the NFT asset image. Can be standard URLs pointing to images on conventional servers, IPFS, or Arweave. Most types of images (SVGs, PNGs, JPEGs, etc.) are supported by NFT marketplaces."
-              },
-              "name": {
-                "type": "string",
-                "description": "String - Name of the NFT asset."
-              },
-              "description": {
-                "type": "string",
-                "description": "String - Human-readable description of the NFT asset. (Markdown is supported/rendered on OpenSea and other NFT platforms)"
-              },
-              "attributes": {
-                "type": "array",
-                "items": {
-                  "type": "object",
-                  "properties": {
-                    "value": {
-                      "type": "string"
-                    },
-                    "trait_type": {
-                      "type": "string"
-                    }
-                  }
-                },
-                "description": "Object - Traits/attributes/characteristics for each NFT asset."
-              }
-            }
-          },
-          "error": {
-            "type": "string",
-            "description": "String - A string describing a particular reason that we were unable to fetch complete metadata for the NFT."
-          }
-        }
-      },
-      "collectionv3": {
-        "type": "object",
-        "description": "The collection object that has details of a collection",
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "String - Collection name"
-          },
-          "slug": {
-            "type": "string",
-            "description": "String - OpenSea collection slug"
-          },
-          "externalUrl": {
-            "type": "string",
-            "description": "String - URL for the external site of the collection"
-          },
-          "bannerImageUrl": {
-            "type": "string",
-            "description": "String - Banner image URL for the collection"
-          }
-        }
-      },
-      "acquiredAt": {
-        "type": "object",
-        "description": "Only present if the request specified `orderBy=transferTime`.",
-        "properties": {
-          "blockTimestamp": {
-            "type": "string",
-            "description": "Block timestamp of the block where the NFT was most recently acquired."
-          },
-          "blockNumber": {
-            "type": "string",
-            "description": "Block number of the block where the NFT was most recently acquired."
-          }
-        }
       }
     }
   }

--- a/fern/apis/portfolio/generators.yaml
+++ b/fern/apis/portfolio/generators.yaml
@@ -1,0 +1,3 @@
+api:
+  specs:
+    - openapi: ../../../build/api-specs/alchemy/rest/portfolio.json

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -1234,6 +1234,9 @@ navigation:
             contents:
               - page: Portfolio APIs
                 path: api-reference/data/portfolio-apis/portfolio-apis.mdx
+              - api: Portfolio API Endpoints
+                api-name: portfolio
+                flattened: true
             slug: portfolio-apis
           - section: 🎨 NFT API
             contents:

--- a/src/openapi/portfolio/assets/nfts/by-address.yaml
+++ b/src/openapi/portfolio/assets/nfts/by-address.yaml
@@ -1,7 +1,7 @@
 summary: NFTs By Wallet
 description: >
   Fetches NFTs for multiple wallet addresses and networks. Returns a list of NFTs and metadata for each wallet/network combination. This endpoint is supported on Ethereum and many L2s, including Polygon, Arbitrum, Optimism, Base, World Chain and more. See the full list of supported networks [here](https://dashboard.alchemy.com/chains?service=token-api&utm_source=readme&utm_medium=link&utm_campaign=docs_method_chains_link_v1_tokens).
-tags: ["📚 Portfolio APIs"]
+tags: ["Portfolio API Endpoints"]
 x-readme:
   samples-languages:
     - javascript

--- a/src/openapi/portfolio/assets/nfts/contracts/by-address.yaml
+++ b/src/openapi/portfolio/assets/nfts/contracts/by-address.yaml
@@ -1,7 +1,7 @@
 summary: NFT Collections By Wallet
 description: >
   Fetches NFT collections (contracts) for multiple wallet addresses and networks. Returns a list of collections and metadata for each wallet/network combination. This endpoint is supported on Ethereum and many L2s, including Polygon, Arbitrum, Optimism, Base, World Chain and more. See the full list of supported networks [here](https://dashboard.alchemy.com/chains?service=token-api&utm_source=readme&utm_medium=link&utm_campaign=docs_method_chains_link_v1_tokens).
-tags: ["📚 Portfolio APIs"]
+tags: ["Portfolio API Endpoints"]
 x-readme:
   samples-languages:
     - javascript

--- a/src/openapi/portfolio/assets/tokens/balances/by-address.yaml
+++ b/src/openapi/portfolio/assets/tokens/balances/by-address.yaml
@@ -1,7 +1,7 @@
 summary: Token Balances By Wallet
 description: >
   Fetches fungible tokens (native and ERC-20) for multiple wallet addresses and networks. Returns a list of tokens with balances for each wallet/network combination. This endpoint is supported on Ethereum, Solana, and 30+ EVM chains. See the full list of supported networks [here](https://dashboard.alchemy.com/chains?service=token-api&utm_source=readme&utm_medium=link&utm_campaign=docs_method_chains_link_v1_tokens)
-tags: ["📚 Portfolio APIs"]
+tags: ["Portfolio API Endpoints"]
 x-readme:
   samples-languages:
     - javascript

--- a/src/openapi/portfolio/assets/tokens/by-address.yaml
+++ b/src/openapi/portfolio/assets/tokens/by-address.yaml
@@ -1,7 +1,7 @@
 summary: Tokens By Wallet
 description: >
   Fetches fungible tokens (native and ERC-20) for multiple wallet addresses and networks. Returns a list of tokens with balances, prices, and metadata for each wallet/network combination. This endpoint is supported on Ethereum, Solana, and 30+ EVM chains. See the full list of supported networks [here](https://dashboard.alchemy.com/chains?service=token-api&utm_source=readme&utm_medium=link&utm_campaign=docs_method_chains_link_v1_tokens).
-tags: ["📚 Portfolio APIs"]
+tags: ["Portfolio API Endpoints"]
 x-readme:
   samples-languages:
     - javascript

--- a/src/openapi/portfolio/portfolio.yaml
+++ b/src/openapi/portfolio/portfolio.yaml
@@ -36,257 +36,257 @@ paths:
   # NFT APIs  (Deprecated / Older)
   ####################################################
   # NOTE: This should be hidden from the user.
-  "/{apiKey}/assets/nfts":
-    post:
-      summary: Placeholder for NFT API
-      description: >
-        Placeholder for the NFT API - in order to update this you'll need to move it back and forth.
-      tags: ["🎨 NFT API"]
-      x-readme:
-        samples-languages:
-          - javascript
-          - curl
-          - python
-          - go
-      parameters:
-        - $ref: "#/components/parameters/apiKey"
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/ByAddressRequest"
-      responses:
-        "200":
-          description: Successful response!
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/TokenPricesResponse"
-      operationId: get-nfts-by-address-placeholder
-  ####################################################
-  # Tokens APIs (Deprecated / Older)
-  ####################################################
-  # NOTE: This should be hidden from the user.
-  "/{apiKey}/assets/tokens":
-    post:
-      summary: Placeholder for Tokens API
-      description: >
-        Placeholder for the Prices API - in order to update this you'll need to move it back and forth.
-      tags: ["🪙 Token API"]
-      x-readme:
-        samples-languages:
-          - javascript
-          - curl
-          - python
-          - go
-      parameters:
-        - $ref: "#/components/parameters/apiKey"
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/ByAddressRequest"
-      responses:
-        "200":
-          description: Successful response!
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/TokenPricesResponse"
-      operationId: get-tokens-by-address-placeholder
-  ####################################################
-  # Prices APIs
-  ####################################################
-  # NOTE: This should be hidden from the user.
-  "/{apiKey}/assets/prices":
-    post:
-      summary: Placeholder for Prices API
-      description: >
-        Placeholder for the Prices API - in order to update this you'll need to move it back and forth.
-      tags: ["📈 Prices API"]
-      x-readme:
-        samples-languages:
-          - javascript
-          - curl
-          - python
-          - go
-      parameters:
-        - $ref: "#/components/parameters/apiKey"
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/ByAddressRequest"
-      responses:
-        "200":
-          description: Successful response!
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/TokenPricesResponse"
-        "400":
-          description: "Bad Request: Invalid input (e.g., malformed JSON)."
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        "429":
-          description: "Too Many Requests: Rate limit exceeded."
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-      operationId: get-tokens-prices-by-address-placeholder
-  ####################################################
-  # Transfer API (Deprecated / Older)
-  ####################################################
-  # NOTE: This should be hidden from the user.
-  "/{apiKey}/assets/transfers":
-    post:
-      summary: Placeholder for Transfers API
-      description: >
-        Placeholder for the Transfers API - in order to update this you'll need to move it back and forth.
-      tags: ["💸 Transfers API"]
-      x-readme:
-        samples-languages:
-          - javascript
-          - curl
-          - python
-          - go
-      parameters:
-        - $ref: "#/components/parameters/apiKey"
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/ByAddressRequest"
-      responses:
-        "200":
-          description: Successful response!
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/TokenPricesResponse"
-        "400":
-          description: "Bad Request: Invalid input (e.g., malformed JSON)."
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        "429":
-          description: "Too Many Requests: Rate limit exceeded."
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-      operationId: get-transfers-by-address-placeholder
-  ####################################################
-  # Utility APIs
-  ####################################################
-  "/{apiKey}/utility/blocks/by-timestamp":
-    get:
-      summary: Blocks by Timestamp
-      description: Fetches the first block before or after a given timestamp. Returns the block's number and on-chain timestamp.
-      tags: ["🛠️ Utility APIs"]
-      x-readme:
-        samples-languages:
-          - javascript
-          - curl
-          - python
-          - go
-      parameters:
-        - $ref: "#/components/parameters/apiKey"
-        - $ref: "#/components/parameters/networks"
-        - $ref: "#/components/parameters/timestamp"
-        - $ref: "#/components/parameters/direction"
-      responses:
-        "200":
-          description: Successful response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/BlockTimestampResponse"
-        "400":
-          description: "Bad Request: Malformed request or missing parameters."
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        "429":
-          description: "Too Many Requests: Rate limit exceeded."
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-      operationId: blocks-by-timestamp
-  ####################################################
-  # Subgraphs
-  ####################################################
-  # NOTE: This should be hidden from the user.
-  "/{apiKey}/subgraphs":
-    post:
-      summary: Placeholder for Subgraphs
-      description: >
-        Placeholder for the Subgraphs - in order to update this you'll need to move it back and forth.
-      tags: ["🍊 Subgraphs"]
-      x-readme:
-        samples-languages:
-          - javascript
-          - curl
-          - python
-          - go
-      parameters:
-        - $ref: "#/components/parameters/apiKey"
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/ByAddressRequest"
-      responses:
-        "200":
-          description: Successful response!
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/TokenPricesResponse"
-      operationId: subgraphs-placeholder
-  ####################################################
-  # Webhooks
-  ####################################################
-  # NOTE: This should be hidden from the user.
-  "/{apiKey}/assets/webhooks":
-    post:
-      summary: Placeholder for Webhooks
-      description: >
-        Placeholder for the Webhooks - in order to update this you'll need to move it back and forth.
-      tags: ["🔔 Webhooks"]
-      x-readme:
-        samples-languages:
-          - javascript
-          - curl
-          - python
-          - go
-      parameters:
-        - $ref: "#/components/parameters/apiKey"
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/ByAddressRequest"
-      responses:
-        "200":
-          description: Successful response!
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/TokenPricesResponse"
-      operationId: webhooks-placeholder
+  # "/{apiKey}/assets/nfts":
+  #   post:
+  #     summary: Placeholder for NFT API
+  #     description: >
+  #       Placeholder for the NFT API - in order to update this you'll need to move it back and forth.
+  #     tags: ["🎨 NFT API"]
+  #     x-readme:
+  #       samples-languages:
+  #         - javascript
+  #         - curl
+  #         - python
+  #         - go
+  #     parameters:
+  #       - $ref: "#/components/parameters/apiKey"
+  #     requestBody:
+  #       required: true
+  #       content:
+  #         application/json:
+  #           schema:
+  #             $ref: "#/components/schemas/ByAddressRequest"
+  #     responses:
+  #       "200":
+  #         description: Successful response!
+  #         content:
+  #           application/json:
+  #             schema:
+  #               $ref: "#/components/schemas/TokenPricesResponse"
+  #     operationId: get-nfts-by-address-placeholder
+  # ####################################################
+  # # Tokens APIs (Deprecated / Older)
+  # ####################################################
+  # # NOTE: This should be hidden from the user.
+  # "/{apiKey}/assets/tokens":
+  #   post:
+  #     summary: Placeholder for Tokens API
+  #     description: >
+  #       Placeholder for the Prices API - in order to update this you'll need to move it back and forth.
+  #     tags: ["🪙 Token API"]
+  #     x-readme:
+  #       samples-languages:
+  #         - javascript
+  #         - curl
+  #         - python
+  #         - go
+  #     parameters:
+  #       - $ref: "#/components/parameters/apiKey"
+  #     requestBody:
+  #       required: true
+  #       content:
+  #         application/json:
+  #           schema:
+  #             $ref: "#/components/schemas/ByAddressRequest"
+  #     responses:
+  #       "200":
+  #         description: Successful response!
+  #         content:
+  #           application/json:
+  #             schema:
+  #               $ref: "#/components/schemas/TokenPricesResponse"
+  #     operationId: get-tokens-by-address-placeholder
+  # ####################################################
+  # # Prices APIs
+  # ####################################################
+  # # NOTE: This should be hidden from the user.
+  # "/{apiKey}/assets/prices":
+  #   post:
+  #     summary: Placeholder for Prices API
+  #     description: >
+  #       Placeholder for the Prices API - in order to update this you'll need to move it back and forth.
+  #     tags: ["📈 Prices API"]
+  #     x-readme:
+  #       samples-languages:
+  #         - javascript
+  #         - curl
+  #         - python
+  #         - go
+  #     parameters:
+  #       - $ref: "#/components/parameters/apiKey"
+  #     requestBody:
+  #       required: true
+  #       content:
+  #         application/json:
+  #           schema:
+  #             $ref: "#/components/schemas/ByAddressRequest"
+  #     responses:
+  #       "200":
+  #         description: Successful response!
+  #         content:
+  #           application/json:
+  #             schema:
+  #               $ref: "#/components/schemas/TokenPricesResponse"
+  #       "400":
+  #         description: "Bad Request: Invalid input (e.g., malformed JSON)."
+  #         content:
+  #           application/json:
+  #             schema:
+  #               $ref: "#/components/schemas/ErrorResponse"
+  #       "429":
+  #         description: "Too Many Requests: Rate limit exceeded."
+  #         content:
+  #           application/json:
+  #             schema:
+  #               $ref: "#/components/schemas/ErrorResponse"
+  #     operationId: get-tokens-prices-by-address-placeholder
+  # ####################################################
+  # # Transfer API (Deprecated / Older)
+  # ####################################################
+  # # NOTE: This should be hidden from the user.
+  # "/{apiKey}/assets/transfers":
+  #   post:
+  #     summary: Placeholder for Transfers API
+  #     description: >
+  #       Placeholder for the Transfers API - in order to update this you'll need to move it back and forth.
+  #     tags: ["💸 Transfers API"]
+  #     x-readme:
+  #       samples-languages:
+  #         - javascript
+  #         - curl
+  #         - python
+  #         - go
+  #     parameters:
+  #       - $ref: "#/components/parameters/apiKey"
+  #     requestBody:
+  #       required: true
+  #       content:
+  #         application/json:
+  #           schema:
+  #             $ref: "#/components/schemas/ByAddressRequest"
+  #     responses:
+  #       "200":
+  #         description: Successful response!
+  #         content:
+  #           application/json:
+  #             schema:
+  #               $ref: "#/components/schemas/TokenPricesResponse"
+  #       "400":
+  #         description: "Bad Request: Invalid input (e.g., malformed JSON)."
+  #         content:
+  #           application/json:
+  #             schema:
+  #               $ref: "#/components/schemas/ErrorResponse"
+  #       "429":
+  #         description: "Too Many Requests: Rate limit exceeded."
+  #         content:
+  #           application/json:
+  #             schema:
+  #               $ref: "#/components/schemas/ErrorResponse"
+  #     operationId: get-transfers-by-address-placeholder
+  # ####################################################
+  # # Utility APIs
+  # ####################################################
+  # "/{apiKey}/utility/blocks/by-timestamp":
+  #   get:
+  #     summary: Blocks by Timestamp
+  #     description: Fetches the first block before or after a given timestamp. Returns the block's number and on-chain timestamp.
+  #     tags: ["🛠️ Utility APIs"]
+  #     x-readme:
+  #       samples-languages:
+  #         - javascript
+  #         - curl
+  #         - python
+  #         - go
+  #     parameters:
+  #       - $ref: "#/components/parameters/apiKey"
+  #       - $ref: "#/components/parameters/networks"
+  #       - $ref: "#/components/parameters/timestamp"
+  #       - $ref: "#/components/parameters/direction"
+  #     responses:
+  #       "200":
+  #         description: Successful response
+  #         content:
+  #           application/json:
+  #             schema:
+  #               $ref: "#/components/schemas/BlockTimestampResponse"
+  #       "400":
+  #         description: "Bad Request: Malformed request or missing parameters."
+  #         content:
+  #           application/json:
+  #             schema:
+  #               $ref: "#/components/schemas/ErrorResponse"
+  #       "429":
+  #         description: "Too Many Requests: Rate limit exceeded."
+  #         content:
+  #           application/json:
+  #             schema:
+  #               $ref: "#/components/schemas/ErrorResponse"
+  #     operationId: blocks-by-timestamp
+  # ####################################################
+  # # Subgraphs
+  # ####################################################
+  # # NOTE: This should be hidden from the user.
+  # "/{apiKey}/subgraphs":
+  #   post:
+  #     summary: Placeholder for Subgraphs
+  #     description: >
+  #       Placeholder for the Subgraphs - in order to update this you'll need to move it back and forth.
+  #     tags: ["🍊 Subgraphs"]
+  #     x-readme:
+  #       samples-languages:
+  #         - javascript
+  #         - curl
+  #         - python
+  #         - go
+  #     parameters:
+  #       - $ref: "#/components/parameters/apiKey"
+  #     requestBody:
+  #       required: true
+  #       content:
+  #         application/json:
+  #           schema:
+  #             $ref: "#/components/schemas/ByAddressRequest"
+  #     responses:
+  #       "200":
+  #         description: Successful response!
+  #         content:
+  #           application/json:
+  #             schema:
+  #               $ref: "#/components/schemas/TokenPricesResponse"
+  #     operationId: subgraphs-placeholder
+  # ####################################################
+  # # Webhooks
+  # ####################################################
+  # # NOTE: This should be hidden from the user.
+  # "/{apiKey}/assets/webhooks":
+  #   post:
+  #     summary: Placeholder for Webhooks
+  #     description: >
+  #       Placeholder for the Webhooks - in order to update this you'll need to move it back and forth.
+  #     tags: ["🔔 Webhooks"]
+  #     x-readme:
+  #       samples-languages:
+  #         - javascript
+  #         - curl
+  #         - python
+  #         - go
+  #     parameters:
+  #       - $ref: "#/components/parameters/apiKey"
+  #     requestBody:
+  #       required: true
+  #       content:
+  #         application/json:
+  #           schema:
+  #             $ref: "#/components/schemas/ByAddressRequest"
+  #     responses:
+  #       "200":
+  #         description: Successful response!
+  #         content:
+  #           application/json:
+  #             schema:
+  #               $ref: "#/components/schemas/TokenPricesResponse"
+  #     operationId: webhooks-placeholder
 ####################################################
 # Common Components for All APIs
 ####################################################

--- a/src/openapi/portfolio/transactions/history/by-address.yaml
+++ b/src/openapi/portfolio/transactions/history/by-address.yaml
@@ -1,7 +1,7 @@
 summary: Transactions By Wallet
 description: >
   Fetches all historical transactions (internal & external) for multiple wallet addresses and networks. Returns a list of transaction objects with metadata and log information. This endpoint will be supported on Ethereum, Solana, and 30+ EVM chains (Beta: currently limited to Ethereum and Base with a limit of 1 address)
-tags: ["📚 Portfolio APIs"]
+tags: ["Portfolio API Endpoints"]
 x-readme:
   samples-languages:
     - javascript


### PR DESCRIPTION
## Description

This PR adds Portfolio APIs to the data section.

## Related Issues

https://app.asana.com/1/1129441638109975/project/1208969177908960/task/1209950798429918?focus=true

## Changes Made

- Updates `docs.yaml` to add Portfolio APIs to navigation.
- Creates a new folder for portfolio apis in `fern/apis` so the built api can be referenced.
- Comments out placeholder sections for apis like Transfers, Prices, Utility etc. in Portfolio APIs as they already exist. Otherwise it renders them twice.
- Updates each porfolio API endpoint to update the tag to be named "Portofio API Endpoints" instead of "Portfolio APIs" as that is the section title.

## Testing

<!-- Describe the tests that you ran to verify your changes -->

- [x] I have tested these changes locally
- [x] I have run the validation scripts (`pnpm run validate`)
- [x] I have checked that the documentation builds correctly
