### PR TITLE
fix: Don't link localhost

### DIFF
--- a/fern/tutorials/creating-smart-contracts/hello-world-smart-contract/integrating-your-smart-contract-with-the-frontend.mdx
+++ b/fern/tutorials/creating-smart-contracts/hello-world-smart-contract/integrating-your-smart-contract-with-the-frontend.mdx
@@ -144,7 +144,7 @@ Once the modules have finished installing and you've updated the `webpack.config
   ```
 </CodeGroup>
 
-Doing so should open [http://localhost:3000/](http://localhost:3000/) in your browser, where you'll see the frontend for our project. It should consist of one field (a place to update the message stored in your smart contract), a "Connect Wallet" button, and an "Update" button.
+Doing so should open `http://localhost:3000/` in your browser, where you'll see the frontend for our project. It should consist of one field (a place to update the message stored in your smart contract), a "Connect Wallet" button, and an "Update" button.
 
 ![2864](e03bff0-Frontend.png "Frontend.png")
 
@@ -470,7 +470,7 @@ Since we want to display this smart contract in our UI, let's update the *useEff
 
 Note that we only want our *loadCurrentMessage* to be called once during the component's first render. We'll soon implement `addSmartContractListener` to automatically update the UI after the message in the smart contract changes.
 
-Before we dive into our listeners, let's check out what we have so far! Save your **HelloWorld.js** and **interact.js** files, and then go to [http://localhost:3000/](http://localhost:3000/)
+Before we dive into our listeners, let's check out what we have so far! Save your **HelloWorld.js** and **interact.js** files, and then go to `http://localhost:3000/`
 
 You'll notice that the current message no longer says "No connection to the network." Instead, it reflects the message stored in the smart contract. Sick!
 
@@ -696,7 +696,7 @@ In *connectWalletPressed*, we make an await call to our imported *connectWallet*
 
 Now, let's save both files (**HelloWorld.js** and **interact.js**) and test our UI.
 
