### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -8,6 +8,8 @@ jobs:
   open-api-specs:
     name: OpenAPI Specs
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -20,6 +22,8 @@ jobs:
   rpc-specs:
     name: JSON-RPC Specs
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -31,6 +35,8 @@ jobs:
   lint:
     name: Lint Files
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/alchemyplatform/docs/security/code-scanning/7](https://github.com/alchemyplatform/docs/security/code-scanning/7)

To fix the issue, we will add a `permissions` block to the `fern-check` job to explicitly define the minimal permissions required. Since the job involves generating and validating API specs, it likely only needs read access to the repository contents. We will set `contents: read` as the permission for this job. This change ensures that the job does not have unnecessary write permissions, adhering to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
