### PR TITLE
add google analytics tracking

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -2374,6 +2374,10 @@ navigation:
             api-name: monad
         slug: monad
 
+analytics:
+  ga4:
+    measurement-id: G-YFDX1WYK3N
+
 redirects:
   # ======================================= Dynamic Redirects ========================================
 


### PR DESCRIPTION
## Description
Adds Google Analytics  `measurement-id` to `docs.yml` for tracking as per [this](https://buildwithfern.com/learn/docs/integrations/analytics/google).

## Related Issues
[Add analytics to Fern Docs
](https://www.notion.so/alchemotion/1d2069f20066807c99f8f463fc563cf3?v=1de069f20066804e9ff4000ca12bdbbd&p=1eb069f2006680b5bfc0d06d25164c44&pm=s)

## Testing
* \[x] I have run the validation scripts (`pnpm run validate`)
* \[x] I have checked that the documentation builds correctly