### PR TITLE
build: add experimental mdx custom components to fern docs.yml

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -67,6 +67,8 @@ js:
 
 experimental:
   openapi-parser-v3: true
+  mdx-components:
+    - wallets/components
 
 # TODO: is it possible to add a Font Awesome icon to a navbar-link?
 navbar-links:


### PR DESCRIPTION
## Description

React Native docs are down atm. I believe it's because the overview uses custom components. I had removed the `experimental: mdx-components` field from `docs.yml` because I didn't think we used any custom components anymore. I expected the build to fail if there was an issue, but it looks like the build succeeds but the individual pages fail. Re-adding this should fix the issue.

## Related Issues

[Slack thread](https://alchemyinsights.slack.com/archives/C08801YNZG9/p1750176991970909)

## Changes Made

- re-add experimental MDX components to fern docs.yml

## Testing

<!-- Describe the tests that you ran to verify your changes -->

* \[ ] I have tested these changes locally
* \[ ] I have run the validation scripts (`pnpm run validate`)
* \[ ] I have checked that the documentation builds correctly
