### PR TITLE
Docs on call: remove 404s from frontend tutorials section

### DIFF
--- a/fern/tutorials/welcome/web3-tutorials-overview/tutorials-overview.mdx
+++ b/fern/tutorials/welcome/web3-tutorials-overview/tutorials-overview.mdx
@@ -112,12 +112,7 @@ Learn how to work with libraries such as Ethers.js and Web3.js.
 
 Learn how to build beautiful web3 dapps with our front-end tutorials!
 
-* [How to Build "Buy Me a Coffee" DeFi dapp](/docs/how-to-build-buy-me-a-coffee-defi-dapp)
-* [How to Create an NFT Gallery](/docs/how-to-create-an-nft-gallery)
-* [How to Build a Staking Dapp](/docs/how-to-build-a-staking-dapp)
-* [How to Build an NFT Marketplace from Scratch](/docs/how-to-build-an-nft-marketplace-from-scratch)
-* [How to Build a Token Swap Dapp With 0x API](/docs/how-to-build-a-token-swap-dapp-with-0x-api)
-* [How to Create a Decentralized Twitter with Lens Protocol](/docs/how-to-create-a-decentralized-twitter-with-lens-protocol)
+* [Scaffold Alchemy Quickstart](/docs/scaffold-alchemy-quickstart)
 * [NFT Minter Tutorial: How to Create a Full Stack DApp](/docs/nft-minter)
 * [How to Build a Solana NFT Collection](/docs/how-to-build-a-solana-nft-collection)
 * [Integrating Historical Transaction Data into your dApp](/docs/integrating-historical-transaction-data-into-your-dapp)


### PR DESCRIPTION
Docs on call: Frontend section in docs was linking to docs that were removed during the migration. Removed the links.