### PR TITLE
add token api

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -1185,12 +1185,8 @@ navigation:
               # - page: Solana Token APIs (Beta)
               #   path: >-
               #     api-reference/data/token-api/beta-alchemy-das-apis-for-solana-nfts-and-fungible-tokens-1ba069f2006680279109d7f34758ac6fpvs4.mdx
-              - section: Token API Endpoints
-                contents:
-                  - page: Token API Endpoints
-                    path: >-
-                      api-reference/data/token-api/token-api-endpoints/alchemy-gettokenmetadata.mdx
-                slug: token-api-endpoints
+              - api: Token API Endpoints
+                api-name: token-api
             slug: token-api
           - section: 📈 Prices API
             contents:


### PR DESCRIPTION
## Description

Add Token API

## Related Issues

[Token API is missing from docs](https://www.notion.so/alchemotion/1d2069f20066807c99f8f463fc563cf3?v=1de069f20066804e9ff4000ca12bdbbd&p=1dc069f2006680b19697e57172ac106e&pm=s)

## Changes Made

- Adds Token api to `docs.yml` to add in navigation

## Testing

* \[x] I have tested these changes locally
* \[x] I have run the validation scripts (`pnpm run validate`)
* \[x] I have checked that the documentation builds correctly
