### PR TITLE
fix: fix incorrect signature type

### DIFF
--- a/fern/api-reference/smart-wallets/quickstart.mdx
+++ b/fern/api-reference/smart-wallets/quickstart.mdx
@@ -396,7 +396,7 @@ curl --request POST \
         }
       }
       "signature": {
-        "type": "secp256k1"
+        "type": "ecdsa"
         "signature": "0xUSEROP_SIGNATURE",
       }
     }


### PR DESCRIPTION
The type in sendPreparedCalls' signature field should be ecdsa, not secp256k1.