### PR TITLE
chore: upgrade fern and remove dummy examples from playground

### DIFF
--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "alchemy",
-  "version": "0.59.4"
+  "version": "0.60.3"
 }


### PR DESCRIPTION
This PR improves default example generation in the docs to not include dummy examples. 