### PR TITLE
chore: use newdocs for custom domain subpath

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -2,7 +2,7 @@
 
 instances:
   - url: https://alchemy.docs.buildwithfern.com/docs
-    custom-domain: https://alchemy.com/docs
+    custom-domain: https://alchemy.com/newdocs
 
 layout:
   searchbar-placement: header


### PR DESCRIPTION
use `https://alchemy.com/newdocs` for custom domain for testing