### PR TITLE
remove replits across the board

### DIFF
--- a/fern/api-reference/alchemy-sdk/sdk-core-methods/call-sdk-v3.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-core-methods/call-sdk-v3.mdx
@@ -124,10 +124,6 @@ The commands for installing it using **npm** or **yarn** are given below:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `call` method using the code sandbox below:
-
 # Use Cases
 
 The `call` method is used for making low-level calls to the EVM blockchains. It can be used for a variety of use cases, including:

--- a/fern/api-reference/alchemy-sdk/sdk-core-methods/estimategas-sdk-v3.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-core-methods/estimategas-sdk-v3.mdx
@@ -108,10 +108,6 @@ Here is an example of how to make an `estimateGas` request using the Alchemy SDK
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `estimateGas` method using the code sandbox below:
-
 # Use Cases
 
 Here are some common use cases for the `estimateGas` method:

--- a/fern/api-reference/alchemy-sdk/sdk-core-methods/findcontractdeployer-sdk-v3.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-core-methods/findcontractdeployer-sdk-v3.mdx
@@ -98,10 +98,6 @@ And here is an example of what a successful response to this request might look 
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `findContractDeployer` method using the code sandbox below:
-
 # Use Cases
 
 Here are some common use cases for `findContractDeployer` method:

--- a/fern/api-reference/alchemy-sdk/sdk-core-methods/getassettransfers-sdk-v3.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-core-methods/getassettransfers-sdk-v3.mdx
@@ -218,10 +218,6 @@ Here is an example of how to make a `getAssetTransfers` request using the Alchem
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `getAssetTransfers` method using the code sandbox below:
-
 # Use Cases
 
 Here are some common use cases for the `getAssetTransfers` method:

--- a/fern/api-reference/alchemy-sdk/sdk-core-methods/getbalance-sdk-v3.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-core-methods/getbalance-sdk-v3.mdx
@@ -91,10 +91,6 @@ Here is an example of how to make a `getBalance` request using the Alchemy SDK:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `getBalance` method using the code sandbox below:
-
 # Use Cases
 
 Here are some common use cases for the `getBalance` method:

--- a/fern/api-reference/alchemy-sdk/sdk-core-methods/getblock-sdk-v3.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-core-methods/getblock-sdk-v3.mdx
@@ -157,10 +157,6 @@ Here is an example of how to make a `getBlock` request using the Alchemy SDK:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `getBlock` method using the code sandbox below:
-
 # Related Methods
 
 Here are the methods related to `getBlock`:

--- a/fern/api-reference/alchemy-sdk/sdk-core-methods/getblocknumber-sdk-v3.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-core-methods/getblocknumber-sdk-v3.mdx
@@ -73,10 +73,6 @@ Here is an example of how to make a `getBlockNumber` request using the Alchemy S
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `getBlockNumber` method using the code sandbox below:
-
 # Use Cases
 
 Here are some potential use cases for the `getBlockNumber` method:

--- a/fern/api-reference/alchemy-sdk/sdk-core-methods/getblockwithtransactions-sdk-v3.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-core-methods/getblockwithtransactions-sdk-v3.mdx
@@ -203,10 +203,6 @@ Here is an example of how to make a `getBlockWithTransactions` request using the
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `getBlockWithTransactions` method using the code sandbox below:
-
 # Use Cases
 
 Here are some possible use cases for this method:

--- a/fern/api-reference/alchemy-sdk/sdk-core-methods/getcode-sdk-v3.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-core-methods/getcode-sdk-v3.mdx
@@ -92,10 +92,6 @@ Here is an example of how to make a `getCode` request using the Alchemy SDK:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `getCode` method using the code sandbox below:
-
 # Use Cases
 
 The everyday use case for the `getCode` method is to return the contract code of an address on the blockchain. However, here are some other possible use cases for the `getCode` method:

--- a/fern/api-reference/alchemy-sdk/sdk-core-methods/getfeedata-sdk-v3.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-core-methods/getfeedata-sdk-v3.mdx
@@ -105,10 +105,6 @@ Here is an example of how to make a `getFeeData` request using the Alchemy SDK:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `getFeeData` method using the code sandbox below:
-
 # Use Cases
 
 Here are some possible use cases for the `getFeeData` method:

--- a/fern/api-reference/alchemy-sdk/sdk-core-methods/getgasprice-sdk-v3.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-core-methods/getgasprice-sdk-v3.mdx
@@ -77,10 +77,6 @@ Here is an example of how to make a `getGasPrice` request using the Alchemy SDK:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `getGasPrice` method using the code sandbox below:
-
 # Use Cases
 
 Here are some possible use cases for the `getGasPrice` method:

--- a/fern/api-reference/alchemy-sdk/sdk-core-methods/getlogs-sdk-v3.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-core-methods/getlogs-sdk-v3.mdx
@@ -185,10 +185,6 @@ Here is an example of how to make a `getLogs` request using the Alchemy SDK:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `getLogs` method using the code sandbox below:
-
 # Use Cases
 
 Here are some possible use cases for the `getLogs` method:

--- a/fern/api-reference/alchemy-sdk/sdk-core-methods/getstorageat-sdk-v3.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-core-methods/getstorageat-sdk-v3.mdx
@@ -95,10 +95,6 @@ Here is an example of how to make a `getStorageAt` request using the Alchemy SDK
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `getStorageAt` method using the code sandbox below:
-
 # Related Methods
 
 Here are the methods related to `getStorageAt`:

