### PR TITLE
Fix: use \ to escape fern interpreting $ as italics in PAYG FAQ docs

### DIFF
--- a/fern/api-reference/pricing-resources/pricing-faq/pay-as-you-go-pricing-faq.mdx
+++ b/fern/api-reference/pricing-resources/pricing-faq/pay-as-you-go-pricing-faq.mdx
@@ -14,13 +14,13 @@ We firmly believe that costs shouldn’t be a barrier to building innovative app
 
 This FAQ answers what you need to know about our Pay As You Go plan.
 
-1. **What is Pay As You Go plan?** Pay As You Go is our new pricing plan. You only pay for what you use, with no platform fees. Rates start at $0.45 per million Compute Units and automatically decrease to $0.40 per million Compute Units after you hit 300M Compute Units.
+1. **What is Pay As You Go plan?** Pay As You Go is our new pricing plan. You only pay for what you use, with no platform fees. Rates start at \$0.45 per million Compute Units and automatically decrease to $0.40 per million Compute Units after you hit 300M Compute Units.
 
 2. **When is Pay As You Go plan available?** The new pricing plan launches on February 1st, 2025.
 
 3. **What does Pay As You Go plan include?** Check out [alchemy.com/pricing](http://alchemy.com/pricing) for full details.
 
-4. **How do I calculate my costs under the Pay As You Go plan?** $0.45 per million Compute Units until you hit 300M monthly Compute Units. After 300M, your rate drops to $0.40 per million Compute Units.
+4. **How do I calculate my costs under the Pay As You Go plan?** \$0.45 per million Compute Units until you hit 300M monthly Compute Units. After 300M, your rate drops to $0.40 per million Compute Units.
 
    ```text
    For an app using 120M Compute Units / month:
@@ -58,7 +58,7 @@ This FAQ answers what you need to know about our Pay As You Go plan.
    | Rate Limit (queries/sec) | 5    | 30            |
    | Stored Entities          | 100K | $25/M         |
 
-   We’re getting rid of the base fees and allotments from our prior plans. Starting Feb 1st, 2025, there’s a single, reduced rate for queries ($20/M) and stored entities ($25/M) to reflect exactly how much you’re using.
+   We’re getting rid of the base fees and allotments from our prior plans. Starting Feb 1st, 2025, there’s a single, reduced rate for queries (\$20/M) and stored entities (\$25/M) to reflect exactly how much you’re using.
 
    Check out [alchemy.com/pricing](http://alchemy.com/pricing) for full details.
 


### PR DESCRIPTION
DOCS ON CALL REQUEST: PAYG FAQ had broken markdown, with fern likely interpreting `$` as italics.

<img width="999" alt="image" src="https://github.com/user-attachments/assets/ae08f0ac-0087-4d93-a42a-23129acdce57" />