### PR TITLE
chore: upgrade to `0.57.36` to improve request params in OpenRPC

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@open-rpc/schema-utils-js": "^2.1.2",
-    "fern-api": "^0.57.33",
+    "fern-api": "0.57.36",
     "js-yaml": "^4.1.0",
     "json-schema-merge-allof": "^0.8.1",
     "ts-node": "^10.9.2"


### PR DESCRIPTION
This PR upgrades the Fern CLI to get rid of double wrapping request bodies. 