### PR TITLE
Fix table of contents, moved JSON RPC method table to the top

### DIFF
--- a/fern/api-reference/pricing-resources/pricing/compute-unit-costs.mdx
+++ b/fern/api-reference/pricing-resources/pricing/compute-unit-costs.mdx
@@ -14,7 +14,7 @@ Build and scale apps with lower CU costs on key APIs
 # Table of Contents
 
 * [What are Compute Units](#what-are-compute-units)
-* [EVM API](/reference/compute-unit-costs#standard-evm-json--rpc-methods)
+* [EVM API](/reference/compute-unit-costs#standard-evm-json-rpc-methods)
 * [NFT API](/reference/compute-unit-costs#nft-api)
 * [Transfers API](/reference/compute-unit-costs#transfers-api)
 * [Token API](/reference/compute-unit-costs#token-api)
@@ -30,13 +30,13 @@ Build and scale apps with lower CU costs on key APIs
 * [Notify & Subscription APIs](/reference/compute-unit-costs#notify-and-subscription-apis)
 * [Error Codes](/reference/compute-unit-costs#compute-unit-cost-for-error-codes)
 
-# What are Compute Units?
+## What are Compute Units and Throughput Compute Units?
 
-Compute units (CUs) are the measure of the total computational resources your apps use on our platform. Different methods consume different amounts of CUs based on their complexity. For example, a lightweight query like `eth_blockNumber` uses fewer CUs than a more intensive query like `eth_getLogs`. For more details, please check out the [Compute Units](/reference/compute-units) page.
+For more details, please check out the [Compute Units](/reference/compute-units#what-are-compute-units) section.
 
-# What are Throughput Compute Units?
+## What are Throughput Compute Units?
 
-Throughput Compute Units define how often you can run the request within your throughput limits. For example, a 500 CU per second limit would be able to run 50 requests per second that cost 10 throughput CUs. The actual cost of the method is still reflected by the CU amount while the threshold CU allows you to increase the number of requests before you hit your rate limit. If there is no throughput CU listed, it defaults to the actual CU cost.
+For more details, please check out the [Throughput Compute Units](/reference/compute-units#what-are-throughput-compute-units) section.
 
 # Standard EVM JSON-RPC Methods
 

--- a/fern/api-reference/pricing-resources/pricing/compute-units.mdx
+++ b/fern/api-reference/pricing-resources/pricing/compute-units.mdx
@@ -23,3 +23,7 @@ Each application has reserved dedicated [Throughput](/reference/throughput), mea
 Since each request is weighted differently, we base this on the total compute units used rather than the number of requests. For example, if you send one eth\_blockNumber (10 CUs), two eth\_getLogs (75 CUs), and two eth\_call(26 CUs) requests in the same second, you will have a total of 212 CUPS. Note that even if your application limit is 200 CUPS, this throughput will likely be allowed still by the system.
 
 If you are experiencing throughput errors, or want create a more robust and reliable experience for your users, we recommend [implementing retries](/reference/throughput).
+
+# What are Throughput Compute Units?
+
+Throughput Compute Units define how often you can run the request within your throughput limits. For example, a 500 CU per second limit would be able to run 50 requests per second that cost 10 throughput CUs. The actual cost of the method is still reflected by the CU amount while the threshold CU allows you to increase the number of requests before you hit your rate limit. If there is no throughput CU listed, it defaults to the actual CU cost.


### PR DESCRIPTION
- made table of contents a bullet list instead of a paragraph of links
- fixed JSON RPC section page link
- brought JSON RPC table of prices to the highest view in the page

Based on Asana ticket here: https://app.asana.com/1/1129441638109975/project/1208969177908960/task/1210404554903691?focus=true