### PR TITLE
fix: remove content that is no longer available

### DIFF
--- a/fern/tutorials/learning-solidity/smart-contract-storage-layout.mdx
+++ b/fern/tutorials/learning-solidity/smart-contract-storage-layout.mdx
@@ -12,8 +12,6 @@ This guide will explain how data stored on smart contracts. Contract storage lay
 The following general prerequisites are helpful for understanding this article:
 
 * Familiarity with object-oriented languages
-* [Bits and bytes](https://www.chainshot.com/article/binary)
-* [hexadecimal](https://www.chainshot.com/article/hexadecimal)
 * [Smart contracts](https://www.alchemy.com/overviews/solidity-smart-contract)
 * [The Ethereum Virtual Machine (EVM)](/docs/web3-glossary#evm-code)
 * [Hashing](/docs/web3-glossary#hash)


### PR DESCRIPTION
## Description

In learn solidity, this removes link to content that is no longer available

## Related Issues

https://www.notion.so/alchemotion/Links-in-page-lead-nowhere-both-in-old-docs-and-new-docs-1dc069f200668096b81bdaa3e1ce3072?pvs=4

## Testing

<!-- Describe the tests that you ran to verify your changes -->

* \[x] I have tested these changes locally
* \[x] I have run the validation scripts (`pnpm run validate`)
* \[ ] I have checked that the documentation builds correctly
