### PR TITLE
chore: update readme to reflect new linting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,10 @@ Account Kit documentation is maintained in the [aa-sdk repository](https://githu
 4. Push to your fork
 5. Create a pull request to the upstream
 
+## Markdown Style Guide
+
+This project implements a modified version of the [Markdown Style Guide](https://google.github.io/styleguide/docguide/style.html) which is enforced in Eslint via [remark-lint](https://github.com/remarkjs/remark-lint). Please ensure you abide by the guidelines set there.
+
 ## Keeping Your Fork Updated
 
 To keep your fork up-to-date with the original repository:
@@ -78,10 +82,6 @@ git push origin main
 ## Creating Issues
 
 Unsure how to make changes yourself? Feel free to open an issue using the appropriate template. Please fill out required fields and provide as much detail as possible to ensure contributors can be as helpful as possible.
-
-## Code of Conduct
-
-By participating in this project, you agree to abide by our Code of Conduct. Please be respectful and considerate of differing viewpoints and experiences.
 
 ## Questions?
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The latest documentation lives on https://alchemy.docs.buildwithfern.com/home
 
 ## Project Structure
 
-```md
+```text
 /
 ├── src/
 │   ├── openapi/     # REST API definitions (OpenAPI)
@@ -60,7 +60,7 @@ This will generate all specs as dereferenced json files in the `build/` director
 
 ### Validation
 
-You can validate both specs and MDX using scripts.
+You can validate both OpenAPI and OpenRPC using scripts.
 
 ```bash
 # Validate REST API specs
@@ -69,15 +69,24 @@ pnpm run validate:rest
 # Validate RPC specs
 pnpm run validate:rpc
 
-# Validate markdown files
-pnpm run validate:mdx
-```
-
-Or you can run them together using
-
-```bash
+# Or you can run them together with
 pnpm run validate
 ```
+
+### Linting
+
+The project uses several linting tools to ensure code quality and consistency:
+
+* **ESLint**: For JavaScript and TypeScript code linting
+* **Prettier**: For code formatting
+* **Remark**: For Markdown/MDX linting
+* **TypeScript**: For type checking
+
+You can find the appropriate commands for running each in `package.json`
+
+#### Enforcement
+
+The project uses [Husky](https://typicode.github.io/husky) and [lint-staged](https://github.com/lint-staged/lint-staged) to run linting checks before commits.
 
 ## Contributing
 


### PR DESCRIPTION
## Description

I forgot to update readme and contributing guide with #86, so this does that

## Changes Made

Update readme/contributing to remove deprecated validate:mdx script and mention markdown style guide

## Testing

<!-- Describe the tests that you ran to verify your changes -->

* \[x] I have tested these changes locally
* \[x] I have run the validation scripts (`pnpm run validate`)
* \[x] I have checked that the documentation builds correctly
