### PR TITLE
add external link for Solana Token APIs to complete token api navigation

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -1185,9 +1185,8 @@ navigation:
             contents:
               - page: Token API Quickstart
                 path: api-reference/data/token-api/token-api-quickstart.mdx
-              # - page: Solana Token APIs (Beta)
-              #   path: >-
-              #     api-reference/data/token-api/beta-alchemy-das-apis-for-solana-nfts-and-fungible-tokens-1ba069f2006680279109d7f34758ac6fpvs4.mdx
+              - link: Solana Token APIs (Beta)
+                href: https://alchemotion.notion.site/Beta-Alchemy-DAS-APIs-for-Solana-NFTs-and-Fungible-Tokens-1ba069f2006680279109d7f34758ac6f
               - api: Token API Endpoints
                 api-name: token-api
             slug: token-api


### PR DESCRIPTION
## Description

Adds an external link to Solana Token APIs to match the structure of old docs site. See screenshots below. 

Old docs site: 
![image](https://github.com/user-attachments/assets/19e42b59-58c2-4fe4-819e-40a5c85e1094)

New docs site (before this PR):
![image](https://github.com/user-attachments/assets/91ad3096-8e8d-4056-a494-d740b8d86cd5)

New docs site (after this PR):
![image](https://github.com/user-attachments/assets/71f7e4aa-4159-4f00-97ff-e151fd7aba12)


## Related Issues

[Token API navigation bar is missin link to solana beta api in nav bar](https://www.notion.so/alchemotion/1d2069f20066807c99f8f463fc563cf3?v=1de069f20066804e9ff4000ca12bdbbd&p=1d9069f2006680569280d6fb5aa811c9&pm=s)

## Changes Made

Adds an external link as page for Solana Token APIs, added based on Fern docs: https://buildwithfern.com/learn/docs/api-references/customize-api-reference-layout#adding-pages-and-links

## Testing

<!-- Describe the tests that you ran to verify your changes -->

* \[x] I have tested these changes locally
* \[x] I have run the validation scripts (`pnpm run validate`)
* \[x] I have checked that the documentation builds correctly
