### PR TITLE
fix(docs): use display names for union naming

### DIFF
--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "alchemy",
-  "version": "0.61.18"
+  "version": "0.62.2"
 }


### PR DESCRIPTION
## Description

This PR fixes issue `oneOf variants not showing correct titles`

## Related Issues

https://docs.google.com/spreadsheets/d/1EtniEPHfK6IIc1jQ7JSVoPS-qCavMrjNIhY6iBX8T9M/edit?gid=0#gid=0 Row 9

## Changes Made

Upgrade Fern

