### PR TITLE
Reorder & rename Blast section

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -1982,7 +1982,7 @@ navigation:
                   api-reference/alchemy-sdk/sdk-v2-methods/sdk-getnftsforcontract.mdx
             slug: sdk-v2-methods
         slug: alchemy-sdk
-      - section: Blast API
+      - section: Blast RPC API
         contents:
           - page: Introduction to Blast
             path: api-reference/blast-api/introduction-to-blast.mdx


### PR DESCRIPTION
## Description

Reorder & rename Blast section

## Related Issues

(https://app.asana.com/1/1129441638109975/project/1209304302080475/task/1210400807082806)

## Changes Made

- Move Blast section up in the menu, just after Alchemy SDK
- Rename Blast section to Blast API
- Remove icons for a few Blast chains to keep consistency with the other entries

## Testing

* \[x] I have tested these changes locally
* \[x] I have run the validation scripts (`pnpm run validate`)
* \[x] I have checked that the documentation builds correctly
