### PR TITLE
add x-fern-parameters to all openrpc apis

### DIFF
--- a/build/api-specs/alchemy/json-rpc/bundler.json
+++ b/build/api-specs/alchemy/json-rpc/bundler.json
@@ -1,5 +1,17 @@
 {
 	"x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
+	"x-fern-parameters": [
+		{
+			"name": "apiKey",
+			"in": "path",
+			"schema": {
+				"type": "string",
+				"default": "docs-demo",
+				"description": "For higher throughput, [create your own API key](https://alchemy.com/?a=docs-demo)"
+			},
+			"required": true
+		}
+	],
 	"$schema": "https://meta.open-rpc.org/",
 	"openrpc": "1.2.4",
 	"info": {

--- a/build/api-specs/alchemy/json-rpc/debug.json
+++ b/build/api-specs/alchemy/json-rpc/debug.json
@@ -1,5 +1,17 @@
 {
 	"x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
+	"x-fern-parameters": [
+		{
+			"name": "apiKey",
+			"in": "path",
+			"schema": {
+				"type": "string",
+				"default": "docs-demo",
+				"description": "For higher throughput, [create your own API key](https://alchemy.com/?a=docs-demo)"
+			},
+			"required": true
+		}
+	],
 	"$schema": "https://meta.open-rpc.org/",
 	"openrpc": "1.2.4",
 	"info": {

--- a/build/api-specs/alchemy/json-rpc/gas-manager-coverage.json
+++ b/build/api-specs/alchemy/json-rpc/gas-manager-coverage.json
@@ -1,5 +1,17 @@
 {
 	"x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
+	"x-fern-parameters": [
+		{
+			"name": "apiKey",
+			"in": "path",
+			"schema": {
+				"type": "string",
+				"default": "docs-demo",
+				"description": "For higher throughput, [create your own API key](https://alchemy.com/?a=docs-demo)"
+			},
+			"required": true
+		}
+	],
 	"$schema": "https://meta.open-rpc.org/",
 	"openrpc": "1.2.4",
 	"info": {

--- a/build/api-specs/alchemy/json-rpc/gas-optimized-txns.json
+++ b/build/api-specs/alchemy/json-rpc/gas-optimized-txns.json
@@ -1,5 +1,17 @@
 {
 	"x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
+	"x-fern-parameters": [
+		{
+			"name": "apiKey",
+			"in": "path",
+			"schema": {
+				"type": "string",
+				"default": "docs-demo",
+				"description": "For higher throughput, [create your own API key](https://alchemy.com/?a=docs-demo)"
+			},
+			"required": true
+		}
+	],
 	"$schema": "https://meta.open-rpc.org/",
 	"openrpc": "1.2.4",
 	"info": {

--- a/build/api-specs/alchemy/json-rpc/private-api.json
+++ b/build/api-specs/alchemy/json-rpc/private-api.json
@@ -1,5 +1,17 @@
 {
 	"x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
+	"x-fern-parameters": [
+		{
+			"name": "apiKey",
+			"in": "path",
+			"schema": {
+				"type": "string",
+				"default": "docs-demo",
+				"description": "For higher throughput, [create your own API key](https://alchemy.com/?a=docs-demo)"
+			},
+			"required": true
+		}
+	],
 	"$schema": "https://meta.open-rpc.org/",
 	"openrpc": "1.2.4",
 	"info": {

--- a/build/api-specs/alchemy/json-rpc/token-api.json
+++ b/build/api-specs/alchemy/json-rpc/token-api.json
@@ -1,5 +1,17 @@
 {
 	"x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
+	"x-fern-parameters": [
+		{
+			"name": "apiKey",
+			"in": "path",
+			"schema": {
+				"type": "string",
+				"default": "docs-demo",
+				"description": "For higher throughput, [create your own API key](https://alchemy.com/?a=docs-demo)"
+			},
+			"required": true
+		}
+	],
 	"$schema": "https://meta.open-rpc.org/",
 	"openrpc": "1.2.4",
 	"info": {

--- a/build/api-specs/alchemy/json-rpc/trace.json
+++ b/build/api-specs/alchemy/json-rpc/trace.json
@@ -1,5 +1,17 @@
 {
 	"x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
+	"x-fern-parameters": [
+		{
+			"name": "apiKey",
+			"in": "path",
+			"schema": {
+				"type": "string",
+				"default": "docs-demo",
+				"description": "For higher throughput, [create your own API key](https://alchemy.com/?a=docs-demo)"
+			},
+			"required": true
+		}
+	],
 	"$schema": "https://meta.open-rpc.org/",
 	"openrpc": "1.2.4",
 	"info": {

--- a/build/api-specs/alchemy/json-rpc/transaction-simulation.json
+++ b/build/api-specs/alchemy/json-rpc/transaction-simulation.json
@@ -1,5 +1,17 @@
 {
 	"x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
+	"x-fern-parameters": [
+		{
+			"name": "apiKey",
+			"in": "path",
+			"schema": {
+				"type": "string",
+				"default": "docs-demo",
+				"description": "For higher throughput, [create your own API key](https://alchemy.com/?a=docs-demo)"
+			},
+			"required": true
+		}
+	],
 	"$schema": "https://meta.open-rpc.org/",
 	"openrpc": "1.2.4",
 	"info": {

--- a/build/api-specs/alchemy/json-rpc/transactions-receipt.json
+++ b/build/api-specs/alchemy/json-rpc/transactions-receipt.json
@@ -1,5 +1,17 @@
 {
 	"x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
+	"x-fern-parameters": [
+		{
+			"name": "apiKey",
+			"in": "path",
+			"schema": {
+				"type": "string",
+				"default": "docs-demo",
+				"description": "For higher throughput, [create your own API key](https://alchemy.com/?a=docs-demo)"
+			},
+			"required": true
+		}
+	],
 	"$schema": "https://meta.open-rpc.org/",
 	"openrpc": "1.2.4",
 	"info": {

--- a/build/api-specs/alchemy/json-rpc/transfers.json
+++ b/build/api-specs/alchemy/json-rpc/transfers.json
@@ -1,5 +1,17 @@
 {
 	"x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
+	"x-fern-parameters": [
+		{
+			"name": "apiKey",
+			"in": "path",
+			"schema": {
+				"type": "string",
+				"default": "docs-demo",
+				"description": "For higher throughput, [create your own API key](https://alchemy.com/?a=docs-demo)"
+			},
+			"required": true
+		}
+	],
 	"$schema": "https://meta.open-rpc.org/",
 	"openrpc": "1.2.4",
 	"info": {

--- a/build/api-specs/alchemy/json-rpc/userop-sim.json
+++ b/build/api-specs/alchemy/json-rpc/userop-sim.json
@@ -1,5 +1,17 @@
 {
 	"x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
+	"x-fern-parameters": [
+		{
+			"name": "apiKey",
+			"in": "path",
+			"schema": {
+				"type": "string",
+				"default": "docs-demo",
+				"description": "For higher throughput, [create your own API key](https://alchemy.com/?a=docs-demo)"
+			},
+			"required": true
+		}
+	],
 	"$schema": "https://meta.open-rpc.org/",
 	"openrpc": "1.2.4",
 	"info": {

--- a/build/api-specs/chains/abstract.json
+++ b/build/api-specs/chains/abstract.json
@@ -1,5 +1,17 @@
 {
 	"x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
+	"x-fern-parameters": [
+		{
+			"name": "apiKey",
+			"in": "path",
+			"schema": {
+				"type": "string",
+				"default": "docs-demo",
+				"description": "For higher throughput, [create your own API key](https://alchemy.com/?a=docs-demo)"
+			},
+			"required": true
+		}
+	],
 	"$schema": "https://meta.open-rpc.org/",
 	"openrpc": "1.2.4",
 	"info": {

--- a/build/api-specs/chains/apechain.json
+++ b/build/api-specs/chains/apechain.json
@@ -1,5 +1,17 @@
 {
 	"x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
+	"x-fern-parameters": [
+		{
+			"name": "apiKey",
+			"in": "path",
+			"schema": {
+				"type": "string",
+				"default": "docs-demo",
+				"description": "For higher throughput, [create your own API key](https://alchemy.com/?a=docs-demo)"
+			},
+			"required": true
+		}
+	],
 	"$schema": "https://meta.open-rpc.org/",
 	"openrpc": "1.2.4",
 	"info": {

--- a/build/api-specs/chains/arbitrum-nova.json
+++ b/build/api-specs/chains/arbitrum-nova.json
@@ -1,5 +1,17 @@
 {
 	"x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
+	"x-fern-parameters": [
+		{
+			"name": "apiKey",
+			"in": "path",
+			"schema": {
+				"type": "string",
+				"default": "docs-demo",
+				"description": "For higher throughput, [create your own API key](https://alchemy.com/?a=docs-demo)"
+			},
+			"required": true
+		}
+	],
 	"$schema": "https://meta.open-rpc.org/",
 	"openrpc": "1.2.4",
 	"info": {

--- a/build/api-specs/chains/arbitrum.json
+++ b/build/api-specs/chains/arbitrum.json
@@ -1,5 +1,17 @@
 {
 	"x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
+	"x-fern-parameters": [
+		{
+			"name": "apiKey",
+			"in": "path",
+			"schema": {
+				"type": "string",
+				"default": "docs-demo",
+				"description": "For higher throughput, [create your own API key](https://alchemy.com/?a=docs-demo)"
+			},
+			"required": true
+		}
+	],
 	"$schema": "https://meta.open-rpc.org/",
 	"openrpc": "1.2.4",
 	"info": {

--- a/build/api-specs/chains/astar.json
+++ b/build/api-specs/chains/astar.json
@@ -1,5 +1,17 @@
 {
 	"x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
+	"x-fern-parameters": [
+		{
+			"name": "apiKey",
+			"in": "path",
+			"schema": {
+				"type": "string",
+				"default": "docs-demo",
+				"description": "For higher throughput, [create your own API key](https://alchemy.com/?a=docs-demo)"
+			},
+			"required": true
+		}
+	],
 	"$schema": "https://meta.open-rpc.org/",
 	"openrpc": "1.2.4",
 	"info": {

--- a/build/api-specs/chains/avalanche.json
+++ b/build/api-specs/chains/avalanche.json
@@ -1,5 +1,17 @@
 {
 	"x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
+	"x-fern-parameters": [
+		{
+			"name": "apiKey",
+			"in": "path",
+			"schema": {
+				"type": "string",
+				"default": "docs-demo",
+				"description": "For higher throughput, [create your own API key](https://alchemy.com/?a=docs-demo)"
+			},
+			"required": true
+		}
+	],
 	"$schema": "https://meta.open-rpc.org/",
 	"openrpc": "1.2.4",
 	"info": {

--- a/build/api-specs/chains/base.json
+++ b/build/api-specs/chains/base.json
@@ -1,5 +1,17 @@
 {
 	"x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
+	"x-fern-parameters": [
+		{
+			"name": "apiKey",
+			"in": "path",
+			"schema": {
+				"type": "string",
+				"default": "docs-demo",
+				"description": "For higher throughput, [create your own API key](https://alchemy.com/?a=docs-demo)"
+			},
+			"required": true
+		}
+	],
 	"$schema": "https://meta.open-rpc.org/",
 	"openrpc": "1.2.4",
 	"info": {

--- a/build/api-specs/chains/berachain.json
+++ b/build/api-specs/chains/berachain.json
@@ -1,5 +1,17 @@
 {
 	"x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
+	"x-fern-parameters": [
+		{
+			"name": "apiKey",
+			"in": "path",
+			"schema": {
+				"type": "string",
+				"default": "docs-demo",
+				"description": "For higher throughput, [create your own API key](https://alchemy.com/?a=docs-demo)"
+			},
+			"required": true
+		}
+	],
 	"$schema": "https://meta.open-rpc.org/",
 	"openrpc": "1.2.4",
 	"info": {

--- a/build/api-specs/chains/blast.json
+++ b/build/api-specs/chains/blast.json
@@ -1,5 +1,17 @@
 {
 	"x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
+	"x-fern-parameters": [
+		{
+			"name": "apiKey",
+			"in": "path",
+			"schema": {
+				"type": "string",
+				"default": "docs-demo",
+				"description": "For higher throughput, [create your own API key](https://alchemy.com/?a=docs-demo)"
+			},
+			"required": true
+		}
+	],
 	"$schema": "https://meta.open-rpc.org/",
 	"openrpc": "1.2.4",
 	"info": {

--- a/build/api-specs/chains/bsc.json
+++ b/build/api-specs/chains/bsc.json
@@ -1,5 +1,17 @@
 {
 	"x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
+	"x-fern-parameters": [
+		{
+			"name": "apiKey",
+			"in": "path",
+			"schema": {
+				"type": "string",
+				"default": "docs-demo",
+				"description": "For higher throughput, [create your own API key](https://alchemy.com/?a=docs-demo)"
+			},
+			"required": true
+		}
+	],
 	"$schema": "https://meta.open-rpc.org/",
 	"openrpc": "1.2.4",
 	"info": {

--- a/build/api-specs/chains/celo.json
+++ b/build/api-specs/chains/celo.json
@@ -1,5 +1,17 @@
 {
 	"x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
+	"x-fern-parameters": [
+		{
+			"name": "apiKey",
+			"in": "path",
+			"schema": {
+				"type": "string",
+				"default": "docs-demo",
+				"description": "For higher throughput, [create your own API key](https://alchemy.com/?a=docs-demo)"
+			},
+			"required": true
+		}
+	],
 	"$schema": "https://meta.open-rpc.org/",
 	"openrpc": "1.2.4",
 	"info": {

--- a/build/api-specs/chains/crossfi.json
+++ b/build/api-specs/chains/crossfi.json
@@ -1,5 +1,17 @@
 {
 	"x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
+	"x-fern-parameters": [
+		{
+			"name": "apiKey",
+			"in": "path",
+			"schema": {
+				"type": "string",
+				"default": "docs-demo",
+				"description": "For higher throughput, [create your own API key](https://alchemy.com/?a=docs-demo)"
+			},
+			"required": true
+		}
+	],
 	"$schema": "https://meta.open-rpc.org/",
 	"openrpc": "1.2.4",
 	"info": {

--- a/build/api-specs/chains/eth.json
+++ b/build/api-specs/chains/eth.json
@@ -1,5 +1,17 @@
 {
 	"x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
+	"x-fern-parameters": [
+		{
+			"name": "apiKey",
+			"in": "path",
+			"schema": {
+				"type": "string",
+				"default": "docs-demo",
+				"description": "For higher throughput, [create your own API key](https://alchemy.com/?a=docs-demo)"
+			},
+			"required": true
+		}
+	],
 	"$schema": "https://meta.open-rpc.org/",
 	"openrpc": "1.2.4",
 	"info": {

--- a/build/api-specs/chains/flow.json
+++ b/build/api-specs/chains/flow.json
@@ -1,5 +1,17 @@
 {
 	"x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
+	"x-fern-parameters": [
+		{
+			"name": "apiKey",
+			"in": "path",
+			"schema": {
+				"type": "string",
+				"default": "docs-demo",
+				"description": "For higher throughput, [create your own API key](https://alchemy.com/?a=docs-demo)"
+			},
+			"required": true
+		}
+	],
 	"$schema": "https://meta.open-rpc.org/",
 	"openrpc": "1.2.4",
 	"info": {

--- a/build/api-specs/chains/geist.json
+++ b/build/api-specs/chains/geist.json
@@ -1,5 +1,17 @@
 {
 	"x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
+	"x-fern-parameters": [
+		{
+			"name": "apiKey",
+			"in": "path",
+			"schema": {
+				"type": "string",
+				"default": "docs-demo",
+				"description": "For higher throughput, [create your own API key](https://alchemy.com/?a=docs-demo)"
+			},
+			"required": true
+		}
+	],
 	"$schema": "https://meta.open-rpc.org/",
 	"openrpc": "1.2.4",
 	"info": {

--- a/build/api-specs/chains/gnosis.json
+++ b/build/api-specs/chains/gnosis.json
@@ -1,5 +1,17 @@
 {
 	"x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
+	"x-fern-parameters": [
+		{
+			"name": "apiKey",
+			"in": "path",
+			"schema": {
+				"type": "string",
+				"default": "docs-demo",
+				"description": "For higher throughput, [create your own API key](https://alchemy.com/?a=docs-demo)"
+			},
+			"required": true
+		}
+	],
 	"$schema": "https://meta.open-rpc.org/",
 	"openrpc": "1.2.4",
 	"info": {

--- a/build/api-specs/chains/ink.json
+++ b/build/api-specs/chains/ink.json
@@ -1,5 +1,17 @@
 {
 	"x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
+	"x-fern-parameters": [
+		{
+			"name": "apiKey",
+			"in": "path",
+			"schema": {
+				"type": "string",
+				"default": "docs-demo",
+				"description": "For higher throughput, [create your own API key](https://alchemy.com/?a=docs-demo)"
+			},
+			"required": true
+		}
+	],
 	"$schema": "https://meta.open-rpc.org/",
 	"openrpc": "1.2.4",
 	"info": {

--- a/build/api-specs/chains/lens.json
+++ b/build/api-specs/chains/lens.json
@@ -1,5 +1,17 @@
 {
 	"x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
+	"x-fern-parameters": [
+		{
+			"name": "apiKey",
+			"in": "path",
+			"schema": {
+				"type": "string",
+				"default": "docs-demo",
+				"description": "For higher throughput, [create your own API key](https://alchemy.com/?a=docs-demo)"
+			},
+			"required": true
+		}
+	],
 	"$schema": "https://meta.open-rpc.org/",
 	"openrpc": "1.2.4",
 	"info": {

--- a/build/api-specs/chains/linea.json
+++ b/build/api-specs/chains/linea.json
@@ -1,5 +1,17 @@
 {
 	"x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
+	"x-fern-parameters": [
+		{
+			"name": "apiKey",
+			"in": "path",
+			"schema": {
+				"type": "string",
+				"default": "docs-demo",
+				"description": "For higher throughput, [create your own API key](https://alchemy.com/?a=docs-demo)"
+			},
+			"required": true
+		}
+	],
 	"$schema": "https://meta.open-rpc.org/",
 	"openrpc": "1.2.4",
 	"info": {

--- a/build/api-specs/chains/lumia.json
+++ b/build/api-specs/chains/lumia.json
@@ -1,5 +1,17 @@
 {
 	"x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
+	"x-fern-parameters": [
+		{
+			"name": "apiKey",
+			"in": "path",
+			"schema": {
+				"type": "string",
+				"default": "docs-demo",
+				"description": "For higher throughput, [create your own API key](https://alchemy.com/?a=docs-demo)"
+			},
+			"required": true
+		}
+	],
 	"$schema": "https://meta.open-rpc.org/",
 	"openrpc": "1.2.4",
 	"info": {

--- a/build/api-specs/chains/mantle.json
+++ b/build/api-specs/chains/mantle.json
@@ -1,5 +1,17 @@
 {
 	"x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
+	"x-fern-parameters": [
+		{
+			"name": "apiKey",
+			"in": "path",
+			"schema": {
+				"type": "string",
+				"default": "docs-demo",
+				"description": "For higher throughput, [create your own API key](https://alchemy.com/?a=docs-demo)"
+			},
+			"required": true
+		}
+	],
 	"$schema": "https://meta.open-rpc.org/",
 	"openrpc": "1.2.4",
 	"info": {

--- a/build/api-specs/chains/metis.json
+++ b/build/api-specs/chains/metis.json
@@ -1,5 +1,17 @@
 {
 	"x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
+	"x-fern-parameters": [
+		{
+			"name": "apiKey",
+			"in": "path",
+			"schema": {
+				"type": "string",
+				"default": "docs-demo",
+				"description": "For higher throughput, [create your own API key](https://alchemy.com/?a=docs-demo)"
+			},
+			"required": true
+		}
+	],
 	"$schema": "https://meta.open-rpc.org/",
 	"openrpc": "1.2.4",
 	"info": {

--- a/build/api-specs/chains/monad.json
+++ b/build/api-specs/chains/monad.json
@@ -1,5 +1,17 @@
 {
 	"x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
+	"x-fern-parameters": [
+		{
+			"name": "apiKey",
+			"in": "path",
+			"schema": {
+				"type": "string",
+				"default": "docs-demo",
+				"description": "For higher throughput, [create your own API key](https://alchemy.com/?a=docs-demo)"
+			},
+			"required": true
+		}
+	],
 	"$schema": "https://meta.open-rpc.org/",
 	"openrpc": "1.2.4",
 	"info": {

--- a/build/api-specs/chains/opBNB.json
+++ b/build/api-specs/chains/opBNB.json
@@ -1,5 +1,17 @@
 {
 	"x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
+	"x-fern-parameters": [
+		{
+			"name": "apiKey",
+			"in": "path",
+			"schema": {
+				"type": "string",
+				"default": "docs-demo",
+				"description": "For higher throughput, [create your own API key](https://alchemy.com/?a=docs-demo)"
+			},
+			"required": true
+		}
+	],
 	"$schema": "https://meta.open-rpc.org/",
 	"openrpc": "1.2.4",
 	"info": {

--- a/build/api-specs/chains/optimism.json
+++ b/build/api-specs/chains/optimism.json
@@ -1,5 +1,17 @@
 {
 	"x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
+	"x-fern-parameters": [
+		{
+			"name": "apiKey",
+			"in": "path",
+			"schema": {
+				"type": "string",
+				"default": "docs-demo",
+				"description": "For higher throughput, [create your own API key](https://alchemy.com/?a=docs-demo)"
+			},
+			"required": true
+		}
+	],
 	"$schema": "https://meta.open-rpc.org/",
 	"openrpc": "1.2.4",
 	"info": {

--- a/build/api-specs/chains/polygon-zkevm.json
+++ b/build/api-specs/chains/polygon-zkevm.json
@@ -1,5 +1,17 @@
 {
 	"x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
+	"x-fern-parameters": [
+		{
+			"name": "apiKey",
+			"in": "path",
+			"schema": {
+				"type": "string",
+				"default": "docs-demo",
+				"description": "For higher throughput, [create your own API key](https://alchemy.com/?a=docs-demo)"
+			},
+			"required": true
+		}
+	],
 	"$schema": "https://meta.open-rpc.org/",
 	"openrpc": "1.2.4",
 	"info": {

--- a/build/api-specs/chains/polygon.json
+++ b/build/api-specs/chains/polygon.json
@@ -1,5 +1,17 @@
 {
 	"x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
+	"x-fern-parameters": [
+		{
+			"name": "apiKey",
+			"in": "path",
+			"schema": {
+				"type": "string",
+				"default": "docs-demo",
+				"description": "For higher throughput, [create your own API key](https://alchemy.com/?a=docs-demo)"
+			},
+			"required": true
+		}
+	],
 	"$schema": "https://meta.open-rpc.org/",
 	"openrpc": "1.2.4",
 	"info": {

--- a/build/api-specs/chains/rootstock.json
+++ b/build/api-specs/chains/rootstock.json
@@ -1,5 +1,17 @@
 {
 	"x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
+	"x-fern-parameters": [
+		{
+			"name": "apiKey",
+			"in": "path",
+			"schema": {
+				"type": "string",
+				"default": "docs-demo",
+				"description": "For higher throughput, [create your own API key](https://alchemy.com/?a=docs-demo)"
+			},
+			"required": true
+		}
+	],
 	"$schema": "https://meta.open-rpc.org/",
 	"openrpc": "1.2.4",
 	"info": {

--- a/build/api-specs/chains/scroll.json
+++ b/build/api-specs/chains/scroll.json
@@ -1,5 +1,17 @@
 {
 	"x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
+	"x-fern-parameters": [
+		{
+			"name": "apiKey",
+			"in": "path",
+			"schema": {
+				"type": "string",
+				"default": "docs-demo",
+				"description": "For higher throughput, [create your own API key](https://alchemy.com/?a=docs-demo)"
+			},
+			"required": true
+		}
+	],
 	"$schema": "https://meta.open-rpc.org/",
 	"openrpc": "1.2.4",
 	"info": {

--- a/build/api-specs/chains/sei.json
+++ b/build/api-specs/chains/sei.json
@@ -1,5 +1,17 @@
 {
 	"x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
+	"x-fern-parameters": [
+		{
+			"name": "apiKey",
+			"in": "path",
+			"schema": {
+				"type": "string",
+				"default": "docs-demo",
+				"description": "For higher throughput, [create your own API key](https://alchemy.com/?a=docs-demo)"
+			},
+			"required": true
+		}
+	],
 	"$schema": "https://meta.open-rpc.org/",
 	"openrpc": "1.2.4",
 	"info": {

--- a/build/api-specs/chains/shape.json
+++ b/build/api-specs/chains/shape.json
@@ -1,5 +1,17 @@
 {
 	"x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
+	"x-fern-parameters": [
+		{
+			"name": "apiKey",
+			"in": "path",
+			"schema": {
+				"type": "string",
+				"default": "docs-demo",
+				"description": "For higher throughput, [create your own API key](https://alchemy.com/?a=docs-demo)"
+			},
+			"required": true
+		}
+	],
 	"$schema": "https://meta.open-rpc.org/",
 	"openrpc": "1.2.4",
 	"info": {

--- a/build/api-specs/chains/solana.json
+++ b/build/api-specs/chains/solana.json
@@ -1,5 +1,17 @@
 {
 	"x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
+	"x-fern-parameters": [
+		{
+			"name": "apiKey",
+			"in": "path",
+			"schema": {
+				"type": "string",
+				"default": "docs-demo",
+				"description": "For higher throughput, [create your own API key](https://alchemy.com/?a=docs-demo)"
+			},
+			"required": true
+		}
+	],
 	"$schema": "https://meta.open-rpc.org/",
 	"openrpc": "1.2.4",
 	"info": {

--- a/build/api-specs/chains/soneium.json
+++ b/build/api-specs/chains/soneium.json
@@ -1,5 +1,17 @@
 {
 	"x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
+	"x-fern-parameters": [
+		{
+			"name": "apiKey",
+			"in": "path",
+			"schema": {
+				"type": "string",
+				"default": "docs-demo",
+				"description": "For higher throughput, [create your own API key](https://alchemy.com/?a=docs-demo)"
+			},
+			"required": true
+		}
+	],
 	"$schema": "https://meta.open-rpc.org/",
 	"openrpc": "1.2.4",
 	"info": {

--- a/build/api-specs/chains/sonic.json
+++ b/build/api-specs/chains/sonic.json
@@ -1,5 +1,17 @@
 {
 	"x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
+	"x-fern-parameters": [
+		{
+			"name": "apiKey",
+			"in": "path",
+			"schema": {
+				"type": "string",
+				"default": "docs-demo",
+				"description": "For higher throughput, [create your own API key](https://alchemy.com/?a=docs-demo)"
+			},
+			"required": true
+		}
+	],
 	"$schema": "https://meta.open-rpc.org/",
 	"openrpc": "1.2.4",
 	"info": {

--- a/build/api-specs/chains/starknet.json
+++ b/build/api-specs/chains/starknet.json
@@ -1,5 +1,17 @@
 {
 	"x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
+	"x-fern-parameters": [
+		{
+			"name": "apiKey",
+			"in": "path",
+			"schema": {
+				"type": "string",
+				"default": "docs-demo",
+				"description": "For higher throughput, [create your own API key](https://alchemy.com/?a=docs-demo)"
+			},
+			"required": true
+		}
+	],
 	"$schema": "https://meta.open-rpc.org/",
 	"openrpc": "1.2.4",
 	"info": {

--- a/build/api-specs/chains/unichain.json
+++ b/build/api-specs/chains/unichain.json
@@ -1,5 +1,17 @@
 {
 	"x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
+	"x-fern-parameters": [
+		{
+			"name": "apiKey",
+			"in": "path",
+			"schema": {
+				"type": "string",
+				"default": "docs-demo",
+				"description": "For higher throughput, [create your own API key](https://alchemy.com/?a=docs-demo)"
+			},
+			"required": true
+		}
+	],
 	"$schema": "https://meta.open-rpc.org/",
 	"openrpc": "1.2.4",
 	"info": {

--- a/build/api-specs/chains/worldchain.json
+++ b/build/api-specs/chains/worldchain.json
@@ -1,5 +1,17 @@
 {
 	"x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
+	"x-fern-parameters": [
+		{
+			"name": "apiKey",
+			"in": "path",
+			"schema": {
+				"type": "string",
+				"default": "docs-demo",
+				"description": "For higher throughput, [create your own API key](https://alchemy.com/?a=docs-demo)"
+			},
+			"required": true
+		}
+	],
 	"$schema": "https://meta.open-rpc.org/",
 	"openrpc": "1.2.4",
 	"info": {

--- a/build/api-specs/chains/zetachain.json
+++ b/build/api-specs/chains/zetachain.json
@@ -1,5 +1,17 @@
 {
 	"x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
+	"x-fern-parameters": [
+		{
+			"name": "apiKey",
+			"in": "path",
+			"schema": {
+				"type": "string",
+				"default": "docs-demo",
+				"description": "For higher throughput, [create your own API key](https://alchemy.com/?a=docs-demo)"
+			},
+			"required": true
+		}
+	],
 	"$schema": "https://meta.open-rpc.org/",
 	"openrpc": "1.2.4",
 	"info": {

--- a/build/api-specs/chains/zksync.json
+++ b/build/api-specs/chains/zksync.json
@@ -1,5 +1,17 @@
 {
 	"x-generated-warning": "⚠️ This file is auto-generated. Do not edit manually",
+	"x-fern-parameters": [
+		{
+			"name": "apiKey",
+			"in": "path",
+			"schema": {
+				"type": "string",
+				"default": "docs-demo",
+				"description": "For higher throughput, [create your own API key](https://alchemy.com/?a=docs-demo)"
+			},
+			"required": true
+		}
+	],
 	"$schema": "https://meta.open-rpc.org/",
 	"openrpc": "1.2.4",
 	"info": {

--- a/src/utils/generateRpcSpecs.ts
+++ b/src/utils/generateRpcSpecs.ts
@@ -33,6 +33,19 @@ export const generateChainRpcSpec = async (
   const doc: OpenrpcDocument = {
     "x-generated-warning":
       "⚠️ This file is auto-generated. Do not edit manually",
+    "x-fern-parameters": [
+      {
+        name: "apiKey",
+        in: "path",
+        schema: {
+          type: "string",
+          default: "docs-demo",
+          description:
+            "For higher throughput, [create your own API key](https://alchemy.com/?a=docs-demo)",
+        },
+        required: true,
+      },
+    ],
     $schema: "https://meta.open-rpc.org/",
     openrpc: "1.2.4",
     ...base,
@@ -69,6 +82,19 @@ export const generateAlchemyRpcSpec = async (
   const doc: OpenrpcDocument = {
     "x-generated-warning":
       "⚠️ This file is auto-generated. Do not edit manually",
+    "x-fern-parameters": [
+      {
+        name: "apiKey",
+        in: "path",
+        schema: {
+          type: "string",
+          default: "docs-demo",
+          description:
+            "For higher throughput, [create your own API key](https://alchemy.com/?a=docs-demo)",
+        },
+        required: true,
+      },
+    ],
     $schema: "https://meta.open-rpc.org/",
     openrpc: "1.2.4",
     ...base,


### PR DESCRIPTION
## Description

Modifies the generation script to add `x-fern-parameters` to all JSON-RPC APIs for adding default values to `apiKey`.

Check the proposal PR [here](https://github.com/alchemyplatform/docs/pull/165).

## Testing

* \[x] I have tested these changes locally
* \[x] I have run the validation scripts (`pnpm run validate`)
* \[x] I have checked that the documentation builds correctly