--- a/fern/api-reference/alchemy-sdk/sdk-core-methods/gettokenbalances-sdk-v3.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-core-methods/gettokenbalances-sdk-v3.mdx
@@ -107,10 +107,6 @@ Here is an example of how to make a `getTokenBalances` request using the Alchemy
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `getTokenBalances` method using the code sandbox below:
-
 # Use Cases
 
 For guidance on how to leverage this method, check out the following tutorials:

--- a/fern/api-reference/alchemy-sdk/sdk-core-methods/gettokenmetadata-sdk-v3.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-core-methods/gettokenmetadata-sdk-v3.mdx
@@ -96,10 +96,6 @@ Here is an example of how to make a `getTokenMetadata` request using the Alchemy
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `getTokenMetadata` method using the code sandbox below:
-
 # Use Cases
 
 Here are some possible use cases for the `getTokenMetadata` method:

--- a/fern/api-reference/alchemy-sdk/sdk-core-methods/gettokensforowner-sdk-v3.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-core-methods/gettokensforowner-sdk-v3.mdx
@@ -148,10 +148,6 @@ Here is an example of how to make a `getTokensForOwner` request using the Alchem
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `getTokensForOwner` method using the code sandbox below:
-
 # Use Cases
 
 Here are some possible use cases for the `getTokensForOwner` method:

--- a/fern/api-reference/alchemy-sdk/sdk-core-methods/gettransactioncount-sdk-v3.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-core-methods/gettransactioncount-sdk-v3.mdx
@@ -91,10 +91,6 @@ Here is an example of how to make a `getTransactionCount` request using the Alch
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `getTransactionCount` method using the code sandbox below:
-
 # Related Methods
 
 * [getTransactionReceipts](/reference/gettransactionreceipts-sdk): Returns the transaction receipt for hash or `null` if the transaction has not been mined.

