### PR TITLE
fix: removes duplicate CTAs on sdk overview

### DIFF
--- a/fern/api-reference/alchemy-sdk/alchemy-sdk-surface-overview/alchemy-sdk-api-surface-overview.mdx
+++ b/fern/api-reference/alchemy-sdk/alchemy-sdk-surface-overview/alchemy-sdk-api-surface-overview.mdx
@@ -373,8 +373,6 @@ Methods on the most commonly used utils from Ethers. These should `DebugNamespac
 
 # Questions and Feedback
 
-If you have any questions, issues, or feedback, please file an issue on [GitHub](https://github.com/alchemyplatform/alchemy-sdk-js/issues), or drop us a message on our [Discord](https://discord.com/channels/735965332958871634/983472322998575174) channel for the SDK.
-
 <Check>
   We'd love your thoughts on what would improve your web3 dev process the most! If you have 5 minutes, tell us what you want at our [Feature Request feedback form](https://alchemyapi.typeform.com/sdk-feedback) and we'd love to build it for you:
 


### PR DESCRIPTION
## Description

Removes one of two duplicate CTAs on the sdk overview

## Related Issues

Fixes: https://www.notion.so/alchemotion/End-of-article-duplicate-CTAs-1de069f20066803fa245cc660109746e?pvs=4

## Testing

<!-- Describe the tests that you ran to verify your changes -->

* \[x] I have tested these changes locally
* \[x] I have run the validation scripts (`pnpm run validate`)
* \[x] I have checked that the documentation builds correctly
