### PR TITLE
remove extra array from params in `alchemy_getTokenBalances`

### DIFF
--- a/build/api-specs/alchemy/json-rpc/token-api.json
+++ b/build/api-specs/alchemy/json-rpc/token-api.json
@@ -101,57 +101,58 @@
 			"description": "Returns ERC-20 token balances for a given address.",
 			"params": [
 				{
-					"name": "addressOrParams",
+					"name": "address",
 					"required": true,
-					"description": "A maximum of three parameters: 1) A 20-byte wallet address.   2) A token specification (the string \"erc20\", \"DEFAULT_TOKENS\" (deprecated), or an array of token contract addresses).   3) (Optional) an object containing pageKey/maxCount for pagination.\n",
+					"description": "A 20-byte wallet address.\n",
 					"schema": {
-						"type": "array",
-						"minItems": 1,
-						"maxItems": 3,
-						"items": {
-							"oneOf": [
-								{
+						"type": "string",
+						"title": "Address",
+						"default": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+					}
+				},
+				{
+					"name": "tokenSpec",
+					"required": false,
+					"description": "A token specification: - The string \"erc20\" - \"DEFAULT_TOKENS\" (deprecated) - An array of token contract addresses.\n",
+					"schema": {
+						"oneOf": [
+							{
+								"type": "string",
+								"title": "Token Specification",
+								"enum": [
+									"erc20",
+									"DEFAULT_TOKENS"
+								],
+								"default": "erc20"
+							},
+							{
+								"type": "array",
+								"title": "Array of Contract Addresses",
+								"items": {
 									"type": "string",
-									"title": "Address",
-									"default": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
-								},
-								{
-									"oneOf": [
-										{
-											"type": "string",
-											"title": "Token Specification",
-											"enum": [
-												"erc20",
-												"DEFAULT_TOKENS"
-											],
-											"default": "erc20"
-										},
-										{
-											"type": "array",
-											"title": "Array of Contract Addresses",
-											"items": {
-												"type": "string",
-												"pattern": "^0[xX][0-9a-fA-F]{40}$"
-											}
-										}
-									]
-								},
-								{
-									"type": "object",
-									"title": "Options",
-									"properties": {
-										"pageKey": {
-											"type": "string",
-											"description": "Used for pagination if more results are available."
-										},
-										"maxCount": {
-											"type": "integer",
-											"description": "Maximum number of token balances to return per call (capped at 100).",
-											"default": 100
-										}
-									}
+									"pattern": "^0[xX][0-9a-fA-F]{40}$"
 								}
-							]
+							}
+						]
+					}
+				},
+				{
+					"name": "options",
+					"required": false,
+					"description": "Optional pagination options.\n",
+					"schema": {
+						"type": "object",
+						"title": "Options",
+						"properties": {
+							"pageKey": {
+								"type": "string",
+								"description": "Used for pagination if more results are available."
+							},
+							"maxCount": {
+								"type": "integer",
+								"description": "Maximum number of token balances to return per call (capped at 100).",
+								"default": 100
+							}
 						}
 					}
 				}
@@ -199,12 +200,13 @@
 					"name": "Single token balance example",
 					"params": [
 						{
-							"name": "addressOrParams",
+							"name": "address",
+							"value": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+						},
+						{
+							"name": "tokenSpec",
 							"value": [
-								"0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
-								[
-									"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
-								]
+								"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
 							]
 						}
 					],

--- a/src/openrpc/alchemy/token-api/methods.yaml
+++ b/src/openrpc/alchemy/token-api/methods.yaml
@@ -44,45 +44,50 @@
 - name: alchemy_getTokenBalances
   description: Returns ERC-20 token balances for a given address.
   params:
-    - name: addressOrParams
+    - name: address
       required: true
       description: >
-        A maximum of three parameters:
-        1) A 20-byte wallet address.  
-        2) A token specification (the string "erc20", "DEFAULT_TOKENS" (deprecated), or an array of token contract addresses).  
-        3) (Optional) an object containing pageKey/maxCount for pagination.
+        A 20-byte wallet address.
       schema:
-        type: array
-        minItems: 1
-        maxItems: 3
-        items:
-          oneOf:
-            # param #1: address string
-            - type: string
-              title: Address
-              default: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
-            # param #2: token spec
-            - oneOf:
-                - type: string
-                  title: "Token Specification"
-                  enum: ["erc20", "DEFAULT_TOKENS"]
-                  default: "erc20"
-                - type: array
-                  title: "Array of Contract Addresses"
-                  items:
-                    type: string
-                    pattern: "^0[xX][0-9a-fA-F]{40}$"
-            # param #3: options
-            - type: object
-              title: "Options"
-              properties:
-                pageKey:
-                  type: string
-                  description: "Used for pagination if more results are available."
-                maxCount:
-                  type: integer
-                  description: "Maximum number of token balances to return per call (capped at 100)."
-                  default: 100
+        type: string
+        title: Address
+        default: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+
+    - name: tokenSpec
+      required: false
+      description: >
+        A token specification:
+        - The string "erc20"
+        - "DEFAULT_TOKENS" (deprecated)
+        - An array of token contract addresses.
+      schema:
+        oneOf:
+          - type: string
+            title: "Token Specification"
+            enum: ["erc20", "DEFAULT_TOKENS"]
+            default: "erc20"
+          - type: array
+            title: "Array of Contract Addresses"
+            items:
+              type: string
+              pattern: "^0[xX][0-9a-fA-F]{40}$"
+
+    - name: options
+      required: false
+      description: >
+        Optional pagination options.
+      schema:
+        type: object
+        title: "Options"
+        properties:
+          pageKey:
+            type: string
+            description: "Used for pagination if more results are available."
+          maxCount:
+            type: integer
+            description: "Maximum number of token balances to return per call (capped at 100)."
+            default: 100
+
   result:
     name: Token Balances
     description: An object containing the queried address and an array of token balance objects.
@@ -107,13 +112,15 @@
               error:
                 type: string
                 description: "Error message if something went wrong retrieving this token's balance; otherwise null."
+
   examples:
     - name: Single token balance example
       params:
-        - name: addressOrParams
+        - name: address
+          value: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+        - name: tokenSpec
           value:
-            - "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
-            - ["0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"]
+            - "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
       result:
         name: Token Balances
         value:


### PR DESCRIPTION
<img width="607" alt="image" src="https://github.com/user-attachments/assets/2a7b4c04-0e67-4050-82bc-0ff79c29c4ef" />

<img width="674" alt="image" src="https://github.com/user-attachments/assets/09bc9f70-f4f6-4637-b4a0-43c4652ed7cc" />


Now looks like this:

<img width="682" alt="image" src="https://github.com/user-attachments/assets/31b3f996-63e4-4533-95ac-deec6903930c" />
