### PR TITLE
add prices api

### DIFF
--- a/fern/apis/prices/generators.yaml
+++ b/fern/apis/prices/generators.yaml
@@ -1,0 +1,3 @@
+api:
+  specs:
+    - openapi: ../../../build/api-specs/alchemy/rest/prices.json

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -1198,12 +1198,9 @@ navigation:
                 path: api-reference/data/prices-api/prices-api-quickstart.mdx
               - page: Prices API FAQ
                 path: api-reference/data/prices-api/prices-api-faq.mdx
-              - section: Prices API Endpoints
-                contents:
-                  - page: Prices API Endpoints
-                    path: >-
-                      api-reference/data/prices-api/prices-api-endpoints/get-token-prices-by-symbol.mdx
-                slug: prices-api-endpoints
+              - api: Prices API Endpoints
+                api-name: prices
+                flattened: true
             slug: prices-api
           - section: 💸 Transfers API
             contents:

--- a/src/openapi/prices/prices.yaml
+++ b/src/openapi/prices/prices.yaml
@@ -4,13 +4,8 @@ openapi: 3.1.0
 info:
   title: 📈 Prices API
   version: "1.0"
-  license:
-    name: MIT
-    url: https://opensource.org/licenses/MIT
 servers:
   - url: https://api.g.alchemy.com/prices/v1
-security:
-  - apiKey: []
 paths:
   "/{apiKey}/tokens/by-symbol":
     get:
@@ -164,7 +159,7 @@ components:
       schema:
         type: string
         default: docs-demo
-      description: For higher throughput, [create your own API key](https://alchemy.com/?a=docs-demo)
+        description: For higher throughput, [create your own API key](https://alchemy.com/?a=docs-demo).
   schemas:
     TokenPricesResponse:
       type: object
@@ -189,7 +184,7 @@ components:
           items:
             $ref: "#/components/schemas/Price"
         error:
-          type: ["string", "null"]
+          type: string
           description: Error message if applicable.
       required:
         - symbol
@@ -220,11 +215,11 @@ components:
         addresses:
           type: array
           minItems: 1
-          maxItems: 25
           description: >
             Array of token network and address pairs (limit 25 addresses, max 3 networks). Networks should match network enums.
           items:
             $ref: "#/components/schemas/AddressItem"
+          maxItems: 25
       required:
         - addresses
 
@@ -277,7 +272,7 @@ components:
           items:
             $ref: "#/components/schemas/Price"
         error:
-          type: ["string", "null"]
+          type: string
           description: Error message if applicable.
       required:
         - network
@@ -320,7 +315,7 @@ components:
                   default: "2024-01-01T00:00:00Z"
                 - type: number
                   description: Start of the time range as a timestamp in seconds since epoch.
-                  default: 1704067200
+                  default: 1704067200 # Equivalent to "2024-01-01T00:00:00Z"
               description: Start of the time range.
               example: "2024-01-01T00:00:00Z"
             endTime:
@@ -331,7 +326,7 @@ components:
                   default: "2024-01-31T23:59:59Z"
                 - type: number
                   description: End of the time range as a timestamp in seconds since epoch.
-                  default: 1706745599
+                  default: 1706745599 # Equivalent to "2024-01-31T23:59:59Z"
               description: End of the time range.
               example: "2024-01-31T23:59:59Z"
             interval:
@@ -341,6 +336,11 @@ components:
               enum: ["5m", "1h", "1d"]
               default: "1d"
               example: "1d"
+            withMarketData:
+              type: boolean
+              description: Whether to include market cap and volume for each token
+              example: true
+              default: false
         - required: ["network", "address", "startTime", "endTime"]
           properties:
             network:
@@ -361,7 +361,7 @@ components:
                   default: "2024-01-01T00:00:00Z"
                 - type: number
                   description: Start of the time range as a timestamp since epoch.
-                  default: 1704067200
+                  default: 1704067200 # Equivalent to "2024-01-01T00:00:00Z"
               description: Start of the time range.
               example: "2024-01-01T00:00:00Z"
             endTime:
@@ -372,7 +372,7 @@ components:
                   default: "2024-01-31T23:59:59Z"
                 - type: number
                   description: End of the time range as a timestamp since epoch.
-                  default: 1706745599
+                  default: 1706745599 # Equivalent to "2024-01-31T23:59:59Z"
               description: End of the time range.
               example: "2024-01-31T23:59:59Z"
             interval:
@@ -382,6 +382,11 @@ components:
               enum: ["5m", "1h", "1d"]
               default: "1d"
               example: "1d"
+            withMarketData:
+              type: boolean
+              description: Whether to include market cap and volume for each token
+              example: true
+              default: false
 
     HistoricalPricesResponse:
       type: object
@@ -447,6 +452,14 @@ components:
           format: date-time
           description: Timestamp of the price data point.
           example: "2024-01-01T00:00:00Z"
+        marketCap:
+          type: string
+          description: Total market capitalization at the timestamp
+          example: "274292310008.21802"
+        totalVolume:
+          type: string
+          description: Volume traded during the defined interval
+          example: "6715146404.608721"
       required:
         - value
         - timestamp


### PR DESCRIPTION
## Description
Make edits to prices api spec to make it valid and add it to navigation

## Related Issues

[Prices API is missing from docs](https://www.notion.so/alchemotion/1d2069f20066807c99f8f463fc563cf3?v=1de069f20066804e9ff4000ca12bdbbd&p=1dc069f2006680f1b9c1f79a3a0f36fc&pm=s)

## Changes Made

- Creation of `generators.yaml` to make prices api compatible with Fern
- Small edits in Prices API specs
- Addition of spec to navigation (`doc.yml`)

## Testing



* \[x] I have tested these changes locally
* \[x] I have run the validation scripts (`pnpm run validate`)
* \[x] I have checked that the documentation builds correctly
