### PR TITLE
fix: Dedupe section pages

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -381,11 +381,9 @@ navigation:
             slug: smart-contract-basics
         slug: alchemy-university
       - section: ✍️ Creating Smart Contracts
-        path: tutorials/creating-smart-contracts/hello-world-smart-contract.mdx
         contents:
           - section: Hello World Smart Contract
-            path: >-
-              tutorials/creating-smart-contracts/hello-world-smart-contract/hello-world-smart-contract.mdx
+            path: tutorials/creating-smart-contracts/hello-world-smart-contract.mdx
             contents:
               - page: Interacting with a Smart Contract
                 path: >-
@@ -532,8 +530,9 @@ navigation:
             slug: learn-subgraphs
         slug: alchemy-subgraphs
       - section: 🔮 Scaffold Alchemy
-        path: tutorials/scaffold-alchemy/scaffold-alchemy.mdx
         contents:
+          - page: What is Scaffold Alchemy?
+            path: tutorials/scaffold-alchemy/scaffold-alchemy.mdx
           - page: Scaffold Alchemy Quickstart
             path: tutorials/scaffold-alchemy/scaffold-alchemy-quickstart.mdx
           - section: Scaffold Alchemy Components
@@ -748,7 +747,6 @@ navigation:
           - section: Understanding Transactions
             path: tutorials/transactions/understanding-transactions.mdx
             contents:
-              - page: Understanding Transactions
               - page: Ethereum Transactions - Pending, Mined, Dropped & Replaced
                 path: >-
                   tutorials/transactions/understanding-transactions/ethereum-transactions-pending-mined-dropped-replaced.mdx
@@ -1101,8 +1099,9 @@ navigation:
       #   slug: introduction
       - section: 📚 Pricing & Resources
         contents:
-          - section: Pricing
+          - page: Pricing
             path: api-reference/pricing-resources/pricing-plans.mdx
+          - section: Pricing
             contents:
               - page: Pricing Plans
                 path: api-reference/pricing-resources/pricing/pricing-plans.mdx
@@ -1399,10 +1398,9 @@ navigation:
                   api-reference/bundler-api/useroperation-simulation-endpoints/alchemy-simulateuseroperationassetchanges.mdx
             slug: useroperation-simulation-endpoints
           - section: EntryPoint Revert Codes
+            path: >-
+              api-reference/bundler-api/entrypoint-revert-codes/entrypoint-v07-revert-codes.mdx
             contents:
-              - page: EntryPoint Revert Codes
-                path: >-
-                  api-reference/bundler-api/entrypoint-revert-codes/entrypoint-v07-revert-codes.mdx
               - page: EntryPoint v0.6 Revert Codes
                 path: >-
                   api-reference/bundler-api/entrypoint-revert-codes/entrypoint-v06-revert-codes.mdx
@@ -1420,10 +1418,9 @@ navigation:
             path: >-
               api-reference/websockets/best-practices-for-using-websockets-in-web3.mdx
           - section: Subscription API Endpoints
+            path: >-
+              api-reference/websockets/subscription-api-endpoints/subscription-api-endpoints.mdx
             contents:
-              - page: Subscription API Endpoints
-                path: >-
-                  api-reference/websockets/subscription-api-endpoints/subscription-api-endpoints.mdx
               - page: alchemy_minedTransactions
                 path: >-
                   api-reference/websockets/subscription-api-endpoints/alchemy-minedtransactions.mdx
@@ -2111,10 +2108,9 @@ navigation:
           - page: Astar API FAQ
             path: api-reference/astar/astar-api-faq.mdx
           - section: Astar API Endpoints
+            path: >-
+              api-reference/astar/astar-api-endpoints/astar-api-endpoints.mdx
             contents:
-              - page: Astar API Endpoints
-                path: >-
-                  api-reference/astar/astar-api-endpoints/astar-api-endpoints.mdx
               - page: eth_subscribe
                 path: >-
                   api-reference/astar/astar-api-endpoints/eth-subscribe-astar.mdx


### PR DESCRIPTION
## Description

### BEFORE

<img width="261" alt="Screenshot 2025-04-21 at 9 20 29 AM" src="https://github.com/user-attachments/assets/b40cc172-c3c1-48d3-96a6-58294239abcc" />

### AFTER

<img width="264" alt="Screenshot 2025-04-21 at 9 22 52 AM" src="https://github.com/user-attachments/assets/4e4a5a5f-ede8-4f8b-bc46-ca1df0d9c00a" />

## Related Issues

Docs QA Issues: [Duplicated Overview Links](https://www.notion.so/alchemotion/Duplicated-Overview-Links-1d2069f2006680089686d540841eeecb?pvs=4)

## Changes Made

- Lots of adding `path` to `section` and deleting the subpage
- Didn't touch the API Reference pages, which look a little different

## Testing

- [ ] I have tested these changes locally
- [ ] I have run the validation scripts (`pnpm run validate`)
- [ ] I have checked that the documentation builds correctly
