### PR TITLE
style: Break method names anywhere instead of at words

### DIFF
--- a/fern/assets/styles.css
+++ b/fern/assets/styles.css
@@ -35,7 +35,7 @@ header#fern-header a.fern-button.filled.normal.primary:after {
   top: 50%;
   width: 7.5rem;
   height: 7.5rem;
-  background-image: url('https://fern-image-hosting.s3.us-east-1.amazonaws.com/alchemy/alchemy-bg-button-blur.png');
+  background-image: url("https://fern-image-hosting.s3.us-east-1.amazonaws.com/alchemy/alchemy-bg-button-blur.png");
   background-size: contain;
   background-repeat: no-repeat;
   background-position: center;
@@ -53,7 +53,7 @@ header#fern-header a.fern-button.filled.normal.primary:after {
 }
 header#fern-header a.fern-button.filled.normal.primary:hover:before {
   opacity: 0.5;
-  animation: 
+  animation:
     slideBlurLeft 6s cubic-bezier(0.45, 0, 0.55, 1) infinite,
     floatVerticalLeft 4s ease-in-out infinite,
     fadeEdges 6s ease-in-out infinite;
@@ -61,7 +61,7 @@ header#fern-header a.fern-button.filled.normal.primary:hover:before {
 }
 header#fern-header a.fern-button.filled.normal.primary:hover:after {
   opacity: 0.5;
-  animation: 
+  animation:
     slideBlurRight 6s cubic-bezier(0.45, 0, 0.55, 1) infinite,
     floatVerticalRight 4s ease-in-out infinite,
     fadeEdges 6s ease-in-out infinite;
@@ -75,7 +75,7 @@ header#fern-header a.fern-button.filled.normal.primary:hover:after {
 }
 :is(.dark) header#fern-header a.fern-button.filled.normal.primary:hover:before {
   opacity: 0.5;
-  animation: 
+  animation:
     slideBlurLeft 6s cubic-bezier(0.45, 0, 0.55, 1) infinite,
     floatVerticalLeft 4s ease-in-out infinite,
     fadeEdgesDark 6s ease-in-out infinite;
@@ -83,7 +83,7 @@ header#fern-header a.fern-button.filled.normal.primary:hover:after {
 }
 :is(.dark) header#fern-header a.fern-button.filled.normal.primary:hover:after {
   opacity: 0.5;
-  animation: 
+  animation:
     slideBlurRight 6s cubic-bezier(0.45, 0, 0.55, 1) infinite,
     floatVerticalRight 4s ease-in-out infinite,
     fadeEdgesDark 6s ease-in-out infinite;
@@ -164,7 +164,8 @@ header#fern-header a.fern-button.filled.normal.primary:hover:after {
 
 /* ----- HERO BUTTON ANIMATIONS ----- */
 @keyframes slideBlurLeft {
-  0%, 100% {
+  0%,
+  100% {
     left: 25%;
   }
   33% {
@@ -182,7 +183,8 @@ header#fern-header a.fern-button.filled.normal.primary:hover:after {
 }
 
 @keyframes slideBlurRight {
-  0%, 100% {
+  0%,
+  100% {
     right: 25%;
   }
   33% {
@@ -200,7 +202,8 @@ header#fern-header a.fern-button.filled.normal.primary:hover:after {
 }
 
 @keyframes floatVerticalLeft {
-  0%, 100% {
+  0%,
+  100% {
     transform: translate(-50%, -60%);
   }
   25% {
@@ -215,7 +218,8 @@ header#fern-header a.fern-button.filled.normal.primary:hover:after {
 }
 
 @keyframes floatVerticalRight {
-  0%, 100% {
+  0%,
+  100% {
     transform: translate(50%, -60%);
   }
   25% {
@@ -230,23 +234,26 @@ header#fern-header a.fern-button.filled.normal.primary:hover:after {
 }
 
 @keyframes fadeEdges {
-  0%, 100% {
+  0%,
+  100% {
     opacity: 0.3;
   }
-  33%, 66% {
+  33%,
+  66% {
     opacity: 0.5;
   }
 }
 
 @keyframes fadeEdgesDark {
-  0%, 100% {
+  0%,
+  100% {
     opacity: 0.1;
   }
-  33%, 66% {
+  33%,
+  66% {
     opacity: 0.3;
   }
 }
-
 
 .fern-anchor {
   border-radius: 50% !important;
@@ -297,6 +304,10 @@ header#fern-header a.fern-button.filled.normal.primary:hover:after {
   color: rgba(var(--body-text), 1) !important;
 }
 
+.fern-sidebar-link .break-words {
+  overflow-wrap: anywhere !important;
+}
+
 /* this selects section headings in the sidebar */
 .fern-sidebar-link-container.font-semibold:not([data-state="active"])
   .fern-sidebar-link
@@ -324,3 +335,4 @@ header#fern-header a.fern-button.filled.normal.primary:hover:after {
 :is(.light) .callout-outlined-tip {
   background-color: #f0fdf4 !important;
 }
+


### PR DESCRIPTION
## Description

### BEFORE

<img width="265" alt="Screenshot 2025-04-23 at 10 31 45 AM" src="https://github.com/user-attachments/assets/8eaf05d0-39cb-40ce-868f-0062a4acb24d" />

### AFTER

<img width="288" alt="Screenshot 2025-04-23 at 10 31 57 AM" src="https://github.com/user-attachments/assets/1f720bdd-ad12-4483-87d9-d34b7375d60a" />

## Related Issues

Docs QA Issue: [Text content in sidebar nav goes over border](https://www.notion.so/alchemotion/Text-content-in-sidebar-nav-goes-over-border-1de069f200668018adf9dfaf5c25f43b?pvs=4)

## Changes Made

- Override style with `overflow-wrap: anywhere`

## Testing

<!-- Describe the tests that you ran to verify your changes -->

- [x] I have tested these changes locally
- [x] I have run the validation scripts (`pnpm run validate`)
- [x] I have checked that the documentation builds correctly