-Open your browser on the [http://localhost:3000/](http://localhost:3000/) page, and press the "Connect Wallet" button on the top right of the page.
+Open your browser on the `http://localhost:3000/` page, and press the "Connect Wallet" button on the top right of the page.
 
 If you have Metamask installed, you should be prompted to connect your wallet to your dApp. Accept the invitation to connect.
 

--- a/fern/tutorials/creating-smart-contracts/hello-world-solana-program/integrating-your-solana-program-with-a-web3-application.mdx
+++ b/fern/tutorials/creating-smart-contracts/hello-world-solana-program/integrating-your-solana-program-with-a-web3-application.mdx
@@ -193,7 +193,7 @@ All this is doing is rendering a giant title for your application! Next, look at
 
 Don’t worry too much about CSS! All this is doing is making our application look pretty. We don’t need CSS to use our Solana program and create our web3 application. It just looks nicer 😅. If you’re still curious, you can learn more about it [here](https://www.w3schools.com/html/html_css.asp).
 
-Awesome! We’re ready to look at our app! You can view your application on `[http://localhost:3000/](http://localhost:3000/)` by running the following from your `app` directory on your terminal:
+Awesome! We’re ready to look at our app! You can view your application on `http://localhost:3000/` by running the following from your `app` directory on your terminal:
 
 <CodeGroup>
   ```shell shell

--- a/fern/tutorials/creating-smart-contracts/nft-minter-tutorial-how-to-create-a-full-stack-dapp/nft-minter.mdx
+++ b/fern/tutorials/creating-smart-contracts/nft-minter-tutorial-how-to-create-a-full-stack-dapp/nft-minter.mdx
@@ -101,7 +101,7 @@ Once those have finished installing, run `npm start` in your terminal:
   ```
 </CodeGroup>
 
-Doing so should open [http://localhost:3000/](http://localhost:3000) in your browser, where you'll see the frontend for our project. It should consist of 3 fields: a place to input a link to your NFT's asset, enter the name of your NFT, and provide a description.
+Doing so should open `http://localhost:3000/` in your browser, where you'll see the frontend for our project. It should consist of 3 fields: a place to input a link to your NFT's asset, enter the name of your NFT, and provide a description.
 
 ![2876](32e01d7-PNrbdLnNM6OriGE32N25TGSl.png "PNrbdLnNM6OriGE32N25TGSl.png")
 
@@ -378,7 +378,7 @@ In `connectWalletPressed`, we simply make an await call to our imported `connect
 
 Now, let's save both files (`Minter.js` and `interact.js`) and test out our UI so far.
 
-Open your browser on the [http://localhost:3000/](http://localhost:3000) page, and press the "Connect Wallet" button on the top right of the page.
+Open your browser on the `http://localhost:3000/` page, and press the "Connect Wallet" button on the top right of the page.
 
 If you have Metamask installed, you should be prompted to connect your wallet to your dApp. Accept the invitation to connect.
 

--- a/fern/tutorials/learning-solidity/how-to-verify-a-message-signature-on-ethereum/how-to-create-a-signature-generator-dapp.mdx
+++ b/fern/tutorials/learning-solidity/how-to-verify-a-message-signature-on-ethereum/how-to-create-a-signature-generator-dapp.mdx
@@ -19,7 +19,7 @@ In your terminal:
 
 1. Navigate to your local repository with \`cd starter files.
 2. Run `npm install` to install your dependencies.
-3. Run `npm start` to deploy a local development server at [http://localhost:3000/](http://localhost:3000/).
+3. Run `npm start` to deploy a local development server at `http://localhost:3000/`.
 
 At your local server, you should see the front end of our Signature Generator app. It should contain:
 

--- a/fern/tutorials/nfts/how-to-create-an-nft-game/how-to-create-an-nft-game-frontend.mdx
+++ b/fern/tutorials/nfts/how-to-create-an-nft-game/how-to-create-an-nft-game-frontend.mdx
@@ -447,9 +447,9 @@ We are all set to go! Let's launch our app on localhost using the following comm
 
 ### Playing the game
 
-* When you open [localhost:3000](https://localhost:3000), you will first be prompted to visit the [localhost:3000/connect]() page. Here, connect your MetaMask wallet to be redirected back to the main breeding page at [localhost:3000](https://localhost:3000).
+* When you open `localhost:3000`, you will first be prompted to visit the `localhost:3000/connect` page. Here, connect your MetaMask wallet to be redirected back to the main breeding page at `localhost:3000`.
 
-* For breeding to work, you must choose two different Alchemons as parents. In case you don't have 2 Alchemons, you can simply mint Genesis NFTs by visiting [localhost:3000/mint-genesis](https://localhost:3000/mint-genesis). Make sure you've got enough Goerli ETH from the [Goerli Faucet](https://goerlifaucet.com/) before you mint.
+* For breeding to work, you must choose two different Alchemons as parents. In case you don't have 2 Alchemons, you can simply mint Genesis NFTs by visiting `localhost:3000/mint-genesis`. Make sure you've got enough Goerli ETH from the [Goerli Faucet](https://goerlifaucet.com/) before you mint.
 
 * You will be redirected back on the main page. Select an Alchemon in both the first and the second dropdown, then click on breed. Metamask will prompt you to pay gas for the transaction.
 


### PR DESCRIPTION
## Description

Mark localhost URLs as code, not links.

## Related Issues

Docs QA Issues: [Localhost is set as a link](https://www.notion.so/alchemotion/Localhost-is-set-as-a-link-1d5069f200668081a45cdaba4d378d03?pvs=4)

## Changes Made

- Replacing `[http://localhost:3000/](http://localhost:3000/)` with `http://localhost:3000`.

## Testing

- [x] I have tested these changes locally
- [x] I have run the validation scripts (`pnpm run validate`)
- [x] I have checked that the documentation builds correctly
