### PR TITLE
chore: add codeowners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @alchemyplatform/devrel 
+* @alchemyplatform/docs 


### PR DESCRIPTION
## Description

Before this repo is made public we should have a codeowners file to ensure the people with most context on the project have final review on submissions.

## Changes Made

- Add codeowners file with docs team

## Testing


* \[x] I have tested these changes locally
* \[x] I have run the validation scripts (`pnpm run validate`)
* \[x] I have checked that the documentation builds correctly
