### PR TITLE
chore: upgrade to the latest version `0.61.17`

### DIFF
--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "alchemy",
-  "version": "0.61.17"
+  "version": "0.61.18"
 }


### PR DESCRIPTION
Upgrade to the latest version of the Fern CLI for OpenRPC conversion.