### PR TITLE
Removing dead link and section from Scaffold Alchemy docs

### DIFF
--- a/fern/tutorials/scaffold-alchemy/scaffold-alchemy-quickstart.mdx
+++ b/fern/tutorials/scaffold-alchemy/scaffold-alchemy-quickstart.mdx
@@ -77,9 +77,3 @@ Visit your app on `http://localhost:3000`. You can interact with your smart cont
 * Edit the app config in `packages/nextjs/scaffold.config.ts`
 * Edit your smart contract test in:
   * `packages/hardhat/test` to run test use `yarn hardhat:test`
-
-***
-
-What’s Next
-
-* [Create Web3 Dapp Folder structure](/docs/cw3d-folder-structure)


### PR DESCRIPTION
Removing dead link and section from Scaffold Alchemy docs.

<img width="897" alt="image" src="https://github.com/user-attachments/assets/8b50a7f7-e3c6-46b7-80b1-3e1419876d52" />