### PR TITLE
fix eth logo on api reference overview page

### DIFF
--- a/fern/api-reference/introduction/api-overview.mdx
+++ b/fern/api-reference/introduction/api-overview.mdx
@@ -15,7 +15,7 @@ slug: reference/api-overview
 Alchemy supports both EVM and non-EVM chains, view API references below:
 
 <CardGroup cols={3}>
-  <Card title="Ethereum" icon={<img src="https://static.alchemyapi.io/images/docs/api_icon.svg" alt="Ethereum logo"/>} href="/reference/ethereum-api-quickstart">
+  <Card title="Ethereum" icon={<img src="https://static.alchemyapi.io/images/docs/api_icon.svg" alt="Ethereum logo" style={{width: "24px"}}/>} href="/reference/ethereum-api-quickstart">
     View Ethereum API reference.
   </Card>
   <Card title="Polygon PoS" icon={<img src="https://static.alchemyapi.io/images/docs/api_icon2.svg" alt="Polygon logo"/>} href="/reference/polygon-api-quickstart">


### PR DESCRIPTION
## Related Issues

[fix eth logo on api reference overview page](https://app.asana.com/1/1129441638109975/project/1208969177908960/task/1210230313978511)

## Testing

* \[x] I have tested these changes locally
* \[x] I have run the validation scripts (`pnpm run validate`)
* \[x] I have checked that the documentation builds correctly