### PR TITLE
fix paymasterstubdata wrong name

### DIFF
--- a/build/api-specs/alchemy/json-rpc/gas-manager-coverage.json
+++ b/build/api-specs/alchemy/json-rpc/gas-manager-coverage.json
@@ -1039,7 +1039,7 @@
 			]
 		},
 		{
-			"name": "pm_getPaymasterDataStub",
+			"name": "pm_getPaymasterStubData",
 			"description": "Returns stub values to be used in paymaster-related fields of an unsigned user operation for gas estimation. Accepts an unsigned user operation, an entrypoint address, a chain ID, and a context object.",
 			"params": [
 				{

--- a/src/openrpc/alchemy/gas-manager-coverage/methods.yaml
+++ b/src/openrpc/alchemy/gas-manager-coverage/methods.yaml
@@ -626,7 +626,7 @@
             paymaster: "0xfeed"
             paymasterData: "0x789abc"
 
-- name: "pm_getPaymasterDataStub"
+- name: "pm_getPaymasterStubData"
   description: "Returns stub values to be used in paymaster-related fields of an unsigned user operation for gas estimation. Accepts an unsigned user operation, an entrypoint address, a chain ID, and a context object."
   params:
     - name: "userOperation"


### PR DESCRIPTION
## Description
change the name of `pm_getPaymasterDataStub` to `pm_getPaymasterStubData` 

## Testing
* \[x] I have tested these changes locally
* \[x] I have run the validation scripts (`pnpm run validate`)
* \[x] I have checked that the documentation builds correctly