### PR TITLE
fix: adds a line break for sdk enums

### DIFF
--- a/fern/api-reference/alchemy-sdk/alchemy-sdk-quickstart/how-to-use-alchemy-sdk-with-typescript.mdx
+++ b/fern/api-reference/alchemy-sdk/alchemy-sdk-quickstart/how-to-use-alchemy-sdk-with-typescript.mdx
@@ -149,18 +149,18 @@ Getting started: This will require a prior installation of the alchemy-SDK. Add 
 
 Here is a short list of enums exported in the Alchemy SDK ready to be used. Each link will direct you to Github highlighting more description for each.
 
-[Network](https://github.com/alchemyplatform/alchemy-sdk-js/blob/main/docs-md/enums/Network.md): The supported networks by Alchemy.\
-[TokenBalanceType](https://github.com/alchemyplatform/alchemy-sdk-js/blob/main/docs-md/enums/TokenBalanceType.md): Token Types for the `getTokenBalances()` endpoint.\
-[NftTokenType](https://github.com/alchemyplatform/alchemy-sdk-js/blob/main/docs-md/enums/NftTokenType.md): An enum for specifying the token type on NFTs. NftSpamClassification: Potential reasons why an NFT contract was classified as spam.\
-[NftFilters](https://github.com/alchemyplatform/alchemy-sdk-js/blob/main/docs-md/enums/NftFilters.md): Enum of NFT filters that can be applied to a getNftsForOwner or a getContractsForOwner request.\
-[NftOrdering](https://github.com/alchemyplatform/alchemy-sdk-js/blob/main/docs-md/enums/NftOrdering.md): Enum of ordering that can be applied to a getNftsForOwner or a getContractsForOwner response.\
-[SortingOrder](https://github.com/alchemyplatform/alchemy-sdk-js/blob/main/docs-md/enums/SortingOrder.md): Enum for representing the supported sorting orders of the API.\
-[NftSaleMarketplace](https://github.com/alchemyplatform/alchemy-sdk-js/blob/main/docs-md/enums/NftSaleMarketplace.md): Enum representing the supported NFT marketplaces by the getNftSales endpoint.\
-[NftSaleTakerType](https://github.com/alchemyplatform/alchemy-sdk-js/blob/main/docs-md/enums/NftSaleTakerType.md): Enum for specifying the taker type for the getNftSales endpoint.\
-[RefreshState](https://github.com/alchemyplatform/alchemy-sdk-js/blob/main/docs-md/enums/RefreshState.md): The current state of the NFT contract refresh process.\
-[OpenSeaSafelistRequestStatus](https://github.com/alchemyplatform/alchemy-sdk-js/blob/main/docs-md/enums/OpenSeaSafelistRequestStatus.md): An OpenSea collection's approval status.\
-[AlchemySubscription](https://github.com/alchemyplatform/alchemy-sdk-js/blob/main/docs-md/enums/AlchemySubscription.md): This value is provided in the `method` field when creating an event filter on the Websocket Namespace.\
-[WebhookVersion](https://github.com/alchemyplatform/alchemy-sdk-js/blob/main/docs-md/enums/WebhookVersion.md): The version of the webhook. All newly created webhooks default to V2.\
-[WebhookType](https://github.com/alchemyplatform/alchemy-sdk-js/blob/main/docs-md/enums/WebhookType.md): The type of Webhook.\
-[CommitmentLevel](https://github.com/alchemyplatform/alchemy-sdk-js/blob/main/docs-md/enums/CommitmentLevel.md): Commitment level of the target block with using methods in the DebugNamespace.\
-[DebugTracerType](https://github.com/alchemyplatform/alchemy-sdk-js/blob/main/docs-md/enums/DebugTracerType.md): The type of tracer to use when running debug methods in the DebugNamespace.
+* [Network](https://github.com/alchemyplatform/alchemy-sdk-js/blob/main/docs-md/enums/Network.md): The supported networks by Alchemy.
+* [TokenBalanceType](https://github.com/alchemyplatform/alchemy-sdk-js/blob/main/docs-md/enums/TokenBalanceType.md): Token Types for the `getTokenBalances()` endpoint.
+* [NftTokenType](https://github.com/alchemyplatform/alchemy-sdk-js/blob/main/docs-md/enums/NftTokenType.md): An enum for specifying the token type on NFTs. NftSpamClassification: Potential reasons why an NFT contract was classified as spam.
+* [NftFilters](https://github.com/alchemyplatform/alchemy-sdk-js/blob/main/docs-md/enums/NftFilters.md): Enum of NFT filters that can be applied to a getNftsForOwner or a getContractsForOwner request.
+* [NftOrdering](https://github.com/alchemyplatform/alchemy-sdk-js/blob/main/docs-md/enums/NftOrdering.md): Enum of ordering that can be applied to a getNftsForOwner or a getContractsForOwner response.
+* [SortingOrder](https://github.com/alchemyplatform/alchemy-sdk-js/blob/main/docs-md/enums/SortingOrder.md): Enum for representing the supported sorting orders of the API.
+* [NftSaleMarketplace](https://github.com/alchemyplatform/alchemy-sdk-js/blob/main/docs-md/enums/NftSaleMarketplace.md): Enum representing the supported NFT marketplaces by the getNftSales endpoint.
+* [NftSaleTakerType](https://github.com/alchemyplatform/alchemy-sdk-js/blob/main/docs-md/enums/NftSaleTakerType.md): Enum for specifying the taker type for the getNftSales endpoint.
+* [RefreshState](https://github.com/alchemyplatform/alchemy-sdk-js/blob/main/docs-md/enums/RefreshState.md): The current state of the NFT contract refresh process.
+* [OpenSeaSafelistRequestStatus](https://github.com/alchemyplatform/alchemy-sdk-js/blob/main/docs-md/enums/OpenSeaSafelistRequestStatus.md): An OpenSea collection's approval status.
+* [AlchemySubscription](https://github.com/alchemyplatform/alchemy-sdk-js/blob/main/docs-md/enums/AlchemySubscription.md): This value is provided in the `method` field when creating an event filter on the Websocket Namespace.
+* [WebhookVersion](https://github.com/alchemyplatform/alchemy-sdk-js/blob/main/docs-md/enums/WebhookVersion.md): The version of the webhook. All newly created webhooks default to V2.
+* [WebhookType](https://github.com/alchemyplatform/alchemy-sdk-js/blob/main/docs-md/enums/WebhookType.md): The type of Webhook.
+* [CommitmentLevel](https://github.com/alchemyplatform/alchemy-sdk-js/blob/main/docs-md/enums/CommitmentLevel.md): Commitment level of the target block with using methods in the DebugNamespace.
+* [DebugTracerType](https://github.com/alchemyplatform/alchemy-sdk-js/blob/main/docs-md/enums/DebugTracerType.md): The type of tracer to use when running debug methods in the DebugNamespace.


### PR DESCRIPTION
## Description

adds a line break for sdk enums

## Related Issues

fixes https://www.notion.so/alchemotion/Section-of-links-not-showing-correct-structure-1de069f20066804a8276d3533f975605?pvs=4

## Testing

<!-- Describe the tests that you ran to verify your changes -->

* \[x] I have tested these changes locally
* \[x] I have run the validation scripts (`pnpm run validate`)
* \[x] I have checked that the documentation builds correctly
