### PR TITLE
fix: Warning callouts should not be empty

### DIFF
--- a/fern/api-reference/alchemy-sdk/sdk-core-methods/getfeedata-sdk-v3.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-core-methods/getfeedata-sdk-v3.mdx
@@ -19,7 +19,7 @@ Returns the recommended fee data to use in a transaction. For an EIP-1559 transa
 
 For legacy transactions and networks which do not support EIP-1559, the `gasPrice` should be used.
 
-<Warning />
+<Warning>Warning: The Ethers.js library hardcodes `maxPriorityFeePerGas` to 1.5 gwei (1,500,000,000 wei), which may not reflect actual network conditions. For accurate `maxPriorityFeePerGas` estimations, use `[getMaxPriorityFeePerGas](/reference/getmaxpriorityfeepergas-sdk)`.</Warning>
 
 # Response
 

--- a/fern/api-reference/data/webhooks/webhook-types/address-activity-webhook.mdx
+++ b/fern/api-reference/data/webhooks/webhook-types/address-activity-webhook.mdx
@@ -29,7 +29,12 @@ There are three main types of transfers that are captured when receiving a `from
 | Token         | Event logs for ERC20, ERC721, and ERC1155 transfers.           |
 | Internal ETH  | Internal Transfers from a smart contract address.              |
 
-<Warning />
+<Warning>
+**Note on Internal Transfers**
+
+1. Internal transfers are currently only supported on Ethereum, Polygon, Arbitrum, Optimism and Base. Support for other networks is a WIP!
+2. Internal Transfers with the call type `delegatecall` are not supported on Alchemy. Although they have a value associated with them, they don't transfer a value. For details read the [Ethereum Yellow Paper](https://ethereum.github.io/yellowpaper/paper.pdf). Internal transfer miner rewards are also unsupported on Alchemy.
+</Warning>
 
 # Example Response
 

--- a/fern/tutorials/smart-wallets/learn-account-abstraction/how-to-create-a-gasless-nft-minter-using-aa-sdk-create-web3-dapp-userbase.mdx
+++ b/fern/tutorials/smart-wallets/learn-account-abstraction/how-to-create-a-gasless-nft-minter-using-aa-sdk-create-web3-dapp-userbase.mdx
@@ -45,7 +45,7 @@ Let's get to it! First up, let's set up our local development environment...
 * Choose your blockchain development environment: `Skip`
 * Login to your [Alchemy](https://www.alchemy.com/) account (or sign up for one) to acquire an API key
 
-<Warning />
+<Warning>Note: please be mindful of the application you use to create your Alchemy API key - you'll need to re-visit this in Step #2!</Warning>
 
 4. As it should say in your terminal, run `cd gasless-nft-minter` and then run `npm run dev`
 
@@ -1542,7 +1542,7 @@ Nice and simple script that uses the Alchemy SDK to fetch a user's NFTs! One mor
 1. Still in the `/api` folder, create a new folder called `/mint-nft-user-op` and create a file inside that folder called `route.ts`
 2. Inside the `route.ts` file, copy-paste the following code:
 
-<Warning />
+<Warning>Warning: This script is heavy!</Warning>
 
 <CodeGroup>
   ```javascript javascript

--- a/fern/tutorials/streaming-data/custom-webhooks-tutorials/how-to-use-custom-webhooks-to-get-push-notifications-for-mined-user-operations.mdx
+++ b/fern/tutorials/streaming-data/custom-webhooks-tutorials/how-to-use-custom-webhooks-to-get-push-notifications-for-mined-user-operations.mdx
@@ -57,7 +57,12 @@ curl --request POST \
 
 2. **[Create](/reference/create-webhook) a new custom webhook that filters by topic 0 and topic 2 (event signature and sender addr). You can use the create webhook endpoint or dashboard.**
 
-<Warning />
+<Warning>
+**Match variable name + network**
+
+- The variable name must match the name you used in step 1
+- Select the network you will be sending user ops on - if you are sending on multiple networks, you will need multiple separate webhooks
+</Warning>
 
 For example:
 
@@ -159,7 +164,12 @@ curl --request POST \
 
 2. **[Create](/reference/create-webhook) a new Custom Webhook that filters by the topic 0 and topic 1 (event signature and user op hash)**
 
-<Warning />
+<Warning>
+**Match variable name + network**
+
+- ensure variable name matches the name you used in step 1
+- select you have selected the network you will be sending user ops on
+</Warning>
 
 For example:
 

--- a/fern/tutorials/understanding-the-evm/how-to-deploy-a-contract-to-the-same-address-on-multiple-networks/how-to-deploy-a-contract-to-the-same-address-on-multiple-networks.mdx
+++ b/fern/tutorials/understanding-the-evm/how-to-deploy-a-contract-to-the-same-address-on-multiple-networks/how-to-deploy-a-contract-to-the-same-address-on-multiple-networks.mdx
@@ -127,7 +127,7 @@ To create a new wallet address, open MetaMask, click your **profile icon > Creat
 
 ![](afe16d7-MetaMask-create-account-set.png "MetaMask-create-account-set.png")
 
-<Warning />
+<Warning>Warning: Once you add an account there is no way to remove it </Warning>
 
 If you want to remove the account later, you can use the method in **Option 2** and **Import Account** instead.
 


### PR DESCRIPTION
## Description

More missing callouts, Warnings this time.

## Related Issues

Docs QA Issue: [missing warning box](https://www.notion.so/alchemotion/missing-warning-box-1d9069f20066807a8e29dcada9acf4d0?pvs=4) (multiple)

## Changes Made

- Copy/pasted from current site
 
## Testing

- [x] I have tested these changes locally
- [x] I have run the validation scripts (`pnpm run validate`)
- [x] I have checked that the documentation builds correctly
