### PR TITLE
fix: Add missing filters to Custom Webhooks

### DIFF
--- a/fern/api-reference/data/webhooks/custom-webhooks-quickstart/custom-webhook-filters.mdx
+++ b/fern/api-reference/data/webhooks/custom-webhooks-quickstart/custom-webhook-filters.mdx
@@ -27,7 +27,12 @@ In particular, Custom Webhook log GraphQL objects accept a *BlockLogsFilterCrite
 If you're not familiar with how topic filters work for *eth\_getLogs*, here's [an article](/docs/deep-dive-into-eth_getlogs) to get you up to speed.
 
 <Info>
-  A transaction with topics will be matched by the following topic filters:
+A transaction with topics will be matched by the following topic filters:
+- `[]` “anything”
+- `[A]` “A in first position (and anything after)”
+- `[[], [B]]` “anything in first position AND B in second position (and anything after)”
+- `[A, B]` “A in first position AND B in second position (and anything after)”
+- `[[A, B], [A, B]]` “(A OR B) in first position AND (A OR B) in second position (and anything after)”
 </Info>
 
 ### Specifying Addresses within Custom Webhook Event Filters


### PR DESCRIPTION
## Description

### BEFORE

<img width="658" alt="Screenshot 2025-04-23 at 10 44 51 AM" src="https://github.com/user-attachments/assets/664d2cf8-3281-4c23-819a-221f70dc6e00" />

### SHOULD BE

<img width="759" alt="Screenshot 2025-04-23 at 10 44 59 AM" src="https://github.com/user-attachments/assets/9eadbe8d-e48f-4542-bd14-d60a0766e492" />

## AFTER

<img width="727" alt="Screenshot 2025-04-23 at 10 45 05 AM" src="https://github.com/user-attachments/assets/8a23bdbd-a23f-4158-b933-01945798f9e3" />

## Related Issues

Docs QA Issue: [missing warning box](https://www.notion.so/alchemotion/missing-warning-box-1d9069f200668065ba90e6314ad067f6?pvs=4)

## Changes Made

- Added text

## Testing

<!-- Describe the tests that you ran to verify your changes -->

- [x] I have tested these changes locally
- [x] I have run the validation scripts (`pnpm run validate`)
- [x] I have checked that the documentation builds correctly
