### PR TITLE
fix: fix incorrect statement in quickstart

### DIFF
--- a/fern/api-reference/smart-wallets/quickstart.mdx
+++ b/fern/api-reference/smart-wallets/quickstart.mdx
@@ -390,9 +390,6 @@ curl --request POST \
       "data": {...useropRequest},
       "chainId": "0xCHAIN_ID" // E.g. "0x66eee" for Arbitrum Sepolia
       "capabilities": {
-        "paymasterService": {
-            "policyId": GAS_MANAGER_POLICY_ID, // put your gas manager policy ID here
-        },
         "permissions": {
           "sessionId": 0xSESSION_ID,
           "signature": 0xPERMISSION_SIG,


### PR DESCRIPTION
If we provide a `capabilities` object in `wallet_sendPreparedCalls` we *MUST* provide permissions. Capabilities in that scenario should not include paymaster data, as it will just be ignored C.C. @jakehobbs 

