### PR TITLE
change links to aa sections on homepage

### DIFF
--- a/fern/home/index.mdx
+++ b/fern/home/index.mdx
@@ -74,7 +74,7 @@ hide-feedback: true
           Use our Node API to start reading and writing to the blockchain—scale infinitely.
         </Card>
 
-        <Card title="Onboard users" icon={<img src="https://fern-image-hosting.s3.us-east-1.amazonaws.com/alchemy/Account.svg" />} href="/docs/account-abstraction-overview">
+        <Card title="Onboard users" icon={<img src="https://fern-image-hosting.s3.us-east-1.amazonaws.com/alchemy/Account.svg" />} href="/wallets">
           Your complete toolkit to build embedded wallets—powered by smart accounts.
         </Card>
 
@@ -86,7 +86,7 @@ hide-feedback: true
           Ship faster with an onchain data API. Reduce data lag by 50%. Backfill data up to 5x faster.
         </Card>
 
-        <Card title="Cheaper, faster, safer transactions" icon={<img src="https://fern-image-hosting.s3.us-east-1.amazonaws.com/alchemy/Account.svg" />} href="/docs/account-abstraction-overview">
+        <Card title="Cheaper, faster, safer transactions" icon={<img src="https://fern-image-hosting.s3.us-east-1.amazonaws.com/alchemy/Account.svg" />} href="/wallets">
           Your complete toolkit to build embedded wallets—powered by smart accounts.
         </Card>
       </CardGroup>


### PR DESCRIPTION
## Description

Changes links to AA sections on homepage

## Related Issues

[Use case wallet links](https://www.notion.so/alchemotion/1d2069f20066807c99f8f463fc563cf3?v=1de069f20066804e9ff4000ca12bdbbd&p=1e4069f2006680b1a7b7fc9cccb168ac&pm=s)

## Testing

* \[x] I have run the validation scripts (`pnpm run validate`)
* \[x] I have checked that the documentation builds correctly
