### PR TITLE
add the correct url to redirect to from sign in button

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -67,7 +67,7 @@ experimental:
 navbar-links:
   - type: filled
     text: Sign in to Alchemy
-    url: https://bit.ly/alchemy-dashboard-docs
+    url: https://dashboard.alchemy.com/signup?a=docs
 
 tabs:
   home:


### PR DESCRIPTION
Created a new redirect URL for tracking + shortened it and linked in the sign-in button.

https://bit.ly/alchemy-dashboard-docs