### PR TITLE
fix email in community tutorials

### DIFF
--- a/fern/tutorials/welcome/web3-tutorials-overview/community-tutorials.mdx
+++ b/fern/tutorials/welcome/web3-tutorials-overview/community-tutorials.mdx
@@ -5,7 +5,7 @@ url: "https://docs.alchemy.com/docs/community-tutorials"
 slug: "docs/community-tutorials"
 ---
 
-We want web3 developers to learn from the best. This page includes great guides and tutorials written by some awesome web3 writers. If you'd like submit your technical content to be included, send us an email at [\[email protected\]](/cdn-cgi/l/email-protection#d1b0bca1bdb8b7a891b0bdb2b9b4bca8ffb2bebc) and we'll let you know.
+We want web3 developers to learn from the best. This page includes great guides and tutorials written by some awesome web3 writers. If you'd like submit your technical content to be included, send us an email at amplify@alchemy.com and we'll let you know.
 
 # 👨‍💻 Web3 Basics
 


### PR DESCRIPTION
## Description
- before:
![image](https://github.com/user-attachments/assets/a6644829-9850-4415-8c46-b8245b3bcee6)

- after:
![image](https://github.com/user-attachments/assets/ec1e597b-5b92-4cdb-9bcb-27a14be9e8d7)

## Related Issues
[Community Tutorials: Email Protected](https://www.notion.so/alchemotion/1d2069f20066807c99f8f463fc563cf3?v=1de069f20066804e9ff4000ca12bdbbd&p=1d8069f20066801f854ac362046f8c54&pm=s)

## Changes Made
Update email

## Testing

<!-- Describe the tests that you ran to verify your changes -->

* \[x] I have tested these changes locally
* \[x] I have run the validation scripts (`pnpm run validate`)
* \[x] I have checked that the documentation builds correctly
