### PR TITLE
fix: upgrade fern to read `x-fern-parameters` from OpenRPC

### DIFF
--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "alchemy",
-  "version": "0.60.3"
+  "version": "0.60.4"
 }


### PR DESCRIPTION
Now the API playground will default the `api-key` to `docs-demo` for OpenRPC.