--- a/fern/api-reference/alchemy-sdk/sdk-core-methods/gettransactionreceipt-sdk-v3.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-core-methods/gettransactionreceipt-sdk-v3.mdx
@@ -129,11 +129,7 @@ Here is an example of how to make a `getTransactionReceipt` request using the Al
       "byzantium": true
   }
   ```
-</CodeGroup>
-
-## Code Sandbox
-
-You can test out the `getTransactionReceipt` method using the code sandbox below:
+</CodeGroup> 
 
 # Use Cases
 

--- a/fern/api-reference/alchemy-sdk/sdk-core-methods/gettransactionreceipts-sdk-v3.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-core-methods/gettransactionreceipts-sdk-v3.mdx
@@ -219,10 +219,6 @@ Here is an example of how to make a `getTransactionReceipts` request using the A
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `getTransactionReceipts` method using the code sandbox below:
-
 # Use Cases
 
 Here are some possible use cases for the `getTransactionReceipts` method:

--- a/fern/api-reference/alchemy-sdk/sdk-core-methods/iscontractaddress-sdk-v3.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-core-methods/iscontractaddress-sdk-v3.mdx
@@ -78,10 +78,6 @@ Here is an example of how to make an `isContractAddress` request using the Alche
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `isContractAddress` method using the code sandbox below:
-
 # Use Cases
 
 Here are some common use cases for the `isContractAddress` method:

--- a/fern/api-reference/alchemy-sdk/sdk-core-methods/send-sdk-v3.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-core-methods/send-sdk-v3.mdx
@@ -136,10 +136,6 @@ Here is an example of how to make a `send` request using the Alchemy SDK:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `send` method using the code sandbox below:
-
 # Use Cases
 
 Here are some possible use cases for the `send` method:

--- a/fern/api-reference/alchemy-sdk/sdk-debug-methods/traceblock-sdk-v3.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-debug-methods/traceblock-sdk-v3.mdx
@@ -777,10 +777,6 @@ And here is an example of what a successful response to this request might look 
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test the `traceBlock` method using the code sandbox below:
-
 # Use Cases
 
 Here's a potential use case for `traceBlock`:

--- a/fern/api-reference/alchemy-sdk/sdk-debug-methods/tracecall-sdk-v3.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-debug-methods/tracecall-sdk-v3.mdx
@@ -128,10 +128,6 @@ And here is an example of what a successful response to this request might look 
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test the `traceCall` method using the code sandbox below:
-
 # Use Cases
 
 Some of the use cases for `traceCall` are:

--- a/fern/api-reference/alchemy-sdk/sdk-debug-methods/tracetransaction-sdk-v3.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-debug-methods/tracetransaction-sdk-v3.mdx
@@ -121,10 +121,6 @@ And here is an example of what a successful response to this request might look 
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test the `traceTransaction` method using the code sandbox below:
-
 # Use Cases
 
 Some of the use cases for `traceCall` are:

--- a/fern/api-reference/alchemy-sdk/sdk-nft-methods/computerarity-sdk-v3.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-nft-methods/computerarity-sdk-v3.mdx
@@ -133,10 +133,6 @@ The commands for installing it using **npm** or **yarn** are given below:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `computeRarity` method using the code sandbox below:
-
 # Use Cases
 
 Here are some potential use cases for the `computeRarity` method:

--- a/fern/api-reference/alchemy-sdk/sdk-nft-methods/getcontractmetadata-sdk-v3.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-nft-methods/getcontractmetadata-sdk-v3.mdx
@@ -116,10 +116,6 @@ The commands for installing it using **npm** or **yarn** are given below:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `getContractMetadata` method using the code sandbox below:
-
 # Use Cases
 
 Here are some potential use cases for the `getContractMetadata` method:

--- a/fern/api-reference/alchemy-sdk/sdk-nft-methods/getcontractsforowner-sdk-v3.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-nft-methods/getcontractsforowner-sdk-v3.mdx
@@ -199,10 +199,6 @@ The commands for installing it using **npm** or **yarn** are given below:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `getContractsForOwner` method using the code sandbox below:
-
 # Use Cases
 
 Some possible use cases for this method include:

--- a/fern/api-reference/alchemy-sdk/sdk-nft-methods/getfloorprice-sdk-v3.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-nft-methods/getfloorprice-sdk-v3.mdx
@@ -116,10 +116,6 @@ The commands for installing it using **npm** or **yarn** are given below:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `getFloorPrice` method using the code sandbox below:
-
 # Use Cases
 
 Here are some potential use cases for the `getFloorPrice` method:

--- a/fern/api-reference/alchemy-sdk/sdk-nft-methods/getmintednfts-sdk-v3.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-nft-methods/getmintednfts-sdk-v3.mdx
@@ -255,10 +255,6 @@ And here is an example of what a successful response to this request might look 
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test the `getMintedNfts` method using the code sandbox below:
-
 # Use Cases
 
 Some of the use cases for `getMintedNfts` are:

--- a/fern/api-reference/alchemy-sdk/sdk-nft-methods/getnftmetadata-sdk-v3.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-nft-methods/getnftmetadata-sdk-v3.mdx
@@ -176,10 +176,6 @@ The commands for installing it using **npm** or **yarn** are given below:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `getNftMetadata` method using the code sandbox below:
-
 # Use Cases
 
 Here are some potential use cases for the `getNftMetadata` function:

--- a/fern/api-reference/alchemy-sdk/sdk-nft-methods/getnftmetadatabatch-sdk-v3.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-nft-methods/getnftmetadatabatch-sdk-v3.mdx
@@ -266,10 +266,6 @@ The commands for installing it using **npm** or **yarn** are given below:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `getNftMetadataBatch` method using the code sandbox below:
-
 # Use Cases
 
 Here are some use cases for the `getNftMetadataBatch` function:

--- a/fern/api-reference/alchemy-sdk/sdk-nft-methods/getnfts-sdk-v3.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-nft-methods/getnfts-sdk-v3.mdx
@@ -299,10 +299,6 @@ The commands for installing it using **npm** or **yarn** are given below:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `getNftsForOwner` method using the code sandbox below:
-
 # Use Cases
 
 The `getNftsForOwner` method can be used to retrieve information about non-fungible tokens (NFTs) owned by a specific address. Some possible use cases for this method include:

--- a/fern/api-reference/alchemy-sdk/sdk-nft-methods/getnftsales-sdk-v3.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-nft-methods/getnftsales-sdk-v3.mdx
@@ -198,10 +198,6 @@ The commands for installing it using **npm** or **yarn** are given below:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `getNftSales` method using the code sandbox below:
-
 # Use Cases
 
 Here are some potential use cases for the `getNftSales` method:

--- a/fern/api-reference/alchemy-sdk/sdk-nft-methods/getnftsforcontract-sdk-v3.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-nft-methods/getnftsforcontract-sdk-v3.mdx
@@ -274,10 +274,6 @@ The commands for installing it using **npm** or **yarn** are given below:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `getNftsForContract` method using the code sandbox below:
-
 # Use Cases
 
 Here are some potential use cases for the `getNftsForContract` method:

--- a/fern/api-reference/alchemy-sdk/sdk-nft-methods/getnftsforcontractiterator-sdk-v3.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-nft-methods/getnftsforcontractiterator-sdk-v3.mdx
@@ -202,10 +202,6 @@ The commands for installing it using **npm** or **yarn** are given below:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `getNftsForContractIterator` method using the code sandbox below:
-
 # Use Cases
 
 Here are some potential use cases for the `getNftsForContractIterator` method:

--- a/fern/api-reference/alchemy-sdk/sdk-nft-methods/getnftsforowneriterator-sdk-v3.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-nft-methods/getnftsforowneriterator-sdk-v3.mdx
@@ -465,10 +465,6 @@ The commands for installing it using **npm** or **yarn** are given below:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `getNftsForOwnerIterator` method using the code sandbox below:
-
 # Use Cases
 
 Here are some potential use cases for the `getNftsForOwnerIterator` method:

--- a/fern/api-reference/alchemy-sdk/sdk-nft-methods/getownersforcontract-sdk-v3.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-nft-methods/getownersforcontract-sdk-v3.mdx
@@ -150,10 +150,6 @@ The commands for installing it using **npm** or **yarn** are given below:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `getOwnersForContract` method using the code sandbox below:
-
 # Use Cases
 
 Here are some potential use cases for the `getOwnersForContract` function:

--- a/fern/api-reference/alchemy-sdk/sdk-nft-methods/getownersfornft-sdk-v3.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-nft-methods/getownersfornft-sdk-v3.mdx
@@ -102,10 +102,6 @@ The commands for installing it using **npm** or **yarn** are given below:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `getOwnersForNft` method using the code sandbox below:
-
 # Use Cases
 
 Here are some potential use cases for the `getOwnersForNft` method:

--- a/fern/api-reference/alchemy-sdk/sdk-nft-methods/getspamcontracts-sdk-v3.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-nft-methods/getspamcontracts-sdk-v3.mdx
@@ -92,10 +92,6 @@ The commands for installing it using **npm** or **yarn** are given below:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `getSpamContracts` method using the code sandbox below:
-
 # Use Cases
 
 Here are some potential use cases for the `getSpamContracts` method:

--- a/fern/api-reference/alchemy-sdk/sdk-nft-methods/gettransfersforcontract-sdk-v3.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-nft-methods/gettransfersforcontract-sdk-v3.mdx
@@ -287,10 +287,6 @@ And here is an example of what a successful response to this request might look 
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test the `getTransfersForContract` method using the code sandbox below:
-
 # Use Cases
 
 Some of the use cases for `getTransfersForContract` are:

--- a/fern/api-reference/alchemy-sdk/sdk-nft-methods/gettransfersforowner-sdk-v3.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-nft-methods/gettransfersforowner-sdk-v3.mdx
@@ -287,10 +287,6 @@ And here is an example of what a successful response to this request might look 
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test the `getTransfersForOwner` method using the code sandbox below:
-
 # Use Cases
 
 Some of the use cases for `getTransfersForOwner` are:

--- a/fern/api-reference/alchemy-sdk/sdk-nft-methods/isspamcontract-sdk-v3.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-nft-methods/isspamcontract-sdk-v3.mdx
@@ -92,10 +92,6 @@ The commands for installing it using **npm** or **yarn** are given below:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `isSpamContract` method using the code sandbox below:
-
 # Use Cases
 
 Here are some potential use cases for the `isSpamContract` method:

--- a/fern/api-reference/alchemy-sdk/sdk-nft-methods/refreshcontract-sdk-v3.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-nft-methods/refreshcontract-sdk-v3.mdx
@@ -92,10 +92,6 @@ The commands for installing it using **npm** or **yarn** are given below:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `refreshContract` method using the code sandbox below:
-
 # Use Cases
 
 Here are some potential use cases for the `refreshContract` method:

--- a/fern/api-reference/alchemy-sdk/sdk-nft-methods/refreshnftmetadata-sdk-v3.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-nft-methods/refreshnftmetadata-sdk-v3.mdx
@@ -94,10 +94,6 @@ The commands for installing it using **npm** or **yarn** are given below:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `refreshNftMetadata` method using the code sandbox below:
-
 # Use Cases
 
 Here are some potential use cases for the `refreshNftMetadata` method:

--- a/fern/api-reference/alchemy-sdk/sdk-nft-methods/searchcontractmetadata-sdk-v3.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-nft-methods/searchcontractmetadata-sdk-v3.mdx
@@ -199,10 +199,6 @@ The commands for installing it using **npm** or **yarn** are given below:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `searchContractMetadata` method using the code sandbox below:
-
 # Use Cases
 
 Here are some potential use cases for the `searchContractMetadata` method:

--- a/fern/api-reference/alchemy-sdk/sdk-nft-methods/summarizenftattributes-sdk-v3.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-nft-methods/summarizenftattributes-sdk-v3.mdx
@@ -278,10 +278,6 @@ The commands for installing it using **npm** or **yarn** are given below:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `summarizeNftAttributes` method using the code sandbox below:
-
 # Use Cases
 
 Here is a potential use case for the `summarizeNftAttributes` method:

--- a/fern/api-reference/alchemy-sdk/sdk-nft-methods/verifynftownership-sdk-v3.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-nft-methods/verifynftownership-sdk-v3.mdx
@@ -82,10 +82,6 @@ The commands for installing it using **npm** or **yarn** are given below:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `verifyNftOwnership` method using the code sandbox below:
-
 # Use Cases
 
 Here are some potential use cases for the `verifyNftOwnership` method:

--- a/fern/api-reference/alchemy-sdk/sdk-transact-methods/cancelprivatetransaction-sdk-v3.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-transact-methods/cancelprivatetransaction-sdk-v3.mdx
@@ -86,10 +86,6 @@ The commands for installing it using **npm** or **yarn** are given below:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `cancelPrivateTransaction` method using the code sandbox below:
-
 ## Use Cases
 
 Here are some potential use cases for the `cancelPrivateTransaction` method:

--- a/fern/api-reference/alchemy-sdk/sdk-transact-methods/estimategas-sdk.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-transact-methods/estimategas-sdk.mdx
@@ -109,10 +109,6 @@ Here is an example of how to make an `estimateGas` request using the Alchemy SDK
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `estimateGas` method using the code sandbox below:
-
 # Use Cases
 
 Here are some common use cases for the `estimateGas` method:

--- a/fern/api-reference/alchemy-sdk/sdk-transact-methods/getmaxpriorityfeepergas-sdk-v3.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-transact-methods/getmaxpriorityfeepergas-sdk-v3.mdx
@@ -75,10 +75,6 @@ The commands for installing it using **npm** or **yarn** are given below:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `getMaxPriorityFeePerGas` method using the code sandbox below:
-
 # Use Cases
 
 Here are some potential use cases for the `getMaxPriorityFeePerGas` method:

--- a/fern/api-reference/alchemy-sdk/sdk-transact-methods/gettransaction-sdk-v3.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-transact-methods/gettransaction-sdk-v3.mdx
@@ -137,10 +137,6 @@ The commands for installing it using **npm** or **yarn** are given below:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `getTransaction` method using the code sandbox below:
-
 # Use Cases
 
 Here are some potential use cases for the `getTransaction` method:

--- a/fern/api-reference/alchemy-sdk/sdk-transact-methods/sendtransaction-sdk-v3.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-transact-methods/sendtransaction-sdk-v3.mdx
@@ -140,10 +140,6 @@ The commands for installing it using **npm** or **yarn** are given below:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `sendTransaction` method using the code sandbox below:
-
 # Use Cases
 
 Here are some potential use cases for the `sendTransaction` method:

--- a/fern/api-reference/alchemy-sdk/sdk-transact-methods/simulateassetchanges-sdk-v3.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-transact-methods/simulateassetchanges-sdk-v3.mdx
@@ -135,10 +135,6 @@ The commands for installing it using **npm** or **yarn** are given below:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `simulateAssestChanges` method using the code sandbox below:
-
 # Use Cases
 
 Here are some potential use cases for the `simulateAssetChanges` method:

--- a/fern/api-reference/alchemy-sdk/sdk-transact-methods/simulateassetchangesbundle-sdk-v3.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-transact-methods/simulateassetchangesbundle-sdk-v3.mdx
@@ -130,10 +130,6 @@ The commands for installing it using **npm** or **yarn** are given below:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `simulateAssetChangesBundle` method using the code sandbox below:
-
 # Use Cases
 
 Here are some potential use cases for the `simulateAssetChangesBundle` method:

--- a/fern/api-reference/alchemy-sdk/sdk-transact-methods/simulateexecution-sdk-v3.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-transact-methods/simulateexecution-sdk-v3.mdx
@@ -139,10 +139,6 @@ The commands for installing it using **npm** or **yarn** are given below:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `simulateExecution` method using the code sandbox below:
-
 # Use Cases
 
 Here are some potential use cases for the `simulateExecution` method:

--- a/fern/api-reference/alchemy-sdk/sdk-transact-methods/simulateexecutionbundle-sdk-v3.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-transact-methods/simulateexecutionbundle-sdk-v3.mdx
@@ -143,10 +143,6 @@ The commands for installing it using **npm** or **yarn** are given below:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `simulateExecutionBundle` method using the code sandbox below:
-
 # Use Cases
 
 Here are some potential use cases for the `simulateExecutionBundle` method:

--- a/fern/api-reference/alchemy-sdk/sdk-transact-methods/waitfortransaction-sdk-v3.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-transact-methods/waitfortransaction-sdk-v3.mdx
@@ -134,10 +134,6 @@ The commands for installing it using **npm** or **yarn** are given below:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `waitForTransaction` method using the code sandbox below:
-
 # Use Cases
 
 Here are some potential use cases for the `waitForTransaction` method:

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/estimategas-sdk-2.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/estimategas-sdk-2.mdx
@@ -110,11 +110,7 @@ Here is an example of how to make an `estimateGas` request using the Alchemy SDK
       "hex": "0x6d22"
   }
   ```
