### PR TITLE
docs: add shell code snippets without specified lang

### DIFF
--- a/fern/api-reference/aptos/aptos-api-quickstart.mdx
+++ b/fern/api-reference/aptos/aptos-api-quickstart.mdx
@@ -108,7 +108,7 @@ To execute your script and make a request to the Aptos App, run:
 
 You should see a list of Aptos accounts (if any exist on your node or fullnode) outputted to your console. For example:
 
-```
+```shell
 [
   {
     "authentication_key": "0x...",

--- a/fern/api-reference/bitcoin/bitcoin-api-quickstart.mdx
+++ b/fern/api-reference/bitcoin/bitcoin-api-quickstart.mdx
@@ -112,7 +112,7 @@ To execute your script and make a request to the Bitcoin App, run:
 
 You should see the current block number on Bitcoin App (in hexadecimal format) outputted to your console:
 
-```
+```shell
 Current block height: 0x6d68e
 ```
 

--- a/fern/api-reference/sui/sui-api-quickstart.mdx
+++ b/fern/api-reference/sui/sui-api-quickstart.mdx
@@ -110,7 +110,7 @@ To execute your script and make a request to the Sui App, run:
 
 You should see the latest checkpoint sequence number on Sui App outputted to your console:
 
-```
+```shell
 Latest checkpoint sequence number: 1029433
 ```
 

--- a/fern/api-reference/superseed/superseed-api-quickstart.mdx
+++ b/fern/api-reference/superseed/superseed-api-quickstart.mdx
@@ -108,7 +108,7 @@ To execute your script and make a request to the Superseed App, run:
 
 You should see the current block number on Superseed App (in hexadecimal format) outputted to your console:
 
-```
+```shell
 Block Number: 0x6d68e
 ```
 


### PR DESCRIPTION
## Description

This fixes some lint warnings that are popping up in PRs.

## Changes Made

- add shell code snippets without specified lang

## Testing

<!-- Describe the tests that you ran to verify your changes -->

* \[x] I have tested these changes locally
* \[x] I have run the validation scripts (`pnpm run validate`)
* \[x] I have checked that the documentation builds correctly
