### PR TITLE
ci: accommodate changes to aa-sdk integration

### DIFF
--- a/.github/actions/insert-wallets-tab/action.yml
+++ b/.github/actions/insert-wallets-tab/action.yml
@@ -19,6 +19,4 @@ runs:
     - name: Copy docs to workspace and insert into fern
       shell: bash
       run: |
-        mkdir -p fern/wallets
-        cp -r aa-sdk/docs/* fern/wallets
-        fern/wallets/scripts/insert-docs.sh
+        aa-sdk/docs/scripts/insert-docs.sh

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -67,8 +67,6 @@ js:
 
 experimental:
   openapi-parser-v3: true
-  mdx-components:
-    # Account Kit components are auto-generated here
 
 # TODO: is it possible to add a Font Awesome icon to a navbar-link?
 navbar-links:
@@ -1404,7 +1402,10 @@ navigation:
             slug: understanding-the-evm
         slug: web3-tutorials
 
-  # Account Kit docs are auto-generated here
+  - tab: wallets
+    layout:
+      - page: Wallets Placeholder
+        path: wallets/README.md
 
   - tab: rollups
     layout:

--- a/fern/wallets/README.md
+++ b/fern/wallets/README.md
@@ -1,1 +1,7 @@
+---
+title: Wallets Placeholder
+description: Learn about wallets and their integration with Alchemy.
+slug: docs/wallets
+---
+
 Account Kit documentation is maintained in the [aa-sdk repository](https://github.com/alchemyplatform/aa-sdk). See its [README](https://github.com/alchemyplatform/aa-sdk/blob/main/docs/README.md) for contribution guidelines.


### PR DESCRIPTION
## Description

I've made some major changes to the aa-sdk integration in order to make local builds there easier/more consistent. This requires some changes in the docs repo itself.

## Related Issues

https://app.asana.com/1/1129441638109975/project/1208969177908953/task/1210457427536112?focus=true

## Changes Made

- Removed unnecessary mdx-components section docs.yml
- Replace wallets comment in docs.yml with a placeholder that gets replaced during CI

## Testing

<!-- Describe the tests that you ran to verify your changes -->

* \[ ] I have tested these changes locally
* \[ ] I have run the validation scripts (`pnpm run validate`)
* \[ ] I have checked that the documentation builds correctly
