### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -17,6 +17,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/alchemyplatform/docs/security/code-scanning/1](https://github.com/alchemyplatform/docs/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the `build` job to explicitly define the minimal permissions required. Since the `build` job only needs to read repository contents and upload artifacts, we will set `contents: read` as the permission. This ensures that the job does not have unnecessary write access to the repository or other resources.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
