### PR TITLE
fix: Prevent double X-Alchemy-Token definition

### DIFF
--- a/build/api-specs/alchemy/rest/notify.json
+++ b/build/api-specs/alchemy/rest/notify.json
@@ -10,11 +10,6 @@
       "url": "https://dashboard.alchemy.com/api"
     }
   ],
-  "security": [
-    {
-      "ApiKeyAuth": []
-    }
-  ],
   "paths": {
     "/graphql/variables/{variable}": {
       "get": {
@@ -22,6 +17,16 @@
         "description": "This endpoint allows you to read the values within a Custom Webhook variable.\nIt supports pagination with `limit` and `after` (and optionally `pageKey`) query parameters.\n",
         "tags": ["Custom Webhook API Methods"],
         "parameters": [
+          {
+            "name": "X-Alchemy-Token",
+            "in": "header",
+            "required": true,
+            "description": "Alchemy Auth token to use the Notify API.",
+            "schema": {
+              "type": "string"
+            },
+            "example": "your-X-Alchemy-Token"
+          },
           {
             "name": "variable",
             "in": "path",
@@ -1518,14 +1523,6 @@
     }
   },
   "components": {
-    "securitySchemes": {
-      "ApiKeyAuth": {
-        "type": "apiKey",
-        "in": "header",
-        "name": "X-Alchemy-Token",
-        "description": "This is the securitySchemes one"
-      }
-    },
     "schemas": {
       "create_webhook": {
         "type": "object",

--- a/src/openapi/notify/notify.yaml
+++ b/src/openapi/notify/notify.yaml
@@ -6,8 +6,6 @@ info:
   version: "1.0"
 servers:
   - url: "https://dashboard.alchemy.com/api"
-security:
-  - ApiKeyAuth: []
 paths:
   /graphql/variables/{variable}:
     get:
@@ -17,6 +15,7 @@ paths:
         It supports pagination with `limit` and `after` (and optionally `pageKey`) query parameters.
       tags: ["Custom Webhook API Methods"]
       parameters:
+        - $ref: "#/components/parameters/X-Alchemy-Token"
         - $ref: "#/components/parameters/variable"
         - $ref: "#/components/parameters/limit"
         - $ref: "#/components/parameters/after"
@@ -434,12 +433,6 @@ components:
       description: "The cursor that points to the end of the current set of results."
       schema:
         type: string
-  securitySchemes:
-    ApiKeyAuth:
-      type: apiKey
-      in: header
-      name: X-Alchemy-Token
-      description: "This is the securitySchemes one"
   schemas:
     cursor:
       type: string


### PR DESCRIPTION
## Description

### BEFORE

<img width="679" alt="Screenshot 2025-04-24 at 11 40 10 AM" src="https://github.com/user-attachments/assets/93dec069-52c0-4791-b50a-0c46315f252f" />

### AFTER

<img width="679" alt="Screenshot 2025-04-24 at 12 34 55 PM" src="https://github.com/user-attachments/assets/a36769de-dec1-48ca-9e58-097b0894f91a" />

## Related Issues

Docs QA Issue: [mentions x alchmey token twice](https://www.notion.so/alchemotion/mentions-x-alchmey-token-twice-1d9069f2006680d1b4e9f1dd7688cefe?pvs=4) and a few more

## Changes Made

- Disabled `securitySchemes` as a test
 
## Testing

<!-- Describe the tests that you ran to verify your changes -->

- [x] I have tested these changes locally
- [x] I have run the validation scripts (`pnpm run validate`)
- [x] I have checked that the documentation builds correctly
