### PR TITLE
fix: Kill link container

### DIFF
--- a/fern/tutorials/learn-about-alchemy/core-products/alchemy-supernode.mdx
+++ b/fern/tutorials/learn-about-alchemy/core-products/alchemy-supernode.mdx
@@ -82,9 +82,7 @@ Scale your infrastructure quickly and seamlessly so that you can spend more time
 
 Do more, quickly with an Alchemy Web3 extension of web3.js as well as Smart WebSockets that automatically handle reconnection and backfilling of missed events.
 
-Check out our full suite of Enhanced APIs here:
-
-[**View**: http://github.com/alchemyplatform/alchemy-docs/blob/master/introduction/core-products/broken-reference/README.md"%20%}%20\[https:/github.com/alchemyplatform/alchemy-docs/blob/master/introduction/core-products/broken-reference/README.md\](https:/github.com/alchemyplatform/alchemy-docs/blob/master/introduction/core-products/broken-reference/README.md](http://github.com/alchemyplatform/alchemy-docs/blob/master/introduction/core-products/broken-reference/README.md"%20%}%20[https:/github.com/alchemyplatform/alchemy-docs/blob/master/introduction/core-products/broken-reference/README.md]\(https:/github.com/alchemyplatform/alchemy-docs/blob/master/introduction/core-products/broken-reference/README.md)
+Check out our full suite of Enhanced APIs [here](/reference/data-overview).
 
 ### Instant On
 


### PR DESCRIPTION
## Description

No idea how this was supposed to work originally (way back on Gitbook), but it's broken on both the new and the old site so I just replaced it with a regular link.

### BEFORE

<img width="822" alt="Screenshot 2025-04-24 at 11 05 50 AM" src="https://github.com/user-attachments/assets/8771e04e-5380-4684-afdc-d2e3400ff226" />

### AFTER

<img width="723" alt="Screenshot 2025-04-24 at 11 06 12 AM" src="https://github.com/user-attachments/assets/1347a3af-1241-4ac9-af1b-30fc274560eb" />

## Related Issues

Docs QA Issues: [Containerized Link section missing](https://www.notion.so/alchemotion/Containerized-Link-section-missing-1d9069f2006680c4aad6d34d21b53464?pvs=4)

## Changes Made

- Replaced with a standard link

## Testing

<!-- Describe the tests that you ran to verify your changes -->

- [ ] I have tested these changes locally
- [ ] I have run the validation scripts (`pnpm run validate`)
- [ ] I have checked that the documentation builds correctly
