### PR TITLE
fix: Add Info callout directly in spec

### DIFF
--- a/build/api-specs/alchemy/rest/notify.json
+++ b/build/api-specs/alchemy/rest/notify.json
@@ -243,7 +243,7 @@
       },
       "patch": {
         "summary": "Update a Variable",
-        "description": "Add and remove elements within a Custom Webhook variable",
+        "description": "Add and remove elements within a Custom Webhook variable\n\n<Info>The use of both `add` and `delete` arrays within a single request is currently not supported. Attempting to send both will result in a 400 error. To add and remove elements, make separate API calls for each action.</Info>\n",
         "tags": ["Custom Webhook API Methods"],
         "parameters": [
           {

--- a/src/openapi/notify/notify.yaml
+++ b/src/openapi/notify/notify.yaml
@@ -103,7 +103,10 @@ paths:
       operationId: delete-custom-webhook-variable
     patch:
       summary: Update a Variable
-      description: "Add and remove elements within a Custom Webhook variable"
+      description: |
+        Add and remove elements within a Custom Webhook variable
+
+        <Info>The use of both `add` and `delete` arrays within a single request is currently not supported. Attempting to send both will result in a 400 error. To add and remove elements, make separate API calls for each action.</Info>
       tags: ["Custom Webhook API Methods"]
       parameters:
         - $ref: "#/components/parameters/X-Alchemy-Token"


### PR DESCRIPTION
## Description

### BEFORE
<img width="652" alt="Screenshot 2025-04-23 at 12 10 29 PM" src="https://github.com/user-attachments/assets/6a2bf073-fb9c-43ef-8f77-5bd7e8d980f8" />

### SHOULD BE
<img width="632" alt="Screenshot 2025-04-23 at 12 10 13 PM" src="https://github.com/user-attachments/assets/1a2a2b5c-6a18-4e4c-9b36-fd9d4fd9a519" />

### AFTER
<img width="685" alt="Screenshot 2025-04-23 at 12 12 44 PM" src="https://github.com/user-attachments/assets/284309b6-f262-4adf-90d3-89160907d1cd" />

## Related Issues

- Docs QA Issues: [missing warning](https://www.notion.so/alchemotion/missing-warning-1d9069f2006680dd90a4eba0bf6dcd49?pvs=4)
- 
## Changes Made

- Add component in the spec itself

## Testing

<!-- Describe the tests that you ran to verify your changes -->

- [x] I have tested these changes locally
- [x] I have run the validation scripts (`pnpm run validate`)
- [x] I have checked that the documentation builds correctly
