### PR TITLE
add notes to `eth_getlogs` pages about block range limit for free tier

### DIFF
--- a/build/api-specs/chains/abstract.json
+++ b/build/api-specs/chains/abstract.json
@@ -2364,7 +2364,7 @@
 		},
 		{
 			"name": "eth_getLogs",
-			"description": "Returns an array of all logs matching the specified filter.",
+			"description": "Returns an array of all logs matching the specified filter.\n\n<Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>\n",
 			"params": [
 				{
 					"name": "Filter",

--- a/build/api-specs/chains/apechain.json
+++ b/build/api-specs/chains/apechain.json
@@ -2364,7 +2364,7 @@
 		},
 		{
 			"name": "eth_getLogs",
-			"description": "Returns an array of all logs matching the specified filter.",
+			"description": "Returns an array of all logs matching the specified filter.\n\n<Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>\n",
 			"params": [
 				{
 					"name": "Filter",

--- a/build/api-specs/chains/arbitrum-nova.json
+++ b/build/api-specs/chains/arbitrum-nova.json
@@ -2360,7 +2360,7 @@
 		},
 		{
 			"name": "eth_getLogs",
-			"description": "Returns an array of all logs matching the specified filter.",
+			"description": "Returns an array of all logs matching the specified filter.\n\n<Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>\n",
 			"params": [
 				{
 					"name": "Filter",

--- a/build/api-specs/chains/arbitrum.json
+++ b/build/api-specs/chains/arbitrum.json
@@ -3431,7 +3431,7 @@
 		},
 		{
 			"name": "eth_getLogs",
-			"description": "Returns an array of all logs matching the specified filter.",
+			"description": "Returns an array of all logs matching the specified filter.\n\n<Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>\n",
 			"params": [
 				{
 					"name": "Filter",

--- a/build/api-specs/chains/astar.json
+++ b/build/api-specs/chains/astar.json
@@ -3427,7 +3427,7 @@
 		},
 		{
 			"name": "eth_getLogs",
-			"description": "Returns an array of all logs matching the specified filter.",
+			"description": "Returns an array of all logs matching the specified filter.\n\n<Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>\n",
 			"params": [
 				{
 					"name": "Filter",

--- a/build/api-specs/chains/avalanche.json
+++ b/build/api-specs/chains/avalanche.json
@@ -2364,7 +2364,7 @@
 		},
 		{
 			"name": "eth_getLogs",
-			"description": "Returns an array of all logs matching the specified filter.",
+			"description": "Returns an array of all logs matching the specified filter.\n\n<Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>\n",
 			"params": [
 				{
 					"name": "Filter",

--- a/build/api-specs/chains/base.json
+++ b/build/api-specs/chains/base.json
@@ -3431,7 +3431,7 @@
 		},
 		{
 			"name": "eth_getLogs",
-			"description": "Returns an array of all logs matching the specified filter.",
+			"description": "Returns an array of all logs matching the specified filter.\n\n<Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>\n",
 			"params": [
 				{
 					"name": "Filter",

--- a/build/api-specs/chains/berachain.json
+++ b/build/api-specs/chains/berachain.json
@@ -2364,7 +2364,7 @@
 		},
 		{
 			"name": "eth_getLogs",
-			"description": "Returns an array of all logs matching the specified filter.",
+			"description": "Returns an array of all logs matching the specified filter.\n\n<Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>\n",
 			"params": [
 				{
 					"name": "Filter",

--- a/build/api-specs/chains/blast.json
+++ b/build/api-specs/chains/blast.json
@@ -2364,7 +2364,7 @@
 		},
 		{
 			"name": "eth_getLogs",
-			"description": "Returns an array of all logs matching the specified filter.",
+			"description": "Returns an array of all logs matching the specified filter.\n\n<Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>\n",
 			"params": [
 				{
 					"name": "Filter",

--- a/build/api-specs/chains/bsc.json
+++ b/build/api-specs/chains/bsc.json
@@ -2364,7 +2364,7 @@
 		},
 		{
 			"name": "eth_getLogs",
-			"description": "Returns an array of all logs matching the specified filter.",
+			"description": "Returns an array of all logs matching the specified filter.\n\n<Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>\n",
 			"params": [
 				{
 					"name": "Filter",

--- a/build/api-specs/chains/celo.json
+++ b/build/api-specs/chains/celo.json
@@ -3435,7 +3435,7 @@
 		},
 		{
 			"name": "eth_getLogs",
-			"description": "Returns an array of all logs matching the specified filter.",
+			"description": "Returns an array of all logs matching the specified filter.\n\n<Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>\n",
 			"params": [
 				{
 					"name": "Filter",

--- a/build/api-specs/chains/crossfi.json
+++ b/build/api-specs/chains/crossfi.json
@@ -2364,7 +2364,7 @@
 		},
 		{
 			"name": "eth_getLogs",
-			"description": "Returns an array of all logs matching the specified filter.",
+			"description": "Returns an array of all logs matching the specified filter.\n\n<Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>\n",
 			"params": [
 				{
 					"name": "Filter",

--- a/build/api-specs/chains/eth.json
+++ b/build/api-specs/chains/eth.json
@@ -3435,7 +3435,7 @@
 		},
 		{
 			"name": "eth_getLogs",
-			"description": "Returns an array of all logs matching the specified filter.",
+			"description": "Returns an array of all logs matching the specified filter.\n\n<Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>\n",
 			"params": [
 				{
 					"name": "Filter",

--- a/build/api-specs/chains/flow.json
+++ b/build/api-specs/chains/flow.json
@@ -2364,7 +2364,7 @@
 		},
 		{
 			"name": "eth_getLogs",
-			"description": "Returns an array of all logs matching the specified filter.",
+			"description": "Returns an array of all logs matching the specified filter.\n\n<Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>\n",
 			"params": [
 				{
 					"name": "Filter",

--- a/build/api-specs/chains/geist.json
+++ b/build/api-specs/chains/geist.json
@@ -2364,7 +2364,7 @@
 		},
 		{
 			"name": "eth_getLogs",
-			"description": "Returns an array of all logs matching the specified filter.",
+			"description": "Returns an array of all logs matching the specified filter.\n\n<Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>\n",
 			"params": [
 				{
 					"name": "Filter",

--- a/build/api-specs/chains/gnosis.json
+++ b/build/api-specs/chains/gnosis.json
@@ -2364,7 +2364,7 @@
 		},
 		{
 			"name": "eth_getLogs",
-			"description": "Returns an array of all logs matching the specified filter.",
+			"description": "Returns an array of all logs matching the specified filter.\n\n<Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>\n",
 			"params": [
 				{
 					"name": "Filter",

--- a/build/api-specs/chains/ink.json
+++ b/build/api-specs/chains/ink.json
@@ -2364,7 +2364,7 @@
 		},
 		{
 			"name": "eth_getLogs",
-			"description": "Returns an array of all logs matching the specified filter.",
+			"description": "Returns an array of all logs matching the specified filter.\n\n<Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>\n",
 			"params": [
 				{
 					"name": "Filter",

--- a/build/api-specs/chains/lens.json
+++ b/build/api-specs/chains/lens.json
@@ -2364,7 +2364,7 @@
 		},
 		{
 			"name": "eth_getLogs",
-			"description": "Returns an array of all logs matching the specified filter.",
+			"description": "Returns an array of all logs matching the specified filter.\n\n<Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>\n",
 			"params": [
 				{
 					"name": "Filter",

--- a/build/api-specs/chains/linea.json
+++ b/build/api-specs/chains/linea.json
@@ -2364,7 +2364,7 @@
 		},
 		{
 			"name": "eth_getLogs",
-			"description": "Returns an array of all logs matching the specified filter.",
+			"description": "Returns an array of all logs matching the specified filter.\n\n<Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>\n",
 			"params": [
 				{
 					"name": "Filter",

--- a/build/api-specs/chains/lumia.json
+++ b/build/api-specs/chains/lumia.json
@@ -2364,7 +2364,7 @@
 		},
 		{
 			"name": "eth_getLogs",
-			"description": "Returns an array of all logs matching the specified filter.",
+			"description": "Returns an array of all logs matching the specified filter.\n\n<Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>\n",
 			"params": [
 				{
 					"name": "Filter",

--- a/build/api-specs/chains/mantle.json
+++ b/build/api-specs/chains/mantle.json
@@ -2364,7 +2364,7 @@
 		},
 		{
 			"name": "eth_getLogs",
-			"description": "Returns an array of all logs matching the specified filter.",
+			"description": "Returns an array of all logs matching the specified filter.\n\n<Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>\n",
 			"params": [
 				{
 					"name": "Filter",

--- a/build/api-specs/chains/metis.json
+++ b/build/api-specs/chains/metis.json
@@ -2360,7 +2360,7 @@
 		},
 		{
 			"name": "eth_getLogs",
-			"description": "Returns an array of all logs matching the specified filter.",
+			"description": "Returns an array of all logs matching the specified filter.\n\n<Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>\n",
 			"params": [
 				{
 					"name": "Filter",

--- a/build/api-specs/chains/monad.json
+++ b/build/api-specs/chains/monad.json
@@ -3427,7 +3427,7 @@
 		},
 		{
 			"name": "eth_getLogs",
-			"description": "Returns an array of all logs matching the specified filter.",
+			"description": "Returns an array of all logs matching the specified filter.\n\n<Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>\n",
 			"params": [
 				{
 					"name": "Filter",

--- a/build/api-specs/chains/opBNB.json
+++ b/build/api-specs/chains/opBNB.json
@@ -2364,7 +2364,7 @@
 		},
 		{
 			"name": "eth_getLogs",
-			"description": "Returns an array of all logs matching the specified filter.",
+			"description": "Returns an array of all logs matching the specified filter.\n\n<Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>\n",
 			"params": [
 				{
 					"name": "Filter",

--- a/build/api-specs/chains/optimism.json
+++ b/build/api-specs/chains/optimism.json
@@ -3431,7 +3431,7 @@
 		},
 		{
 			"name": "eth_getLogs",
-			"description": "Returns an array of all logs matching the specified filter.",
+			"description": "Returns an array of all logs matching the specified filter.\n\n<Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>\n",
 			"params": [
 				{
 					"name": "Filter",

--- a/build/api-specs/chains/polygon-zkevm.json
+++ b/build/api-specs/chains/polygon-zkevm.json
@@ -3431,7 +3431,7 @@
 		},
 		{
 			"name": "eth_getLogs",
-			"description": "Returns an array of all logs matching the specified filter.",
+			"description": "Returns an array of all logs matching the specified filter.\n\n<Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>\n",
 			"params": [
 				{
 					"name": "Filter",

--- a/build/api-specs/chains/polygon.json
+++ b/build/api-specs/chains/polygon.json
@@ -3604,7 +3604,7 @@
 		},
 		{
 			"name": "eth_getLogs",
-			"description": "Returns an array of all logs matching the specified filter.",
+			"description": "Returns an array of all logs matching the specified filter.\n\n<Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>\n",
 			"params": [
 				{
 					"name": "Filter",

--- a/build/api-specs/chains/rootstock.json
+++ b/build/api-specs/chains/rootstock.json
@@ -2364,7 +2364,7 @@
 		},
 		{
 			"name": "eth_getLogs",
-			"description": "Returns an array of all logs matching the specified filter.",
+			"description": "Returns an array of all logs matching the specified filter.\n\n<Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>\n",
 			"params": [
 				{
 					"name": "Filter",

--- a/build/api-specs/chains/scroll.json
+++ b/build/api-specs/chains/scroll.json
@@ -2364,7 +2364,7 @@
 		},
 		{
 			"name": "eth_getLogs",
-			"description": "Returns an array of all logs matching the specified filter.",
+			"description": "Returns an array of all logs matching the specified filter.\n\n<Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>\n",
 			"params": [
 				{
 					"name": "Filter",

--- a/build/api-specs/chains/sei.json
+++ b/build/api-specs/chains/sei.json
@@ -3431,7 +3431,7 @@
 		},
 		{
 			"name": "eth_getLogs",
-			"description": "Returns an array of all logs matching the specified filter.",
+			"description": "Returns an array of all logs matching the specified filter.\n\n<Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>\n",
 			"params": [
 				{
 					"name": "Filter",

--- a/build/api-specs/chains/shape.json
+++ b/build/api-specs/chains/shape.json
@@ -2364,7 +2364,7 @@
 		},
 		{
 			"name": "eth_getLogs",
-			"description": "Returns an array of all logs matching the specified filter.",
+			"description": "Returns an array of all logs matching the specified filter.\n\n<Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>\n",
 			"params": [
 				{
 					"name": "Filter",

--- a/build/api-specs/chains/soneium.json
+++ b/build/api-specs/chains/soneium.json
@@ -2364,7 +2364,7 @@
 		},
 		{
 			"name": "eth_getLogs",
-			"description": "Returns an array of all logs matching the specified filter.",
+			"description": "Returns an array of all logs matching the specified filter.\n\n<Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>\n",
 			"params": [
 				{
 					"name": "Filter",

--- a/build/api-specs/chains/sonic.json
+++ b/build/api-specs/chains/sonic.json
@@ -2364,7 +2364,7 @@
 		},
 		{
 			"name": "eth_getLogs",
-			"description": "Returns an array of all logs matching the specified filter.",
+			"description": "Returns an array of all logs matching the specified filter.\n\n<Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>\n",
 			"params": [
 				{
 					"name": "Filter",

--- a/build/api-specs/chains/unichain.json
+++ b/build/api-specs/chains/unichain.json
@@ -2364,7 +2364,7 @@
 		},
 		{
 			"name": "eth_getLogs",
-			"description": "Returns an array of all logs matching the specified filter.",
+			"description": "Returns an array of all logs matching the specified filter.\n\n<Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>\n",
 			"params": [
 				{
 					"name": "Filter",

--- a/build/api-specs/chains/worldchain.json
+++ b/build/api-specs/chains/worldchain.json
@@ -2364,7 +2364,7 @@
 		},
 		{
 			"name": "eth_getLogs",
-			"description": "Returns an array of all logs matching the specified filter.",
+			"description": "Returns an array of all logs matching the specified filter.\n\n<Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>\n",
 			"params": [
 				{
 					"name": "Filter",

--- a/build/api-specs/chains/zetachain.json
+++ b/build/api-specs/chains/zetachain.json
@@ -2364,7 +2364,7 @@
 		},
 		{
 			"name": "eth_getLogs",
-			"description": "Returns an array of all logs matching the specified filter.",
+			"description": "Returns an array of all logs matching the specified filter.\n\n<Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>\n",
 			"params": [
 				{
 					"name": "Filter",

--- a/build/api-specs/chains/zksync.json
+++ b/build/api-specs/chains/zksync.json
@@ -3431,7 +3431,7 @@
 		},
 		{
 			"name": "eth_getLogs",
-			"description": "Returns an array of all logs matching the specified filter.",
+			"description": "Returns an array of all logs matching the specified filter.\n\n<Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>\n",
 			"params": [
 				{
 					"name": "Filter",

--- a/src/openrpc/chains/abstract/methods/filter.yaml
+++ b/src/openrpc/chains/abstract/methods/filter.yaml
@@ -1,5 +1,8 @@
 - name: eth_getLogs
-  description: Returns an array of all logs matching the specified filter.
+  description: |
+    Returns an array of all logs matching the specified filter.
+
+    <Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>
   params:
     - name: Filter
       required: true

--- a/src/openrpc/chains/apechain/methods/filter.yaml
+++ b/src/openrpc/chains/apechain/methods/filter.yaml
@@ -1,5 +1,8 @@
 - name: eth_getLogs
-  description: Returns an array of all logs matching the specified filter.
+  description: |
+    Returns an array of all logs matching the specified filter.
+
+    <Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>
   params:
     - name: Filter
       required: true

--- a/src/openrpc/chains/arbitrum-nova/methods/filter.yaml
+++ b/src/openrpc/chains/arbitrum-nova/methods/filter.yaml
@@ -1,5 +1,8 @@
 - name: eth_getLogs
-  description: Returns an array of all logs matching the specified filter.
+  description: |
+    Returns an array of all logs matching the specified filter.
+
+    <Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>
   params:
     - name: Filter
       required: true

--- a/src/openrpc/chains/arbitrum/methods/filter.yaml
+++ b/src/openrpc/chains/arbitrum/methods/filter.yaml
@@ -161,7 +161,10 @@
               - "0x04474795f5b996ff80cb47c148d4c5ccdbe09ef27551820caa9c2f8ed149cce3"
 
 - name: eth_getLogs
-  description: Returns an array of all logs matching the specified filter.
+  description: |
+    Returns an array of all logs matching the specified filter.
+
+    <Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>
   params:
     - name: Filter
       required: true

--- a/src/openrpc/chains/astar/methods/filter.yaml
+++ b/src/openrpc/chains/astar/methods/filter.yaml
@@ -161,7 +161,10 @@
               - "0x04474795f5b996ff80cb47c148d4c5ccdbe09ef27551820caa9c2f8ed149cce3"
 
 - name: eth_getLogs
-  description: Returns an array of all logs matching the specified filter.
+  description: |
+    Returns an array of all logs matching the specified filter.
+
+    <Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>
   params:
     - name: Filter
       required: true

--- a/src/openrpc/chains/avalanche/methods/filter.yaml
+++ b/src/openrpc/chains/avalanche/methods/filter.yaml
@@ -1,5 +1,8 @@
 - name: eth_getLogs
-  description: Returns an array of all logs matching the specified filter.
+  description: |
+    Returns an array of all logs matching the specified filter.
+
+    <Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>
   params:
     - name: Filter
       required: true

--- a/src/openrpc/chains/base/methods/filter.yaml
+++ b/src/openrpc/chains/base/methods/filter.yaml
@@ -161,7 +161,10 @@
               - "0x04474795f5b996ff80cb47c148d4c5ccdbe09ef27551820caa9c2f8ed149cce3"
 
 - name: eth_getLogs
-  description: Returns an array of all logs matching the specified filter.
+  description: |
+    Returns an array of all logs matching the specified filter.
+
+    <Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>
   params:
     - name: Filter
       required: true

--- a/src/openrpc/chains/berachain/methods/filter.yaml
+++ b/src/openrpc/chains/berachain/methods/filter.yaml
@@ -1,5 +1,8 @@
 - name: eth_getLogs
-  description: Returns an array of all logs matching the specified filter.
+  description: |
+    Returns an array of all logs matching the specified filter.
+
+    <Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>
   params:
     - name: Filter
       required: true

--- a/src/openrpc/chains/blast/methods/filter.yaml
+++ b/src/openrpc/chains/blast/methods/filter.yaml
@@ -1,5 +1,8 @@
 - name: eth_getLogs
-  description: Returns an array of all logs matching the specified filter.
+  description: |
+    Returns an array of all logs matching the specified filter.
+
+    <Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>
   params:
     - name: Filter
       required: true

--- a/src/openrpc/chains/bsc/methods/filter.yaml
+++ b/src/openrpc/chains/bsc/methods/filter.yaml
@@ -1,5 +1,8 @@
 - name: eth_getLogs
-  description: Returns an array of all logs matching the specified filter.
+  description: |
+    Returns an array of all logs matching the specified filter.
+
+    <Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>
   params:
     - name: Filter
       required: true

--- a/src/openrpc/chains/celo/methods/filter.yaml
+++ b/src/openrpc/chains/celo/methods/filter.yaml
@@ -161,7 +161,10 @@
               - "0x04474795f5b996ff80cb47c148d4c5ccdbe09ef27551820caa9c2f8ed149cce3"
 
 - name: eth_getLogs
-  description: Returns an array of all logs matching the specified filter.
+  description: |
+    Returns an array of all logs matching the specified filter.
+
+    <Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>
   params:
     - name: Filter
       required: true

--- a/src/openrpc/chains/crossfi/methods/filter.yaml
+++ b/src/openrpc/chains/crossfi/methods/filter.yaml
@@ -1,5 +1,8 @@
 - name: eth_getLogs
-  description: Returns an array of all logs matching the specified filter.
+  description: |
+    Returns an array of all logs matching the specified filter.
+
+    <Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>
   params:
     - name: Filter
       required: true

--- a/src/openrpc/chains/eth/methods/filter.yaml
+++ b/src/openrpc/chains/eth/methods/filter.yaml
@@ -161,7 +161,10 @@
               - "0x04474795f5b996ff80cb47c148d4c5ccdbe09ef27551820caa9c2f8ed149cce3"
 
 - name: eth_getLogs
-  description: Returns an array of all logs matching the specified filter.
+  description: |
+    Returns an array of all logs matching the specified filter.
+
+    <Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>
   params:
     - name: Filter
       required: true

--- a/src/openrpc/chains/flow/methods/filter.yaml
+++ b/src/openrpc/chains/flow/methods/filter.yaml
@@ -1,5 +1,8 @@
 - name: eth_getLogs
-  description: Returns an array of all logs matching the specified filter.
+  description: |
+    Returns an array of all logs matching the specified filter.
+
+    <Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>
   params:
     - name: Filter
       required: true

--- a/src/openrpc/chains/geist/methods/filter.yaml
+++ b/src/openrpc/chains/geist/methods/filter.yaml
@@ -1,5 +1,8 @@
 - name: eth_getLogs
-  description: Returns an array of all logs matching the specified filter.
+  description: |
+    Returns an array of all logs matching the specified filter.
+
+    <Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>
   params:
     - name: Filter
       required: true

--- a/src/openrpc/chains/gnosis/methods/filter.yaml
+++ b/src/openrpc/chains/gnosis/methods/filter.yaml
@@ -1,5 +1,8 @@
 - name: eth_getLogs
-  description: Returns an array of all logs matching the specified filter.
+  description: |
+    Returns an array of all logs matching the specified filter.
+
+    <Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>
   params:
     - name: Filter
       required: true

--- a/src/openrpc/chains/ink/methods/filter.yaml
+++ b/src/openrpc/chains/ink/methods/filter.yaml
@@ -1,5 +1,8 @@
 - name: eth_getLogs
-  description: Returns an array of all logs matching the specified filter.
+  description: |
+    Returns an array of all logs matching the specified filter.
+
+    <Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>
   params:
     - name: Filter
       required: true

--- a/src/openrpc/chains/lens/methods/filter.yaml
+++ b/src/openrpc/chains/lens/methods/filter.yaml
@@ -1,5 +1,8 @@
 - name: eth_getLogs
-  description: Returns an array of all logs matching the specified filter.
+  description: |
+    Returns an array of all logs matching the specified filter.
+
+    <Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>
   params:
     - name: Filter
       required: true

--- a/src/openrpc/chains/linea/methods/filter.yaml
+++ b/src/openrpc/chains/linea/methods/filter.yaml
@@ -1,5 +1,8 @@
 - name: eth_getLogs
-  description: Returns an array of all logs matching the specified filter.
+  description: |
+    Returns an array of all logs matching the specified filter.
+
+    <Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>
   params:
     - name: Filter
       required: true

--- a/src/openrpc/chains/lumia/methods/filter.yaml
+++ b/src/openrpc/chains/lumia/methods/filter.yaml
@@ -1,5 +1,8 @@
 - name: eth_getLogs
-  description: Returns an array of all logs matching the specified filter.
+  description: |
+    Returns an array of all logs matching the specified filter.
+
+    <Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>
   params:
     - name: Filter
       required: true

--- a/src/openrpc/chains/mantle/methods/filter.yaml
+++ b/src/openrpc/chains/mantle/methods/filter.yaml
@@ -1,5 +1,8 @@
 - name: eth_getLogs
-  description: Returns an array of all logs matching the specified filter.
+  description: |
+    Returns an array of all logs matching the specified filter.
+
+    <Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>
   params:
     - name: Filter
       required: true

--- a/src/openrpc/chains/metis/methods/filter.yaml
+++ b/src/openrpc/chains/metis/methods/filter.yaml
@@ -1,5 +1,8 @@
 - name: eth_getLogs
-  description: Returns an array of all logs matching the specified filter.
+  description: |
+    Returns an array of all logs matching the specified filter.
+
+    <Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>
   params:
     - name: Filter
       required: true

--- a/src/openrpc/chains/monad/methods/filter.yaml
+++ b/src/openrpc/chains/monad/methods/filter.yaml
@@ -161,7 +161,10 @@
               - "0x04474795f5b996ff80cb47c148d4c5ccdbe09ef27551820caa9c2f8ed149cce3"
 
 - name: eth_getLogs
-  description: Returns an array of all logs matching the specified filter.
+  description: |
+    Returns an array of all logs matching the specified filter.
+
+    <Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>
   params:
     - name: Filter
       required: true

--- a/src/openrpc/chains/opBNB/methods/filter.yaml
+++ b/src/openrpc/chains/opBNB/methods/filter.yaml
@@ -1,5 +1,8 @@
 - name: eth_getLogs
-  description: Returns an array of all logs matching the specified filter.
+  description: |
+    Returns an array of all logs matching the specified filter.
+
+    <Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>
   params:
     - name: Filter
       required: true

--- a/src/openrpc/chains/optimism/methods/filter.yaml
+++ b/src/openrpc/chains/optimism/methods/filter.yaml
@@ -161,7 +161,10 @@
               - "0x04474795f5b996ff80cb47c148d4c5ccdbe09ef27551820caa9c2f8ed149cce3"
 
 - name: eth_getLogs
-  description: Returns an array of all logs matching the specified filter.
+  description: |
+    Returns an array of all logs matching the specified filter.
+
+    <Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>
   params:
     - name: Filter
       required: true

--- a/src/openrpc/chains/polygon-zkevm/methods/filter.yaml
+++ b/src/openrpc/chains/polygon-zkevm/methods/filter.yaml
@@ -161,7 +161,10 @@
               - "0x04474795f5b996ff80cb47c148d4c5ccdbe09ef27551820caa9c2f8ed149cce3"
 
 - name: eth_getLogs
-  description: Returns an array of all logs matching the specified filter.
+  description: |
+    Returns an array of all logs matching the specified filter.
+
+    <Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>
   params:
     - name: Filter
       required: true

--- a/src/openrpc/chains/polygon/methods/filter.yaml
+++ b/src/openrpc/chains/polygon/methods/filter.yaml
@@ -161,7 +161,10 @@
               - "0x04474795f5b996ff80cb47c148d4c5ccdbe09ef27551820caa9c2f8ed149cce3"
 
 - name: eth_getLogs
-  description: Returns an array of all logs matching the specified filter.
+  description: |
+    Returns an array of all logs matching the specified filter.
+
+    <Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>
   params:
     - name: Filter
       required: true

--- a/src/openrpc/chains/rootstock/methods/filter.yaml
+++ b/src/openrpc/chains/rootstock/methods/filter.yaml
@@ -1,5 +1,8 @@
 - name: eth_getLogs
-  description: Returns an array of all logs matching the specified filter.
+  description: |
+    Returns an array of all logs matching the specified filter.
+
+    <Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>
   params:
     - name: Filter
       required: true

--- a/src/openrpc/chains/scroll/methods/filter.yaml
+++ b/src/openrpc/chains/scroll/methods/filter.yaml
@@ -1,5 +1,8 @@
 - name: eth_getLogs
-  description: Returns an array of all logs matching the specified filter.
+  description: |
+    Returns an array of all logs matching the specified filter.
+
+    <Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>
   params:
     - name: Filter
       required: true

--- a/src/openrpc/chains/sei/methods/filter.yaml
+++ b/src/openrpc/chains/sei/methods/filter.yaml
@@ -161,7 +161,10 @@
               - "0x04474795f5b996ff80cb47c148d4c5ccdbe09ef27551820caa9c2f8ed149cce3"
 
 - name: eth_getLogs
-  description: Returns an array of all logs matching the specified filter.
+  description: |
+    Returns an array of all logs matching the specified filter.
+
+    <Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>
   params:
     - name: Filter
       required: true

--- a/src/openrpc/chains/shape/methods/filter.yaml
+++ b/src/openrpc/chains/shape/methods/filter.yaml
@@ -1,5 +1,8 @@
 - name: eth_getLogs
-  description: Returns an array of all logs matching the specified filter.
+  description: |
+    Returns an array of all logs matching the specified filter.
+
+    <Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>
   params:
     - name: Filter
       required: true

--- a/src/openrpc/chains/soneium/methods/filter.yaml
+++ b/src/openrpc/chains/soneium/methods/filter.yaml
@@ -1,5 +1,8 @@
 - name: eth_getLogs
-  description: Returns an array of all logs matching the specified filter.
+  description: |
+    Returns an array of all logs matching the specified filter.
+
+    <Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>
   params:
     - name: Filter
       required: true

--- a/src/openrpc/chains/sonic/methods/filter.yaml
+++ b/src/openrpc/chains/sonic/methods/filter.yaml
@@ -1,5 +1,8 @@
 - name: eth_getLogs
-  description: Returns an array of all logs matching the specified filter.
+  description: |
+    Returns an array of all logs matching the specified filter.
+
+    <Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>
   params:
     - name: Filter
       required: true

--- a/src/openrpc/chains/unichain/methods/filter.yaml
+++ b/src/openrpc/chains/unichain/methods/filter.yaml
@@ -1,5 +1,8 @@
 - name: eth_getLogs
-  description: Returns an array of all logs matching the specified filter.
+  description: |
+    Returns an array of all logs matching the specified filter.
+
+    <Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>
   params:
     - name: Filter
       required: true

--- a/src/openrpc/chains/worldchain/methods/filter.yaml
+++ b/src/openrpc/chains/worldchain/methods/filter.yaml
@@ -1,5 +1,8 @@
 - name: eth_getLogs
-  description: Returns an array of all logs matching the specified filter.
+  description: |
+    Returns an array of all logs matching the specified filter.
+
+    <Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>
   params:
     - name: Filter
       required: true

--- a/src/openrpc/chains/zetachain/methods/filter.yaml
+++ b/src/openrpc/chains/zetachain/methods/filter.yaml
@@ -1,5 +1,8 @@
 - name: eth_getLogs
-  description: Returns an array of all logs matching the specified filter.
+  description: |
+    Returns an array of all logs matching the specified filter.
+
+    <Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>
   params:
     - name: Filter
       required: true

--- a/src/openrpc/chains/zksync/methods/filter.yaml
+++ b/src/openrpc/chains/zksync/methods/filter.yaml
@@ -161,7 +161,10 @@
               - "0x04474795f5b996ff80cb47c148d4c5ccdbe09ef27551820caa9c2f8ed149cce3"
 
 - name: eth_getLogs
-  description: Returns an array of all logs matching the specified filter.
+  description: |
+    Returns an array of all logs matching the specified filter.
+
+    <Note>Requests to `eth_getLogs` are limited to a maximum 500-block range for users on the Free Tier. For access to larger block ranges (up to 10,000 blocks), please upgrade to a paid plan (PAYG or Enterprise). </Note>
   params:
     - name: Filter
       required: true


### PR DESCRIPTION
## Description

https://alchemyinsights.slack.com/archives/C03306R8XTL/p1747076287018129

## Related Issues

[add notes to eth_getlogs pages about block range limit for free tier](https://app.asana.com/1/1129441638109975/project/1208969177908960/task/1210230825600803)

## Testing
* \[x] I have tested these changes locally
* \[x] I have run the validation scripts (`pnpm run validate`)
* \[x] I have checked that the documentation builds correctly