-</CodeGroup>
-
-## Code Sandbox
-
-You can test out the `estimateGas` method using the code sandbox below:
+</CodeGroup> 
 
 # Use Cases
 

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/getmaxpriorityfeepergas-sdk.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/getmaxpriorityfeepergas-sdk.mdx
@@ -75,10 +75,6 @@ The commands for installing it using **npm** or **yarn** are given below:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `getMaxPriorityFeePerGas` method using the code sandbox below:
-
 # Use Cases
 
 Here are some potential use cases for the `getMaxPriorityFeePerGas` method:

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/gettokensforowner-sdk.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/gettokensforowner-sdk.mdx
@@ -354,10 +354,6 @@ Here is an example of how to make a `getTokensForOwner` request using the Alchem
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `getTokensForOwner` method using the code sandbox below:
-
 # Use Cases
 
 Here are some possible use cases for the `getTokensForOwner` method:

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/iscontractaddress-sdk.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/iscontractaddress-sdk.mdx
@@ -78,10 +78,6 @@ Here is an example of how to make an `isContractAddress` request using the Alche
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `isContractAddress` method using the code sandbox below:
-
 # Use Cases
 
 Here are some common use cases for the `isContractAddress` method:

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-call.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-call.mdx
@@ -124,10 +124,6 @@ The commands for installing it using **npm** or **yarn** are given below:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `call` method using the code sandbox below:
-
 # Use Cases
 
 The `call` method is used for making low-level calls to the EVM blockchains. It can be used for a variety of use cases, including:

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-computerarity.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-computerarity.mdx
@@ -97,10 +97,6 @@ The commands for installing it using **npm** or **yarn** are given below:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `computeRarity` method using the code sandbox below:
-
 # Use Cases
 
 Here are some potential use cases for the `computeRarity` method:

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-estimategas.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-estimategas.mdx
@@ -105,10 +105,6 @@ Here is an example of how to make an `estimateGas` request using the Alchemy SDK
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `estimateGas` method using the code sandbox below:
-
 # Use Cases
 
 Here are some common use cases for the `estimateGas` method:

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-findcontractdeployer.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-findcontractdeployer.mdx
@@ -98,10 +98,6 @@ And here is an example of what a successful response to this request might look 
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `findContractDeployer` method using the code sandbox below:
-
 # Use Cases
 
 Here are some common use cases for `findContractDeployer` method:

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getassettransfers.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getassettransfers.mdx
@@ -204,10 +204,6 @@ Here is an example of how to make a `getAssetTransfers` request using the Alchem
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `getAssetTransfers` method using the code sandbox below:
-
 # Use Cases
 
 Here are some common use cases for the `getAssetTransfers` method:

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getbalance.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getbalance.mdx
@@ -88,10 +88,6 @@ Here is an example of how to make a `getBalance` request using the Alchemy SDK:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `getBalance` method using the code sandbox below:
-
 # Use Cases
 
 Here are some common use cases for the `getBalance` method:

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getblock.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getblock.mdx
@@ -117,11 +117,7 @@ Here is an example of how to make a `getBlock` request using the Alchemy SDK:
     _difficulty: BigNumber { _hex: '0x2a31d8a2cf4dd7', _isBigNumber: true }
   }
   ```
-</CodeGroup>
-
-## Code Sandbox
-
-You can test out the `getBlock` method using the code sandbox below:
+</CodeGroup> 
 
 # Related Methods
 

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getblocknumber.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getblocknumber.mdx
@@ -73,10 +73,6 @@ Here is an example of how to make a `getBlockNumber` request using the Alchemy S
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `getBlockNumber` method using the code sandbox below:
-
 # Use Cases
 
 Here are some potential use cases for the `getBlockNumber` method:

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getblockwithtransactions.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getblockwithtransactions.mdx
@@ -122,10 +122,6 @@ Here is an example of how to make a `getBlockWithTransactions` request using the
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `getBlockWithTransactions` method using the code sandbox below:
-
 # Use Cases
 
 Here are some possible use cases for this method:

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getcode.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getcode.mdx
@@ -92,10 +92,6 @@ Here is an example of how to make a `getCode` request using the Alchemy SDK:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `getCode` method using the code sandbox below:
-
 # Use Cases
 
 The everyday use case for the `getCode` method is to return the contract code of an address on the blockchain. However, here are some other possible use cases for the `getCode` method:

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getcontractmetadata.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getcontractmetadata.mdx
@@ -145,10 +145,6 @@ The commands for installing it using **npm** or **yarn** are given below:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `getContractMetadata` method using the code sandbox below:
-
 # Use Cases
 
 Here are some potential use cases for the `getContractMetadata` method:

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getfeedata.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getfeedata.mdx
@@ -93,10 +93,6 @@ Here is an example of how to make a `getFeeData` request using the Alchemy SDK:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `getFeeData` method using the code sandbox below:
-
 # Use Cases
 
 Here are some possible use cases for the `getFeeData` method:

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getfloorprice.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getfloorprice.mdx
@@ -102,10 +102,6 @@ The commands for installing it using **npm** or **yarn** are given below:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `getFloorPrice` method using the code sandbox below:
-
 # Use Cases
 
 Here are some potential use cases for the `getFloorPrice` method:

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getgasprice.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getgasprice.mdx
@@ -74,10 +74,6 @@ Here is an example of how to make a `getGasPrice` request using the Alchemy SDK:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `getGasPrice` method using the code sandbox below:
-
 # Use Cases
 
 Here are some possible use cases for the `getGasPrice` method:

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getlogs.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getlogs.mdx
@@ -155,10 +155,6 @@ Here is an example of how to make a `getLogs` request using the Alchemy SDK:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `getLogs` method using the code sandbox below:
-
 # Use Cases
 
 Here are some possible use cases for the `getLogs` method:

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getmintednfts.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getmintednfts.mdx
@@ -229,10 +229,6 @@ And here is an example of what a successful response to this request might look 
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test the `getMintedNfts` method using the code sandbox below:
-
 # Use Cases
 
 Some of the use cases for `getMintedNfts` are:

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getnftmetadata.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getnftmetadata.mdx
@@ -234,10 +234,6 @@ The commands for installing it using **npm** or **yarn** are given below:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `getNftMetadata` method using the code sandbox below:
-
 # Use Cases
 
 Here are some potential use cases for the `getNftMetadata` function:

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getnftmetadatabatch.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getnftmetadatabatch.mdx
@@ -169,10 +169,6 @@ The commands for installing it using **npm** or **yarn** are given below:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `getNftMetadataBatch` method using the code sandbox below:
-
 # Use Cases
 
 Here are some use cases for the `getNftMetadataBatch` function:

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getnfts.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getnfts.mdx
@@ -151,10 +151,6 @@ The commands for installing it using **npm** or **yarn** are given below:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `getNftsForOwner` method using the code sandbox below:
-
 # Use Cases
 
 The `getNftsForOwner` method can be used to retrieve information about non-fungible tokens (NFTs) owned by a specific address. Some possible use cases for this method include:

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getnftsales.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getnftsales.mdx
@@ -215,10 +215,6 @@ The commands for installing it using **npm** or **yarn** are given below:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `getNftSales` method using the code sandbox below:
-
 # Use Cases
 
 Here are some potential use cases for the `getNftSales` method:

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getnftsforcontract.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getnftsforcontract.mdx
@@ -224,10 +224,6 @@ The commands for installing it using **npm** or **yarn** are given below:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `getNftsForContract` method using the code sandbox below:
-
 # Use Cases
 
 Here are some potential use cases for the `getNftsForContract` method:

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getnftsforcontractiterator.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getnftsforcontractiterator.mdx
@@ -185,10 +185,6 @@ The commands for installing it using **npm** or **yarn** are given below:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `getNftsForContractIterator` method using the code sandbox below:
-
 # Use Cases
 
 Here are some potential use cases for the `getNftsForContractIterator` method:

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getnftsforowneriterator.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getnftsforowneriterator.mdx
@@ -228,10 +228,6 @@ The commands for installing it using **npm** or **yarn** are given below:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `getNftsForOwnerIterator` method using the code sandbox below:
-
 # Use Cases
 
 Here are some potential use cases for the `getNftsForOwnerIterator` method:

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getownersforcontract.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getownersforcontract.mdx
@@ -140,10 +140,6 @@ The commands for installing it using **npm** or **yarn** are given below:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `getOwnersForContract` method using the code sandbox below:
-
 # Use Cases
 
 Here are some potential use cases for the `getOwnersForContract` function:

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getownersfornft.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getownersfornft.mdx
@@ -82,10 +82,6 @@ The commands for installing it using **npm** or **yarn** are given below:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `getOwnersForNft` method using the code sandbox below:
-
 # Use Cases
 
 Here are some potential use cases for the `getOwnersForNft` method:

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getspamcontracts.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getspamcontracts.mdx
@@ -95,10 +95,6 @@ The commands for installing it using **npm** or **yarn** are given below:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `getSpamContracts` method using the code sandbox below:
-
 # Use Cases
 
 Here are some potential use cases for the `getSpamContracts` method:

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getstorageat.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getstorageat.mdx
@@ -95,10 +95,6 @@ Here is an example of how to make a `getStorageAt` request using the Alchemy SDK
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `getStorageAt` method using the code sandbox below:
-
 # Related Methods
 
 Here are the methods related to `getStorageAt`:

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-gettokenbalances.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-gettokenbalances.mdx
@@ -100,10 +100,6 @@ Here is an example of how to make a `getTokenBalances` request using the Alchemy
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `getTokenBalances` method using the code sandbox below:
-
 # Use Cases
 
 For guidance on how to leverage this method, check out the following tutorials:

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-gettokenmetadata.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-gettokenmetadata.mdx
@@ -96,10 +96,6 @@ Here is an example of how to make a `getTokenMetadata` request using the Alchemy
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `getTokenMetadata` method using the code sandbox below:
-
 # Use Cases
 
 Here are some possible use cases for the `getTokenMetadata` method:

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-gettransaction.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-gettransaction.mdx
@@ -119,10 +119,6 @@ The commands for installing it using **npm** or **yarn** are given below:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `getTransaction` method using the code sandbox below:
-
 # Use Cases
 
 Here are some potential use cases for the `getTransaction` method:

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-gettransactioncount.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-gettransactioncount.mdx
@@ -91,10 +91,6 @@ Here is an example of how to make a `getTransactionCount` request using the Alch
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `getTransactionCount` method using the code sandbox below:
-
 # Related Methods
 
 * [getTransactionReceipts](/reference/gettransactionreceipts-sdk): Returns the transaction receipt for hash or `null` if the transaction has not been mined.

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-gettransactionreceipt.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-gettransactionreceipt.mdx
@@ -120,10 +120,6 @@ Here is an example of how to make a `getTransactionReceipt` request using the Al
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `getTransactionReceipt` method using the code sandbox below:
-
 # Use Cases
 
 Here are some potential use cases for the `getTransactionReceipt` method:

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-gettransactionreceipts.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-gettransactionreceipts.mdx
@@ -146,10 +146,6 @@ Here is an example of how to make a `getTransactionReceipts` request using the A
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `getTransactionReceipts` method using the code sandbox below:
-
 # Use Cases
 
 Here are some possible use cases for the `getTransactionReceipts` method:

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-gettransfersforcontract.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-gettransfersforcontract.mdx
@@ -286,10 +286,6 @@ And here is an example of what a successful response to this request might look 
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test the `getTransfersForContract` method using the code sandbox below:
-
 # Use Cases
 
 Some of the use cases for `getTransfersForContract` are:

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-gettransfersforowner.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-gettransfersforowner.mdx
@@ -292,10 +292,6 @@ And here is an example of what a successful response to this request might look 
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test the `getTransfersForOwner` method using the code sandbox below:
-
 # Use Cases
 
 Some of the use cases for `getTransfersForOwner` are:

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-isspamcontract.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-isspamcontract.mdx
@@ -80,10 +80,6 @@ The commands for installing it using **npm** or **yarn** are given below:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `isSpamContract` method using the code sandbox below:
-
 # Use Cases
 
 Here are some potential use cases for the `isSpamContract` method:

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-refreshcontract.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-refreshcontract.mdx
@@ -92,10 +92,6 @@ The commands for installing it using **npm** or **yarn** are given below:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `refreshContract` method using the code sandbox below:
-
 # Use Cases
 
 Here are some potential use cases for the `refreshContract` method:

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-refreshnftmetadata.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-refreshnftmetadata.mdx
@@ -88,10 +88,6 @@ The commands for installing it using **npm** or **yarn** are given below:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `refreshNftMetadata` method using the code sandbox below:
-
 # Use Cases
 
 Here are some potential use cases for the `refreshNftMetadata` method:

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-searchcontractmetadata.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-searchcontractmetadata.mdx
@@ -169,10 +169,6 @@ The commands for installing it using **npm** or **yarn** are given below:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `searchContractMetadata` method using the code sandbox below:
-
 # Use Cases
 
 Here are some potential use cases for the `searchContractMetadata` method:

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-send.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-send.mdx
@@ -136,10 +136,6 @@ Here is an example of how to make a `send` request using the Alchemy SDK:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `send` method using the code sandbox below:
-
 # Use Cases
 
 Here are some possible use cases for the `send` method:

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-sendtransaction.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-sendtransaction.mdx
@@ -119,10 +119,6 @@ The commands for installing it using **npm** or **yarn** are given below:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `sendTransaction` method using the code sandbox below:
-
 # Use Cases
 
 Here are some potential use cases for the `sendTransaction` method:

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-summarizenftattributes.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-summarizenftattributes.mdx
@@ -221,10 +221,6 @@ The commands for installing it using **npm** or **yarn** are given below:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `summarizeNftAttributes` method using the code sandbox below:
-
 # Use Cases
 
 Here is a potential use case for the `summarizeNftAttributes` method:

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-traceblock.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-traceblock.mdx
@@ -2002,10 +2002,6 @@ And here is an example of what a successful response to this request might look 
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test the `traceBlock` method using the code sandbox below:
-
 # Use Cases
 
 Here's a potential use case for `traceBlock`:

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-tracecall.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-tracecall.mdx
@@ -128,10 +128,6 @@ And here is an example of what a successful response to this request might look 
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test the `traceCall` method using the code sandbox below:
-
 # Use Cases
 
 Some of the use cases for `traceCall` are:

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-tracetransaction.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-tracetransaction.mdx
@@ -121,10 +121,6 @@ And here is an example of what a successful response to this request might look 
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test the `traceTransaction` method using the code sandbox below:
-
 # Use Cases
 
 Some of the use cases for `traceCall` are:

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-verifynftownership.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-verifynftownership.mdx
@@ -82,10 +82,6 @@ The commands for installing it using **npm** or **yarn** are given below:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `verifyNftOwnership` method using the code sandbox below:
-
 # Use Cases
 
 Here are some potential use cases for the `verifyNftOwnership` method:

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-waitfortransaction.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-waitfortransaction.mdx
@@ -127,10 +127,6 @@ The commands for installing it using **npm** or **yarn** are given below:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `waitForTransaction` method using the code sandbox below:
-
 # Use Cases
 
 Here are some potential use cases for the `waitForTransaction` method:

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/simulateassetchanges-sdk.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/simulateassetchanges-sdk.mdx
@@ -138,10 +138,6 @@ The commands for installing it using **npm** or **yarn** are given below:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `simulateAssestChanges` method using the code sandbox below:
-
 # Use Cases
 
 Here are some potential use cases for the `simulateAssetChanges` method:

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/simulateassetchangesbundle-sdk.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/simulateassetchangesbundle-sdk.mdx
@@ -125,10 +125,6 @@ The commands for installing it using **npm** or **yarn** are given below:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `simulateAssetChangesBundle` method using the code sandbox below:
-
 # Use Cases
 
 Here are some potential use cases for the `simulateAssetChangesBundle` method:

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/simulateexecution-sdk.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/simulateexecution-sdk.mdx
@@ -139,10 +139,6 @@ The commands for installing it using **npm** or **yarn** are given below:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `simulateExecution` method using the code sandbox below:
-
 # Use Cases
 
 Here are some potential use cases for the `simulateExecution` method:

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/simulateexecutionbundle-sdk.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/simulateexecutionbundle-sdk.mdx
@@ -143,10 +143,6 @@ The commands for installing it using **npm** or **yarn** are given below:
   ```
 </CodeGroup>
 
-## Code Sandbox
-
-You can test out the `simulateExecutionBundle` method using the code sandbox below:
-
 # Use Cases
 
 Here are some potential use cases for the `simulateExecutionBundle` method:


### PR DESCRIPTION
## Description

The embedded replits in docs are not being displayed and we concluded it’s safe to remove them as we include request/response examples on those pages anyway. This PR removes replits from those pages.

## Related Issues

[Embedded code sandbox replits not being displayed](https://www.notion.so/alchemotion/1d2069f20066807c99f8f463fc563cf3?v=1de069f20066804e9ff4000ca12bdbbd&p=1d5069f20066807bba47eb934d6429e5&pm=s)

## Testing

* \[x] I have tested these changes locally
* \[x] I have run the validation scripts (`pnpm run validate`)
* \[x] I have checked that the documentation builds correctly
