### PR TITLE
feat: update capabilities to use explicit parameters instead of context

### DIFF
--- a/fern/api-reference/smart-wallets/quickstart.mdx
+++ b/fern/api-reference/smart-wallets/quickstart.mdx
@@ -307,7 +307,7 @@ Sign the signature request from the owner key (used in step 1), then store the r
 
 ### 4. Prepare Calls With the Session Key
 
-With the session ID received in step 2 and the signature from step 3, we’re now ready to prepare some calls!  
+With the session ID received in step 2 and the signature from step 3, we’re now ready to prepare some calls!
 
 If you aren't using a session key, you can omit the "permissions" parameter in the capabilities object.
 
@@ -370,7 +370,7 @@ Note that the `type` field in the `signatureRequest` indicates the signature typ
 
 ### 6. Send the Prepared Calls!
 
-With the signature from step 5 and the `useropRequest` from step 4,  you’re good to go to send the call!
+With the signature from step 5 and the `useropRequest` from step 4, you’re good to go to send the call!
 
 If you are signing with the owner of the account and not a session key, you can omit the "permissions" parameter from the capabilities object.
 


### PR DESCRIPTION
Modified the description around "capabilities" to use the sessionId & signature without needing to concatenate them into a single "context." 