### PR TITLE
fix: Add links to homepage cards

### DIFF
--- a/fern/home/index.mdx
+++ b/fern/home/index.mdx
@@ -549,23 +549,23 @@ hide-feedback: true
 
     <div class="use-cases">
       <CardGroup cols={1}>
-        <Card title="JSON RPC" icon={<img src="https://fern-image-hosting.s3.us-east-1.amazonaws.com/alchemy/Supernode.svg" />} href="/" className="flex-1 min-w-[200px] p-5 h-full flex flex-col text-left md:w-1/3 before:content-['🕐_5_min'] before:absolute before:top-4 before:right-4 before:bg-[#eff4f9] before:text-[#475569] before:px-2 before:py-1 before:rounded before:text-sm before:font-normal">
+        <Card title="JSON RPC" icon={<img src="https://fern-image-hosting.s3.us-east-1.amazonaws.com/alchemy/Supernode.svg" />} href="/reference/chain-apis-overview" className="flex-1 min-w-[200px] p-5 h-full flex flex-col text-left md:w-1/3 before:content-['🕐_5_min'] before:absolute before:top-4 before:right-4 before:bg-[#eff4f9] before:text-[#475569] before:px-2 before:py-1 before:rounded before:text-sm before:font-normal">
           Use our Node API to start reading and writing to the blockchain—scale infinitely.
         </Card>
 
-        <Card title="Onboard users" icon={<img src="https://fern-image-hosting.s3.us-east-1.amazonaws.com/alchemy/Account.svg" />} href="/">
+        <Card title="Onboard users" icon={<img src="https://fern-image-hosting.s3.us-east-1.amazonaws.com/alchemy/Account.svg" />} href="/docs/account-abstraction-overview">
           Your complete toolkit to build embedded wallets—powered by smart accounts.
         </Card>
 
-        <Card title="Stream events" icon={<img src="https://fern-image-hosting.s3.us-east-1.amazonaws.com/alchemy/Webhooks.svg" />} href="/">
+        <Card title="Stream events" icon={<img src="https://fern-image-hosting.s3.us-east-1.amazonaws.com/alchemy/Webhooks.svg" />} href="/reference/notify-api-quickstart">
           Get consistent push notifications and subscribe to ongoing onchain data.
         </Card>
 
-        <Card title="Index data" icon={<img src="https://fern-image-hosting.s3.us-east-1.amazonaws.com/alchemy/Index.svg" />} href="/">
+        <Card title="Index data" icon={<img src="https://fern-image-hosting.s3.us-east-1.amazonaws.com/alchemy/Index.svg" />} href="/reference/subgraphs-quickstart/">
           Ship faster with an onchain data API. Reduce data lag by 50%. Backfill data up to 5x faster.
         </Card>
 
-        <Card title="Cheaper, faster, safer transactions" icon={<img src="https://fern-image-hosting.s3.us-east-1.amazonaws.com/alchemy/Account.svg" />} href="/">
+        <Card title="Cheaper, faster, safer transactions" icon={<img src="https://fern-image-hosting.s3.us-east-1.amazonaws.com/alchemy/Account.svg" />} href="/docs/account-abstraction-overview">
           Your complete toolkit to build embedded wallets—powered by smart accounts.
         </Card>
       </CardGroup>


### PR DESCRIPTION
## Description

The cards on the homepage didn't link anywhere, now they do. But they're almost certainly linking to the wrong places (i.e. we should probably center these on Nodes, Wallets, Rollups, and Data) which we'll revisit once we've migrated.

## Related Issues

Docs QA Issue: [Homepage links not working](https://www.notion.so/alchemotion/Homepage-links-not-working-1d5069f2006680ee880ee71acb6fb0fd?pvs=4)

## Changes Made

- Added `href` values for cards

## Testing

<!-- Describe the tests that you ran to verify your changes -->

- [x] I have tested these changes locally
- [x] I have run the validation scripts (`pnpm run validate`)
- [x] I have checked that the documentation builds correctly
