### PR TITLE
remove outdated links from the add alchemy rpc to metamask guide

### DIFF
--- a/fern/tutorials/wallet-set-up/how-to-add-alchemy-rpc-endpoints-to-metamask/how-to-add-alchemy-rpc-endpoints-to-metamask.mdx
+++ b/fern/tutorials/wallet-set-up/how-to-add-alchemy-rpc-endpoints-to-metamask/how-to-add-alchemy-rpc-endpoints-to-metamask.mdx
@@ -83,4 +83,4 @@ Example Polygon Configuration
 
 Example Ethereum Mainnet Configuration
 
-And that's it! Your MetaMask is now hooked up to Alchemy 🎉 You've now unlocked game changing tools like the [Mempool Visualizer](/docs/alchemy-build#mempool-visualizer) (where you can view all your transactions as they are being mined), [Alchemy Notify](/docs/alchemy-notify) (receive notifications about address activity, dropped/mined transactions, etc.), and more!
+And that's it! Your MetaMask is now hooked up to Alchemy 🎉


### PR DESCRIPTION
## Description

removes outdated links from the metamask add alchemy rpc guide, we deprecated some products and were still linking there!

## Related Issues

[Mempool Visualizer Link not working](https://www.notion.so/alchemotion/1d2069f20066807c99f8f463fc563cf3?v=1de069f20066804e9ff4000ca12bdbbd&p=1d8069f20066809f8c65f2edbcae5186&pm=s)


## Testing

* \[x] I have tested these changes locally
* \[x] I have run the validation scripts (`pnpm run validate`)
* \[x] I have checked that the documentation builds correctly
