### PR TITLE
Fix: Optimism endpoints were incorrectly referencing opBNB

### DIFF
--- a/fern/api-reference/pricing-resources/pricing/compute-unit-costs.mdx
+++ b/fern/api-reference/pricing-resources/pricing/compute-unit-costs.mdx
@@ -13,7 +13,7 @@ Build and scale apps with lower CU costs on key APIs
 
 # Table of Contents
 
-* [What are Compute Units](#what-are-compute-units)
+* [What are Compute Units](#what-are-compute-units-and-throughput-compute-units)
 * [EVM API](/reference/compute-unit-costs#standard-evm-json-rpc-methods)
 * [NFT API](/reference/compute-unit-costs#nft-api)
 * [Transfers API](/reference/compute-unit-costs#transfers-api)

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -2066,7 +2066,7 @@ navigation:
                   api-reference/op-mainnet/op-mainnet-api-faq/optimism-error-codes.mdx
             slug: op-mainnet-api-faq
           - api: OP Mainnet API Endpoints
-            api-name: opBNB
+            api-name: optimism
         slug: op-mainnet
       - section: Base
         contents:

--- a/src/openrpc/chains/optimism/optimism.yaml
+++ b/src/openrpc/chains/optimism/optimism.yaml
@@ -7,9 +7,9 @@ info:
   description: A specification of the standard JSON-RPC methods for Optimism.
   version: 0.0.0
 servers:
-  - url: https://optimism-mainnet.g.alchemy.com/v2
+  - url: https://opt-mainnet.g.alchemy.com/v2
     name: Optimism Mainnet
-  - url: https://optimism-sepolia.g.alchemy.com/v2
+  - url: https://opt-sepolia.g.alchemy.com/v2
     name: Optimism Sepolia
 
 methods:


### PR DESCRIPTION
Optimism endpoints were showing the incorrect URL, using `opBNB` instead of correct `opt` precursor.

<img width="503" alt="image" src="https://github.com/user-attachments/assets/8102e96b-f572-4f07-a838-7751b1fa0156" />


DOC issue called out by @lsqproduction: https://alchemyinsights.slack.com/archives/C03306R8XTL/p1748978123792069