### PR TITLE
feat: change all redirects to permanent

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -2202,3292 +2202,4799 @@ redirects:
   # Remove the duplicate /docs from the url
   - source: "/docs/docs/:path*"
     destination: "/docs/:path*"
+    permanent: true
   - source: "/docs/node/smart-wallets/:path*"
     destination: "/docs/wallets/api/smart-wallets/:path*"
+    permanent: true
   - source: "/docs/node/gas-manager-admin-api/:path*"
     destination: "/docs/wallets/api/gas-manager-admin-api/:path*"
+    permanent: true
   - source: "/docs/node/bundler-api/:path*"
     destination: "/docs/wallets/api/bundler-api/:path*"
+    permanent: true
 
   # ========================================= Node Redirects =========================================
 
   # Ethereum
   - source: /reference/ethereum-api-endpoints
     destination: /docs/node/ethereum/ethereum-api-endpoints/eth-accounts
+    permanent: true
   - source: /reference/eth-accounts
     destination: /docs/node/ethereum/ethereum-api-endpoints/eth-accounts
+    permanent: true
   - source: /reference/eth-blocknumber
     destination: /docs/node/ethereum/ethereum-api-endpoints/eth-block-number
+    permanent: true
   - source: /reference/eth-call
     destination: /docs/node/ethereum/ethereum-api-endpoints/eth-call
+    permanent: true
   - source: /reference/eth-chainid
     destination: /docs/node/ethereum/ethereum-api-endpoints/eth-chain-id
+    permanent: true
   - source: /reference/eth-createaccesslist
     destination: /docs/node/ethereum/ethereum-api-endpoints/eth-create-access-list
+    permanent: true
   - source: /reference/eth-estimategas
     destination: /docs/node/ethereum/ethereum-api-endpoints/eth-estimate-gas
+    permanent: true
   - source: /reference/eth-feehistory
     destination: /docs/node/ethereum/ethereum-api-endpoints/eth-fee-history
+    permanent: true
   - source: /reference/eth-gasprice
     destination: /docs/node/ethereum/ethereum-api-endpoints/eth-gas-price
+    permanent: true
   - source: /reference/eth-getbalance
     destination: /docs/node/ethereum/ethereum-api-endpoints/eth-get-balance
+    permanent: true
   - source: /reference/eth-getblockbyhash
     destination: /docs/node/ethereum/ethereum-api-endpoints/eth-get-block-by-hash
+    permanent: true
   - source: /reference/eth-getblockbynumber
     destination: /docs/node/ethereum/ethereum-api-endpoints/eth-get-block-by-number
+    permanent: true
   - source: /reference/eth-getblockreceipts
     destination: /docs/node/ethereum/ethereum-api-endpoints/eth-get-block-receipts
+    permanent: true
   - source: /reference/eth-getblocktransactioncountbyhash
     destination: >-
       /docs/node/ethereum/ethereum-api-endpoints/eth-get-block-transaction-count-by-hash
+    permanent: true
   - source: /reference/eth-getblocktransactioncountbynumber
     destination: >-
       /docs/node/ethereum/ethereum-api-endpoints/eth-get-block-transaction-count-by-number
+    permanent: true
   - source: /reference/eth-getcode
     destination: /docs/node/ethereum/ethereum-api-endpoints/eth-get-code
+    permanent: true
   - source: /reference/eth-getfilterchanges-1
     destination: /docs/node/ethereum/ethereum-api-endpoints/eth-get-filter-changes
+    permanent: true
   - source: /reference/eth-getfilterlogs-1
     destination: /docs/node/ethereum/ethereum-api-endpoints/eth-get-filter-logs
+    permanent: true
   - source: /reference/eth-getlogs
     destination: /docs/node/ethereum/ethereum-api-endpoints/eth-get-logs
+    permanent: true
   - source: /reference/eth-getproof
     destination: /docs/node/ethereum/ethereum-api-endpoints/eth-get-proof
+    permanent: true
   - source: /reference/eth-getstorageat
     destination: /docs/node/ethereum/ethereum-api-endpoints/eth-get-storage-at
+    permanent: true
   - source: /reference/eth-gettransactionbyblockhashandindex
     destination: >-
       /docs/node/ethereum/ethereum-api-endpoints/eth-get-transaction-by-block-hash-and-index
+    permanent: true
   - source: /reference/eth-gettransactionbyblocknumberandindex
     destination: >-
       /docs/node/ethereum/ethereum-api-endpoints/eth-get-transaction-by-block-number-and-index
+    permanent: true
   - source: /reference/eth-gettransactionbyhash
     destination: /docs/node/ethereum/ethereum-api-endpoints/eth-get-transaction-by-hash
+    permanent: true
   - source: /reference/eth-gettransactioncount
     destination: /docs/node/ethereum/ethereum-api-endpoints/eth-get-transaction-count
+    permanent: true
   - source: /reference/eth-gettransactionreceipt
     destination: /docs/node/ethereum/ethereum-api-endpoints/eth-get-transaction-receipt
+    permanent: true
   - source: /reference/eth-getunclebyblockhashandindex
     destination: >-
       /docs/node/ethereum/ethereum-api-endpoints/eth-get-uncle-by-block-hash-and-index
+    permanent: true
   - source: /reference/eth-getunclebyblocknumberandindex
     destination: >-
       /docs/node/ethereum/ethereum-api-endpoints/eth-get-uncle-by-block-number-and-index
+    permanent: true
   - source: /reference/eth-getunclecountbyblockhash
     destination: >-
       /docs/node/ethereum/ethereum-api-endpoints/eth-get-uncle-count-by-block-hash
+    permanent: true
   - source: /reference/eth-getunclecountbyblocknumber
     destination: >-
       /docs/node/ethereum/ethereum-api-endpoints/eth-get-uncle-count-by-block-number
+    permanent: true
   - source: /reference/eth-maxpriorityfeepergas
     destination: /docs/node/ethereum/ethereum-api-endpoints/eth-max-priority-fee-per-gas
+    permanent: true
   - source: /reference/eth-newblockfilter-1
     destination: /docs/node/ethereum/ethereum-api-endpoints/eth-new-block-filter
+    permanent: true
   - source: /reference/eth-newfilter-1
     destination: /docs/node/ethereum/ethereum-api-endpoints/eth-new-filter
+    permanent: true
   - source: /reference/eth-newpendingtransactionfilter-1
     destination: >-
       /docs/node/ethereum/ethereum-api-endpoints/eth-new-pending-transaction-filter
+    permanent: true
   - source: /reference/eth-protocolversion
     destination: /docs/node/ethereum/ethereum-api-endpoints/eth-protocol-version
+    permanent: true
   - source: /reference/eth-sendrawtransaction
     destination: /docs/node/ethereum/ethereum-api-endpoints/eth-send-raw-transaction
+    permanent: true
   - source: /reference/eth-uninstallfilter-1
     destination: /docs/node/ethereum/ethereum-api-endpoints/eth-uninstall-filter
+    permanent: true
   - source: /reference/eth_simulatev1
     destination: /docs/node/ethereum/ethereum-api-endpoints/eth-simulate-v-1
+    permanent: true
   - source: /reference/net-listening
     destination: /docs/node/ethereum/ethereum-api-endpoints/net-listening
+    permanent: true
   - source: /reference/net-version
     destination: /docs/node/ethereum/ethereum-api-endpoints/net-version
+    permanent: true
   - source: /reference/web3-clientversion
     destination: /docs/node/ethereum/ethereum-api-endpoints/web-3-client-version
+    permanent: true
   - source: /reference/web3-sha3
     destination: /docs/node/ethereum/ethereum-api-endpoints/web-3-sha-3
+    permanent: true
 
   # Arbitrum
   - source: /reference/eth-accounts-arbitrum
     destination: /docs/node/arbitrum/arbitrum-api-endpoints/eth-accounts
+    permanent: true
   - source: /reference/eth-blocknumber-arbitrum
     destination: /docs/node/arbitrum/arbitrum-api-endpoints/eth-block-number
+    permanent: true
   - source: /reference/eth-call-arbitrum
     destination: /docs/node/arbitrum/arbitrum-api-endpoints/eth-call
+    permanent: true
   - source: /reference/eth-chainid-arbitrum
     destination: /docs/node/arbitrum/arbitrum-api-endpoints/eth-chain-id
+    permanent: true
   - source: /reference/eth-createaccesslist-arbitrum
     destination: /docs/node/arbitrum/arbitrum-api-endpoints/eth-create-access-list
+    permanent: true
   - source: /reference/eth-estimategas-arbitrum
     destination: /docs/node/arbitrum/arbitrum-api-endpoints/eth-estimate-gas
+    permanent: true
   - source: /reference/eth-feehistory-arbitrum
     destination: /docs/node/arbitrum/arbitrum-api-endpoints/eth-fee-history
+    permanent: true
   - source: /reference/eth-gasprice-arbitrum
     destination: /docs/node/arbitrum/arbitrum-api-endpoints/eth-gas-price
+    permanent: true
   - source: /reference/eth-getbalance-arbitrum
     destination: /docs/node/arbitrum/arbitrum-api-endpoints/eth-get-balance
+    permanent: true
   - source: /reference/eth-getblockbyhash-arbitrum
     destination: /docs/node/arbitrum/arbitrum-api-endpoints/eth-get-block-by-hash
+    permanent: true
   - source: /reference/eth-getblockbynumber-arbitrum
     destination: /docs/node/arbitrum/arbitrum-api-endpoints/eth-get-block-by-number
+    permanent: true
   - source: /reference/eth-getblockreceipts-arbitrum
     destination: /docs/node/arbitrum/arbitrum-api-endpoints/eth-get-block-receipts
+    permanent: true
   - source: /reference/eth-getblocktransactioncountbyhash-arbitrum
     destination: >-
       /docs/node/arbitrum/arbitrum-api-endpoints/eth-get-block-transaction-count-by-hash
+    permanent: true
   - source: /reference/eth-getblocktransactioncountbynumber-arbitrum
     destination: >-
       /docs/node/arbitrum/arbitrum-api-endpoints/eth-get-block-transaction-count-by-number
+    permanent: true
   - source: /reference/eth-getcode-arbitrum
     destination: /docs/node/arbitrum/arbitrum-api-endpoints/eth-get-code
+    permanent: true
   - source: /reference/eth-getfilterchanges-arbitrum
     destination: /docs/node/arbitrum/arbitrum-api-endpoints/eth-get-filter-changes
+    permanent: true
   - source: /reference/eth-getfilterlogs-arbitrum
     destination: /docs/node/arbitrum/arbitrum-api-endpoints/eth-get-filter-logs
+    permanent: true
   - source: /reference/eth-getlogs-arbitrum
     destination: /docs/node/arbitrum/arbitrum-api-endpoints/eth-get-logs
+    permanent: true
   - source: /reference/eth-getproof-arbitrum-1
     destination: /docs/node/arbitrum/arbitrum-api-endpoints/eth-get-proof
+    permanent: true
   - source: /reference/eth-getstorageat-arbitrum
     destination: /docs/node/arbitrum/arbitrum-api-endpoints/eth-get-storage-at
+    permanent: true
   - source: /reference/eth-gettransactionbyblockhashandindex-arbitrum
     destination: >-
       /docs/node/arbitrum/arbitrum-api-endpoints/eth-get-transaction-by-block-hash-and-index
+    permanent: true
   - source: /reference/eth-gettransactionbyblocknumberandindex-arbitrum-1
     destination: >-
       /docs/node/arbitrum/arbitrum-api-endpoints/eth-get-transaction-by-block-number-and-index
+    permanent: true
   - source: /reference/eth-gettransactionbyhash-arbitrum-1
     destination: /docs/node/arbitrum/arbitrum-api-endpoints/eth-get-transaction-by-hash
+    permanent: true
   - source: /reference/eth-gettransactioncount-arbitrum
     destination: /docs/node/arbitrum/arbitrum-api-endpoints/eth-get-transaction-count
+    permanent: true
   - source: /reference/eth-gettransactionreceipt-arbitrum-1
     destination: /docs/node/arbitrum/arbitrum-api-endpoints/eth-get-transaction-receipt
+    permanent: true
   - source: /reference/eth-getunclebyblockhashandindex-arbitrum
     destination: >-
       /docs/node/arbitrum/arbitrum-api-endpoints/eth-get-uncle-by-block-hash-and-index
+    permanent: true
   - source: /reference/eth-getunclebyblocknumberandindex-arbitrum
     destination: >-
       /docs/node/arbitrum/arbitrum-api-endpoints/eth-get-uncle-by-block-number-and-index
+    permanent: true
   - source: /reference/eth-getunclecountbyblockhash-arbitrum
     destination: >-
       /docs/node/arbitrum/arbitrum-api-endpoints/eth-get-uncle-count-by-block-hash
+    permanent: true
   - source: /reference/eth-getunclecountbyblocknumber-arbitrum
     destination: >-
       /docs/node/arbitrum/arbitrum-api-endpoints/eth-get-uncle-count-by-block-number
+    permanent: true
   - source: /reference/eth-maxpriorityfeepergas-arbitrum
     destination: /docs/node/arbitrum/arbitrum-api-endpoints/eth-max-priority-fee-per-gas
+    permanent: true
   - source: /reference/eth-newblockfilter-arbitrum
     destination: /docs/node/arbitrum/arbitrum-api-endpoints/eth-new-block-filter
+    permanent: true
   - source: /reference/eth-newfilter-arbitrum
     destination: /docs/node/arbitrum/arbitrum-api-endpoints/eth-new-filter
+    permanent: true
   - source: /reference/eth-newpendingtransactionfilter-arbitrum
     destination: >-
       /docs/node/arbitrum/arbitrum-api-endpoints/eth-new-pending-transaction-filter
+    permanent: true
   - source: /reference/eth-sendrawtransaction-arbitrum
     destination: /docs/node/arbitrum/arbitrum-api-endpoints/eth-send-raw-transaction
+    permanent: true
   - source: /reference/eth-uninstallfilter-arbitrum
     destination: /docs/node/arbitrum/arbitrum-api-endpoints/eth-uninstall-filter
+    permanent: true
   - source: /reference/net-listening-arbitrum
     destination: /docs/node/arbitrum/arbitrum-api-endpoints/net-listening
+    permanent: true
   - source: /reference/net-version-arbitrum
     destination: /docs/node/arbitrum/arbitrum-api-endpoints/net-version
+    permanent: true
   - source: /reference/web3-clientversion-arbitrum
     destination: /docs/node/arbitrum/arbitrum-api-endpoints/web-3-client-version
+    permanent: true
   - source: /reference/web3-sha3-arbitrum
     destination: /docs/node/arbitrum/arbitrum-api-endpoints/web-3-sha-3
+    permanent: true
   - source: /reference/arbitrum-api-endpoints
     destination: /docs/node/arbitrum/arbitrum-api-endpoints/eth-accounts
+    permanent: true
 
   # Optimism
   - source: /reference/optimism-api-endpoints
     destination: /docs/node/op-mainnet/op-mainnet-api-endpoints/eth-block-number
+    permanent: true
   - source: /reference/eth-accounts-optimism
     destination: /docs/node/op-mainnet/op-mainnet-api-endpoints/eth-call
+    permanent: true
   - source: /reference/eth-blocknumber-optimism
     destination: /docs/node/op-mainnet/op-mainnet-api-endpoints/eth-block-number
+    permanent: true
   - source: /reference/eth-call-optimism
     destination: /docs/node/op-mainnet/op-mainnet-api-endpoints/eth-call
+    permanent: true
   - source: /reference/eth-chainid-optimism
     destination: /docs/node/op-mainnet/op-mainnet-api-endpoints/eth-chain-id
+    permanent: true
   - source: /reference/eth-estimategas-optimism
     destination: /docs/node/op-mainnet/op-mainnet-api-endpoints/eth-estimate-gas
+    permanent: true
   - source: /reference/eth-gasprice-optimism
     destination: /docs/node/op-mainnet/op-mainnet-api-endpoints/eth-gas-price
+    permanent: true
   - source: /reference/eth-getbalance-optimism
     destination: /docs/node/op-mainnet/op-mainnet-api-endpoints/eth-get-balance
+    permanent: true
   - source: /reference/eth-getblockbyhash-optimism
     destination: /docs/node/op-mainnet/op-mainnet-api-endpoints/eth-get-block-by-hash
+    permanent: true
   - source: /reference/eth-getblockbynumber-optimism
     destination: /docs/node/op-mainnet/op-mainnet-api-endpoints/eth-get-block-by-number
+    permanent: true
   - source: /reference/eth-getblockreceipts-optimism
     destination: /docs/node/op-mainnet/op-mainnet-api-endpoints/eth-get-block-receipts
+    permanent: true
   - source: /reference/eth-getblocktransactioncountbyhash-optimism
     destination: >-
       /docs/node/op-mainnet/op-mainnet-api-endpoints/eth-get-block-transaction-count-by-hash
+    permanent: true
   - source: /reference/eth-getblocktransactioncountbynumber-optimism
     destination: >-
       /docs/node/op-mainnet/op-mainnet-api-endpoints/eth-get-block-transaction-count-by-number
+    permanent: true
   - source: /reference/eth-getcode-optimism
     destination: /docs/node/op-mainnet/op-mainnet-api-endpoints/eth-get-code
+    permanent: true
   - source: /reference/eth-getfilterchanges-optimism
     destination: /docs/node/op-mainnet/op-mainnet-api-endpoints/eth-get-filter-changes
+    permanent: true
   - source: /reference/eth-getfilterlogs-optimism
     destination: /docs/node/op-mainnet/op-mainnet-api-endpoints/eth-get-filter-logs
+    permanent: true
   - source: /reference/eth-getlogs-optimism
     destination: /docs/node/op-mainnet/op-mainnet-api-endpoints/eth-get-logs
+    permanent: true
   - source: /reference/eth-getproof-optimism-1
     destination: /docs/node/op-mainnet/op-mainnet-api-endpoints/eth-get-proof
+    permanent: true
   - source: /reference/eth-getstorageat-optimism
     destination: /docs/node/op-mainnet/op-mainnet-api-endpoints/eth-get-storage-at
+    permanent: true
   - source: /reference/eth-gettransactionbyblockhashandindex-optimism
     destination: >-
       /docs/node/op-mainnet/op-mainnet-api-endpoints/eth-get-transaction-by-block-hash-and-index
+    permanent: true
   - source: /reference/eth-gettransactionbyblocknumberandindex-optimism
     destination: >-
       /docs/node/op-mainnet/op-mainnet-api-endpoints/eth-get-transaction-by-block-number-and-index
+    permanent: true
   - source: /reference/eth-gettransactionbyhash-optimism
     destination: /docs/node/op-mainnet/op-mainnet-api-endpoints/eth-get-transaction-by-hash
+    permanent: true
   - source: /reference/eth-gettransactioncount-optimism
     destination: /docs/node/op-mainnet/op-mainnet-api-endpoints/eth-get-transaction-count
+    permanent: true
   - source: /reference/eth-gettransactionreceipt-optimism
     destination: /docs/node/op-mainnet/op-mainnet-api-endpoints/eth-get-transaction-receipt
+    permanent: true
   - source: /reference/eth-getunclebyblockhashandindex-optimism
     destination: >-
       /docs/node/op-mainnet/op-mainnet-api-endpoints/eth-get-uncle-by-block-hash-and-index
+    permanent: true
   - source: /reference/eth-getunclebyblocknumberandindex-optimism
     destination: >-
       /docs/node/op-mainnet/op-mainnet-api-endpoints/eth-get-uncle-by-block-number-and-index
+    permanent: true
   - source: /reference/eth-getunclecountbyblockhash-optimism
     destination: >-
       /docs/node/op-mainnet/op-mainnet-api-endpoints/eth-get-uncle-count-by-block-hash
+    permanent: true
   - source: /reference/eth-getunclecountbyblocknumber-optimism
     destination: >-
       /docs/node/op-mainnet/op-mainnet-api-endpoints/eth-get-uncle-count-by-block-number
+    permanent: true
   - source: /reference/eth-sendrawtransaction-optimism
     destination: /docs/node/op-mainnet/op-mainnet-api-endpoints/eth-send-raw-transaction
+    permanent: true
   - source: /reference/eth-syncing-optimism
     destination: /docs/node/op-mainnet/op-mainnet-api-endpoints/eth-syncing
+    permanent: true
   - source: /reference/net-listening-optimism-1
     destination: /docs/node/op-mainnet/op-mainnet-api-endpoints/net-listening
+    permanent: true
   - source: /reference/net-version-optimism-1
     destination: /docs/node/op-mainnet/op-mainnet-api-endpoints/net-version
+    permanent: true
   - source: /reference/web3-clientversion-optimism
     destination: /docs/node/op-mainnet/op-mainnet-api-endpoints/web-3-client-version
+    permanent: true
   - source: /reference/web3-sha3-optimism
     destination: /docs/node/op-mainnet/op-mainnet-api-endpoints/web-3-sha-3
+    permanent: true
   - source: /reference/eth-newblockfilter-optimism
     destination: /docs/node/op-mainnet/op-mainnet-api-endpoints/eth-new-block-filter
+    permanent: true
   - source: /reference/eth-newfilter-optimism
     destination: /docs/node/op-mainnet/op-mainnet-api-endpoints/eth-new-filter
+    permanent: true
   - source: /reference/eth-newpendingtransactionfilter-optimism
     destination: >-
       /docs/node/op-mainnet/op-mainnet-api-endpoints/eth-new-pending-transaction-filter
+    permanent: true
   - source: /reference/eth-protocolversion-optimism
     destination: /docs/node/op-mainnet/op-mainnet-api-endpoints/eth-protocol-version
+    permanent: true
   - source: /reference/eth-uninstallfilter-optimism-1
     destination: /docs/node/op-mainnet/op-mainnet-api-endpoints/eth-uninstall-filter
+    permanent: true
 
   # Polygon PoS
   - source: /reference/polygon-api-endpoints
     destination: /docs/node/polygon-pos/polygon-pos-api-endpoints/bor-get-author
+    permanent: true
   - source: /reference/eth-accounts-polygon
     destination: /docs/node/polygon-pos/polygon-pos-api-endpoints/eth-accounts
+    permanent: true
   - source: /reference/eth-blocknumber-polygon
     destination: /docs/node/polygon-pos/polygon-pos-api-endpoints/eth-block-number
+    permanent: true
   - source: /reference/eth-call-polygon
     destination: /docs/node/polygon-pos/polygon-pos-api-endpoints/eth-call
+    permanent: true
   - source: /reference/eth-chainid-polygon
     destination: /docs/node/polygon-pos/polygon-pos-api-endpoints/eth-chain-id
+    permanent: true
   - source: /reference/eth-createaccesslist-polygon
     destination: /docs/node/polygon-pos/polygon-pos-api-endpoints/eth-create-access-list
+    permanent: true
   - source: /reference/eth-estimategas-polygon
     destination: /docs/node/polygon-pos/polygon-pos-api-endpoints/eth-estimate-gas
+    permanent: true
   - source: /reference/eth-gasprice-polygon
     destination: /docs/node/polygon-pos/polygon-pos-api-endpoints/eth-gas-price
+    permanent: true
   - source: /reference/eth-getbalance-polygon
     destination: /docs/node/polygon-pos/polygon-pos-api-endpoints/eth-get-balance
+    permanent: true
   - source: /reference/eth-getblockbyhash-polygon
     destination: /docs/node/polygon-pos/polygon-pos-api-endpoints/eth-get-block-by-hash
+    permanent: true
   - source: /reference/eth-getblockbynumber-polygon
     destination: /docs/node/polygon-pos/polygon-pos-api-endpoints/eth-get-block-by-number
+    permanent: true
   - source: /reference/eth-getblockreceipts-polygon-pos
     destination: /docs/node/polygon-pos/polygon-pos-api-endpoints/eth-get-block-receipts
+    permanent: true
   - source: /reference/eth-getblocktransactioncountbyhash-polygon
     destination: >-
       /docs/node/polygon-pos/polygon-pos-api-endpoints/eth-get-block-transaction-count-by-hash
+    permanent: true
   - source: /reference/eth-getblocktransactioncountbynumber-polygon
     destination: >-
       /docs/node/polygon-pos/polygon-pos-api-endpoints/eth-get-block-transaction-count-by-number
+    permanent: true
   - source: /reference/eth-getcode-polygon
     destination: /docs/node/polygon-pos/polygon-pos-api-endpoints/eth-get-code
+    permanent: true
   - source: /reference/eth-getfilterchanges-polygon
     destination: /docs/node/polygon-pos/polygon-pos-api-endpoints/eth-get-filter-changes
+    permanent: true
   - source: /reference/eth-getfilterlogs-polygon
     destination: /docs/node/polygon-pos/polygon-pos-api-endpoints/eth-get-filter-logs
+    permanent: true
   - source: /reference/eth-getlogs-polygon
     destination: /docs/node/polygon-pos/polygon-pos-api-endpoints/eth-get-logs
+    permanent: true
   - source: /reference/eth-getproof-polygon-1
     destination: /docs/node/polygon-pos/polygon-pos-api-endpoints/eth-get-proof
+    permanent: true
   - source: /reference/eth-getroothash-polygon
     destination: /docs/node/polygon-pos/polygon-pos-api-endpoints/eth-get-root-hash
+    permanent: true
   - source: /reference/eth-getstorageat-polygon
     destination: /docs/node/polygon-pos/polygon-pos-api-endpoints/eth-get-storage-at
+    permanent: true
   - source: /reference/eth-gettransactionbyblockhashandindex-polygon
     destination: >-
       /docs/node/polygon-pos/polygon-pos-api-endpoints/eth-get-transaction-by-block-hash-and-index
+    permanent: true
   - source: /reference/eth-gettransactionbyblocknumberandindex-polygon
     destination: >-
       /docs/node/polygon-pos/polygon-pos-api-endpoints/eth-get-transaction-by-block-number-and-index
+    permanent: true
   - source: /reference/eth-gettransactionbyhash-polygon
     destination: >-
       /docs/node/polygon-pos/polygon-pos-api-endpoints/eth-get-transaction-by-hash
+    permanent: true
   - source: /reference/eth-gettransactioncount-polygon
     destination: /docs/node/polygon-pos/polygon-pos-api-endpoints/eth-get-transaction-count
+    permanent: true
   - source: /reference/eth-gettransactionreceipt-polygon
     destination: >-
       /docs/node/polygon-pos/polygon-pos-api-endpoints/eth-get-transaction-receipt
+    permanent: true
   - source: /reference/eth-gettransactionreceiptsbyblock-polygon
     destination: /docs/node/polygon-pos/polygon-pos-api-endpoints/eth-get-block-receipts
+    permanent: true
   - source: /reference/eth-getunclebyblocknumberandindex-polygon
     destination: >-
       /docs/node/polygon-pos/polygon-pos-api-endpoints/eth-get-uncle-by-block-number-and-index
+    permanent: true
   - source: /reference/eth-getunclecountbyblockhash-polygon
     destination: >-
       /docs/node/polygon-pos/polygon-pos-api-endpoints/eth-get-uncle-count-by-block-hash
+    permanent: true
   - source: /reference/eth-getunclecountbyblocknumber-polygon
     destination: >-
       /docs/node/polygon-pos/polygon-pos-api-endpoints/eth-get-uncle-count-by-block-number
+    permanent: true
   - source: /reference/eth-maxpriorityfeepergas-polygon
     destination: >-
       /docs/node/polygon-pos/polygon-pos-api-endpoints/eth-max-priority-fee-per-gas
+    permanent: true
   - source: /reference/eth-newblockfilter-polygon
     destination: /docs/node/polygon-pos/polygon-pos-api-endpoints/eth-new-block-filter
+    permanent: true
   - source: /reference/eth-newfilter-polygon
     destination: /docs/node/polygon-pos/polygon-pos-api-endpoints/eth-new-filter
+    permanent: true
   - source: /reference/eth-newpendingtransactionfilter-polygon
     destination: >-
       /docs/node/polygon-pos/polygon-pos-api-endpoints/eth-new-pending-transaction-filter
+    permanent: true
   - source: /reference/eth-sendrawtransaction-polygon
     destination: /docs/node/polygon-pos/polygon-pos-api-endpoints/eth-send-raw-transaction
+    permanent: true
   - source: /reference/eth-blocknumber-polygon-1
     destination: /docs/node/polygon-pos/polygon-pos-api-endpoints/net-version
+    permanent: true
   - source: /reference/web3-clientversion-polygon
     destination: /docs/node/polygon-pos/polygon-pos-api-endpoints/web-3-client-version
+    permanent: true
 
   # Polygon zkEVM
   - source: /reference/polygon-zkevm-endpoints
     destination: /docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-accounts
+    permanent: true
   - source: /reference/zkevm-estimatefee-polygon-zkevm
     destination: /docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/zkevm-batch-number
+    permanent: true
   - source: /reference/zkevm-estimategasprice-polygon-zkevm
     destination: /docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/zkevm-batch-number
+    permanent: true
   - source: /reference/zkevm-getbroadcasturi-polygon-zkevm
     destination: /docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/zkevm-batch-number
+    permanent: true
   - source: /reference/eth-blocknumber-polygon-zkevm
     destination: /docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-block-number
+    permanent: true
   - source: /reference/eth-call-polygon-zkevm
     destination: /docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-call
+    permanent: true
   - source: /reference/eth-chainid-polygon-zkevm
     destination: /docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-chain-id
+    permanent: true
   - source: /reference/eth-estimategas-polygon-zkevm
     destination: /docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-estimate-gas
+    permanent: true
   - source: /reference/eth-gasprice-polygon-zkevm
     destination: /docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-gas-price
+    permanent: true
   - source: /reference/eth-getbalance-polygon-zkevm
     destination: /docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-get-balance
+    permanent: true
   - source: /reference/eth-getblockbyhash-polygon-zkevm
     destination: /docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-get-block-by-hash
+    permanent: true
   - source: /reference/eth-getblockbynumber-polygon-zkevm
     destination: >-
       /docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-get-block-by-number
+    permanent: true
   - source: /reference/eth-getblocktransactioncountbyhash-polygon-zkevm
     destination: >-
       /docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-get-block-transaction-count-by-hash
+    permanent: true
   - source: /reference/eth-getblocktransactioncountbynumber-polygon-zkevm
     destination: >-
       /docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-get-block-transaction-count-by-number
+    permanent: true
   - source: /reference/eth-getcode-polygon-zkevm
     destination: /docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-get-code
+    permanent: true
   - source: /reference/eth-getcompilers-polygon-zkevm
     destination: /docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-get-code
+    permanent: true
   - source: /reference/eth-getfilterchanges-polygon-zkevm
     destination: >-
       /docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-get-filter-changes
+    permanent: true
   - source: /reference/eth-getfilterlogs-polygon-zkevm
     destination: /docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-get-filter-logs
+    permanent: true
   - source: /reference/eth-getlogs-polygon-zkevm
     destination: /docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-get-logs
+    permanent: true
   - source: /reference/eth-getstorageat-polygon-zkevm
     destination: /docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-get-storage-at
+    permanent: true
   - source: /reference/eth-gettransactionbyblockhashandindex-polygon-zkevm
     destination: >-
       /docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-get-transaction-by-block-hash-and-index
+    permanent: true
   - source: /reference/eth-gettransactionbyblocknumberandindex-polygon-zkevm
     destination: >-
       /docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-get-transaction-by-block-number-and-index
+    permanent: true
   - source: /reference/eth-gettransactionbyhash-polygon-zkevm
     destination: >-
       /docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-get-transaction-by-hash
+    permanent: true
   - source: /reference/eth-gettransactioncount-polygon-zkevm
     destination: >-
       /docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-get-transaction-count
+    permanent: true
   - source: /reference/eth-gettransactionreceipt-zkevm
     destination: >-
       /docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-get-transaction-receipt
+    permanent: true
   - source: /reference/eth-getunclebyblockhashandindex-polygon-zkevm
     destination: >-
       /docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-get-uncle-by-block-hash-and-index
+    permanent: true
   - source: /reference/eth-getunclebyblocknumberandindex-polygon-zkevm
     destination: >-
       /docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-get-uncle-by-block-number-and-index
+    permanent: true
   - source: /reference/eth-getunclecountbyblockhash-polygon-zkevm
     destination: >-
       /docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-get-uncle-count-by-block-hash
+    permanent: true
   - source: /reference/eth-getunclecountbyblocknumber-polygon-zkevm
     destination: >-
       /docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-get-uncle-count-by-block-number
+    permanent: true
   - source: /reference/eth-newblockfilter-polygon-zkevm
     destination: /docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-new-block-filter
+    permanent: true
   - source: /reference/eth-newfilter-polygon-zkevm
     destination: /docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-new-filter
+    permanent: true
   - source: /reference/eth-sendrawtransaction-polygon-zkevm
     destination: >-
       /docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-send-raw-transaction
+    permanent: true
   - source: /reference/eth-uninstallfilter-optimism-zkevm
     destination: /docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-uninstall-filter
+    permanent: true
   - source: /reference/net-version-polygon-zkevm
     destination: /docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/net-version
+    permanent: true
   - source: /reference/web3-clientversion-polygon-zkevm
     destination: /docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/web-3-client-version
+    permanent: true
   - source: /reference/zkevm-batchnumber-polygon-zkevm
     destination: /docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/zkevm-batch-number
+    permanent: true
   - source: /reference/zkevm-batchnumberbyblocknumber-polygon-zkevm-1
     destination: >-
       /docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/zkevm-batch-number-by-block-number
+    permanent: true
   - source: /reference/zkevm-consolidatedblocknumber-polygon-zkevm
     destination: >-
       /docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/zkevm-consolidated-block-number
+    permanent: true
   - source: /reference/zkevm-getbatchbynumber-polygon-zkevm
     destination: >-
       /docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/zkevm-get-batch-by-number
+    permanent: true
   - source: /reference/zkevm-isblockconsolidated-polygon-zkevm
     destination: >-
       /docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/zkevm-is-block-consolidated
+    permanent: true
   - source: /reference/zkevm-isblockvirtualized-polygon-zkevm
     destination: >-
       /docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/zkevm-is-block-virtualized
+    permanent: true
   - source: /reference/zkevm-verifiedbatchnumber-polygon-zkevm
     destination: >-
       /docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/zkevm-verified-batch-number
+    permanent: true
   - source: /reference/zkevm-virtualbatchnumber-polygon-zkevm
     destination: >-
       /docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/zkevm-virtual-batch-number
+    permanent: true
   - source: /reference/eth-protocolversion-polygon-zkevm
     destination: /docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-protocol-version
+    permanent: true
 
   # zkSync
   - source: /reference/zksync-api-endpoints
     destination: /docs/node/zksync/zk-sync-api-endpoints/eth-accounts
+    permanent: true
   - source: /reference/eth-accounts-zksync
     destination: /docs/node/zksync/zk-sync-api-endpoints/eth-accounts
+    permanent: true
   - source: /reference/eth-blocknumber-zksync
     destination: /docs/node/zksync/zk-sync-api-endpoints/eth-block-number
+    permanent: true
   - source: /reference/eth-call-zksync
     destination: /docs/node/zksync/zk-sync-api-endpoints/eth-call
+    permanent: true
   - source: /reference/eth-chainid-zksync
     destination: /docs/node/zksync/zk-sync-api-endpoints/eth-chain-id
+    permanent: true
   - source: /reference/eth-createaccesslist-zksync
     destination: /docs/node/zksync/zk-sync-api-endpoints/eth-create-access-list
+    permanent: true
   - source: /reference/eth-estimategas-zksync
     destination: /docs/node/zksync/zk-sync-api-endpoints/eth-estimate-gas
+    permanent: true
   - source: /reference/eth-feehistory-zksync
     destination: /docs/node/zksync/zk-sync-api-endpoints/eth-fee-history
+    permanent: true
   - source: /reference/eth-gasprice-zksync
     destination: /docs/node/zksync/zk-sync-api-endpoints/eth-gas-price
+    permanent: true
   - source: /reference/eth-getbalance-zksync
     destination: /docs/node/zksync/zk-sync-api-endpoints/eth-get-balance
+    permanent: true
   - source: /reference/eth-getblockbyhash-zksync
     destination: /docs/node/zksync/zk-sync-api-endpoints/eth-get-block-by-hash
+    permanent: true
   - source: /reference/eth-getblockbynumber-zksync
     destination: /docs/node/zksync/zk-sync-api-endpoints/eth-get-block-by-number
+    permanent: true
   - source: /reference/eth-getblockreceipts-zksync
     destination: /docs/node/zksync/zk-sync-api-endpoints/eth-get-block-receipts
+    permanent: true
   - source: /reference/eth-getblocktransactioncountbyhash-zksync
     destination: >-
       /docs/node/zksync/zk-sync-api-endpoints/eth-get-block-transaction-count-by-hash
+    permanent: true
   - source: /reference/eth-getblocktransactioncountbynumber-zksync
     destination: >-
       /docs/node/zksync/zk-sync-api-endpoints/eth-get-block-transaction-count-by-number
+    permanent: true
   - source: /reference/eth-getcode-zksync
     destination: /docs/node/zksync/zk-sync-api-endpoints/eth-get-code
+    permanent: true
   - source: /reference/eth-getfilterchanges-zksync
     destination: /docs/node/zksync/zk-sync-api-endpoints/eth-get-filter-changes
+    permanent: true
   - source: /reference/eth-getfilterlogs-zksync
     destination: /docs/node/zksync/zk-sync-api-endpoints/eth-get-filter-logs
+    permanent: true
   - source: /reference/eth-getlogs-zksync
     destination: /docs/node/zksync/zk-sync-api-endpoints/eth-get-logs
+    permanent: true
   - source: /reference/eth-getproof-zksync
     destination: /docs/node/zksync/zk-sync-api-endpoints/eth-get-proof
+    permanent: true
   - source: /reference/eth-getstorageat-zksync
     destination: /docs/node/zksync/zk-sync-api-endpoints/eth-get-storage-at
+    permanent: true
   - source: /reference/eth-gettransactionbyblockhashandindex-zksync
     destination: >-
       /docs/node/zksync/zk-sync-api-endpoints/eth-get-transaction-by-block-hash-and-index
+    permanent: true
   - source: /reference/eth-gettransactionbyblocknumberandindex-zksync
     destination: >-
       /docs/node/zksync/zk-sync-api-endpoints/eth-get-transaction-by-block-number-and-index
+    permanent: true
   - source: /reference/eth-gettransactionbyhash-zksync
     destination: /docs/node/zksync/zk-sync-api-endpoints/eth-get-transaction-by-hash
+    permanent: true
   - source: /reference/eth-gettransactioncount-zksync
     destination: /docs/node/zksync/zk-sync-api-endpoints/eth-get-transaction-count
+    permanent: true
   - source: /reference/eth-gettransactionreceipt-zksync
     destination: /docs/node/zksync/zk-sync-api-endpoints/eth-get-transaction-receipt
+    permanent: true
   - source: /reference/eth-getunclebyblockhashandindex-zksync
     destination: >-
       /docs/node/zksync/zk-sync-api-endpoints/eth-get-uncle-by-block-hash-and-index
+    permanent: true
   - source: /reference/eth-getunclebyblocknumberandindex-zksync
     destination: >-
       /docs/node/zksync/zk-sync-api-endpoints/eth-get-uncle-by-block-number-and-index
+    permanent: true
   - source: /reference/eth-getunclecountbyblockhash-zksync
     destination: /docs/node/zksync/zk-sync-api-endpoints/eth-get-uncle-count-by-block-hash
+    permanent: true
   - source: /reference/eth-getunclecountbyblocknumber-zksync
     destination: >-
       /docs/node/zksync/zk-sync-api-endpoints/eth-get-uncle-count-by-block-number
+    permanent: true
   - source: /reference/eth-newblockfilter-zksync
     destination: /docs/node/zksync/zk-sync-api-endpoints/eth-new-block-filter
+    permanent: true
   - source: /reference/eth-newfilter-zksync
     destination: /docs/node/zksync/zk-sync-api-endpoints/eth-new-filter
+    permanent: true
   - source: /reference/eth-newpendingtransactionfilter-zksync
     destination: /docs/node/zksync/zk-sync-api-endpoints/eth-new-pending-transaction-filter
+    permanent: true
   - source: /reference/eth-protocolversion-zksync
     destination: /docs/node/zksync/zk-sync-api-endpoints/eth-protocol-version
+    permanent: true
   - source: /reference/eth-sendrawtransaction-zksync
     destination: /docs/node/zksync/zk-sync-api-endpoints/eth-send-raw-transaction
+    permanent: true
   - source: /reference/eth-uninstallfilter-zksync
     destination: /docs/node/zksync/zk-sync-api-endpoints/eth-uninstall-filter
+    permanent: true
   - source: /reference/net-listening-zksync
     destination: /docs/node/zksync/zk-sync-api-endpoints/net-listening
+    permanent: true
   - source: /reference/net-version-zksync
     destination: /docs/node/zksync/zk-sync-api-endpoints/net-version
+    permanent: true
   - source: /reference/web3-clientversion-zksync
     destination: /docs/node/zksync/zk-sync-api-endpoints/web-3-client-version
+    permanent: true
   - source: /reference/web3-sha3-zksync
     destination: /docs/node/zksync/zk-sync-api-endpoints/web-3-sha-3
+    permanent: true
   - source: /reference/zks-estimatefee-zksync
     destination: /docs/node/zksync/zk-sync-api-endpoints/zks-estimate-fee
+    permanent: true
   - source: /reference/zks-estimategasl1tol2-zksync
     destination: /docs/node/zksync/zk-sync-api-endpoints/zks-estimate-gas-l-1-to-l-2
+    permanent: true
   - source: /reference/zks-getallaccountbalances-zksync
     destination: /docs/node/zksync/zk-sync-api-endpoints/zks-get-all-account-balances
+    permanent: true
   - source: /reference/zks-getblockdetails-zksync
     destination: /docs/node/zksync/zk-sync-api-endpoints/zks-get-block-details
+    permanent: true
   - source: /reference/zks-getbridgecontracts-zksync
     destination: /docs/node/zksync/zk-sync-api-endpoints/zks-get-bridge-contracts
+    permanent: true
   - source: /reference/zks-getbytecodebyhash-zksync
     destination: /docs/node/zksync/zk-sync-api-endpoints/zks-get-bytecode-by-hash
+    permanent: true
   - source: /reference/zks-getl1batchblockrange-zksync
     destination: /docs/node/zksync/zk-sync-api-endpoints/zks-get-l-1-batch-block-range
+    permanent: true
   - source: /reference/zks-getl1batchdetails-zksync
     destination: /docs/node/zksync/zk-sync-api-endpoints/zks-get-l-1-batch-details
+    permanent: true
   - source: /reference/zks-getl2tol1logproof-zksync
     destination: /docs/node/zksync/zk-sync-api-endpoints/zks-get-l-2-to-l-1-log-proof
+    permanent: true
   - source: /reference/zks-getl2tol1msgproof-zksync
     destination: /docs/node/zksync/zk-sync-api-endpoints/zks-get-l-2-to-l-1-msg-proof
+    permanent: true
   - source: /reference/zks-getmaincontract-zksync
     destination: /docs/node/zksync/zk-sync-api-endpoints/zks-get-main-contract
+    permanent: true
   - source: /reference/zks-getproof-zksync
     destination: /docs/node/zksync/zk-sync-api-endpoints/zks-get-proof
+    permanent: true
   - source: /reference/zks-getrawblocktransactions-zksync
     destination: /docs/node/zksync/zk-sync-api-endpoints/zks-get-raw-block-transactions
+    permanent: true
   - source: /reference/zks-gettestnetpaymaster-zksync
     destination: /docs/node/zksync/zk-sync-api-endpoints/zks-get-testnet-paymaster
+    permanent: true
   - source: /reference/zks-gettransactiondetails-zksync
     destination: /docs/node/zksync/zk-sync-api-endpoints/zks-get-transaction-details
+    permanent: true
   - source: /reference/zks-l1batchnumber-zksync
     destination: /docs/node/zksync/zk-sync-api-endpoints/zks-l-1-batch-number
+    permanent: true
   - source: /reference/zks-l1chainid-zksync
     destination: /docs/node/zksync/zk-sync-api-endpoints/zks-l-1-chain-id
+    permanent: true
 
   # Starknet
   - source: /reference/starknet-api-endpoints
     destination: /docs/node/starknet/starknet-api-endpoints/starknet-block-hash-and-number
+    permanent: true
   - source: /reference/starknet-adddeclaretransaction
     destination: >-
       /docs/node/starknet/starknet-api-endpoints/starknet-add-declare-transaction
+    permanent: true
   - source: /reference/starknet-adddeployaccounttransaction
     destination: >-
       /docs/node/starknet/starknet-api-endpoints/starknet-add-deploy-account-transaction
+    permanent: true
   - source: /reference/starknet-addinvoketransaction
     destination: /docs/node/starknet/starknet-api-endpoints/starknet-add-invoke-transaction
+    permanent: true
   - source: /reference/starknet-blockhashandnumber
     destination: /docs/node/starknet/starknet-api-endpoints/starknet-block-hash-and-number
+    permanent: true
   - source: /reference/starknet-blocknumber
     destination: /docs/node/starknet/starknet-api-endpoints/starknet-block-number
+    permanent: true
   - source: /reference/starknet-call
     destination: /docs/node/starknet/starknet-api-endpoints/starknet-call
+    permanent: true
   - source: /reference/starknet-chainid
     destination: /docs/node/starknet/starknet-api-endpoints/starknet-chain-id
+    permanent: true
   - source: /reference/starknet-estimatefee
     destination: /docs/node/starknet/starknet-api-endpoints/starknet-estimate-fee
+    permanent: true
   - source: /reference/starknet-estimatemessagefee
     destination: /docs/node/starknet/starknet-api-endpoints/starknet-estimate-message-fee
+    permanent: true
   - source: /reference/starknet-getblocktransactioncount
     destination: >-
       /docs/node/starknet/starknet-api-endpoints/starknet-get-block-transaction-count
+    permanent: true
   - source: /reference/starknet-getblockwithreceipts
     destination: >-
       /docs/node/starknet/starknet-api-endpoints/starknet-get-block-with-receipts
+    permanent: true
   - source: /reference/starknet-getblockwithtxhashes
     destination: >-
       /docs/node/starknet/starknet-api-endpoints/starknet-get-block-with-tx-hashes
+    permanent: true
   - source: /reference/starknet-getblockwithtxs
     destination: /docs/node/starknet/starknet-api-endpoints/starknet-get-block-with-txs
+    permanent: true
   - source: /reference/starknet-getclass
     destination: /docs/node/starknet/starknet-api-endpoints/starknet-get-class
+    permanent: true
   - source: /reference/starknet-getclassat
     destination: /docs/node/starknet/starknet-api-endpoints/starknet-get-class-at
+    permanent: true
   - source: /reference/starknet-getclasshashat
     destination: /docs/node/starknet/starknet-api-endpoints/starknet-get-class-hash-at
+    permanent: true
   - source: /reference/starknet-getevents
     destination: /docs/node/starknet/starknet-api-endpoints/starknet-get-events
+    permanent: true
   - source: /reference/starknet-getnonce
     destination: /docs/node/starknet/starknet-api-endpoints/starknet-get-nonce
+    permanent: true
   - source: /reference/starknet-getstateupdate
     destination: /docs/node/starknet/starknet-api-endpoints/starknet-get-state-update
+    permanent: true
   - source: /reference/starknet-getstorageat
     destination: /docs/node/starknet/starknet-api-endpoints/starknet-get-storage-at
+    permanent: true
   - source: /reference/starknet-gettransactionbyblockidandindex
     destination: >-
       /docs/node/starknet/starknet-api-endpoints/starknet-get-transaction-by-block-id-and-index
+    permanent: true
   - source: /reference/starknet-gettransactionbyhash
     destination: >-
       /docs/node/starknet/starknet-api-endpoints/starknet-get-transaction-by-hash
+    permanent: true
   - source: /reference/starknet-gettransactionreceipt
     destination: >-
       /docs/node/starknet/starknet-api-endpoints/starknet-get-transaction-receipt
+    permanent: true
   - source: /reference/starknet-pendingtransactions
     destination: /docs/node/starknet/starknet-api-endpoints/starknet-pending-transactions
+    permanent: true
   - source: /reference/starknet-syncing
     destination: /docs/node/starknet/starknet-api-endpoints/starknet-syncing
+    permanent: true
 
   # Solana
   - source: /reference/solana-api-endpoints
     destination: /docs/node/solana/solana-api-endpoints/get-account-info
+    permanent: true
   - source: /reference/getaccountinfo
     destination: /docs/node/solana/solana-api-endpoints/get-account-info
+    permanent: true
   - source: /reference/getbalance
     destination: /docs/node/solana/solana-api-endpoints/get-balance
+    permanent: true
   - source: /reference/getblock
     destination: /docs/node/solana/solana-api-endpoints/get-block
+    permanent: true
   - source: /reference/getblockcommitment
     destination: /docs/node/solana/solana-api-endpoints/get-block-commitment
+    permanent: true
   - source: /reference/getblockheight
     destination: /docs/node/solana/solana-api-endpoints/get-block-height
+    permanent: true
   - source: /reference/getblockproduction
     destination: /docs/node/solana/solana-api-endpoints/get-block-production
+    permanent: true
   - source: /reference/getblocktime
     destination: /docs/node/solana/solana-api-endpoints/get-block-time
+    permanent: true
   - source: /reference/getblocks
     destination: /docs/node/solana/solana-api-endpoints/get-blocks
+    permanent: true
   - source: /reference/getblockswithlimit
     destination: /docs/node/solana/solana-api-endpoints/get-blocks-with-limit
+    permanent: true
   - source: /reference/getclusternodes
     destination: /docs/node/solana/solana-api-endpoints/get-cluster-nodes
+    permanent: true
   - source: /reference/getepochinfo
     destination: /docs/node/solana/solana-api-endpoints/get-epoch-info
+    permanent: true
   - source: /reference/getepochschedule
     destination: /docs/node/solana/solana-api-endpoints/get-epoch-schedule
+    permanent: true
   - source: /reference/getfeeformessage
     destination: /docs/node/solana/solana-api-endpoints/get-fee-for-message
+    permanent: true
   - source: /reference/getfirstavailableblock
     destination: /docs/node/solana/solana-api-endpoints/get-first-available-block
+    permanent: true
   - source: /reference/getgenesishash
     destination: /docs/node/solana/solana-api-endpoints/get-genesis-hash
+    permanent: true
   - source: /reference/gethealth
     destination: /docs/node/solana/solana-api-endpoints/get-health
+    permanent: true
   - source: /reference/gethighestsnapshotslot
     destination: /docs/node/solana/solana-api-endpoints/get-highest-snapshot-slot
+    permanent: true
   - source: /reference/getidentity
     destination: /docs/node/solana/solana-api-endpoints/get-identity
+    permanent: true
   - source: /reference/getinflationgovernor
     destination: /docs/node/solana/solana-api-endpoints/get-inflation-governor
+    permanent: true
   - source: /reference/getinflationrate
     destination: /docs/node/solana/solana-api-endpoints/get-inflation-rate
+    permanent: true
   - source: /reference/getinflationreward
     destination: /docs/node/solana/solana-api-endpoints/get-inflation-reward
+    permanent: true
   - source: /reference/getlargestaccounts
     destination: /docs/node/solana/solana-api-endpoints/get-largest-accounts
+    permanent: true
   - source: /reference/getlatestblockhash
     destination: /docs/node/solana/solana-api-endpoints/get-latest-blockhash
+    permanent: true
   - source: /reference/getmaxretransmitslot
     destination: /docs/node/solana/solana-api-endpoints/get-max-retransmit-slot
+    permanent: true
   - source: /reference/getmaxshredinsertslot
     destination: /docs/node/solana/solana-api-endpoints/get-max-shred-insert-slot
+    permanent: true
   - source: /reference/getminimumbalanceforrentexemption
     destination: >-
       /docs/node/solana/solana-api-endpoints/get-minimum-balance-for-rent-exemption
+    permanent: true
   - source: /reference/getmultipleaccounts
     destination: /docs/node/solana/solana-api-endpoints/get-multiple-accounts
+    permanent: true
   - source: /reference/getprogramaccounts
     destination: /docs/node/solana/solana-api-endpoints/get-program-accounts
+    permanent: true
   - source: /reference/getrecentperformancesamples
     destination: /docs/node/solana/solana-api-endpoints/get-recent-performance-samples
+    permanent: true
   - source: /reference/getrecentprioritizationfees
     destination: /docs/node/solana/solana-api-endpoints/get-recent-prioritization-fees
+    permanent: true
   - source: /reference/getsignaturestatuses
     destination: /docs/node/solana/solana-api-endpoints/get-signature-statuses
+    permanent: true
   - source: /reference/getsignaturesforaddress
     destination: /docs/node/solana/solana-api-endpoints/get-signatures-for-address
+    permanent: true
   - source: /reference/getslot
     destination: /docs/node/solana/solana-api-endpoints/get-slot
+    permanent: true
   - source: /reference/getslotleader
     destination: /docs/node/solana/solana-api-endpoints/get-slot-leader
+    permanent: true
   - source: /reference/getslotleaders
     destination: /docs/node/solana/solana-api-endpoints/get-slot-leaders
+    permanent: true
   - source: /reference/getsupply
     destination: /docs/node/solana/solana-api-endpoints/get-supply
+    permanent: true
   - source: /reference/gettokenaccountbalance
     destination: /docs/node/solana/solana-api-endpoints/get-token-account-balance
+    permanent: true
   - source: /reference/gettokenaccountsbyowner
     destination: /docs/node/solana/solana-api-endpoints/get-token-accounts-by-owner
+    permanent: true
   - source: /reference/gettokensupply
     destination: /docs/node/solana/solana-api-endpoints/get-token-supply
+    permanent: true
   - source: /reference/gettransaction
     destination: /docs/node/solana/solana-api-endpoints/get-transaction
+    permanent: true
   - source: /reference/getversion
     destination: /docs/node/solana/solana-api-endpoints/get-version
+    permanent: true
   - source: /reference/getvoteaccounts
     destination: /docs/node/solana/solana-api-endpoints/get-vote-accounts
+    permanent: true
   - source: /reference/isblockhashvalid
     destination: /docs/node/solana/solana-api-endpoints/is-blockhash-valid
+    permanent: true
   - source: /reference/minimumledgerslot
     destination: /docs/node/solana/solana-api-endpoints/minimum-ledger-slot
+    permanent: true
   - source: /reference/requestairdrop
     destination: /docs/node/solana/solana-api-endpoints/request-airdrop
+    permanent: true
   - source: /reference/sendtransaction
     destination: /docs/node/solana/solana-api-endpoints/send-transaction
+    permanent: true
   - source: /reference/simulatetransaction
     destination: /docs/node/solana/solana-api-endpoints/simulate-transaction
+    permanent: true
   - source: /reference/getrecentblockhash
     destination: /docs/node/solana/solana-api-endpoints/get-recent-blockhash
+    permanent: true
 
   # Astar
   - source: /reference/eth-accounts-astar
     destination: /docs/node/astar/astar-api-endpoints/eth-accounts
+    permanent: true
   - source: /reference/eth-blocknumber-astar
     destination: /docs/node/astar/astar-api-endpoints/eth-block-number
+    permanent: true
   - source: /reference/eth-call-astar
     destination: /docs/node/astar/astar-api-endpoints/eth-call
+    permanent: true
   - source: /reference/eth-chainid-astar
     destination: /docs/node/astar/astar-api-endpoints/eth-chain-id
+    permanent: true
   - source: /reference/eth-estimategas-astar
     destination: /docs/node/astar/astar-api-endpoints/eth-estimate-gas
+    permanent: true
   - source: /reference/eth-gasprice-astar
     destination: /docs/node/astar/astar-api-endpoints/eth-gas-price
+    permanent: true
   - source: /reference/eth-getbalance-astar
     destination: /docs/node/astar/astar-api-endpoints/eth-get-balance
+    permanent: true
   - source: /reference/eth-getblockbyhash-astar
     destination: /docs/node/astar/astar-api-endpoints/eth-get-block-by-hash
+    permanent: true
   - source: /reference/eth-getblockbynumber-astar
     destination: /docs/node/astar/astar-api-endpoints/eth-get-block-by-number
+    permanent: true
   - source: /reference/eth-getblockreceipts-astar
     destination: /docs/node/astar/astar-api-endpoints/eth-get-block-receipts
+    permanent: true
   - source: /reference/eth-getblocktransactioncountbyhash-astar
     destination: >-
       /docs/node/astar/astar-api-endpoints/eth-get-block-transaction-count-by-hash
+    permanent: true
   - source: /reference/eth-getblocktransactioncountbynumber-astar
     destination: >-
       /docs/node/astar/astar-api-endpoints/eth-get-block-transaction-count-by-number
+    permanent: true
   - source: /reference/eth-getcode-astar
     destination: /docs/node/astar/astar-api-endpoints/eth-get-code
+    permanent: true
   - source: /reference/eth-getfilterchanges-astar
     destination: /docs/node/astar/astar-api-endpoints/eth-get-filter-changes
+    permanent: true
   - source: /reference/eth-getfilterlogs-astar
     destination: /docs/node/astar/astar-api-endpoints/eth-get-filter-logs
+    permanent: true
   - source: /reference/eth-getlogs-astar
     destination: /docs/node/astar/astar-api-endpoints/eth-get-logs
+    permanent: true
   - source: /reference/eth-getstorageat-astar
     destination: /docs/node/astar/astar-api-endpoints/eth-get-storage-at
+    permanent: true
   - source: /reference/eth-gettransactionbyblockhashandindex-astar
     destination: >-
       /docs/node/astar/astar-api-endpoints/eth-get-transaction-by-block-hash-and-index
+    permanent: true
   - source: /reference/eth-gettransactionbyblocknumberandindex-astar
     destination: >-
       /docs/node/astar/astar-api-endpoints/eth-get-transaction-by-block-number-and-index
+    permanent: true
   - source: /reference/eth-gettransactionbyhash-astar
     destination: /docs/node/astar/astar-api-endpoints/eth-get-transaction-by-hash
+    permanent: true
   - source: /reference/eth-gettransactioncount-astar
     destination: /docs/node/astar/astar-api-endpoints/eth-get-transaction-count
+    permanent: true
   - source: /reference/eth-gettransactionreceipt-astar
     destination: /docs/node/astar/astar-api-endpoints/eth-get-transaction-receipt
+    permanent: true
   - source: /reference/eth-getunclebyblocknumberandindex-astar
     destination: >-
       /docs/node/astar/astar-api-endpoints/eth-get-uncle-by-block-number-and-index
+    permanent: true
   - source: /reference/eth-sendrawtransaction-astar
     destination: /docs/node/astar/astar-api-endpoints/eth-send-raw-transaction
+    permanent: true
   - source: /reference/web3-clientversion-astar
     destination: /docs/node/astar/astar-api-endpoints/web-3-client-version
+    permanent: true
   - source: /reference/web3-sha3-astar
     destination: /docs/node/astar/astar-api-endpoints/web-3-sha-3
+    permanent: true
   - source: /reference/eth-maxpriorityfeepergas-astar
     destination: /docs/node/astar/astar-api-endpoints/eth-max-priority-fee-per-gas
+    permanent: true
   - source: /reference/eth-newblockfilter-astar
     destination: /docs/node/astar/astar-api-endpoints/eth-new-block-filter
+    permanent: true
   - source: /reference/eth-newfilter-astar
     destination: /docs/node/astar/astar-api-endpoints/eth-new-filter
+    permanent: true
   - source: /reference/eth-newpendingtransactionfilter-astar
     destination: /docs/node/astar/astar-api-endpoints/eth-new-pending-transaction-filter
+    permanent: true
   - source: /reference/eth-uninstallfilter-astar
     destination: /docs/node/astar/astar-api-endpoints/eth-uninstall-filter
+    permanent: true
 
   # BNB Smart Chain
   - source: /reference/eth-blocknumber-bnb
     destination: /docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-block-number
+    permanent: true
   - source: /reference/eth-call-bnb
     destination: /docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-call
+    permanent: true
   - source: /reference/eth-chainid-bnb
     destination: /docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-chain-id
+    permanent: true
   - source: /reference/eth-estimategas-bnb
     destination: /docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-estimate-gas
+    permanent: true
   - source: /reference/eth-gasprice-bnb
     destination: /docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-gas-price
+    permanent: true
   - source: /reference/eth-getbalance-bnb
     destination: /docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-balance
+    permanent: true
   - source: /reference/eth-getblockbyhash-bnb
     destination: >-
       /docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-block-by-hash
+    permanent: true
   - source: /reference/eth-getblockbynumber-bnb
     destination: >-
       /docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-block-by-number
+    permanent: true
   - source: /reference/eth-getblocktransactioncountbyhash-bnb
     destination: >-
       /docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-block-transaction-count-by-hash
+    permanent: true
   - source: /reference/eth-getblocktransactioncountbynumber-bnb
     destination: >-
       /docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-block-transaction-count-by-number
+    permanent: true
   - source: /reference/eth-getcode-bnb
     destination: /docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-code
+    permanent: true
   - source: /reference/eth-getlogs-bnb
     destination: /docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-logs
+    permanent: true
   - source: /reference/eth-getproof-bnb
     destination: /docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-proof
+    permanent: true
   - source: /reference/eth-getstorageat-bnb
     destination: >-
       /docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-storage-at
+    permanent: true
   - source: /reference/eth-gettransactionbyblockhashandindex-bnb
     destination: >-
       /docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-transaction-by-block-hash-and-index
+    permanent: true
   - source: /reference/eth-gettransactionbyblocknumberandindex-bnb
     destination: >-
       /docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-transaction-by-block-number-and-index
+    permanent: true
   - source: /reference/eth-gettransactionbyhash-bnb
     destination: >-
       /docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-transaction-by-hash
+    permanent: true
   - source: /reference/eth-gettransactioncount-bnb
     destination: >-
       /docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-transaction-count
+    permanent: true
   - source: /reference/eth-gettransactionreceipt-bnb
     destination: >-
       /docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-transaction-receipt
+    permanent: true
   - source: /reference/eth-getunclebyblockhashandindex-bnb
     destination: >-
       /docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-uncle-by-block-hash-and-index
+    permanent: true
   - source: /reference/eth-getunclebyblocknumberandindex-bnb
     destination: >-
       /docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-uncle-by-block-number-and-index
+    permanent: true
   - source: /reference/eth-getunclecountbyblockhash-bnb
     destination: >-
       /docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-uncle-count-by-block-hash
+    permanent: true
   - source: /reference/eth-getunclecountbyblocknumber-bnb
     destination: >-
       /docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-uncle-count-by-block-number
+    permanent: true
   - source: /reference/eth-sendrawtransaction-bnb
     destination: >-
       /docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-send-raw-transaction
+    permanent: true
   - source: /reference/web3-clientversion-bnb
     destination: >-
       /docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/web-3-client-version
+    permanent: true
   - source: /reference/web3-sha3-bnb
     destination: /docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/web-3-sha-3
+    permanent: true
 
   # Base
   - source: /reference/eth-accounts-base
     destination: /docs/node/base/base-api-endpoints/eth-accounts
+    permanent: true
   - source: /reference/eth-blocknumber-base
     destination: /docs/node/base/base-api-endpoints/eth-block-number
+    permanent: true
   - source: /reference/eth-call-base
     destination: /docs/node/base/base-api-endpoints/eth-call
+    permanent: true
   - source: /reference/eth-chainid-base
     destination: /docs/node/base/base-api-endpoints/eth-chain-id
+    permanent: true
   - source: /reference/eth-estimategas-base
     destination: /docs/node/base/base-api-endpoints/eth-estimate-gas
+    permanent: true
   - source: /reference/eth-feehistory-base
     destination: /docs/node/base/base-api-endpoints/eth-fee-history
+    permanent: true
   - source: /reference/eth-gasprice-base
     destination: /docs/node/base/base-api-endpoints/eth-gas-price
+    permanent: true
   - source: /reference/eth-getbalance-base
     destination: /docs/node/base/base-api-endpoints/eth-get-balance
+    permanent: true
   - source: /reference/eth-getblockbyhash-base
     destination: /docs/node/base/base-api-endpoints/eth-get-block-by-hash
+    permanent: true
   - source: /reference/eth-getblockbynumber-base
     destination: /docs/node/base/base-api-endpoints/eth-get-block-by-number
+    permanent: true
   - source: /reference/eth-getblockreceipts-base
     destination: /docs/node/base/base-api-endpoints/eth-get-block-receipts
+    permanent: true
   - source: /reference/eth-getblocktransactioncountbyhash-base
     destination: /docs/node/base/base-api-endpoints/eth-get-block-transaction-count-by-hash
+    permanent: true
   - source: /reference/eth-getblocktransactioncountbynumber-base
     destination: >-
       /docs/node/base/base-api-endpoints/eth-get-block-transaction-count-by-number
+    permanent: true
   - source: /reference/eth-getcode-base
     destination: /docs/node/base/base-api-endpoints/eth-get-code
+    permanent: true
   - source: /reference/eth-getfilterchanges-base
     destination: /docs/node/base/base-api-endpoints/eth-get-filter-changes
+    permanent: true
   - source: /reference/eth-getfilterlogs-base
     destination: /docs/node/base/base-api-endpoints/eth-get-filter-logs
+    permanent: true
   - source: /reference/eth-getlogs-base
     destination: /docs/node/base/base-api-endpoints/eth-get-logs
+    permanent: true
   - source: /reference/eth-getproof-base
     destination: /docs/node/base/base-api-endpoints/eth-get-proof
+    permanent: true
   - source: /reference/eth-getstorageat-base
     destination: /docs/node/base/base-api-endpoints/eth-get-storage-at
+    permanent: true
   - source: /reference/eth-gettransactionbyblockhashandindex-base
     destination: >-
       /docs/node/base/base-api-endpoints/eth-get-transaction-by-block-hash-and-index
+    permanent: true
   - source: /reference/eth-gettransactionbyblocknumberandindex-base
     destination: >-
       /docs/node/base/base-api-endpoints/eth-get-transaction-by-block-number-and-index
+    permanent: true
   - source: /reference/eth-gettransactionbyhash-base
     destination: /docs/node/base/base-api-endpoints/eth-get-transaction-by-hash
+    permanent: true
   - source: /reference/eth-gettransactioncount-base
     destination: /docs/node/base/base-api-endpoints/eth-get-transaction-count
+    permanent: true
   - source: /reference/eth-gettransactionreceipt-base
     destination: /docs/node/base/base-api-endpoints/eth-get-transaction-receipt
+    permanent: true
   - source: /reference/eth-getunclebyblockhashandindex-base
     destination: /docs/node/base/base-api-endpoints/eth-get-uncle-by-block-hash-and-index
+    permanent: true
   - source: /reference/eth-getunclebyblocknumberandindex-base
     destination: /docs/node/base/base-api-endpoints/eth-get-uncle-by-block-number-and-index
+    permanent: true
   - source: /reference/eth-getunclecountbyblockhash-base
     destination: /docs/node/base/base-api-endpoints/eth-get-uncle-count-by-block-hash
+    permanent: true
   - source: /reference/eth-getunclecountbyblocknumber-base
     destination: /docs/node/base/base-api-endpoints/eth-get-uncle-count-by-block-number
+    permanent: true
   - source: /reference/eth-maxpriorityfeepergas-base
     destination: /docs/node/base/base-api-endpoints/eth-max-priority-fee-per-gas
+    permanent: true
   - source: /reference/eth-newblockfilter-base
     destination: /docs/node/base/base-api-endpoints/eth-new-block-filter
+    permanent: true
   - source: /reference/eth-newfilter-base
     destination: /docs/node/base/base-api-endpoints/eth-new-filter
+    permanent: true
   - source: /reference/eth-newpendingtransactionfilter-base
     destination: /docs/node/base/base-api-endpoints/eth-new-pending-transaction-filter
+    permanent: true
   - source: /reference/eth-protocolversion-base
     destination: /docs/node/base/base-api-endpoints/eth-protocol-version
+    permanent: true
   - source: /reference/eth-sendrawtransaction-base
     destination: /docs/node/base/base-api-endpoints/eth-send-raw-transaction
+    permanent: true
   - source: /reference/eth-uninstallfilter-base
     destination: /docs/node/base/base-api-endpoints/eth-uninstall-filter
+    permanent: true
   - source: /reference/web3-sha3-base
     destination: /docs/node/base/base-api-endpoints/web-3-sha-3
+    permanent: true
 
   # Abstract
   - source: /reference/abstract-api-endpoints
     destination: /docs/node/abstract/abstract-api-endpoints/eth-block-number
+    permanent: true
 
   # Arbitrum Nova
   - source: /reference/arbitrum-nova-chain-api-endpoints
     destination: /docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/eth-block-number
+    permanent: true
 
   # Apechain
   - source: /reference/apechain-api-endpoints
     destination: /docs/node/apechain/ape-chain-api-endpoints/eth-block-number
+    permanent: true
 
   # Avalanche
   - source: /reference/avalanche-api-endpoints
     destination: >-
       /docs/node/avalanche-c-chain/avalanche-c-chain-api-endpoints/eth-block-number
+    permanent: true
 
   # Berachain
   - source: /reference/berachain-api-endpoints
     destination: /docs/node/berachain/berachain-api-endpoints/eth-block-number
+    permanent: true
 
   # Blast
   - source: /reference/blast-chain-api-endpoints
     destination: /docs/node/blast/blast-api-endpoints/eth-block-number
+    permanent: true
 
   # Celo
   - source: /reference/celo-chain-api-endpoints
     destination: /docs/node/celo/celo-chain-api-endpoints/eth-block-number
+    permanent: true
 
   # Crossfi
   - source: /reference/crossfi-api-endpoints
     destination: /docs/node/crossfi/cross-fi-api-endpoints/eth-block-number
+    permanent: true
 
   # Flow
   - source: /reference/flow-api-endpoints
     destination: /docs/node/flow/flow-api-endpoints/eth-block-number
+    permanent: true
 
   # Geist
   - source: /reference/geist-api-endpoints
     destination: /docs/node/geist/geist-api-endpoints/eth-block-number
+    permanent: true
 
   # Gnosis Chain
   - source: /reference/gnosis-chain-api-endpoints
     destination: /docs/node/gnosis/gnosis-api-endpoints/eth-block-number
+    permanent: true
 
   # Ink
   - source: /reference/ink-api-endpoints
     destination: /docs/node/ink/ink-api-endpoints/eth-block-number
+    permanent: true
 
   # Lens
   - source: /reference/lens-api-endpoints
     destination: /docs/node/lens/lens-api-endpoints/eth-block-number
+    permanent: true
 
   # Linea
   - source: /reference/linea-chain-api-endpoints
     destination: /docs/node/linea/linea-api-endpoints/eth-block-number
+    permanent: true
 
   # Lumia
   - source: /reference/lumia-api-endpoints
     destination: /docs/node/lumia/lumia-api-endpoints/eth-block-number
+    permanent: true
 
   # Mantle
   - source: /reference/mantle-chain-api-endpoints
     destination: /docs/node/mantle/mantle-api-endpoints/eth-block-number
+    permanent: true
 
   # Metis
   - source: /reference/metis-chain-api-endpoints
     destination: /docs/node/metis/metis-api-endpoints/eth-block-number
+    permanent: true
 
   # Monad
   - source: /reference/monad-api-endpoints
     destination: /docs/node/monad/monad-api-endpoints/eth-block-number
+    permanent: true
 
   # OpBNB
   - source: /reference/opbnb-chain-api-endpoints
     destination: /docs/node/opbnb/op-bnb-api-endpoints/eth-block-number
+    permanent: true
 
   # Rootstock
   - source: /reference/rootstock-api-endpoints
     destination: /docs/node/rootstock/rootstock-api-endpoints/eth-block-number
+    permanent: true
 
   # Scroll
   - source: /reference/scroll-chain-api-endpoints
     destination: /docs/node/scroll/scroll-api-endpoints/eth-block-number
+    permanent: true
 
   # Sei
   - source: /reference/sei-api-endpoints
     destination: /docs/node/sei/sei-api-endpoints/eth-block-number
+    permanent: true
 
   # Shape
   - source: /reference/shape-api-endpoints
     destination: /docs/node/shape/shape-api-endpoints/eth-block-number
+    permanent: true
 
   # Soneium
   - source: /reference/soneium-api-endpoints
     destination: /docs/node/soneium/soneium-api-endpoints/eth-block-number
+    permanent: true
 
   # Sonic
   - source: /reference/sonic-api-endpoints
     destination: /docs/node/sonic/sonic-api-endpoints/eth-block-number
+    permanent: true
 
   # Unichain
   - source: /reference/unichain-api-endpoints
     destination: /docs/node/unichain/unichain-api-endpoints/eth-block-number
+    permanent: true
 
   # World Chain
   - source: /reference/world-chain-api-endpoints
     destination: /docs/node/world-chain/world-chain-api-endpoints/eth-block-number
+    permanent: true
 
   # zetachain
   - source: /reference/zetachain-api-endpoints
     destination: /docs/node/zetachain/zetachain-api-endpoints/eth-block-number
+    permanent: true
 
   # Bundler
   - source: /reference/eth-estimateuseroperationgas
     destination: >-
       /docs/node/bundler-api/bundler-api-endpoints/eth-estimate-user-operation-gas
+    permanent: true
   - source: /reference/eth-getuseroperationbyhash
     destination: >-
       /docs/node/bundler-api/bundler-api-endpoints/eth-get-user-operation-by-hash
+    permanent: true
   - source: /reference/eth-getuseroperationreceipt
     destination: >-
       /docs/node/bundler-api/bundler-api-endpoints/eth-get-user-operation-receipt
+    permanent: true
   - source: /reference/eth-senduseroperation
     destination: /docs/node/bundler-api/bundler-api-endpoints/eth-send-user-operation
+    permanent: true
   - source: /reference/eth-supportedentrypoints
     destination: /docs/node/bundler-api/bundler-api-endpoints/eth-supported-entry-points
+    permanent: true
   - source: /reference/rundler-maxpriorityfeepergas
     destination: >-
       /docs/node/bundler-api/bundler-api-endpoints/rundler-max-priority-fee-per-gas
+    permanent: true
   - source: /reference/bundler-api-endpoints
     destination: >-
       /docs/node/bundler-api/bundler-api-endpoints/eth-estimate-user-operation-gas
+    permanent: true
 
   # Gas Manager
   - source: /reference/gas-manager-admin-api-endpoints
     destination: >-
       /docs/node/gas-manager-admin-api/gas-manager-admin-api-endpoints/gas-manager-admin-api-endpoints/create-policy
+    permanent: true
   - source: /reference/alchemy-requestfeepayer
     destination: >-
       /docs/node/gas-manager-admin-api/gas-coverage-api-endpoints/alchemy-request-fee-payer
+    permanent: true
   - source: /reference/alchemy-requestgasandpaymasteranddata
     destination: >-
       /docs/node/gas-manager-admin-api/gas-coverage-api-endpoints/alchemy-request-gas-and-paymaster-and-data
+    permanent: true
   - source: /reference/alchemy-requestpaymasteranddata
     destination: >-
       /docs/node/gas-manager-admin-api/gas-coverage-api-endpoints/alchemy-request-paymaster-and-data
+    permanent: true
   - source: /reference/pm_getpaymasterdata
     destination: >-
       /docs/node/gas-manager-admin-api/gas-coverage-api-endpoints/pm-get-paymaster-data
+    permanent: true
   - source: /reference/pm_getpaymasterstubdata
     destination: >-
       /docs/node/gas-manager-admin-api/gas-coverage-api-endpoints/pm-get-paymaster-data-stub
+    permanent: true
   - source: /reference/create-policy
     destination: >-
       /docs/node/gas-manager-admin-api/gas-manager-admin-api-endpoints/gas-manager-admin-api-endpoints/create-policy
+    permanent: true
   - source: /reference/delete-policy
     destination: >-
       /docs/node/gas-manager-admin-api/gas-manager-admin-api-endpoints/gas-manager-admin-api-endpoints/delete-policy
+    permanent: true
   - source: /reference/get-all-policies
     destination: >-
       /docs/node/gas-manager-admin-api/gas-manager-admin-api-endpoints/gas-manager-admin-api-endpoints/get-all-policies
+    permanent: true
   - source: /reference/get-policy
     destination: >-
       /docs/node/gas-manager-admin-api/gas-manager-admin-api-endpoints/gas-manager-admin-api-endpoints/get-policy
+    permanent: true
   - source: /reference/get-policy-stats
     destination: >-
       /docs/node/gas-manager-admin-api/gas-manager-admin-api-endpoints/gas-manager-admin-api-endpoints/get-policy-stats
+    permanent: true
   - source: /reference/get-sponsorships
     destination: >-
       /docs/node/gas-manager-admin-api/gas-manager-admin-api-endpoints/gas-manager-admin-api-endpoints/get-sponsorships
+    permanent: true
   - source: /reference/replace-policy
     destination: >-
       /docs/node/gas-manager-admin-api/gas-manager-admin-api-endpoints/gas-manager-admin-api-endpoints/replace-policy
+    permanent: true
   - source: /reference/update-policy-status
     destination: >-
       /docs/node/gas-manager-admin-api/gas-manager-admin-api-endpoints/gas-manager-admin-api-endpoints/update-policy-status
+    permanent: true
 
   # Signer
   - source: /docs/node/smart-wallets/wallets-api-endpoints/signer-api-endpoints/:method*
     destination: /docs/node/smart-wallets/signer-api-endpoints/signer-api-endpoints/:method*
+    permanent: true
   - source: /docs/node/smart-wallets/wallets-api-endpoints/wallets-api-endpoints/:method*
     destination: /docs/node/smart-wallets/wallet-api-endpoints/wallet-api-endpoints/:method*
+    permanent: true
 
   # Trace
   - source: /reference/trace-api
     destination: /docs/node/trace-api/trace-api-endpoints/trace-block
+    permanent: true
   - source: /reference/trace-block
     destination: /docs/node/trace-api/trace-api-endpoints/trace-block
+    permanent: true
   - source: /reference/trace-call
     destination: /docs/node/trace-api/trace-api-endpoints/trace-call
+    permanent: true
   - source: /reference/trace-filter
     destination: /docs/node/trace-api/trace-api-endpoints/trace-filter
+    permanent: true
   - source: /reference/trace-get
     destination: /docs/node/trace-api/trace-api-endpoints/trace-get
+    permanent: true
   - source: /reference/trace-rawtransaction
     destination: /docs/node/trace-api/trace-api-endpoints/trace-raw-transaction
+    permanent: true
   - source: /reference/trace-replayblocktransactions
     destination: /docs/node/trace-api/trace-api-endpoints/trace-replay-block-transactions
+    permanent: true
   - source: /reference/trace-replaytransaction
     destination: /docs/node/trace-api/trace-api-endpoints/trace-replay-transaction
+    permanent: true
   - source: /reference/trace-transaction
     destination: /docs/node/trace-api/trace-api-endpoints/trace-transaction
+    permanent: true
 
   # Debug
   - source: /reference/debug-getrawblock
     destination: /docs/node/debug-api/debug-api-endpoints/debug-get-raw-block
+    permanent: true
   - source: /reference/debug-getrawheader
     destination: /docs/node/debug-api/debug-api-endpoints/debug-get-raw-header
+    permanent: true
   - source: /reference/debug-getrawreceipts
     destination: /docs/node/debug-api/debug-api-endpoints/debug-get-raw-receipts
+    permanent: true
   - source: /reference/debug-traceblockbyhash
     destination: /docs/node/debug-api/debug-api-endpoints/debug-trace-block-by-hash
+    permanent: true
   - source: /reference/debug-traceblockbynumber
     destination: /docs/node/debug-api/debug-api-endpoints/debug-trace-block-by-number
+    permanent: true
   - source: /reference/debug-tracecall
     destination: /docs/node/debug-api/debug-api-endpoints/debug-trace-call
+    permanent: true
   - source: /reference/debug-tracetransaction
     destination: /docs/node/debug-api/debug-api-endpoints/debug-trace-transaction
+    permanent: true
   - source: /reference/debug-api-endpoints
     destination: /docs/node/debug-api/debug-api-endpoints/debug-get-raw-block
+    permanent: true
 
   # ========================================= Data Redirects =========================================
 
   # Transfers
   - source: /reference/alchemy-getassettransfers
     destination: /docs/data/transfers-api/transfers-endpoints/alchemy-get-asset-transfers
+    permanent: true
   - source: /reference/alchemy-getassettransfers-1
     destination: /docs/data/transfers-api/transfers-endpoints/alchemy-get-asset-transfers
+    permanent: true
 
   # Token
   - source: /reference/alchemy-gettokenallowance
     destination: /docs/data/token-api/token-api-endpoints/alchemy-get-token-allowance
+    permanent: true
   - source: /reference/alchemy-gettokenbalances
     destination: /docs/data/token-api/token-api-endpoints/alchemy-get-token-balances
+    permanent: true
   - source: /reference/alchemy-gettokenmetadata
     destination: /docs/data/token-api/token-api-endpoints/alchemy-get-token-metadata
+    permanent: true
 
   # Utility
   - source: /reference/alchemy-gettransactionreceipts
     destination: >-
       /docs/data/utility-apis/transactions-receipts-endpoints/alchemy-get-transaction-receipts
+    permanent: true
   - source: /reference/blocks-by-timestamp
     destination: >-
       /docs/data/utility-apis/api-reference/blocks-api-endpoints/blocks-by-timestamp
+    permanent: true
 
   # Portfolio
   - source: /reference/get-nft-contracts-by-address
     destination: >-
       /docs/data/portfolio-apis/portfolio-api-endpoints/portfolio-api-endpoints/get-nft-contracts-by-address
+    permanent: true
   - source: /reference/get-nfts-by-address
     destination: >-
       /docs/data/portfolio-apis/portfolio-api-endpoints/portfolio-api-endpoints/get-nfts-by-address
+    permanent: true
   - source: /reference/get-token-balances-by-address
     destination: >-
       /docs/data/portfolio-apis/portfolio-api-endpoints/portfolio-api-endpoints/get-token-balances-by-address
+    permanent: true
   - source: /reference/get-tokens-by-address
     destination: >-
       /docs/data/portfolio-apis/portfolio-api-endpoints/portfolio-api-endpoints/get-tokens-by-address
+    permanent: true
   - source: /reference/get-transaction-history-by-address
     destination: >-
       /docs/data/portfolio-apis/portfolio-api-endpoints/portfolio-api-endpoints/get-transaction-history-by-address
+    permanent: true
 
   # Prices
   - source: /reference/get-historical-token-prices
     destination: >-
       /docs/data/prices-api/prices-api-endpoints/prices-api-endpoints/get-historical-token-prices
+    permanent: true
   - source: /reference/get-token-prices-by-address
     destination: >-
       /docs/data/prices-api/prices-api-endpoints/prices-api-endpoints/get-token-prices-by-address
+    permanent: true
   - source: /reference/get-token-prices-by-symbol
     destination: >-
       /docs/data/prices-api/prices-api-endpoints/prices-api-endpoints/get-token-prices-by-symbol
+    permanent: true
 
   # NFT API - Metadata
   - source: /reference/computerarity-v3
     destination: /docs/data/nft-api/api-reference/nft-metadata-endpoints/compute-rarity-v-3
+    permanent: true
   - source: /reference/getcollectionmetadata-v3
     destination: >-
       /docs/data/nft-api/api-reference/nft-metadata-endpoints/get-collection-metadata-v-3
+    permanent: true
   - source: /reference/getcontractmetadata-v3
     destination: >-
       /docs/data/nft-api/api-reference/nft-metadata-endpoints/get-contract-metadata-v-3
+    permanent: true
   - source: /reference/getcontractmetadatabatch-v3
     destination: >-
       /docs/data/nft-api/api-reference/nft-metadata-endpoints/get-contract-metadata-batch-v-3
+    permanent: true
   - source: /reference/getnftmetadata-v3
     destination: >-
       /docs/data/nft-api/api-reference/nft-metadata-endpoints/get-nft-metadata-v-3
+    permanent: true
   - source: /reference/getnftmetadatabatch-v3
     destination: >-
       /docs/data/nft-api/api-reference/nft-metadata-endpoints/get-nft-metadata-batch-v-3
+    permanent: true
   - source: /reference/getnftsforcollection-v3
     destination: >-
       /docs/data/nft-api/api-reference/nft-metadata-endpoints/get-nf-ts-for-collection-v-3
+    permanent: true
   - source: /reference/getnftsforcontract-v3
     destination: >-
       /docs/data/nft-api/api-reference/nft-metadata-endpoints/get-nf-ts-for-contract-v-3
+    permanent: true
   - source: /reference/invalidatecontract-v3
     destination: >-
       /docs/data/nft-api/api-reference/nft-metadata-endpoints/invalidate-contract-v-3
+    permanent: true
   - source: /reference/refreshnftmetadata-v3
     destination: >-
       /docs/data/nft-api/api-reference/nft-metadata-endpoints/refresh-nft-metadata-v-3
+    permanent: true
   - source: /reference/searchcontractmetadata-v3
     destination: >-
       /docs/data/nft-api/api-reference/nft-metadata-endpoints/search-contract-metadata-v-3
+    permanent: true
   - source: /reference/summarizenftattributes-v3
     destination: >-
       /docs/data/nft-api/api-reference/nft-metadata-endpoints/summarize-nft-attributes-v-3
+    permanent: true
 
   # NFT API - Ownership
   - source: /reference/getcollectionsforowner-v3
     destination: >-
       /docs/data/nft-api/api-reference/nft-ownership-endpoints/get-collections-for-owner-v-3
+    permanent: true
   - source: /reference/getcontractsforowner-v3
     destination: >-
       /docs/data/nft-api/api-reference/nft-ownership-endpoints/get-contracts-for-owner-v-3
+    permanent: true
   - source: /reference/getnftsforowner-v3
     destination: >-
       /docs/data/nft-api/api-reference/nft-ownership-endpoints/get-nf-ts-for-owner-v-3
+    permanent: true
   - source: /reference/getownersforcontract-v3
     destination: >-
       /docs/data/nft-api/api-reference/nft-ownership-endpoints/get-owners-for-contract-v-3
+    permanent: true
   - source: /reference/getownersfornft-v3
     destination: >-
       /docs/data/nft-api/api-reference/nft-ownership-endpoints/get-owners-for-nft-v-3
+    permanent: true
   - source: /reference/isholderofcontract-v3
     destination: >-
       /docs/data/nft-api/api-reference/nft-ownership-endpoints/is-holder-of-contract-v-3
+    permanent: true
 
   # NFT API - Sales
   - source: /reference/getfloorprice-v3
     destination: /docs/data/nft-api/api-reference/nft-sales-endpoints/get-floor-price-v-3
+    permanent: true
   - source: /reference/getnftsales-v3
     destination: /docs/data/nft-api/api-reference/nft-sales-endpoints/get-nft-sales-v-3
+    permanent: true
 
   # NFT API - Spam
   - source: /reference/getspamcontracts-v3
     destination: /docs/data/nft-api/api-reference/nft-spam-endpoints/get-spam-contracts-v-3
+    permanent: true
   - source: /reference/isairdropnft-v3
     destination: /docs/data/nft-api/api-reference/nft-spam-endpoints/is-airdrop-nft-v-3
+    permanent: true
   - source: /reference/isspamcontract-v3
     destination: /docs/data/nft-api/api-reference/nft-spam-endpoints/is-spam-contract-v-3
+    permanent: true
   - source: /reference/reportspam-v3
     destination: /docs/data/nft-api/api-reference/nft-spam-endpoints/report-spam-v-3
+    permanent: true
 
   # Webhooks - Custom Webhook
   - source: /reference/create-custom-webhook-variable
     destination: >-
       /docs/data/webhooks/custom-webhook-api-methods/custom-webhook-api-methods/custom-webhook-api-methods/create-custom-webhook-variable
+    permanent: true
   - source: /reference/delete-custom-webhook-variable
     destination: >-
       /docs/data/webhooks/custom-webhook-api-methods/custom-webhook-api-methods/custom-webhook-api-methods/delete-custom-webhook-variable
+    permanent: true
   - source: /reference/read-custom-webhook-variable
     destination: >-
       /docs/data/webhooks/custom-webhook-api-methods/custom-webhook-api-methods/custom-webhook-api-methods/read-custom-webhook-variable
+    permanent: true
   - source: /reference/update-custom-webhook-variable
     destination: >-
       /docs/data/webhooks/custom-webhook-api-methods/custom-webhook-api-methods/custom-webhook-api-methods/update-custom-webhook-variable
+    permanent: true
 
   # Webhooks - Notify
   - source: /reference/create-webhook
     destination: >-
       /docs/data/webhooks/custom-webhook-api-methods/custom-webhook-api-methods/notify-api-methods/create-webhook
+    permanent: true
   - source: /reference/delete-webhook
     destination: >-
       /docs/data/webhooks/custom-webhook-api-methods/custom-webhook-api-methods/notify-api-methods/delete-webhook
+    permanent: true
   - source: /reference/replace-webhook-addresses
     destination: >-
       /docs/data/webhooks/custom-webhook-api-methods/custom-webhook-api-methods/notify-api-methods/replace-webhook-addresses
+    permanent: true
   - source: /reference/team-webhooks
     destination: >-
       /docs/data/webhooks/custom-webhook-api-methods/custom-webhook-api-methods/notify-api-methods/team-webhooks
+    permanent: true
   - source: /reference/update-webhook
     destination: >-
       /docs/data/webhooks/custom-webhook-api-methods/custom-webhook-api-methods/notify-api-methods/update-webhook
+    permanent: true
   - source: /reference/update-webhook-addresses
     destination: >-
       /docs/data/webhooks/custom-webhook-api-methods/custom-webhook-api-methods/notify-api-methods/update-webhook-addresses
+    permanent: true
   - source: /reference/update-webhook-nft-filters
     destination: >-
       /docs/data/webhooks/custom-webhook-api-methods/custom-webhook-api-methods/notify-api-methods/update-webhook-nft-filters
+    permanent: true
   - source: /reference/update-webhook-nft-metadata-filters
     destination: >-
       /docs/data/webhooks/custom-webhook-api-methods/custom-webhook-api-methods/notify-api-methods/update-webhook-nft-metadata-filters
+    permanent: true
   - source: /reference/webhook-addresses
     destination: >-
       /docs/data/webhooks/custom-webhook-api-methods/custom-webhook-api-methods/notify-api-methods/webhook-addresses
+    permanent: true
   - source: /reference/webhook-nft-filters
     destination: >-
       /docs/data/webhooks/custom-webhook-api-methods/custom-webhook-api-methods/notify-api-methods/webhook-nft-filters
+    permanent: true
 
   # =========================================================== Internal Redirects ===========================================================
 
   - source: /docs/how-to-read-data-from-the-blockchain
     destination: /docs/how-to-get-the-latest-block-on-ethereum
+    permanent: true
   - source: /alchemy/enhanced-apis/nft-api/how-to-check-the-owner-of-an-nft
     destination: /docs/how-to-check-the-owner-of-an-nft
+    permanent: true
   - source: /alchemy/
     destination: /docs
+    permanent: true
   - source: /alchemy/apis/arbitrum
     destination: /docs/reference/arbitrum-api-quickstart
+    permanent: true
   - source: /alchemy/apis/ethereum
     destination: /docs/reference/ethereum-api-quickstart
+    permanent: true
   - source: /alchemy/apis/optimism
     destination: /docs/reference/optimism-api-quickstart
+    permanent: true
   - source: /alchemy/documentation/enhanced-apis/notify-api
     destination: /docs/reference/notify-api-quickstart
+    permanent: true
   - source: /alchemy/documentation/subscription-api-websockets
     destination: /docs/reference/subscription-api
+    permanent: true
   - source: /alchemy/enhanced-apis
     destination: /docs/reference/enhanced-apis-overview
+    permanent: true
   - source: /alchemy/guides/nft-api-quickstart-guide
     destination: /docs/reference/nft-api-quickstart
+    permanent: true
   - source: /alchemy/guides/using-notify
     destination: /docs/reference/notify-api-quickstart
+    permanent: true
   - source: /alchemy/resources/faq
     destination: /alchemy-docs/discuss
+    permanent: true
   - source: /alchemy/guides/alchemy-for-macs
     destination: /docs/alchemy-quickstart-guide
+    permanent: true
   - source: /alchemy/guides/demo-app
     destination: /docs/alchemy-quickstart-guide
+    permanent: true
   - source: /alchemy/introduction/why-use-alchemy
     destination: /docs/why-use-alchemy
+    permanent: true
   - source: /alchemy/tutorials/how-to-create-an-nft/how-to-mint-a-nft
     destination: /docs/how-to-mint-an-nft-with-ethers
+    permanent: true
   - source: /cdn-cgi/l/email-protection
     destination: /docs/how-to-mint-an-nft-from-code
+    permanent: true
   - source: /alchemy/enhanced-apis/nft-api/how-to-get-all-nfts-in-a-collection
     destination: /docs/how-to-get-all-nfts-in-a-collection
+    permanent: true
   - source: /alchemy/enhanced-apis/nft-api/how-to-get-all-nfts-owned-by-an-address
     destination: /docs/how-to-get-all-nfts-owned-by-an-address
+    permanent: true
   - source: /alchemy/enhanced-apis/nft-api/how-to-get-ens
     destination: /docs/how-to-resolve-ens-domains-given-a-wallet-address
+    permanent: true
   - source: /alchemy/enhanced-apis/token-api/get-all-tokens-owned-by-address
     destination: /docs/how-to-get-all-tokens-owned-by-an-address
+    permanent: true
   - source: /alchemy/enhanced-apis/token-api/how-to-get-token-balance-for-an-address
     destination: /docs/how-to-get-token-balance-for-an-address
+    permanent: true
   - source: /alchemy/enhanced-apis/token-api/how-to-get-token-metadata
     destination: /docs/how-to-get-token-metadata
+    permanent: true
   - source: /alchemy/enhanced-apis/transfers-api/how-to-get-the-transfer-history-of-an-nft
     destination: /docs/how-to-get-the-transfer-history-of-an-nft
+    permanent: true
   - source: /alchemy/tutorials/how-to-create-an-on-chain-nft-allowlist
     destination: /docs/how-to-create-an-on-chain-nft-allowlist
+    permanent: true
   - source: /alchemy/guides/what-are-internal-transactions
     destination: /docs/what-are-internal-transactions
+    permanent: true
   - source: /alchemy/guides/understanding-the-transaction-object-on-ethereum
     destination: /docs/understanding-the-transaction-object-on-ethereum
+    permanent: true
   - source: /alchemy/documentation/alchemy-web3/enhanced-web3-api
     destination: /docs/reference/alchemyweb3js#enhanced-api-calls
+    permanent: true
   - source: /alchemy/enhanced-apis/nft-api
     destination: /docs/reference/nft-api-quickstart
+    permanent: true
   - source: /alchemy/enhanced-apis/nft-api/nft-api-faq
     destination: /docs/reference/nft-api-quickstart#faqs
+    permanent: true
   - source: /alchemy/enhanced-apis/nft-api/nft-api-faq/handling-errors
     destination: /docs/reference/nft-api-quickstart#handling-errors
+    permanent: true
   - source: /alchemy/enhanced-apis/nft-api/nft-api-faq/nft-image-caching
     destination: /docs/reference/nft-api-quickstart#why-does-alchemy-cache-nft-media
+    permanent: true
   - source: /alchemy/enhanced-apis/nft-api/nft-api-quickstart-guide
     destination: /docs/reference/nft-api-quickstart
+    permanent: true
   - source: /alchemy/documentation/best-practices-when-using-alchemy
     destination: /docs/best-practices-when-using-alchemy
+    permanent: true
   - source: /alchemy/enhanced-apis/subscription-api-websockets/best-practices-for-using-websockets-in-web3
     destination: /alchemy-docs/docs/how-to-listen-to-nft-mints/reference/best-practices-for-using-websockets-in-web3
+    permanent: true
   - source: /alchemy/enhanced-apis/subscription-api-websockets/how-to-listen-to-nft-mints
     destination: /alchemy-docs/docs/how-to-listen-to-nft-mints
+    permanent: true
   - source: /alchemy/guides/connecting-metamask-to-alchemy
     destination: /docs/how-to-add-alchemy-rpc-endpoints-to-metamask
+    permanent: true
   - source: /alchemy/guides/connecting-metamask-to-alchemy/how-to-add-arbitrum-to-metamask
     destination: /docs/how-to-add-arbitrum-to-metamask
+    permanent: true
   - source: /alchemy/guides/connecting-metamask-to-alchemy/how-to-add-avalanche-to-metamask
     destination: /docs/how-to-add-avalanche-to-metamask
+    permanent: true
   - source: /alchemy/guides/connecting-metamask-to-alchemy/how-to-add-cronos-to-metamask
     destination: /docs/how-to-add-cronos-to-metamask
+    permanent: true
   - source: /alchemy/guides/connecting-metamask-to-alchemy/how-to-add-near-aurora-to-metamask
     destination: /docs/how-to-add-near-aurora-to-metamask
+    permanent: true
   - source: /alchemy/guides/connecting-metamask-to-alchemy/how-to-add-optimism-to-metamask
     destination: /docs/how-to-add-optimism-to-metamask
+    permanent: true
   - source: /alchemy/guides/connecting-metamask-to-alchemy/how-to-add-polygon-to-metamask
     destination: /docs/how-to-add-polygon-to-metamask
+    permanent: true
   - source: /alchemy/guides/how-to-fork-ethereum-mainnet
     destination: /docs/how-to-fork-ethereum-mainnet
+    permanent: true
   - source: /alchemy/guides/how-to-set-up-core-web3-developer-tools
     destination: /docs/how-to-set-up-core-web3-developer-tools
+    permanent: true
   - source: /alchemy/guides/running-an-eth2-node-with-alchemy
     destination: /docs/running-an-eth20-staking-node-or-validator-with-alchemy
+    permanent: true
   - source: /alchemy/guides/running-an-eth2-node-with-alchemy/eth2-staking-prysm
     destination: /docs/setting-up-an-eth-20-staking-validator-with-prysm
+    permanent: true
   - source: /alchemy/guides/running-an-eth2-node-with-alchemy/eth2-staking-teku
     destination: /docs/setting-up-an-eth-20-staking-validator-with-teku
+    permanent: true
   - source: /alchemy/introduction/getting-started
     destination: /docs/alchemy-quickstart-guide
+    permanent: true
   - source: /guides/getting-started
     destination: /docs/alchemy-quickstart-guide
+    permanent: true
   - source: /alchemy/guides/getting-started
     destination: /docs/alchemy-quickstart-guide
+    permanent: true
   - source: /alchemy/introduction/getting-started/simple-web3-script
     destination: /docs/how-to-get-the-latest-block-on-ethereum
+    permanent: true
   - source: /alchemy/road-to-web3
     destination: /docs/welcome-to-the-road-to-web3
+    permanent: true
   - source: /alchemy/road-to-web3/important-info
     destination: /docs/welcome-to-the-road-to-web3
+    permanent: true
   - source: /alchemy/road-to-web3/weekly-hackathons
     destination: /docs/weekly-hackathons
+    permanent: true
   - source: /alchemy/road-to-web3/weekly-hackathons/hackathon-1-governance
     destination: /docs/hackathon-1-governance
+    permanent: true
   - source: /alchemy/road-to-web3/weekly-learning-challenges
     destination: /docs/weekly-learning-challenges
+    permanent: true
   - source: /alchemy/road-to-web3/weekly-learning-challenges/1.-how-to-develop-an-nft-smart-contract-erc721-with-alchemy
     destination: /docs/1-how-to-develop-an-nft-smart-contract-erc721-with-alchemy
+    permanent: true
   - source: /alchemy/road-to-web3/weekly-learning-challenges/2.-how-to-build-buy-me-a-coffee-defi-dapp
     destination: /docs/2-how-to-build-buy-me-a-coffee-defi-dapp
+    permanent: true
   - source: /alchemy/road-to-web3/weekly-learning-challenges/3.-how-to-make-nfts-with-on-chain-metadata-hardhat-and-javascript
     destination: /docs/3-how-to-make-nfts-with-on-chain-metadata-hardhat-and-javascript
+    permanent: true
   - source: /alchemy/road-to-web3/weekly-learning-challenges/4.-how-to-create-an-nft-gallery
     destination: /docs/4-how-to-create-an-nft-gallery
+    permanent: true
   - source: /alchemy/road-to-web3/weekly-learning-challenges/5.-connect-apis-to-your-smart-contracts-using-chainlink
     destination: /docs/5-connect-apis-to-your-smart-contracts-using-chainlink
+    permanent: true
   - source: /alchemy/road-to-web3/weekly-learning-challenges/6.-how-to-build-a-staking-dapp
     destination: /docs/6-how-to-build-a-staking-dapp
+    permanent: true
   - source: /alchemy/road-to-web3/weekly-learning-challenges/7.-how-to-build-an-nft-marketplace-from-scratch
     destination: /docs/7-how-to-build-an-nft-marketplace-from-scratch
+    permanent: true
   - source: /alchemy/road-to-web3/weekly-learning-challenges/8.-how-to-build-a-betting-game-on-optimism
     destination: /docs/8-how-to-build-a-betting-game-on-optimism
+    permanent: true
   - source: /alchemy/road-to-web3/weekly-learning-challenges/9.-how-to-build-a-token-swap-dapp-with-0x-api
     destination: /docs/9-how-to-build-a-token-swap-dapp-with-0x-api
+    permanent: true
   - source: /alchemy/road-to-web3/welcome
     destination: /docs/welcome-to-the-road-to-web3
+    permanent: true
   - source: /alchemy/road-to-web3/welcome-to-the-road-to-web3
     destination: /docs/welcome-to-the-road-to-web3
+    permanent: true
   - source: /alchemy/tutorials/arbitrum-nft
     destination: /docs/arbitrum-nfts-creating-and-deploying-erc-721
+    permanent: true
   - source: /alchemy/tutorials/deploy-your-own-erc20-token
     destination: /docs/how-to-create-an-erc-20-token-4-steps
+    permanent: true
   - source: /alchemy/tutorials/hello-world-smart-contract
     destination: /docs/hello-world-smart-contract
+    permanent: true
   - source: /alchemy/tutorials/hello-world-smart-contract/interacting-with-a-smart-contract
     destination: /docs/interacting-with-a-smart-contract
+    permanent: true
   - source: /alchemy/tutorials/hello-world-smart-contract/part-4
     destination: /docs/integrating-your-smart-contract-with-the-frontend
+    permanent: true
   - source: /alchemy/tutorials/hello-world-smart-contract/submitting-your-smart-contract-to-etherscan
     destination: /docs/submitting-your-smart-contract-to-etherscan
+    permanent: true
   - source: /alchemy/tutorials/how-to-code-and-deploy-a-polygon-smart-contract
     destination: /docs/how-to-code-and-deploy-a-polygon-smart-contract
+    permanent: true
   - source: /alchemy/guides/running-an-eth2-node-with-alchemy/setting-up-an-eth-2.0-node-or-validator-with-prysm
     destination: /docs/setting-up-an-eth-20-staking-validator-with-prysm
+    permanent: true
   - source: /alchemy/tutorials/how-to-deploy-a-polygon-smart-contract
     destination: /docs/how-to-code-and-deploy-a-polygon-smart-contract
+    permanent: true
   - source: /alchemy/guides/internal-playbook-upgrading-ethereum-nodes
     destination: /docs/internal-playbook-upgrading-ethereum-nodes
+    permanent: true
   - source: /alchemy/introduction/core-products
     destination: /docs/core-products
+    permanent: true
   - source: /alchemy/introduction/core-products/alchemy-build
     destination: /docs/alchemy-build
+    permanent: true
   - source: /alchemy/introduction/core-products/alchemy-monitor
     destination: /docs/alchemy-monitor
+    permanent: true
   - source: /alchemy/introduction/core-products/alchemy-notify
     destination: /docs/alchemy-notify
+    permanent: true
   - source: /alchemy/introduction/core-products/alchemy-supernode
     destination: /docs/alchemy-supernode
+    permanent: true
   - source: /alchemy/guides/eip-1559
     destination: /docs/eip-1559-resource-and-tutorial-hub
+    permanent: true
   - source: /alchemy/guides/eip-1559/gas-estimator
     destination: /docs/how-to-build-a-gas-fee-estimator-using-eip-1559
+    permanent: true
   - source: /alchemy/guides/eip-1559/maxpriorityfeepergas-vs-maxfeepergas
     destination: /docs/maxpriorityfeepergas-vs-maxfeepergas
+    permanent: true
   - source: /alchemy/guides/eip-1559/retry-eip-1559-tx
     destination: /docs/retrying-an-eip-1559-transaction
+    permanent: true
   - source: /alchemy/guides/eip-1559/send-tx-eip-1559
     destination: /docs/how-to-send-transactions-with-eip-1559
+    permanent: true
   - source: /alchemy/enhanced-apis/transaction-receipts-api/how-to-get-nft-contract-creator-address
     destination: /docs/how-to-get-nft-contract-creator-address
+    permanent: true
   - source: /alchemy/enhanced-apis/transfers-api/how-to-get-a-contracts-first-transfer-event
     destination: /docs/how-to-get-a-contracts-first-transfer-event
+    permanent: true
   - source: /alchemy/enhanced-apis/transfers-api/how-to-get-a-contracts-last-transfer-event
     destination: /docs/how-to-get-a-contracts-last-transfer-event
+    permanent: true
   - source: /alchemy/enhanced-apis/transfers-api/how-to-get-all-nft-transactions-by-an-address
     destination: /docs/how-to-get-all-nft-transactions-by-an-address
+    permanent: true
   - source: /alchemy/enhanced-apis/transfers-api/how-to-get-nfts-minted-by-an-address
     destination: /docs/how-to-get-nfts-minted-by-an-address
+    permanent: true
   - source: /alchemy/enhanced-apis/transfers-api/how-to-get-transaction-history-for-an-address-on-ethereum
     destination: /docs/how-to-get-transaction-history-for-an-address-on-ethereum
+    permanent: true
   - source: /alchemy/apis/feature-support-by-chain
     destination: /docs/reference/feature-support-by-chain
+    permanent: true
   - source: /alchemy/enhanced-apis/enhanced-apis-overview
     destination: /docs/reference/enhanced-apis-overview
+    permanent: true
   - source: /alchemy/enhanced-apis/notify-api/using-notify
     destination: /docs/reference/notify-api-quickstart-guide
+    permanent: true
   - source: /alchemy/enhanced-apis/subscription-api-websockets
     destination: /docs/reference/subscription-api
+    permanent: true
   - source: /alchemy/enhanced-apis/token-api
     destination: /docs/reference/token-api
+    permanent: true
   - source: /alchemy/enhanced-apis/token-api/token-api-quickstart-guide
     destination: /docs/reference/token-api-quickstart
+    permanent: true
   - source: /alchemy/enhanced-apis/trace-api
     destination: /docs/reference/trace-api
+    permanent: true
   - source: /alchemy/introduction/contributing-to-docs
     destination: /docs/contributing-to-these-docs
+    permanent: true
   - source: /alchemy/introduction/referral-program
     destination: /docs/referral-program
+    permanent: true
   - source: /alchemy/documentation/alchemy-web3
     destination: /docs/reference/use-alchemyweb3js
+    permanent: true
   - source: /alchemy/enhanced-apis/notify-api/building-a-dapp-with-real-time-transaction-notifications
     destination: /docs/building-a-dapp-with-real-time-transaction-notifications
+    permanent: true
   - source: /alchemy/enhanced-apis/notify-api/how-to-create-a-slack-whale-alert-bot
     destination: /docs/how-to-create-a-slack-whale-alert-bot
+    permanent: true
   - source: /alchemy/enhanced-apis/notify-api/how-to-create-a-whale-alert-discord-bot
     destination: /docs/how-to-create-a-whale-alert-discord-bot
+    permanent: true
   - source: /alchemy/enhanced-apis/notify-api/how-to-create-a-whale-alert-twitter-bot
     destination: /docs/how-to-create-a-whale-alert-twitter-bot
+    permanent: true
   - source: /alchemy/guides/choosing-a-network
     destination: /docs/choosing-a-web3-network
+    permanent: true
   - source: /alchemy/guides/debugging-cors
     destination: /docs/debugging-cors-problems-for-end-users
+    permanent: true
   - source: /alchemy/guides/eth_getlogs
     destination: /docs/deep-dive-into-eth_getlogs
+    permanent: true
   - source: /alchemy/guides/ethereum-transactions-pending-mined-dropped-and-replaced
     destination: /docs/ethereum-transactions-pending-mined-dropped-replaced
+    permanent: true
   - source: /alchemy/guides/how-to-enable-compression-to-speed-up-json-rpc-blockchain-requests
     destination: /docs/how-to-enable-compression-to-speed-up-json-rpc-blockchain-requests
+    permanent: true
   - source: /alchemy/guides/how-to-interpret-binaries-in-solidity
     destination: /docs/how-to-interpret-binaries-in-solidity
+    permanent: true
   - source: /alchemy/guides/how-to-verify-a-message-signature-on-ethereum
     destination: /docs/how-to-verify-a-message-signature-on-ethereum
+    permanent: true
   - source: /alchemy/guides/understanding-ethereum-logs
     destination: /docs/deep-dive-into-eth_getlogs
+    permanent: true
   - source: /alchemy/introduction/getting-started/sending-txs
     destination: /docs/how-to-send-transactions-on-ethereum
+    permanent: true
   - source: /alchemy/sdk/alchemy-sdk-quickstart
     destination: /docs/reference/alchemy-sdk-quickstart
+    permanent: true
   - source: /alchemy/tutorials/how-to-track-ethereum-transactions
     destination: /docs/how-to-track-mined-and-pending-ethereum-transactions
+    permanent: true
   - source: /alchemy/tutorials/nft-minter
     destination: /docs/nft-minter
+    permanent: true
   - source: /alchemy/tutorials/nft-minter/how-do-i-deploy-nfts-online
     destination: /docs/how-to-build-an-nft-website
+    permanent: true
   - source: /alchemy/tutorials/send-private-transaction
     destination: /docs/how-to-send-a-transaction
+    permanent: true
   - source: /alchemy/tutorials/transfers-tutorial
     destination: /docs/integrating-historical-transaction-data-into-your-dapp
+    permanent: true
   - source: /alchemy/resources/blockchain-101
     destination: /docs/blockchain-101
+    permanent: true
   - source: /alchemy/resources/web3-glossary
     destination: /docs/web3-glossary
+    permanent: true
   - source: /alchemy/resources/web3-glossary/what-are-uncle-blocks
     destination: /docs/what-are-uncle-blocks
+    permanent: true
   - source: /alchemy/tutorials/building-a-dapp-with-real-time-transaction-notifications
     destination: /docs/building-a-dapp-with-real-time-transaction-notifications
+    permanent: true
   - source: /alchemy/documentation/batch-requests
     destination: /docs/reference/batch-requests
+    permanent: true
   - source: /alchemy/documentation/compute-units
     destination: /docs/reference/compute-units
+    permanent: true
   - source: /alchemy/documentation/error-reference
     destination: /docs/reference/error-reference
+    permanent: true
   - source: /alchemy/documentation/gas-limits-for-eth_call-and-eth_estimategas
     destination: /docs/reference/gas-limits-for-eth_call-and-eth_estimategas
+    permanent: true
   - source: /alchemy/documentation/throughput
     destination: /docs/reference/throughput
+    permanent: true
   - source: /alchemy/guides/how-to-cancel-a-pending-transaction-on-ethereum
     destination: /docs/how-to-cancel-a-private-transaction-on-ethereum
+    permanent: true
   - source: /alchemy/guides/how-to-verify-a-message-signature-on-ethereum/how-to-create-a-signature-generator-dapp
     destination: /docs/how-to-create-a-signature-generator-dapp
+    permanent: true
   - source: /alchemy/sdk/sdk-quickstart
     destination: /docs/reference/alchemy-sdk-quickstart
+    permanent: true
   - source: /alchemy/enhanced-apis/notify-api/integrate-alchemy-zapier
     destination: /docs/how-to-integrate-alchemy-webhooks-with-zapier
+    permanent: true
   - source: /alchemy/tutorials/how-to-create-an-nft
     destination: /docs/how-to-create-an-nft
+    permanent: true
   - source: /alchemy/tutorials/how-to-create-an-nft/how-to-mint-an-nft-with-ethers
     destination: /docs/how-to-mint-an-nft-from-code
+    permanent: true
   - source: /alchemy/tutorials/how-to-create-an-nft/how-to-view-your-nft-in-your-wallet
     destination: /docs/how-to-view-your-nft-in-your-mobile-wallet
+    permanent: true
   - source: /alchemy/tutorials/how-to-create-an-nft/nft-price
     destination: /docs/how-do-i-set-a-price-on-an-nft
+    permanent: true
   - source: /alchemy/tutorials/how-to-add-royalties-to-an-erc-20-token
     destination: /docs/how-to-add-royalties-to-an-erc-20-token
+    permanent: true
   - source: /alchemy/resources/contact-us
     destination: https://discord.com/invite/frSF7J8Ktw
+    permanent: true
   - source: /alchemy/tutorials/sending-txs/eip-1559
     destination: /docs/how-to-send-transactions-with-eip-1559
+    permanent: true
   - source: /alchemy/road-to-web3/weekly-learning-challenges/10.-how-to-create-a-decentralized-twitter-with-lens-protocol
     destination: /docs/10-how-to-create-a-decentralized-twitter-with-lens-protocol
+    permanent: true
   - source: /alchemy/guides/using-websockets#2-alchemy_filterednewfullpendingtransactions
     destination: /docs/reference/eth-subscribe#alchemy_pendingtransactions
+    permanent: true
   - source: /alchemy/apis/arbitrum/eth-accounts
     destination: /docs/reference/eth-accounts-arbitrum
+    permanent: true
   - source: /alchemy/apis/arbitrum/eth-blocknumber
     destination: /docs/reference/eth-blocknumber-arbitrum
+    permanent: true
   - source: /alchemy/apis/arbitrum/eth-call
     destination: /docs/reference/eth-call-arbitrum
+    permanent: true
   - source: /alchemy/apis/arbitrum/eth-chainid
     destination: /docs/reference/eth-chainid-arbitrum
+    permanent: true
   - source: /alchemy/apis/arbitrum/eth-estimategas
     destination: /docs/reference/eth-estimategas-arbitrum
+    permanent: true
   - source: /alchemy/apis/arbitrum/eth-gasprice
     destination: /docs/reference/eth-gasprice-arbitrum
+    permanent: true
   - source: /alchemy/apis/arbitrum/eth-getbalance
     destination: /docs/reference/eth-getbalance-arbitrum
+    permanent: true
   - source: /alchemy/apis/arbitrum/eth-getblockbyhash
     destination: /docs/reference/eth-getblockbyhash-arbitrum
+    permanent: true
   - source: /alchemy/apis/arbitrum/eth-getblockbynumber
     destination: /docs/reference/eth-getblockbynumber-arbitrum
+    permanent: true
   - source: /alchemy/apis/arbitrum/eth-getblocktransactioncountbyhash
     destination: /docs/reference/eth-getblocktransactioncountbyhash-arbitrum
+    permanent: true
   - source: /alchemy/apis/arbitrum/eth-getblocktransactioncountbynumber
     destination: /docs/reference/eth-getblocktransactioncountbynumber-arbitrum
+    permanent: true
   - source: /alchemy/apis/arbitrum/eth-getcode
     destination: /docs/reference/eth-getcode-arbitrum
+    permanent: true
   - source: /alchemy/apis/arbitrum/eth-getfilterchanges
     destination: /docs/reference/eth-getfilterchanges-arbitrum
+    permanent: true
   - source: /alchemy/apis/arbitrum/eth-getfilterlogs
     destination: /docs/reference/eth-getfilterlogs-arbitrum
+    permanent: true
   - source: /alchemy/apis/arbitrum/eth-getlogs
     destination: /docs/reference/eth-getlogs-arbitrum
+    permanent: true
   - source: /alchemy/apis/arbitrum/eth-getstorageat
     destination: /docs/reference/eth-getstorageat-arbitrum
+    permanent: true
   - source: /alchemy/apis/arbitrum/eth-gettransactionbyblockhashandindex
     destination: /docs/reference/eth-gettransactionbyblockhashandindex-arbitrum
+    permanent: true
   - source: /alchemy/apis/arbitrum/eth-gettransactionbyblocknumberandindex
     destination: /docs/reference/eth-gettransactionbyblocknumberandindex-arbitrum
+    permanent: true
   - source: /alchemy/apis/arbitrum/eth-gettransactionbyhash
     destination: /docs/reference/eth-gettransactionbyhash-arbitrum
+    permanent: true
   - source: /alchemy/apis/arbitrum/eth-gettransactioncount
     destination: /docs/reference/eth-gettransactioncount-arbitrum
+    permanent: true
   - source: /alchemy/apis/arbitrum/eth-gettransactionreceipt
     destination: /docs/reference/eth-gettransactionreceipt-arbitrum
+    permanent: true
   - source: /alchemy/apis/arbitrum/eth-newblockfilter
     destination: /docs/reference/eth-newblockfilter-arbitrum
+    permanent: true
   - source: /alchemy/apis/arbitrum/eth-newfilter
     destination: /docs/reference/eth-newfilter-arbitrum
+    permanent: true
   - source: /alchemy/apis/arbitrum/eth-sendrawtransaction
     destination: /docs/reference/eth-sendrawtransaction-arbitrum
+    permanent: true
   - source: /alchemy/apis/arbitrum/eth-subscribe
     destination: /docs/reference/eth-subscribe-arbitrum
+    permanent: true
   - source: /alchemy/apis/arbitrum/eth-uninstallfilter
     destination: /docs/reference/eth-uninstallfilter-arbitrum
+    permanent: true
   - source: /alchemy/apis/arbitrum/eth-unsubscribe
     destination: /docs/reference/eth-unsubscribe-arbitrum
+    permanent: true
   - source: /alchemy/apis/arbitrum/net-version
     destination: /docs/reference/net-version-arbitrum
+    permanent: true
   - source: /alchemy/apis/arbitrum/web3-clientversion
     destination: /docs/reference/web3-clientversion-arbitrum
+    permanent: true
   - source: /alchemy/apis/arbitrum/web3-sha3
     destination: /docs/reference/web3-sha3-arbitrum
+    permanent: true
   - source: /alchemy/apis/enhanced-apis/notify-api
     destination: /docs/reference/notify-api-endpoints
+    permanent: true
   - source: /alchemy/apis/ethereum/eth_cancelPrivateTransaction
     destination: /docs/reference/eth-cancelprivatetransaction
+    permanent: true
   - source: /alchemy/apis/ethereum/eth_getblockbyhash
     destination: /docs/reference/eth-getblockbyhash
+    permanent: true
   - source: /alchemy/apis/ethereum/eth_getblockbynumber
     destination: /docs/reference/eth-getblockbynumber
+    permanent: true
   - source: /alchemy/apis/ethereum/eth_gettransactionbyhash
     destination: /docs/reference/eth-gettransactionbyhash
+    permanent: true
   - source: /alchemy/apis/ethereum/eth_gettransactionreceipt
     destination: /docs/reference/eth-gettransactionreceipt
+    permanent: true
   - source: /alchemy/apis/ethereum/eth_sendrawtransaction
     destination: /docs/reference/eth-sendrawtransaction
+    permanent: true
   - source: /alchemy/apis/ethereum/eth-accounts
     destination: /docs/reference/eth-accounts
+    permanent: true
   - source: /alchemy/apis/ethereum/eth-blocknumber
     destination: /docs/reference/eth-blocknumber
+    permanent: true
   - source: /alchemy/apis/ethereum/eth-call
     destination: /docs/reference/eth-call
+    permanent: true
   - source: /alchemy/apis/ethereum/eth-chainid
     destination: /docs/reference/eth-chainid
+    permanent: true
   - source: /alchemy/apis/ethereum/eth-estimategas
     destination: /docs/reference/eth-estimategas
+    permanent: true
   - source: /alchemy/apis/ethereum/eth-feehistory
     destination: /docs/reference/eth-feehistory
+    permanent: true
   - source: /alchemy/apis/ethereum/eth-gasprice
     destination: /docs/reference/eth-gasprice
+    permanent: true
   - source: /alchemy/apis/ethereum/eth-getbalance
     destination: /docs/reference/eth-getbalance
+    permanent: true
   - source: /alchemy/apis/ethereum/eth-getblockbyhash
     destination: /docs/reference/eth-getblockbyhash
+    permanent: true
   - source: /alchemy/apis/ethereum/eth-getblockbynumber
     destination: /docs/reference/eth-getblockbynumber
+    permanent: true
   - source: /alchemy/apis/ethereum/eth-getBlockReceipts
     destination: /docs/reference/eth-getblockreceipts
+    permanent: true
   - source: /alchemy/apis/ethereum/eth-getblocktransactioncountbyhash
     destination: /docs/reference/eth-getblocktransactioncountbyhash
+    permanent: true
   - source: /alchemy/apis/ethereum/eth-getblocktransactioncountbynumber
     destination: /docs/reference/eth-getblocktransactioncountbynumber
+    permanent: true
   - source: /alchemy/apis/ethereum/eth-getcode
     destination: /docs/reference/eth-getcode
+    permanent: true
   - source: /alchemy/apis/ethereum/eth-getfilterchanges
     destination: /docs/reference/eth-getfilterchanges
+    permanent: true
   - source: /alchemy/apis/ethereum/eth-getfilterlogs
     destination: /docs/reference/eth-getfilterlogs
+    permanent: true
   - source: /alchemy/apis/ethereum/eth-getlogs
     destination: /docs/reference/eth-getlogs
+    permanent: true
   - source: /alchemy/apis/ethereum/eth-getproof
     destination: /docs/reference/eth-getproof
+    permanent: true
   - source: /alchemy/apis/ethereum/eth-getstorageat
     destination: /docs/reference/eth-getstorageat
+    permanent: true
   - source: /alchemy/apis/ethereum/eth-gettransactionbyblockhashandindex
     destination: /docs/reference/eth-gettransactionbyblockhashandindex
+    permanent: true
   - source: /alchemy/apis/ethereum/eth-gettransactionbyblocknumberandindex
     destination: /docs/reference/eth-gettransactionbyblocknumberandindex
+    permanent: true
   - source: /alchemy/apis/ethereum/eth-gettransactionbyhash
     destination: /docs/reference/eth-gettransactionbyhash
+    permanent: true
   - source: /alchemy/apis/ethereum/eth-gettransactioncount
     destination: /docs/reference/eth-gettransactioncount
+    permanent: true
   - source: /alchemy/apis/ethereum/eth-gettransactionreceipt
     destination: /docs/reference/eth-gettransactionreceipt
+    permanent: true
   - source: /alchemy/apis/ethereum/eth-getunclebyblockhashandindex
     destination: /docs/reference/eth-getunclebyblockhashandindex
+    permanent: true
   - source: /alchemy/apis/ethereum/eth-getunclebyblocknumberandindex
     destination: /docs/reference/eth-getunclebyblocknumberandindex
+    permanent: true
   - source: /alchemy/apis/ethereum/eth-getunclecountbyblockhash
     destination: /docs/reference/eth-getunclecountbyblockhash
+    permanent: true
   - source: /alchemy/apis/ethereum/eth-getunclecountbyblocknumber
     destination: /docs/reference/eth-getunclecountbyblocknumber
+    permanent: true
   - source: /alchemy/apis/ethereum/eth-maxpriorityfeepergas
     destination: /docs/reference/eth-maxpriorityfeepergas
+    permanent: true
   - source: /alchemy/apis/ethereum/eth-newblockfilter
     destination: /docs/reference/eth-newblockfilter
+    permanent: true
   - source: /alchemy/apis/ethereum/eth-newfilter
     destination: /docs/reference/eth-newfilter
+    permanent: true
   - source: /alchemy/apis/ethereum/eth-newpendingtransactionfilter
     destination: /docs/reference/eth-newpendingtransactionfilter
+    permanent: true
   - source: /alchemy/apis/ethereum/eth-protocolversion
     destination: /docs/reference/eth-protocolversion
+    permanent: true
   - source: /alchemy/apis/ethereum/eth-sendPrivateTransaction
     destination: /docs/reference/eth-sendPrivateTransaction
+    permanent: true
   - source: /alchemy/apis/ethereum/eth-sendrawtransaction
     destination: /docs/reference/eth-sendrawtransaction
+    permanent: true
   - source: /alchemy/apis/ethereum/eth-subscribe-1
     destination: /docs/reference/eth-subscribe
+    permanent: true
   - source: /alchemy/apis/ethereum/eth-uninstallfilter
     destination: /docs/reference/eth-uninstallfilter
+    permanent: true
   - source: /alchemy/apis/ethereum/eth-unsubscribe-1
     destination: /docs/reference/eth-unsubscribe
+    permanent: true
   - source: /alchemy/apis/ethereum/net-listening
     destination: /docs/reference/net-listening
+    permanent: true
   - source: /alchemy/apis/ethereum/net-version
     destination: /docs/reference/net-version
+    permanent: true
   - source: /alchemy/apis/ethereum/web3-clientversion-1
     destination: /docs/reference/web3-clientversion
+    permanent: true
   - source: /alchemy/apis/ethereum/web3-sha3-1
     destination: /docs/reference/web3-sha3
+    permanent: true
   - source: /alchemy/apis/ethereum/eth_gasprice
     destination: /docs/reference/eth-gasprice
+    permanent: true
   - source: /alchemy/apis/ethereum/eth-sendPrivateTransaction
     destination: /docs/reference/eth-sendprivatetransaction
+    permanent: true
   - source: /alchemy/apis/ethereum/eth_feehistory
     destination: /docs/reference/eth-feehistory
+    permanent: true
   - source: /alchemy/apis/optimism/eth_newblockfilter
     destination: /docs/reference/eth-newblockfilter-optimism
+    permanent: true
   - source: /alchemy/apis/optimism/eth-accounts
     destination: /docs/reference/eth-accounts-optimism
+    permanent: true
   - source: /alchemy/apis/optimism/eth-blocknumber
     destination: /docs/reference/eth-blocknumber-optimism
+    permanent: true
   - source: /alchemy/apis/optimism/eth-call
     destination: /docs/reference/eth-call-optimism
+    permanent: true
   - source: /alchemy/apis/optimism/eth-chainId
     destination: /docs/reference/eth-chainId-optimism
+    permanent: true
   - source: /alchemy/apis/optimism/eth-estimategas
     destination: /docs/reference/eth-estimategas-optimism
+    permanent: true
   - source: /alchemy/apis/optimism/eth-gasprice
     destination: /docs/reference/eth-gasprice-optimism
+    permanent: true
   - source: /alchemy/apis/optimism/eth-getbalance
     destination: /docs/reference/eth-getbalance-optimism
+    permanent: true
   - source: /alchemy/apis/optimism/eth-getblockbyhash
     destination: /docs/reference/eth-getblockbyhash-optimism
+    permanent: true
   - source: /alchemy/apis/optimism/eth-getblockbynumber
     destination: /docs/reference/eth-getblockbynumber-optimism
+    permanent: true
   - source: /alchemy/apis/optimism/eth-getblocktransactioncountbyhash
     destination: /docs/reference/eth-getblocktransactioncountbyhash-optimism
+    permanent: true
   - source: /alchemy/apis/optimism/eth-getblocktransactioncountbynumber
     destination: /docs/reference/eth-getblocktransactioncountbynumber-optimism
+    permanent: true
   - source: /alchemy/apis/optimism/eth-getcode
     destination: /docs/reference/eth-getcode-optimism
+    permanent: true
   - source: /alchemy/apis/optimism/eth-getfilterchanges
     destination: /docs/reference/eth-getfilterchanges-optimism
+    permanent: true
   - source: /alchemy/apis/optimism/eth-getfilterlogs
     destination: /docs/reference/eth-getfilterlogs-optimism
+    permanent: true
   - source: /alchemy/apis/optimism/eth-getLogs
     destination: /docs/reference/eth-getLogs-optimism
+    permanent: true
   - source: /alchemy/apis/optimism/eth-getproof
     destination: /docs/reference/eth-getproof-optimism
+    permanent: true
   - source: /alchemy/apis/optimism/eth-getstorageat
     destination: /docs/reference/eth-getstorageat-optimism
+    permanent: true
   - source: /alchemy/apis/optimism/eth-gettransactionbyblockhashandindex
     destination: /docs/reference/eth-gettransactionbyblockhashandindex-optimism
+    permanent: true
   - source: /alchemy/apis/optimism/eth-gettransactionbyblocknumberandindex
     destination: /docs/reference/eth-gettransactionbyblocknumberandindex-optimism
+    permanent: true
   - source: /alchemy/apis/optimism/eth-gettransactionbyhash
     destination: /docs/reference/eth-gettransactionbyhash-optimism
+    permanent: true
   - source: /alchemy/apis/optimism/eth-gettransactioncount
     destination: /docs/reference/eth-gettransactioncount-optimism
+    permanent: true
   - source: /alchemy/apis/optimism/eth-gettransactionreceipt
     destination: /docs/reference/eth-gettransactionreceipt-optimism
+    permanent: true
   - source: /alchemy/apis/optimism/eth-getunclebyblockhashandindex
     destination: /docs/reference/eth-getunclebyblockhashandindex-optimism
+    permanent: true
   - source: /alchemy/apis/optimism/eth-getunclebyblocknumberandindex
     destination: /docs/reference/eth-getunclebyblocknumberandindex-optimism
+    permanent: true
   - source: /alchemy/apis/optimism/eth-getunclecountbyblockhash
     destination: /docs/reference/eth-getunclecountbyblockhash-optimism
+    permanent: true
   - source: /alchemy/apis/optimism/eth-getunclecountbyblocknumber
     destination: /docs/reference/eth-getunclecountbyblocknumber-optimism
+    permanent: true
   - source: /alchemy/apis/optimism/eth-newfilter
     destination: /docs/reference/eth-newfilter-optimism
+    permanent: true
   - source: /alchemy/apis/optimism/eth-newpendingtransactionfilter
     destination: /docs/reference/eth-newpendingtransactionfilter-optimism
+    permanent: true
   - source: /alchemy/apis/optimism/eth-protocolVersion
     destination: /docs/reference/eth-protocolVersion-optimism
+    permanent: true
   - source: /alchemy/apis/optimism/eth-sendrawtransaction
     destination: /docs/reference/eth-sendrawtransaction-optimism
+    permanent: true
   - source: /alchemy/apis/optimism/eth-subscribe
     destination: /docs/reference/eth-subscribe-optimism
+    permanent: true
   - source: /alchemy/apis/optimism/eth-syncing
     destination: /docs/reference/eth-syncing-optimism
+    permanent: true
   - source: /alchemy/apis/optimism/eth-uninstallfilter
     destination: /docs/reference/eth-uninstallfilter-optimism
+    permanent: true
   - source: /alchemy/apis/optimism/eth-unsubscribe
     destination: /docs/reference/eth-unsubscribe-optimism
+    permanent: true
   - source: /alchemy/apis/optimism/net-listening
     destination: /docs/reference/net-listening-optimism
+    permanent: true
   - source: /alchemy/apis/optimism/net-version
     destination: /docs/reference/net-version-optimism
+    permanent: true
   - source: /alchemy/apis/optimism/web3-clientversion
     destination: /docs/reference/web3-clientversion-optimism
+    permanent: true
   - source: /alchemy/apis/optimism/web3-sha3
     destination: /docs/reference/web3-sha3-optimism
+    permanent: true
   - source: /alchemy/apis/polygon
     destination: /docs/reference/polygon-api-quickstart
+    permanent: true
   - source: /alchemy/apis/polygon/bor-getauthor
     destination: /docs/reference/bor-getauthor-polygon
+    permanent: true
   - source: /alchemy/apis/polygon/bor-getcurrentproposer
     destination: /docs/reference/bor-getcurrentproposer-polygon
+    permanent: true
   - source: /alchemy/apis/polygon/bor-getcurrentvalidators
     destination: /docs/reference/bor-getcurrentvalidators-polygon
+    permanent: true
   - source: /alchemy/apis/polygon/bor-getroothash
     destination: /docs/reference/bor-getroothash-polygon
+    permanent: true
   - source: /alchemy/apis/polygon/debug_tracetransaction
     destination: /docs/reference/debug_tracetransaction-polygon
+    permanent: true
   - source: /alchemy/apis/polygon/eth-accounts
     destination: /docs/reference/eth-accounts-polygon
+    permanent: true
   - source: /alchemy/apis/polygon/eth-blocknumber
     destination: /docs/reference/eth-blocknumber-polygon
+    permanent: true
   - source: /alchemy/apis/polygon/eth-call
     destination: /docs/reference/eth-call-polygon
+    permanent: true
   - source: /alchemy/apis/polygon/eth-chainid
     destination: /docs/reference/eth-chainid-polygon
+    permanent: true
   - source: /alchemy/apis/polygon/eth-estimategas
     destination: /docs/reference/eth-estimategas-polygon
+    permanent: true
   - source: /alchemy/apis/polygon/eth-gasprice
     destination: /docs/reference/eth-gasprice-polygon
+    permanent: true
   - source: /alchemy/apis/polygon/eth-getbalance
     destination: /docs/reference/eth-getbalance-polygon
+    permanent: true
   - source: /alchemy/apis/polygon/eth-getblockbyhash
     destination: /docs/reference/eth-getblockbyhash-polygon
+    permanent: true
   - source: /alchemy/apis/polygon/eth-getblockbynumber
     destination: /docs/reference/eth-getblockbynumber-polygon
+    permanent: true
   - source: /alchemy/apis/polygon/eth-getblocktransactioncountbyhash
     destination: /docs/reference/eth-getblocktransactioncountbyhash-polygon
+    permanent: true
   - source: /alchemy/apis/polygon/eth-getblocktransactioncountbynumber
     destination: /docs/reference/eth-getblocktransactioncountbynumber-polygon
+    permanent: true
   - source: /alchemy/apis/polygon/eth-getcode
     destination: /docs/reference/eth-getcode-polygon
+    permanent: true
   - source: /alchemy/apis/polygon/eth-getfilterchanges
     destination: /docs/reference/eth-getfilterchanges-polygon
+    permanent: true
   - source: /alchemy/apis/polygon/eth-getfilterlogs
     destination: /docs/reference/eth-getfilterlogs-polygon
+    permanent: true
   - source: /alchemy/apis/polygon/eth-getlogs
     destination: /docs/reference/eth-getlogs-polygon
+    permanent: true
   - source: /alchemy/apis/polygon/eth-getproof
     destination: /docs/reference/eth-getproof-polygon
+    permanent: true
   - source: /alchemy/apis/polygon/eth-getroothash
     destination: /docs/reference/eth-getroothash-polygon
+    permanent: true
   - source: /alchemy/apis/polygon/eth-getsignersathash
     destination: /docs/reference/eth-getsignersathash-polygon
+    permanent: true
   - source: /alchemy/apis/polygon/eth-getstorageat
     destination: /docs/reference/eth-getstorageat-polygon
+    permanent: true
   - source: /alchemy/apis/polygon/eth-gettransactionbyblockhashandindex
     destination: /docs/reference/eth-gettransactionbyblockhashandindex-polygon
+    permanent: true
   - source: /alchemy/apis/polygon/eth-gettransactionbyblocknumberandindex
     destination: /docs/reference/eth-gettransactionbyblocknumberandindex-polygon
+    permanent: true
   - source: /alchemy/apis/polygon/eth-gettransactionbyhash
     destination: /docs/reference/eth-gettransactionbyhash-polygon
+    permanent: true
   - source: /alchemy/apis/polygon/eth-gettransactioncount
     destination: /docs/reference/eth-gettransactioncount-polygon
+    permanent: true
   - source: /alchemy/apis/polygon/eth-gettransactionreceipt
     destination: /docs/reference/eth-gettransactionreceipt-polygon
+    permanent: true
   - source: /alchemy/apis/polygon/eth-gettransactionreceiptsbyblock
     destination: /docs/reference/eth-gettransactionreceiptsbyblock-polygon
+    permanent: true
   - source: /alchemy/apis/polygon/eth-getunclebyblockhashandindex
     destination: /docs/reference/eth-getunclebyblockhashandindex-polygon
+    permanent: true
   - source: /alchemy/apis/polygon/eth-getunclebyblocknumberandindex
     destination: /docs/reference/eth-getunclebyblocknumberandindex-polygon
+    permanent: true
   - source: /alchemy/apis/polygon/eth-getunclecountbyblockhash
     destination: /docs/reference/eth-getunclecountbyblockhash-polygon
+    permanent: true
   - source: /alchemy/apis/polygon/eth-getunclecountbyblocknumber
     destination: /docs/reference/eth-getunclecountbyblocknumber-polygon
+    permanent: true
   - source: /alchemy/apis/polygon/eth-newblockfilter
     destination: /docs/reference/eth-newblockfilter-polygon
+    permanent: true
   - source: /alchemy/apis/polygon/eth-newfilter
     destination: /docs/reference/eth-newfilter-polygon
+    permanent: true
   - source: /alchemy/apis/polygon/eth-newpendingtransactionfilter
     destination: /docs/reference/eth-newpendingtransactionfilter-polygon
+    permanent: true
   - source: /alchemy/apis/polygon/eth-sendrawtransaction
     destination: /docs/reference/eth-sendrawtransaction-polygon
+    permanent: true
   - source: /alchemy/apis/polygon/eth-subscribe
     destination: /docs/reference/eth-subscribe-polygon
+    permanent: true
   - source: /alchemy/apis/polygon/eth-uninstallfilter
     destination: /docs/reference/eth-uninstallfilter-polygon
+    permanent: true
   - source: /alchemy/apis/polygon/eth-unsubscribe
     destination: /docs/reference/eth-unsubscribe-polygon
+    permanent: true
   - source: /alchemy/apis/polygon/net-listening
     destination: /docs/reference/net-listening-polygon
+    permanent: true
   - source: /alchemy/apis/polygon/net-version
     destination: /docs/reference/net-version-polygon
+    permanent: true
   - source: /alchemy/apis/polygon/web3-clientversion
     destination: /docs/reference/web3-clientversion-polygon
+    permanent: true
   - source: /alchemy/apis/polygon/web3-sha3
     destination: /docs/reference/web3-sha3-polygon
+    permanent: true
   - source: /alchemy/apis/solana-api
     destination: /docs/reference/solana-api-quickstart
+    permanent: true
   - source: /alchemy/apis/solana-api/getaccountinfo
     destination: /docs/reference/getaccountinfo
+    permanent: true
   - source: /alchemy/apis/solana-api/getbalance
     destination: /docs/reference/getbalance
+    permanent: true
   - source: /alchemy/apis/solana-api/getblock
     destination: /docs/reference/getblock
+    permanent: true
   - source: /alchemy/apis/solana-api/getblockcommitment
     destination: /docs/reference/getblockcommitment
+    permanent: true
   - source: /alchemy/apis/solana-api/getblockheight
     destination: /docs/reference/getblockheight
+    permanent: true
   - source: /alchemy/apis/solana-api/getblockproduction
     destination: /docs/reference/getblockproduction
+    permanent: true
   - source: /alchemy/apis/solana-api/getblocks
     destination: /docs/reference/getblocks
+    permanent: true
   - source: /alchemy/apis/solana-api/getblockswithlimit
     destination: /docs/reference/getblockswithlimit
+    permanent: true
   - source: /alchemy/apis/solana-api/getblocktime
     destination: /docs/reference/getblocktime
+    permanent: true
   - source: /alchemy/apis/solana-api/getclusternodes
     destination: /docs/reference/getclusternodes
+    permanent: true
   - source: /alchemy/apis/solana-api/getepochinfo
     destination: /docs/reference/getepochinfo
+    permanent: true
   - source: /alchemy/apis/solana-api/getepochinfo-1
     destination: /docs/reference/getepochinfo
+    permanent: true
   - source: /alchemy/apis/solana-api/getepochschedule
     destination: /docs/reference/getepochschedule
+    permanent: true
   - source: /alchemy/apis/solana-api/getfeeformessage
     destination: /docs/reference/getfeeformessage
+    permanent: true
   - source: /alchemy/apis/solana-api/getfirstavailableblock
     destination: /docs/reference/getfirstavailableblock
+    permanent: true
   - source: /alchemy/apis/solana-api/getgenesishash
     destination: /docs/reference/getgenesishash
+    permanent: true
   - source: /alchemy/apis/solana-api/gethealth
     destination: /docs/reference/gethealth
+    permanent: true
   - source: /alchemy/apis/solana-api/gethighestsnapshotslot
     destination: /docs/reference/gethighestsnapshotslot
+    permanent: true
   - source: /alchemy/apis/solana-api/getidentity
     destination: /docs/reference/getidentity
+    permanent: true
   - source: /alchemy/apis/solana-api/getinflationgovernor
     destination: /docs/reference/getinflationgovernor
+    permanent: true
   - source: /alchemy/apis/solana-api/getinflationrate
     destination: /docs/reference/getinflationrate
+    permanent: true
   - source: /alchemy/apis/solana-api/getinflationreward
     destination: /docs/reference/getinflationreward
+    permanent: true
   - source: /alchemy/apis/solana-api/getlargestaccounts
     destination: /docs/reference/getlargestaccounts
+    permanent: true
   - source: /alchemy/apis/solana-api/getmaxretransmitslot
     destination: /docs/reference/getmaxretransmitslot
+    permanent: true
   - source: /alchemy/apis/solana-api/getmaxshredinsertslot
     destination: /docs/reference/getmaxshredinsertslot
+    permanent: true
   - source: /alchemy/apis/solana-api/getminimumbalanceforrentexemption
     destination: /docs/reference/getminimumbalanceforrentexemption
+    permanent: true
   - source: /alchemy/apis/solana-api/getmultipleaccounts
     destination: /docs/reference/getmultipleaccounts
+    permanent: true
   - source: /alchemy/apis/solana-api/getprogramaccounts
     destination: /docs/reference/getprogramaccounts
+    permanent: true
   - source: /alchemy/apis/solana-api/getrecentperformancesamples
     destination: /docs/reference/getrecentperformancesamples
+    permanent: true
   - source: /alchemy/apis/solana-api/getsignaturesforaddress
     destination: /docs/reference/getsignaturesforaddress
+    permanent: true
   - source: /alchemy/apis/solana-api/getsignaturestatuses
     destination: /docs/reference/getsignaturestatuses
+    permanent: true
   - source: /alchemy/apis/solana-api/getslot
     destination: /docs/reference/getslot
+    permanent: true
   - source: /alchemy/apis/solana-api/getslotleader
     destination: /docs/reference/getslotleader
+    permanent: true
   - source: /alchemy/apis/solana-api/getslotleaders
     destination: /docs/reference/getslotleaders
+    permanent: true
   - source: /alchemy/apis/solana-api/getsupply
     destination: /docs/reference/getsupply
+    permanent: true
   - source: /alchemy/apis/solana-api/gettokenaccountbalance
     destination: /docs/reference/gettokenaccountbalance
+    permanent: true
   - source: /alchemy/apis/solana-api/gettokenaccountsbyowner
     destination: /docs/reference/gettokenaccountsbyowner
+    permanent: true
   - source: /alchemy/apis/solana-api/gettokensupply
     destination: /docs/reference/gettokensupply
+    permanent: true
   - source: /alchemy/apis/solana-api/gettransaction
     destination: /docs/reference/gettransaction
+    permanent: true
   - source: /alchemy/apis/solana-api/getversion
     destination: /docs/reference/getversion
+    permanent: true
   - source: /alchemy/apis/solana-api/getvoteaccounts
     destination: /docs/reference/getvoteaccounts
+    permanent: true
   - source: /alchemy/apis/solana-api/isblockhashvalid
     destination: /docs/reference/isblockhashvalid
+    permanent: true
   - source: /alchemy/apis/solana-api/minimumledgerslot
     destination: /docs/reference/minimumledgerslot
+    permanent: true
   - source: /alchemy/apis/solana-api/sendtransaction
     destination: /docs/reference/sendtransaction
+    permanent: true
   - source: /alchemy/apis/solana-api/simulatetransaction
     destination: /docs/reference/simulatetransaction
+    permanent: true
   - source: /alchemy/enhanced-apis/nft-api/getcontractmetadata
     destination: /docs/reference/getcontractmetadata
+    permanent: true
   - source: /alchemy/enhanced-apis/nft-api/getfloorprice
     destination: /docs/reference/getfloorprice
+    permanent: true
   - source: /alchemy/enhanced-apis/nft-api/getnftmetadata
     destination: /docs/reference/getnftmetadata
+    permanent: true
   - source: /alchemy/enhanced-apis/nft-api/getnfts
     destination: /docs/reference/getnfts
+    permanent: true
   - source: /alchemy/enhanced-apis/nft-api/getnftsforcollection
     destination: /docs/reference/getnftsforcollection
+    permanent: true
   - source: /alchemy/enhanced-apis/nft-api/getownersforcollection
     destination: /docs/reference/getownersforcollection
+    permanent: true
   - source: /alchemy/enhanced-apis/nft-api/getOwnersForToken
     destination: /docs/reference/getownersfortoken
+    permanent: true
   - source: /alchemy/enhanced-apis/nft-api/getspamcontracts
     destination: /docs/reference/getspamcontracts
+    permanent: true
   - source: /alchemy/enhanced-apis/nft-api/isspamcontract
     destination: /docs/reference/isspamcontract
+    permanent: true
   - source: /alchemy/enhanced-apis/nft-api/reingestcontract
     destination: /docs/reference/reingestcontract
+    permanent: true
   - source: /alchemy/enhanced-apis/token-api/alchemy_gettokenallowance
     destination: /docs/reference/alchemy-gettokenallowance
+    permanent: true
   - source: /alchemy/enhanced-apis/token-api/alchemy_gettokenbalances
     destination: /docs/reference/alchemy-gettokenbalances
+    permanent: true
   - source: /alchemy/enhanced-apis/token-api/alchemy_gettokenmetadata
     destination: /docs/reference/alchemy-gettokenmetadata
+    permanent: true
   - source: /alchemy/enhanced-apis/trace-api/trace_block
     destination: /docs/reference/trace-block
+    permanent: true
   - source: /alchemy/enhanced-apis/trace-api/trace_call
     destination: /docs/reference/trace-call
+    permanent: true
   - source: /alchemy/enhanced-apis/trace-api/trace_callmany
     destination: /docs/reference/trace-callmany
+    permanent: true
   - source: /docs/reference/trace-callmany
     destination: /docs/reference/trace-api-quickstart
+    permanent: true
   - source: /alchemy/enhanced-apis/trace-api/trace_filter
     destination: /docs/reference/trace-filter
+    permanent: true
   - source: /alchemy/enhanced-apis/trace-api/trace_get
     destination: /docs/reference/trace-get
+    permanent: true
   - source: /alchemy/enhanced-apis/trace-api/trace_rawtransaction
     destination: /docs/reference/trace-rawtransaction
+    permanent: true
   - source: /alchemy/enhanced-apis/trace-api/trace_replayblocktransactions
     destination: /docs/reference/trace-replayblocktransaction
+    permanent: true
   - source: /alchemy/enhanced-apis/trace-api/trace_replaytransaction
     destination: /docs/reference/trace-replaytransaction
+    permanent: true
   - source: /alchemy/enhanced-apis/trace-api/trace_transaction
     destination: /docs/reference/trace-transaction
+    permanent: true
   - source: /alchemy/enhanced-apis/transaction-receipts-api
     destination: /docs/reference/alchemy-gettransactionreceipts
+    permanent: true
   - source: /alchemy/enhanced-apis/transfers-api
     destination: /docs/reference/transfers-api
+    permanent: true
   - source: /alchemy/enhanced-apis/unstoppable-domains-apis
     destination: /docs/reference/unstoppable-domains-api-quickstart
+    permanent: true
   - source: /alchemy/enhanced-apis/unstoppable-domains-apis/authentication
     destination: /docs/reference/unstoppable-domains-api-quickstart
+    permanent: true
   - source: /alchemy/enhanced-apis/unstoppable-domains-apis/get-domain-transfer-events
     destination: /docs/reference/domain-transfer-events
+    permanent: true
   - source: /alchemy/enhanced-apis/unstoppable-domains-apis/get-records-for-a-domain
     destination: /docs/reference/domain-record
+    permanent: true
   - source: /alchemy/enhanced-apis/unstoppable-domains-apis/get-records-for-owner-addresses
     destination: /docs/reference/owner-record
+    permanent: true
   - source: /alchemy/enhanced-apis/debug-api
     destination: /docs/reference/trace-api
+    permanent: true
   - source: /alchemy/apis/solana-api/signaturesubscribe
     destination: /docs/reference/signaturesubscribe
+    permanent: true
   - source: /alchemy/apis/solana-api/signatureunsubscribe
     destination: /docs/reference/signatureunsubscribe
+    permanent: true
   - source: /alchemy/apis/solana-api/slotsubscribe
     destination: /docs/reference/slotsubscribe
+    permanent: true
   - source: /alchemy/apis/solana-api/slotunsubscribe
     destination: /docs/reference/slotunsubscribe
+    permanent: true
   - source: /alchemy/apis/solana-api/slotupdatesubscribe
     destination: /docs/reference/slotupdatesubscribe
+    permanent: true
   - source: /enhanced-apis/nft-api/how-to-check-the-owner-of-an-nft
     destination: /docs/how-to-check-the-owner-of-an-nft
+    permanent: true
   - source: /apis/arbitrum
     destination: /docs/reference/arbitrum-api-quickstart
+    permanent: true
   - source: /apis/ethereum
     destination: /docs/reference/ethereum-api-quickstart
+    permanent: true
   - source: /apis/optimism
     destination: /docs/reference/optimism-api-quickstart
+    permanent: true
   - source: /documentation/subscription-api-websockets
     destination: /docs/reference/subscription-api
+    permanent: true
   - source: /enhanced-apis
     destination: /docs/reference/enhanced-apis-overview
+    permanent: true
   - source: /guides/nft-api-quickstart-guide
     destination: /docs/reference/nft-api-quickstart
+    permanent: true
   - source: /guides/using-notify
     destination: /docs/reference/notify-api-quickstart-guide
+    permanent: true
   - source: /resources/faq
     destination: /alchemy-docs/discuss
+    permanent: true
   - source: /guides/alchemy-for-macs
     destination: /docs/alchemy-quickstart-guide
+    permanent: true
   - source: /guides/demo-app
     destination: https://www.youtube.com/watch?v=8X7SkLM2sbA
+    permanent: true
   - source: /introduction/why-use-alchemy
     destination: /docs/why-use-alchemy
+    permanent: true
   - source: /tutorials/how-to-create-an-nft/how-to-mint-a-nft
     destination: /docs/how-to-mint-an-nft-with-ethers
+    permanent: true
   - source: /cdn-cgi/l/email-protection
     destination: /docs/how-to-mint-an-nft-from-code
+    permanent: true
   - source: /enhanced-apis/nft-api/how-to-get-all-nfts-in-a-collection
     destination: /docs/how-to-get-all-nfts-in-a-collection
+    permanent: true
   - source: /enhanced-apis/nft-api/how-to-get-all-nfts-owned-by-an-address
     destination: /docs/how-to-get-all-nfts-owned-by-an-address
+    permanent: true
   - source: /enhanced-apis/nft-api/how-to-get-ens
     destination: /docs/how-to-resolve-ens-domains-given-a-wallet-address
+    permanent: true
   - source: /enhanced-apis/token-api/get-all-tokens-owned-by-address
     destination: /docs/how-to-get-all-tokens-owned-by-an-address
+    permanent: true
   - source: /enhanced-apis/token-api/how-to-get-token-balance-for-an-address
     destination: /docs/how-to-get-token-balance-for-an-address
+    permanent: true
   - source: /enhanced-apis/token-api/how-to-get-token-metadata
     destination: /docs/how-to-get-token-metadata
+    permanent: true
   - source: /enhanced-apis/transfers-api/how-to-get-the-transfer-history-of-an-nft
     destination: /docs/how-to-get-the-transfer-history-of-an-nft
+    permanent: true
   - source: /tutorials/how-to-create-an-on-chain-nft-allowlist
     destination: /docs/how-to-create-an-on-chain-nft-allowlist
+    permanent: true
   - source: /guides/what-are-internal-transactions
     destination: /docs/what-are-internal-transactions
+    permanent: true
   - source: /guides/understanding-the-transaction-object-on-ethereum
     destination: /docs/understanding-the-transaction-object-on-ethereum
+    permanent: true
   - source: /documentation/alchemy-web3/enhanced-web3-api
     destination: reference/use-alchemyweb3js#enhanced-api-calls
+    permanent: true
   - source: /enhanced-apis/nft-api
     destination: /docs/reference/nft-api
+    permanent: true
   - source: /enhanced-apis/nft-api/nft-api-faq
     destination: /docs/reference/nft-api#faqs
+    permanent: true
   - source: /enhanced-apis/nft-api/nft-api-faq/handling-errors
     destination: /docs/reference/nft-api#handling-errors
+    permanent: true
   - source: /enhanced-apis/nft-api/nft-api-faq/nft-image-caching
     destination: /docs/reference/nft-api#why-does-alchemy-cache-nft-media
+    permanent: true
   - source: /enhanced-apis/nft-api/nft-api-quickstart-guide
     destination: /docs/reference/nft-api-quickstart
+    permanent: true
   - source: /documentation/best-practices-when-using-alchemy
     destination: /docs/best-practices-when-using-alchemy
+    permanent: true
   - source: /enhanced-apis/subscription-api-websockets/best-practices-for-using-websockets-in-web3
     destination: /alchemy-docs/docs/how-to-listen-to-nft-mints/reference/best-practices-for-using-websockets-in-web3
+    permanent: true
   - source: /enhanced-apis/subscription-api-websockets/how-to-listen-to-nft-mints
     destination: /alchemy-docs/docs/how-to-listen-to-nft-mints
+    permanent: true
   - source: /guides/connecting-metamask-to-alchemy
     destination: /docs/how-to-add-alchemy-rpc-endpoints-to-metamask
+    permanent: true
   - source: /guides/connecting-metamask-to-alchemy/how-to-add-arbitrum-to-metamask
     destination: /docs/how-to-add-arbitrum-to-metamask
+    permanent: true
   - source: /guides/connecting-metamask-to-alchemy/how-to-add-avalanche-to-metamask
     destination: /docs/how-to-add-avalanche-to-metamask
+    permanent: true
   - source: /guides/connecting-metamask-to-alchemy/how-to-add-cronos-to-metamask
     destination: /docs/how-to-add-cronos-to-metamask
+    permanent: true
   - source: /guides/connecting-metamask-to-alchemy/how-to-add-near-aurora-to-metamask
     destination: /docs/how-to-add-near-aurora-to-metamask
+    permanent: true
   - source: /guides/connecting-metamask-to-alchemy/how-to-add-optimism-to-metamask
     destination: /docs/how-to-add-optimism-to-metamask
+    permanent: true
   - source: /guides/connecting-metamask-to-alchemy/how-to-add-polygon-to-metamask
     destination: /docs/how-to-add-polygon-to-metamask
+    permanent: true
   - source: /guides/how-to-fork-ethereum-mainnet
     destination: /docs/how-to-fork-ethereum-mainnet
+    permanent: true
   - source: /guides/how-to-set-up-core-web3-developer-tools
     destination: /docs/how-to-set-up-core-web3-developer-tools
+    permanent: true
   - source: /guides/running-an-eth2-node-with-alchemy
     destination: /docs/running-an-eth20-staking-node-or-validator-with-alchemy
+    permanent: true
   - source: /guides/running-an-eth2-node-with-alchemy/eth2-staking-prysm
     destination: /docs/setting-up-an-eth-20-staking-validator-with-prysm
+    permanent: true
   - source: /guides/running-an-eth2-node-with-alchemy/eth2-staking-teku
     destination: /docs/setting-up-an-eth-20-staking-validator-with-teku
+    permanent: true
   - source: /introduction/getting-started
     destination: /docs/alchemy-quickstart-guide
+    permanent: true
   - source: /introduction/getting-started/simple-web3-script
     destination: /docs/how-to-get-the-latest-block-on-ethereum
+    permanent: true
   - source: /road-to-web3
     destination: /docs/welcome-to-the-road-to-web3
+    permanent: true
   - source: /road-to-web3/important-info
     destination: /docs/welcome-to-the-road-to-web3
+    permanent: true
   - source: /road-to-web3/weekly-hackathons
     destination: /docs/weekly-hackathons
+    permanent: true
   - source: /road-to-web3/weekly-hackathons/hackathon-1-governance
     destination: /docs/hackathon-1-governance
+    permanent: true
   - source: /road-to-web3/weekly-learning-challenges
     destination: /docs/weekly-learning-challenges
+    permanent: true
   - source: /road-to-web3/weekly-learning-challenges/1.-how-to-develop-an-nft-smart-contract-erc721-with-alchemy
     destination: /docs/how-to-develop-an-nft-smart-contract-erc721-with-alchemy
+    permanent: true
   - source: /road-to-web3/weekly-learning-challenges/2.-how-to-build-buy-me-a-coffee-defi-dapp
     destination: /docs/how-to-build-buy-me-a-coffee-defi-dapp
+    permanent: true
   - source: /road-to-web3/weekly-learning-challenges/3.-how-to-make-nfts-with-on-chain-metadata-hardhat-and-javascript
     destination: /docs/how-to-make-nfts-with-on-chain-metadata-hardhat-and-javascript
+    permanent: true
   - source: /road-to-web3/weekly-learning-challenges/4.-how-to-create-an-nft-gallery
     destination: /docs/how-to-create-an-nft-gallery
+    permanent: true
   - source: /road-to-web3/weekly-learning-challenges/5.-connect-apis-to-your-smart-contracts-using-chainlink
     destination: /docs/connect-apis-to-your-smart-contracts-using-chainlink
+    permanent: true
   - source: /road-to-web3/weekly-learning-challenges/6.-how-to-build-a-staking-dapp
     destination: /docs/how-to-build-a-staking-dapp
+    permanent: true
   - source: /road-to-web3/weekly-learning-challenges/7.-how-to-build-an-nft-marketplace-from-scratch
     destination: /docs/how-to-build-an-nft-marketplace-from-scratch
+    permanent: true
   - source: /road-to-web3/weekly-learning-challenges/8.-how-to-build-a-betting-game-on-optimism
     destination: /docs/how-to-build-a-betting-game-on-optimism
+    permanent: true
   - source: /road-to-web3/weekly-learning-challenges/9.-how-to-build-a-token-swap-dapp-with-0x-api
     destination: /docs/how-to-build-a-token-swap-dapp-with-0x-api
+    permanent: true
   - source: /docs/1-how-to-develop-an-nft-smart-contract-erc721-with-alchemy
     destination: /docs/how-to-develop-an-nft-smart-contract-erc721-with-alchemy
+    permanent: true
   - source: /docs/2-how-to-build-buy-me-a-coffee-defi-dapp
     destination: /docs/how-to-build-buy-me-a-coffee-defi-dapp
+    permanent: true
   - source: /docs/3-how-to-make-nfts-with-on-chain-metadata-hardhat-and-javascript
     destination: /docs/how-to-make-nfts-with-on-chain-metadata-hardhat-and-javascript
+    permanent: true
   - source: /docs/4-how-to-create-an-nft-gallery
     destination: /docs/how-to-create-an-nft-gallery
+    permanent: true
   - source: /docs/5-connect-apis-to-your-smart-contracts-using-chainlink
     destination: /docs/connect-apis-to-your-smart-contracts-using-chainlink
+    permanent: true
   - source: /docs/6-how-to-build-a-staking-dapp
     destination: /docs/how-to-build-a-staking-dapp
+    permanent: true
   - source: /docs/7-how-to-build-an-nft-marketplace-from-scratch
     destination: /docs/how-to-build-an-nft-marketplace-from-scratch
+    permanent: true
   - source: /docs/8-how-to-build-a-betting-game-on-optimism
     destination: docs/how-to-build-a-betting-game-on-optimism
+    permanent: true
   - source: /docs/9-how-to-build-a-token-swap-dapp-with-0x-api
     destination: /docs/how-to-build-a-token-swap-dapp-with-0x-api
+    permanent: true
   - source: /road-to-web3/welcome
     destination: /docs/welcome-to-the-road-to-web3
+    permanent: true
   - source: /road-to-web3/welcome-to-the-road-to-web3
     destination: /docs/welcome-to-the-road-to-web3
+    permanent: true
   - source: /tutorials/arbitrum-nft
     destination: /docs/arbitrum-nfts-creating-and-deploying-erc-721
+    permanent: true
   - source: /tutorials/deploy-your-own-erc20-token
     destination: /docs/how-to-create-an-erc-20-token-4-steps
+    permanent: true
   - source: /tutorials/hello-world-smart-contract
     destination: /docs/hello-world-smart-contract
+    permanent: true
   - source: /tutorials/hello-world-smart-contract/interacting-with-a-smart-contract
     destination: /docs/interacting-with-a-smart-contract
+    permanent: true
   - source: /tutorials/hello-world-smart-contract/part-4
     destination: /docs/integrating-your-smart-contract-with-the-frontend
+    permanent: true
   - source: /tutorials/hello-world-smart-contract/submitting-your-smart-contract-to-etherscan
     destination: /docs/submitting-your-smart-contract-to-etherscan
+    permanent: true
   - source: /tutorials/how-to-code-and-deploy-a-polygon-smart-contract
     destination: /docs/how-to-code-and-deploy-a-polygon-smart-contract
+    permanent: true
   - source: /guides/running-an-eth2-node-with-alchemy/setting-up-an-eth-2.0-node-or-validator-with-prysm
     destination: /docs/setting-up-an-eth-20-staking-validator-with-prysm
+    permanent: true
   - source: /tutorials/how-to-deploy-a-polygon-smart-contract
     destination: /docs/how-to-code-and-deploy-a-polygon-smart-contract
+    permanent: true
   - source: /guides/internal-playbook-upgrading-ethereum-nodes
     destination: /docs/internal-playbook-upgrading-ethereum-nodes
+    permanent: true
   - source: /introduction/core-products
     destination: /docs/core-products
+    permanent: true
   - source: /introduction/core-products/alchemy-build
     destination: /docs/alchemy-build
+    permanent: true
   - source: /introduction/core-products/alchemy-monitor
     destination: /docs/alchemy-monitor
+    permanent: true
   - source: /introduction/core-products/alchemy-notify
     destination: /docs/alchemy-notify
+    permanent: true
   - source: /introduction/core-products/alchemy-supernode
     destination: /docs/alchemy-supernode
+    permanent: true
   - source: /guides/eip-1559
     destination: /docs/eip-1559-resource-and-tutorial-hub
+    permanent: true
   - source: /guides/eip-1559/gas-estimator
     destination: /docs/how-to-build-a-gas-fee-estimator-using-eip-1559
+    permanent: true
   - source: /guides/eip-1559/maxpriorityfeepergas-vs-maxfeepergas
     destination: /docs/maxpriorityfeepergas-vs-maxfeepergas
+    permanent: true
   - source: /guides/eip-1559/retry-eip-1559-tx
     destination: /docs/retrying-an-eip-1559-transaction
+    permanent: true
   - source: /guides/eip-1559/send-tx-eip-1559
     destination: /docs/how-to-send-transactions-with-eip-1559
+    permanent: true
   - source: /enhanced-apis/transaction-receipts-api/how-to-get-nft-contract-creator-address
     destination: /docs/how-to-get-nft-contract-creator-address
+    permanent: true
   - source: /enhanced-apis/transfers-api/how-to-get-a-contracts-first-transfer-event
     destination: /docs/how-to-get-a-contracts-first-transfer-event
+    permanent: true
   - source: /enhanced-apis/transfers-api/how-to-get-a-contracts-last-transfer-event
     destination: /docs/how-to-get-a-contracts-last-transfer-event
+    permanent: true
   - source: /enhanced-apis/transfers-api/how-to-get-all-nft-transactions-by-an-address
     destination: /docs/how-to-get-all-nft-transactions-by-an-address
+    permanent: true
   - source: /enhanced-apis/transfers-api/how-to-get-nfts-minted-by-an-address
     destination: /docs/how-to-get-nfts-minted-by-an-address
+    permanent: true
   - source: /enhanced-apis/transfers-api/how-to-get-transaction-history-for-an-address-on-ethereum
     destination: /docs/how-to-get-transaction-history-for-an-address-on-ethereum
+    permanent: true
   - source: /apis/feature-support-by-chain
     destination: /docs/reference/feature-support-by-chain
+    permanent: true
   - source: /enhanced-apis/enhanced-apis-overview
     destination: /docs/reference/enhanced-apis-overview
+    permanent: true
   - source: /enhanced-apis/notify-api/using-notify
     destination: /docs/reference/notify-api-quickstart-guide
+    permanent: true
   - source: /enhanced-apis/subscription-api-websockets
     destination: /docs/reference/subscription-api
+    permanent: true
   - source: /enhanced-apis/token-api
     destination: /docs/reference/token-api
+    permanent: true
   - source: /enhanced-apis/token-api/token-api-quickstart-guide
     destination: /docs/reference/token-api-quickstart
+    permanent: true
   - source: /enhanced-apis/trace-api
     destination: /docs/reference/trace-api
+    permanent: true
   - source: /introduction/contributing-to-docs
     destination: /docs/contributing-to-these-docs
+    permanent: true
   - source: /introduction/referral-program
     destination: /docs/referral-program
+    permanent: true
   - source: /documentation/alchemy-web3
     destination: /docs/reference/alchemyweb3js
+    permanent: true
   - source: /enhanced-apis/notify-api/building-a-dapp-with-real-time-transaction-notifications
     destination: /docs/building-a-dapp-with-real-time-transaction-notifications
+    permanent: true
   - source: /enhanced-apis/notify-api/how-to-create-a-slack-whale-alert-bot
     destination: /docs/how-to-create-a-slack-whale-alert-bot
+    permanent: true
   - source: /enhanced-apis/notify-api/how-to-create-a-whale-alert-discord-bot
     destination: /docs/how-to-create-a-whale-alert-discord-bot
+    permanent: true
   - source: /enhanced-apis/notify-api/how-to-create-a-whale-alert-twitter-bot
     destination: /docs/how-to-create-a-whale-alert-twitter-bot
+    permanent: true
   - source: /guides/choosing-a-network
     destination: /docs/choosing-a-web3-network
+    permanent: true
   - source: /guides/debugging-cors
     destination: /docs/debugging-cors-problems-for-end-users
+    permanent: true
   - source: /guides/eth_getlogs
     destination: /docs/deep-dive-into-eth_getlogs
+    permanent: true
   - source: /guides/ethereum-transactions-pending-mined-dropped-and-replaced
     destination: /docs/ethereum-transactions-pending-mined-dropped-replaced
+    permanent: true
   - source: /guides/how-to-enable-compression-to-speed-up-json-rpc-blockchain-requests
     destination: /docs/how-to-enable-compression-to-speed-up-json-rpc-blockchain-requests
+    permanent: true
   - source: /guides/how-to-interpret-binaries-in-solidity
     destination: /docs/how-to-interpret-binaries-in-solidity
+    permanent: true
   - source: /guides/how-to-verify-a-message-signature-on-ethereum
     destination: /docs/how-to-verify-a-message-signature-on-ethereum
+    permanent: true
   - source: /guides/understanding-ethereum-logs
     destination: /docs/deep-dive-into-eth_getlogs
+    permanent: true
   - source: /introduction/getting-started/sending-txs
     destination: /docs/how-to-send-transactions-on-ethereum
+    permanent: true
   - source: /sdk/alchemy-sdk-quickstart
     destination: /docs/reference/alchemy-sdk-quickstart
+    permanent: true
   - source: /tutorials/how-to-track-ethereum-transactions
     destination: /docs/how-to-track-mined-and-pending-ethereum-transactions
+    permanent: true
   - source: /tutorials/nft-minter
     destination: /docs/nft-minter
+    permanent: true
   - source: /tutorials/nft-minter/how-do-i-deploy-nfts-online
     destination: /docs/how-to-build-an-nft-website
+    permanent: true
   - source: /tutorials/send-private-transaction
     destination: /docs/how-to-send-a-transaction
+    permanent: true
   - source: /tutorials/transfers-tutorial
     destination: /docs/integrating-historical-transaction-data-into-your-dapp
+    permanent: true
   - source: /resources/blockchain-101
     destination: /docs/blockchain-101
+    permanent: true
   - source: /resources/web3-glossary
     destination: /docs/web3-glossary
+    permanent: true
   - source: /resources/web3-glossary/what-are-uncle-blocks
     destination: /docs/what-are-uncle-blocks
+    permanent: true
   - source: /tutorials/building-a-dapp-with-real-time-transaction-notifications
     destination: /docs/building-a-dapp-with-real-time-transaction-notifications
+    permanent: true
   - source: /documentation/batch-requests
     destination: /docs/reference/batch-requests
+    permanent: true
   - source: /documentation/compute-units
     destination: /docs/reference/compute-units
+    permanent: true
   - source: /documentation/error-reference
     destination: /docs/reference/error-reference
+    permanent: true
   - source: /documentation/gas-limits-for-eth_call-and-eth_estimategas
     destination: /docs/reference/gas-limits-for-eth_call-and-eth_estimategas
+    permanent: true
   - source: /documentation/throughput
     destination: /docs/reference/throughput
+    permanent: true
   - source: /guides/how-to-cancel-a-pending-transaction-on-ethereum
     destination: /docs/how-to-cancel-a-private-transaction-on-ethereum
+    permanent: true
   - source: /guides/how-to-verify-a-message-signature-on-ethereum/how-to-create-a-signature-generator-dapp
     destination: /docs/how-to-create-a-signature-generator-dapp
+    permanent: true
   - source: /sdk/sdk-quickstart
     destination: /docs/reference/alchemy-sdk-quickstart
+    permanent: true
   - source: /enhanced-apis/notify-api/integrate-alchemy-zapier
     destination: /docs/how-to-integrate-alchemy-webhooks-with-zapier
+    permanent: true
   - source: /tutorials/how-to-create-an-nft
     destination: /docs/how-to-create-an-nft
+    permanent: true
   - source: /tutorials/how-to-create-an-nft/how-to-mint-an-nft-with-ethers
     destination: /docs/how-to-mint-an-nft-from-code
+    permanent: true
   - source: /tutorials/how-to-create-an-nft/how-to-view-your-nft-in-your-wallet
     destination: /docs/how-to-view-your-nft-in-your-mobile-wallet
+    permanent: true
   - source: /tutorials/how-to-create-an-nft/nft-price
     destination: /docs/how-do-i-set-a-price-on-an-nft
+    permanent: true
   - source: /tutorials/how-to-add-royalties-to-an-erc-20-token
     destination: /docs/how-to-add-royalties-to-an-erc-20-token
+    permanent: true
   - source: /resources/contact-us
     destination: https://discord.com/invite/frSF7J8Ktw
+    permanent: true
   - source: /other/contact-us
     destination: https://discord.com/invite/frSF7J8Ktw
+    permanent: true
   - source: /tutorials/sending-txs/eip-1559
     destination: /docs/how-to-send-transactions-with-eip-1559
+    permanent: true
   - source: /road-to-web3/weekly-learning-challenges/10.-how-to-create-a-decentralized-twitter-with-lens-protocol
     destination: /docs/10-how-to-create-a-decentralized-twitter-with-lens-protocol
+    permanent: true
   - source: /apis/arbitrum/eth-accounts
     destination: /docs/reference/eth-accounts-arbitrum
+    permanent: true
   - source: /apis/arbitrum/eth-blocknumber
     destination: /docs/reference/eth-blocknumber-arbitrum
+    permanent: true
   - source: /apis/arbitrum/eth-call
     destination: /docs/reference/eth-call-arbitrum
+    permanent: true
   - source: /apis/arbitrum/eth-chainid
     destination: /docs/reference/eth-chainid-arbitrum
+    permanent: true
   - source: /apis/arbitrum/eth-estimategas
     destination: /docs/reference/eth-estimategas-arbitrum
+    permanent: true
   - source: /apis/arbitrum/eth-gasprice
     destination: /docs/reference/eth-gasprice-arbitrum
+    permanent: true
   - source: /apis/arbitrum/eth-getbalance
     destination: /docs/reference/eth-getbalance-arbitrum
+    permanent: true
   - source: /apis/arbitrum/eth-getblockbyhash
     destination: /docs/reference/eth-getblockbyhash-arbitrum
+    permanent: true
   - source: /apis/arbitrum/eth-getblockbynumber
     destination: /docs/reference/eth-getblockbynumber-arbitrum
+    permanent: true
   - source: /apis/arbitrum/eth-getblocktransactioncountbyhash
     destination: /docs/reference/eth-getblocktransactioncountbyhash-arbitrum
+    permanent: true
   - source: /apis/arbitrum/eth-getblocktransactioncountbynumber
     destination: /docs/reference/eth-getblocktransactioncountbynumber-arbitrum
+    permanent: true
   - source: /apis/arbitrum/eth-getcode
     destination: /docs/reference/eth-getcode-arbitrum
+    permanent: true
   - source: /apis/arbitrum/eth-getfilterchanges
     destination: /docs/reference/eth-getfilterchanges-arbitrum
+    permanent: true
   - source: /apis/arbitrum/eth-getfilterlogs
     destination: /docs/reference/eth-getfilterlogs-arbitrum
+    permanent: true
   - source: /apis/arbitrum/eth-getlogs
     destination: /docs/reference/eth-getlogs-arbitrum
+    permanent: true
   - source: /apis/arbitrum/eth-getstorageat
     destination: /docs/reference/eth-getstorageat-arbitrum
+    permanent: true
   - source: /apis/arbitrum/eth-gettransactionbyblockhashandindex
     destination: /docs/reference/eth-gettransactionbyblockhashandindex-arbitrum
+    permanent: true
   - source: /apis/arbitrum/eth-gettransactionbyblocknumberandindex
     destination: /docs/reference/eth-gettransactionbyblocknumberandindex-arbitrum
+    permanent: true
   - source: /apis/arbitrum/eth-gettransactionbyhash
     destination: /docs/reference/eth-gettransactionbyhash-arbitrum
+    permanent: true
   - source: /apis/arbitrum/eth-gettransactioncount
     destination: /docs/reference/eth-gettransactioncount-arbitrum
+    permanent: true
   - source: /apis/arbitrum/eth-gettransactionreceipt
     destination: /docs/reference/eth-gettransactionreceipt-arbitrum
+    permanent: true
   - source: /apis/arbitrum/eth-newblockfilter
     destination: /docs/reference/eth-newblockfilter-arbitrum
+    permanent: true
   - source: /apis/arbitrum/eth-newfilter
     destination: /docs/reference/eth-newfilter-arbitrum
+    permanent: true
   - source: /apis/arbitrum/eth-sendrawtransaction
     destination: /docs/reference/eth-sendrawtransaction-arbitrum
+    permanent: true
   - source: /apis/arbitrum/eth-subscribe
     destination: /docs/reference/eth-subscribe-arbitrum
+    permanent: true
   - source: /apis/arbitrum/eth-uninstallfilter
     destination: /docs/reference/eth-uninstallfilter-arbitrum
+    permanent: true
   - source: /apis/arbitrum/eth-unsubscribe
     destination: /docs/reference/eth-unsubscribe-arbitrum
+    permanent: true
   - source: /apis/arbitrum/net-version
     destination: /docs/reference/net-version-arbitrum
+    permanent: true
   - source: /apis/arbitrum/web3-clientversion
     destination: /docs/reference/web3-clientversion-arbitrum
+    permanent: true
   - source: /apis/arbitrum/web3-sha3
     destination: /docs/reference/web3-sha3-arbitrum
+    permanent: true
   - source: /apis/enhanced-apis/notify-api
     destination: /docs/reference/notify-api
+    permanent: true
   - source: /apis/ethereum/eth_cancelPrivateTransaction
     destination: /docs/reference/eth-cancelprivatetransaction
+    permanent: true
   - source: /apis/ethereum/eth_getblockbyhash
     destination: /docs/reference/eth-getblockbyhash
+    permanent: true
   - source: /apis/ethereum/eth_getblockbynumber
     destination: /docs/reference/eth-getblockbynumber
+    permanent: true
   - source: /apis/ethereum/eth_gettransactionbyhash
     destination: /docs/reference/eth-gettransactionbyhash
+    permanent: true
   - source: /apis/ethereum/eth_gettransactionreceipt
     destination: /docs/reference/eth-gettransactionreceipt
+    permanent: true
   - source: /apis/ethereum/eth_sendrawtransaction
     destination: /docs/reference/eth-sendrawtransaction
+    permanent: true
   - source: /apis/ethereum/eth-accounts
     destination: /docs/reference/eth-accounts
+    permanent: true
   - source: /apis/ethereum/eth-blocknumber
     destination: /docs/reference/eth-blocknumber
+    permanent: true
   - source: /apis/ethereum/eth-call
     destination: /docs/reference/eth-call
+    permanent: true
   - source: /apis/ethereum/eth-chainid
     destination: /docs/reference/eth-chainid
+    permanent: true
   - source: /apis/ethereum/eth-estimategas
     destination: /docs/reference/eth-estimategas
+    permanent: true
   - source: /apis/ethereum/eth-feehistory
     destination: /docs/reference/eth-feehistory
+    permanent: true
   - source: /apis/ethereum/eth-gasprice
     destination: /docs/reference/eth-gasprice
+    permanent: true
   - source: /apis/ethereum/eth-getbalance
     destination: /docs/reference/eth-getbalance
+    permanent: true
   - source: /apis/ethereum/eth-getblockbyhash
     destination: /docs/reference/eth-getblockbyhash
+    permanent: true
   - source: /apis/ethereum/eth-getblockbynumber
     destination: /docs/reference/eth-getblockbynumber
+    permanent: true
   - source: /apis/ethereum/eth-getBlockReceipts
     destination: /docs/reference/eth-getblockreceipts
+    permanent: true
   - source: /apis/ethereum/eth-getblocktransactioncountbyhash
     destination: /docs/reference/eth-getblocktransactioncountbyhash
+    permanent: true
   - source: /apis/ethereum/eth-getblocktransactioncountbynumber
     destination: /docs/reference/eth-getblocktransactioncountbynumber
+    permanent: true
   - source: /apis/ethereum/eth-getcode
     destination: /docs/reference/eth-getcode
+    permanent: true
   - source: /apis/ethereum/eth-getfilterchanges
     destination: /docs/reference/eth-getfilterchanges
+    permanent: true
   - source: /apis/ethereum/eth-getfilterlogs
     destination: /docs/reference/eth-getfilterlogs
+    permanent: true
   - source: /apis/ethereum/eth-getlogs
     destination: /docs/reference/eth-getlogs
+    permanent: true
   - source: /apis/ethereum/eth-getproof
     destination: /docs/reference/eth-getproof
+    permanent: true
   - source: /apis/ethereum/eth-getstorageat
     destination: /docs/reference/eth-getstorageat
+    permanent: true
   - source: /apis/ethereum/eth-gettransactionbyblockhashandindex
     destination: /docs/reference/eth-gettransactionbyblockhashandindex
+    permanent: true
   - source: /apis/ethereum/eth-gettransactionbyblocknumberandindex
     destination: /docs/reference/eth-gettransactionbyblocknumberandindex
+    permanent: true
   - source: /apis/ethereum/eth-gettransactionbyhash
     destination: /docs/reference/eth-gettransactionbyhash
+    permanent: true
   - source: /apis/ethereum/eth-gettransactioncount
     destination: /docs/reference/eth-gettransactioncount
+    permanent: true
   - source: /apis/ethereum/eth-gettransactionreceipt
     destination: /docs/reference/eth-gettransactionreceipt
+    permanent: true
   - source: /apis/ethereum/eth-getunclebyblockhashandindex
     destination: /docs/reference/eth-getunclebyblockhashandindex
+    permanent: true
   - source: /apis/ethereum/eth-getunclebyblocknumberandindex
     destination: /docs/reference/eth-getunclebyblocknumberandindex
+    permanent: true
   - source: /apis/ethereum/eth-getunclecountbyblockhash
     destination: /docs/reference/eth-getunclecountbyblockhash
+    permanent: true
   - source: /apis/ethereum/eth-getunclecountbyblocknumber
     destination: /docs/reference/eth-getunclecountbyblocknumber
+    permanent: true
   - source: /apis/ethereum/eth-maxpriorityfeepergas
     destination: /docs/reference/eth-maxpriorityfeepergas
+    permanent: true
   - source: /apis/ethereum/eth-newblockfilter
     destination: /docs/reference/eth-newblockfilter
+    permanent: true
   - source: /apis/ethereum/eth-newfilter
     destination: /docs/reference/eth-newfilter
+    permanent: true
   - source: /apis/ethereum/eth-newpendingtransactionfilter
     destination: /docs/reference/eth-newpendingtransactionfilter
+    permanent: true
   - source: /apis/ethereum/eth-protocolversion
     destination: /docs/reference/eth-protocolversion
+    permanent: true
   - source: /apis/ethereum/eth-sendPrivateTransaction
     destination: /docs/reference/eth-sendPrivateTransaction
+    permanent: true
   - source: /apis/ethereum/eth-sendrawtransaction
     destination: /docs/reference/eth-sendrawtransaction
+    permanent: true
   - source: /apis/ethereum/eth-subscribe-1
     destination: /docs/reference/eth-subscribe
+    permanent: true
   - source: /apis/ethereum/eth-uninstallfilter
     destination: /docs/reference/eth-uninstallfilter
+    permanent: true
   - source: /apis/ethereum/eth-unsubscribe-1
     destination: /docs/reference/eth-unsubscribe
+    permanent: true
   - source: /apis/ethereum/net-listening
     destination: /docs/reference/net-listening
+    permanent: true
   - source: /apis/ethereum/net-version
     destination: /docs/reference/net-version
+    permanent: true
   - source: /apis/ethereum/web3-clientversion-1
     destination: /docs/reference/web3-clientversion
+    permanent: true
   - source: /apis/ethereum/web3-sha3-1
     destination: /docs/reference/web3-sha3
+    permanent: true
   - source: /apis/optimism/eth_newblockfilter
     destination: /docs/reference/eth-newblockfilter-optimism
+    permanent: true
   - source: /apis/optimism/eth-accounts
     destination: /docs/reference/eth-accounts-optimism
+    permanent: true
   - source: /apis/optimism/eth-blocknumber
     destination: /docs/reference/eth-blocknumber-optimism
+    permanent: true
   - source: /apis/optimism/eth-call
     destination: /docs/reference/eth-call-optimism
+    permanent: true
   - source: /apis/optimism/eth-chainId
     destination: /docs/reference/eth-chainId-optimism
+    permanent: true
   - source: /apis/optimism/eth-estimategas
     destination: /docs/reference/eth-estimategas-optimism
+    permanent: true
   - source: /apis/optimism/eth-gasprice
     destination: /docs/reference/eth-gasprice-optimism
+    permanent: true
   - source: /apis/optimism/eth-getbalance
     destination: /docs/reference/eth-getbalance-optimism
+    permanent: true
   - source: /apis/optimism/eth-getblockbyhash
     destination: /docs/reference/eth-getblockbyhash-optimism
+    permanent: true
   - source: /apis/optimism/eth-getblockbynumber
     destination: /docs/reference/eth-getblockbynumber-optimism
+    permanent: true
   - source: /apis/optimism/eth-getblocktransactioncountbyhash
     destination: /docs/reference/eth-getblocktransactioncountbyhash-optimism
+    permanent: true
   - source: /apis/optimism/eth-getblocktransactioncountbynumber
     destination: /docs/reference/eth-getblocktransactioncountbynumber-optimism
+    permanent: true
   - source: /apis/optimism/eth-getcode
     destination: /docs/reference/eth-getcode-optimism
+    permanent: true
   - source: /apis/optimism/eth-getfilterchanges
     destination: /docs/reference/eth-getfilterchanges-optimism
+    permanent: true
   - source: /apis/optimism/eth-getfilterlogs
     destination: /docs/reference/eth-getfilterlogs-optimism
+    permanent: true
   - source: /apis/optimism/eth-getLogs
     destination: /docs/reference/eth-getLogs-optimism
+    permanent: true
   - source: /apis/optimism/eth-getproof
     destination: /docs/reference/eth-getproof-optimism
+    permanent: true
   - source: /apis/optimism/eth-getstorageat
     destination: /docs/reference/eth-getstorageat-optimism
+    permanent: true
   - source: /apis/optimism/eth-gettransactionbyblockhashandindex
     destination: /docs/reference/eth-gettransactionbyblockhashandindex-optimism
+    permanent: true
   - source: /apis/optimism/eth-gettransactionbyblocknumberandindex
     destination: /docs/reference/eth-gettransactionbyblocknumberandindex-optimism
+    permanent: true
   - source: /apis/optimism/eth-gettransactionbyhash
     destination: /docs/reference/eth-gettransactionbyhash-optimism
+    permanent: true
   - source: /apis/optimism/eth-gettransactioncount
     destination: /docs/reference/eth-gettransactioncount-optimism
+    permanent: true
   - source: /apis/optimism/eth-gettransactionreceipt
     destination: /docs/reference/eth-gettransactionreceipt-optimism
+    permanent: true
   - source: /apis/optimism/eth-getunclebyblockhashandindex
     destination: /docs/reference/eth-getunclebyblockhashandindex-optimism
+    permanent: true
   - source: /apis/optimism/eth-getunclebyblocknumberandindex
     destination: /docs/reference/eth-getunclebyblocknumberandindex-optimism
+    permanent: true
   - source: /apis/optimism/eth-getunclecountbyblockhash
     destination: /docs/reference/eth-getunclecountbyblockhash-optimism
+    permanent: true
   - source: /apis/optimism/eth-getunclecountbyblocknumber
     destination: /docs/reference/eth-getunclecountbyblocknumber-optimism
+    permanent: true
   - source: /apis/optimism/eth-newfilter
     destination: /docs/reference/eth-newfilter-optimism
+    permanent: true
   - source: /apis/optimism/eth-newpendingtransactionfilter
     destination: /docs/reference/eth-newpendingtransactionfilter-optimism
+    permanent: true
   - source: /apis/optimism/eth-protocolVersion
     destination: /docs/reference/eth-protocolVersion-optimism
+    permanent: true
   - source: /apis/optimism/eth-sendrawtransaction
     destination: /docs/reference/eth-sendrawtransaction-optimism
+    permanent: true
   - source: /apis/optimism/eth-subscribe
     destination: /docs/reference/eth-subscribe-optimism
+    permanent: true
   - source: /apis/optimism/eth-syncing
     destination: /docs/reference/eth-syncing-optimism
+    permanent: true
   - source: /apis/optimism/eth-uninstallfilter
     destination: /docs/reference/eth-uninstallfilter-optimism
+    permanent: true
   - source: /apis/optimism/eth-unsubscribe
     destination: /docs/reference/eth-unsubscribe-optimism
+    permanent: true
   - source: /apis/optimism/net-listening
     destination: /docs/reference/net-listening-optimism
+    permanent: true
   - source: /apis/optimism/net-version
     destination: /docs/reference/net-version-optimism
+    permanent: true
   - source: /apis/optimism/web3-clientversion
     destination: /docs/reference/web3-clientversion-optimism
+    permanent: true
   - source: /apis/optimism/web3-sha3
     destination: /docs/reference/web3-sha3-optimism
+    permanent: true
   - source: /apis/polygon
     destination: /docs/reference/polygon-api-quickstart
+    permanent: true
   - source: /apis/polygon/bor-getauthor
     destination: /docs/reference/bor-getauthor-polygon
+    permanent: true
   - source: /apis/polygon/bor-getcurrentproposer
     destination: /docs/reference/bor-getcurrentproposer-polygon
+    permanent: true
   - source: /apis/polygon/bor-getcurrentvalidators
     destination: /docs/reference/bor-getcurrentvalidators-polygon
+    permanent: true
   - source: /apis/polygon/bor-getroothash
     destination: /docs/reference/bor-getroothash-polygon
+    permanent: true
   - source: /apis/polygon/debug_tracetransaction
     destination: /docs/reference/debug_tracetransaction-polygon
+    permanent: true
   - source: /apis/polygon/eth-accounts
     destination: /docs/reference/eth-accounts-polygon
+    permanent: true
   - source: /apis/polygon/eth-blocknumber
     destination: /docs/reference/eth-blocknumber-polygon
+    permanent: true
   - source: /apis/polygon/eth-call
     destination: /docs/reference/eth-call-polygon
+    permanent: true
   - source: /apis/polygon/eth-chainid
     destination: /docs/reference/eth-chainid-polygon
+    permanent: true
   - source: /apis/polygon/eth-estimategas
     destination: /docs/reference/eth-estimategas-polygon
+    permanent: true
   - source: /apis/polygon/eth-gasprice
     destination: /docs/reference/eth-gasprice-polygon
+    permanent: true
   - source: /apis/polygon/eth-getbalance
     destination: /docs/reference/eth-getbalance-polygon
+    permanent: true
   - source: /apis/polygon/eth-getblockbyhash
     destination: /docs/reference/eth-getblockbyhash-polygon
+    permanent: true
   - source: /apis/polygon/eth-getblockbynumber
     destination: /docs/reference/eth-getblockbynumber-polygon
+    permanent: true
   - source: /apis/polygon/eth-getblocktransactioncountbyhash
     destination: /docs/reference/eth-getblocktransactioncountbyhash-polygon
+    permanent: true
   - source: /apis/polygon/eth-getblocktransactioncountbynumber
     destination: /docs/reference/eth-getblocktransactioncountbynumber-polygon
+    permanent: true
   - source: /apis/polygon/eth-getcode
     destination: /docs/reference/eth-getcode-polygon
+    permanent: true
   - source: /apis/polygon/eth-getfilterchanges
     destination: /docs/reference/eth-getfilterchanges-polygon
+    permanent: true
   - source: /apis/polygon/eth-getfilterlogs
     destination: /docs/reference/eth-getfilterlogs-polygon
+    permanent: true
   - source: /apis/polygon/eth-getlogs
     destination: /docs/reference/eth-getlogs-polygon
+    permanent: true
   - source: /apis/polygon/eth-getproof
     destination: /docs/reference/eth-getproof-polygon
+    permanent: true
   - source: /apis/polygon/eth-getroothash
     destination: /docs/reference/eth-getroothash-polygon
+    permanent: true
   - source: /apis/polygon/eth-getsignersathash
     destination: /docs/reference/eth-getsignersathash-polygon
+    permanent: true
   - source: /apis/polygon/eth-getstorageat
     destination: /docs/reference/eth-getstorageat-polygon
+    permanent: true
   - source: /apis/polygon/eth-gettransactionbyblockhashandindex
     destination: /docs/reference/eth-gettransactionbyblockhashandindex-polygon
+    permanent: true
   - source: /apis/polygon/eth-gettransactionbyblocknumberandindex
     destination: /docs/reference/eth-gettransactionbyblocknumberandindex-polygon
+    permanent: true
   - source: /apis/polygon/eth-gettransactionbyhash
     destination: /docs/reference/eth-gettransactionbyhash-polygon
+    permanent: true
   - source: /apis/polygon/eth-gettransactioncount
     destination: /docs/reference/eth-gettransactioncount-polygon
+    permanent: true
   - source: /apis/polygon/eth-gettransactionreceipt
     destination: /docs/reference/eth-gettransactionreceipt-polygon
+    permanent: true
   - source: /apis/polygon/eth-gettransactionreceiptsbyblock
     destination: /docs/reference/eth-gettransactionreceiptsbyblock-polygon
+    permanent: true
   - source: /apis/polygon/eth-getunclebyblockhashandindex
     destination: /docs/reference/eth-getunclebyblockhashandindex-polygon
+    permanent: true
   - source: /apis/polygon/eth-getunclebyblocknumberandindex
     destination: /docs/reference/eth-getunclebyblocknumberandindex-polygon
+    permanent: true
   - source: /apis/polygon/eth-getunclecountbyblockhash
     destination: /docs/reference/eth-getunclecountbyblockhash-polygon
+    permanent: true
   - source: /apis/polygon/eth-getunclecountbyblocknumber
     destination: /docs/reference/eth-getunclecountbyblocknumber-polygon
+    permanent: true
   - source: /apis/polygon/eth-newblockfilter
     destination: /docs/reference/eth-newblockfilter-polygon
+    permanent: true
   - source: /apis/polygon/eth-newfilter
     destination: /docs/reference/eth-newfilter-polygon
+    permanent: true
   - source: /apis/polygon/eth-newpendingtransactionfilter
     destination: /docs/reference/eth-newpendingtransactionfilter-polygon
+    permanent: true
   - source: /apis/polygon/eth-sendrawtransaction
     destination: /docs/reference/eth-sendrawtransaction-polygon
+    permanent: true
   - source: /apis/polygon/eth-subscribe
     destination: /docs/reference/eth-subscribe-polygon
+    permanent: true
   - source: /apis/polygon/eth-uninstallfilter
     destination: /docs/reference/eth-uninstallfilter-polygon
+    permanent: true
   - source: /apis/polygon/eth-unsubscribe
     destination: /docs/reference/eth-unsubscribe-polygon
+    permanent: true
   - source: /apis/polygon/net-listening
     destination: /docs/reference/net-listening-polygon
+    permanent: true
   - source: /apis/polygon/net-version
     destination: /docs/reference/net-version-polygon
+    permanent: true
   - source: /apis/polygon/web3-clientversion
     destination: /docs/reference/web3-clientversion-polygon
+    permanent: true
   - source: /apis/polygon/web3-sha3
     destination: /docs/reference/web3-sha3-polygon
+    permanent: true
   - source: /apis/solana-api
     destination: /docs/reference/solana-api-quickstart
+    permanent: true
   - source: /apis/solana-api/getaccountinfo
     destination: /docs/reference/getaccountinfo
+    permanent: true
   - source: /apis/solana-api/getbalance
     destination: /docs/reference/getbalance
+    permanent: true
   - source: /apis/solana-api/getblock
     destination: /docs/reference/getblock
+    permanent: true
   - source: /apis/solana-api/getblockcommitment
     destination: /docs/reference/getblockcommitment
+    permanent: true
   - source: /apis/solana-api/getblockheight
     destination: /docs/reference/getblockheight
+    permanent: true
   - source: /apis/solana-api/getblockproduction
     destination: /docs/reference/getblockproduction
+    permanent: true
   - source: /apis/solana-api/getblocks
     destination: /docs/reference/getblocks
+    permanent: true
   - source: /apis/solana-api/getblockswithlimit
     destination: /docs/reference/getblockswithlimit
+    permanent: true
   - source: /apis/solana-api/getblocktime
     destination: /docs/reference/getblocktime
+    permanent: true
   - source: /apis/solana-api/getclusternodes
     destination: /docs/reference/getclusternodes
+    permanent: true
   - source: /apis/solana-api/getepochinfo
     destination: /docs/reference/getepochinfo
+    permanent: true
   - source: /apis/solana-api/getepochinfo-1
     destination: /docs/reference/getepochinfo
+    permanent: true
   - source: /apis/solana-api/getepochschedule
     destination: /docs/reference/getepochschedule
+    permanent: true
   - source: /apis/solana-api/getfeeformessage
     destination: /docs/reference/getfeeformessage
+    permanent: true
   - source: /apis/solana-api/getfirstavailableblock
     destination: /docs/reference/getfirstavailableblock
+    permanent: true
   - source: /apis/solana-api/getgenesishash
     destination: /docs/reference/getgenesishash
+    permanent: true
   - source: /apis/solana-api/gethealth
     destination: /docs/reference/gethealth
+    permanent: true
   - source: /apis/solana-api/gethighestsnapshotslot
     destination: /docs/reference/gethighestsnapshotslot
+    permanent: true
   - source: /apis/solana-api/getidentity
     destination: /docs/reference/getidentity
+    permanent: true
   - source: /apis/solana-api/getinflationgovernor
     destination: /docs/reference/getinflationgovernor
+    permanent: true
   - source: /apis/solana-api/getinflationrate
     destination: /docs/reference/getinflationrate
+    permanent: true
   - source: /apis/solana-api/getinflationreward
     destination: /docs/reference/getinflationreward
+    permanent: true
   - source: /apis/solana-api/getlargestaccounts
     destination: /docs/reference/getlargestaccounts
+    permanent: true
   - source: /apis/solana-api/getmaxretransmitslot
     destination: /docs/reference/getmaxretransmitslot
+    permanent: true
   - source: /apis/solana-api/getmaxshredinsertslot
     destination: /docs/reference/getmaxshredinsertslot
+    permanent: true
   - source: /apis/solana-api/getminimumbalanceforrentexemption
     destination: /docs/reference/getminimumbalanceforrentexemption
+    permanent: true
   - source: /apis/solana-api/getmultipleaccounts
     destination: /docs/reference/getmultipleaccounts
+    permanent: true
   - source: /apis/solana-api/getprogramaccounts
     destination: /docs/reference/getprogramaccounts
+    permanent: true
   - source: /apis/solana-api/getrecentperformancesamples
     destination: /docs/reference/getrecentperformancesamples
+    permanent: true
   - source: /apis/solana-api/getsignaturesforaddress
     destination: /docs/reference/getsignaturesforaddress
+    permanent: true
   - source: /apis/solana-api/getsignaturestatuses
     destination: /docs/reference/getsignaturestatuses
+    permanent: true
   - source: /apis/solana-api/getslot
     destination: /docs/reference/getslot
+    permanent: true
   - source: /apis/solana-api/getslotleader
     destination: /docs/reference/getslotleader
+    permanent: true
   - source: /apis/solana-api/getslotleaders
     destination: /docs/reference/getslotleaders
+    permanent: true
   - source: /apis/solana-api/getsupply
     destination: /docs/reference/getsupply
+    permanent: true
   - source: /apis/solana-api/gettokenaccountbalance
     destination: /docs/reference/gettokenaccountbalance
+    permanent: true
   - source: /apis/solana-api/gettokenaccountsbyowner
     destination: /docs/reference/gettokenaccountsbyowner
+    permanent: true
   - source: /apis/solana-api/gettokensupply
     destination: /docs/reference/gettokensupply
+    permanent: true
   - source: /apis/solana-api/gettransaction
     destination: /docs/reference/gettransaction
+    permanent: true
   - source: /apis/solana-api/getversion
     destination: /docs/reference/getversion
+    permanent: true
   - source: /apis/solana-api/getvoteaccounts
     destination: /docs/reference/getvoteaccounts
+    permanent: true
   - source: /apis/solana-api/isblockhashvalid
     destination: /docs/reference/isblockhashvalid
+    permanent: true
   - source: /apis/solana-api/minimumledgerslot
     destination: /docs/reference/minimumledgerslot
+    permanent: true
   - source: /apis/solana-api/sendtransaction
     destination: /docs/reference/sendtransaction
+    permanent: true
   - source: /apis/solana-api/simulatetransaction
     destination: /docs/reference/simulatetransaction
+    permanent: true
   - source: /enhanced-apis/nft-api/getcontractmetadata
     destination: /docs/reference/getcontractmetadata
+    permanent: true
   - source: /enhanced-apis/nft-api/getfloorprice
     destination: /docs/reference/getfloorprice
+    permanent: true
   - source: /enhanced-apis/nft-api/getnftmetadata
     destination: /docs/reference/getnftmetadata
+    permanent: true
   - source: /enhanced-apis/nft-api/getnfts
     destination: /docs/reference/getnfts
+    permanent: true
   - source: /enhanced-apis/nft-api/getnftsforcollection
     destination: /docs/reference/getnftsforcollection
+    permanent: true
   - source: /enhanced-apis/nft-api/getownersforcollection
     destination: /docs/reference/getownersforcollection
+    permanent: true
   - source: /enhanced-apis/nft-api/getOwnersForToken
     destination: /docs/reference/getownersfortoken
+    permanent: true
   - source: /enhanced-apis/nft-api/getspamcontracts
     destination: /docs/reference/getspamcontracts
+    permanent: true
   - source: /enhanced-apis/nft-api/isspamcontract
     destination: /docs/reference/isspamcontract
+    permanent: true
   - source: /enhanced-apis/nft-api/reingestcontract
     destination: /docs/reference/reingestcontract
+    permanent: true
   - source: /enhanced-apis/token-api/alchemy_gettokenallowance
     destination: /docs/reference/alchemy-gettokenallowance
+    permanent: true
   - source: /enhanced-apis/token-api/alchemy_gettokenbalances
     destination: /docs/reference/alchemy-gettokenbalances
+    permanent: true
   - source: /enhanced-apis/token-api/alchemy_gettokenmetadata
     destination: /docs/reference/alchemy-gettokenmetadata
+    permanent: true
   - source: /enhanced-apis/trace-api/trace_block
     destination: /docs/reference/trace-block
+    permanent: true
   - source: /enhanced-apis/trace-api/trace_call
     destination: /docs/reference/trace-call
+    permanent: true
   - source: /enhanced-apis/trace-api/trace_callmany
     destination: /docs/reference/trace-callmany
+    permanent: true
   - source: /enhanced-apis/trace-api/trace_filter
     destination: /docs/reference/trace-filter
+    permanent: true
   - source: /enhanced-apis/trace-api/trace_get
     destination: /docs/reference/trace-get
+    permanent: true
   - source: /enhanced-apis/trace-api/trace_rawtransaction
     destination: /docs/reference/trace-rawtransaction
+    permanent: true
   - source: /enhanced-apis/trace-api/trace_replayblocktransactions
     destination: /docs/reference/trace-replayblocktransaction
+    permanent: true
   - source: /enhanced-apis/trace-api/trace_replaytransaction
     destination: /docs/reference/trace-replaytransaction
+    permanent: true
   - source: /enhanced-apis/trace-api/trace_transaction
     destination: /docs/reference/trace-transaction
+    permanent: true
   - source: /enhanced-apis/transaction-receipts-api
     destination: /docs/reference/alchemy-gettransactionreceipts
+    permanent: true
   - source: /enhanced-apis/transfers-api
     destination: /docs/reference/transfers-api
+    permanent: true
   - source: /enhanced-apis/unstoppable-domains-apis
     destination: /docs/reference/unstoppable-domains-api-quickstart
+    permanent: true
   - source: /enhanced-apis/unstoppable-domains-apis/authentication
     destination: /docs/reference/unstoppable-domains-api-quickstart
+    permanent: true
   - source: /enhanced-apis/unstoppable-domains-apis/get-domain-transfer-events
     destination: /docs/reference/domain-transfer-events
+    permanent: true
   - source: /enhanced-apis/unstoppable-domains-apis/get-records-for-a-domain
     destination: /docs/reference/domain-record
+    permanent: true
   - source: /enhanced-apis/unstoppable-domains-apis/get-records-for-owner-addresses
     destination: /docs/reference/owner-record
+    permanent: true
   - source: /enhanced-apis/debug-api
     destination: /docs/reference/trace-api
+    permanent: true
   - source: /apis/solana-api/signaturesubscribe
     destination: /docs/reference/signaturesubscribe
+    permanent: true
   - source: /apis/solana-api/signatureunsubscribe
     destination: /docs/reference/signatureunsubscribe
+    permanent: true
   - source: /apis/solana-api/slotsubscribe
     destination: /docs/reference/slotsubscribe
+    permanent: true
   - source: /apis/solana-api/slotunsubscribe
     destination: /docs/reference/slotunsubscribe
+    permanent: true
   - source: /apis/solana-api/slotupdatesubscribe
     destination: /docs/reference/slotupdatesubscribe
+    permanent: true
   - source: /docs/reference/unstoppable-domains-api
     destination: /docs/reference/unstoppable-domains-api-quickstart
+    permanent: true
   - source: /alchemy/enhanced-apis/transfers-api
     destination: /docs/reference/alchemy-getassettransfers
+    permanent: true
   - source: /alchemy/enhanced-apis/notify-api
     destination: /docs/reference/notify-api-quickstart
+    permanent: true
   - source: /alchemy/documentation/alchemy-web3
     destination: /docs/reference/use-alchemyweb3js
+    permanent: true
   - source: /alchemy/documentation/alchemy-api-reference/json-rpc
     destination: /docs/reference/json-rpc
+    permanent: true
   - source: /alchemy/documentation/alchemy-api-reference/json-rpc#eth_getbalance
     destination: /docs/reference/getbalance#request
+    permanent: true
   - source: /alchemy/tutorials/deploy-your-own-erc20-token
     destination: /docs/how-to-create-an-erc-20-token-4-steps
+    permanent: true
   - source: /alchemy/tutorials/how-to-write-and-deploy-a-nft-smart-contract/how-to-view-your-nft-in-your-wallet
     destination: /docs/how-to-view-your-nft-in-your-mobile-wallet
+    permanent: true
   - source: /alchemy/guides/internal-playbook-upgrading-ethereum-nodes
     destination: /docs/internal-playbook-upgrading-ethereum-nodes
+    permanent: true
   - source: /alchemy/enhanced-apis/notify-api/how-to-create-a-slack-whale-alert-bot
     destination: /docs/how-to-create-a-whale-alert-slack-bot
+    permanent: true
   - source: /alchemy/enhanced-apis/notify-api/how-to-create-a-telegram-whale-alert-bot
     destination: /docs/how-to-create-whale-alert-bots
+    permanent: true
   - source: /alchemy/enhanced-apis/trace-api/trace_replayblocktransactions
     destination: /docs/reference/trace-replayblocktransactions
+    permanent: true
   - source: /alchemy/enhanced-apis/subscription-api-websockets/best-practices-for-using-websockets-in-web3
     destination: /docs/reference/best-practices-for-using-websockets-in-web3
+    permanent: true
   - source: /alchemy/apis/ethereum/eth_getbalance
     destination: /docs/reference/eth-getbalance
+    permanent: true
   - source: /alchemy/apis/ethereum/eth-sendPrivateTransaction
     destination: /docs/reference/eth-sendprivatetransaction
+    permanent: true
   - source: /alchemy/apis/polygon/net-version
     destination: /docs/reference/net-version-polygon
+    permanent: true
   - source: /alchemy/apis/polygon/net-listening
     destination: /docs/reference/net-listening-polygon
+    permanent: true
   - source: /alchemy/apis/polygon/eth-uninstallfilter
     destination: /docs/reference/eth-uninstallfilter-polygon
+    permanent: true
   - source: /alchemy/apis/polygon/debug_tracetransaction
     destination: /docs/reference/polygon-api-quickstart
+    permanent: true
   - source: /alchemy/apis/optimism/eth-getLogs
     destination: /docs/reference/eth-getlogs-optimism
+    permanent: true
   - source: /alchemy/apis/optimism/eth-protocolVersion
     destination: /docs/reference/eth-protocolVersion-optimism
+    permanent: true
   - source: /alchemy/apis/optimism/eth-chainId
     destination: /docs/reference/eth-chainId-optimism
+    permanent: true
   - source: /alchemy/documentation/alchemy-web3/enhanced-web3-api
     destination: /docs/reference/use-alchemyweb3js#enhanced-api-calls
+    permanent: true
   - source: /alchemy/documentation/alchemy-web3/reference/use-alchemyweb3js#enhanced-api-calls
     destination: /docs/reference/use-alchemyweb3js#enhanced-api-calls
+    permanent: true
   - source: /alchemy/documentation/rate-limits
     destination: /docs/reference/throughput#-what-is-throughput
+    permanent: true
   - source: /reference/debug_tracetransaction-polygon
     destination: /docs/reference/polygon-api-quickstart
+    permanent: true
   - source: /tutorials/simple-web3-script
     destination: /docs/how-to-read-data-from-the-blockchain
+    permanent: true
   - source: /alchemy/tutorials/sending-txs
     destination: /docs/how-to-send-transactions-on-ethereum
+    permanent: true
   - source: /alchemy/tutorials/sending-transactions-using-web3-and-alchemy
     destination: /docs/how-to-send-transactions-on-ethereum
+    permanent: true
   - source: /reference/transfers-api
     destination: /docs/reference/transfers-api-endpoints
+    permanent: true
   - source: /reference/nft-api
     destination: /docs/reference/nft-api-quickstart
+    permanent: true
   - source: /reference/notify-api
     destination: /docs/reference/notify-api-quickstart
+    permanent: true
   - source: /reference/transaction-receipts
     destination: /docs/reference/transaction-receipts-endpoints
+    permanent: true
   - source: /reference/transaction-receipts-quickstart
     destination: /docs/reference/alchemy-gettransactionreceipts
+    permanent: true
   - source: /reference/alchemy-sendgasoptimizedtransaction
     destination: /docs/reference/alchemy-sendgasoptimizedtransaction-1
+    permanent: true
   - source: /reference/how-to-get-general-information-about-a-transaction
     destination: /docs/reference/eth-gettransactionreceipt#use-cases-for-eth_gettransactionreceipt
+    permanent: true
   - source: /reference/get_-apikey-getownersfortoken
     destination: /docs/reference/getownersfortoken
+    permanent: true
   - source: /alchemy/apis/ethereum/eth-sendPrivateTransaction
     destination: /docs/reference/eth-sendprivatetransaction
+    permanent: true
   - source: /alchemy/documentation/alchemy-web3
     destination: /docs/reference/use-alchemyweb3js
+    permanent: true
   - source: /guides/rate-limits
     destination: /docs/reference/throughput
+    permanent: true
   - source: /alchemy/guides/rate-limits
     destination: /docs/reference/throughput
+    permanent: true
   - source: /docs/how-to-mint-an-nft-with-ethers
     destination: /docs/how-to-mint-an-nft-from-code
+    permanent: true
   - source: /alchemy/documentation/apis/polygon-api
     destination: /docs/reference/polygon-api-quickstart
+    permanent: true
   - source: /alchemy/apis/polygon-api
     destination: /docs/reference/polygon-api-quickstart
+    permanent: true
   - source: /alchemy/documentation/apis/optimism-api
     destination: /docs/reference/optimism-api-quickstart
+    permanent: true
   - source: /alchemy/documentation/apis/arbitrum-api
     destination: /docs/reference/arbitrum-api-quickstart
+    permanent: true
   - source: /alchemy/documentation/apis/solana-api
     destination: /docs/reference/solana-api-quickstart
+    permanent: true
   - source: /alchemy/documentation/apis/ethereum-api
     destination: /docs/reference/ethereum-api-quickstart
+    permanent: true
   - source: /alchemy/documentation/alchemy-api-reference/transfers-api
     destination: /docs/reference/transfers-api-quickstart
+    permanent: true
   - source: /alchemy/documentation/apis
     destination: /docs/reference/api-overview
+    permanent: true
   - source: /alchemy/tutorials/how-to-write-and-deploy-a-nft-smart-contract/how-to-mint-a-nft
     destination: /docs/how-to-mint-an-nft-from-code
+    permanent: true
   - source: /alchemy/guides/how-to-develop-an-nft-smart-contract-erc721-with-alchemy
     destination: /docs/how-to-develop-an-nft-smart-contract-erc721-with-alchemy
+    permanent: true
   - source: /alchemy/tutorials/how-to-build-buy-me-a-coffee-defi-dapp
     destination: /docs/how-to-build-buy-me-a-coffee-defi-dapp
+    permanent: true
   - source: /guides/alchemy-notify
     destination: /docs/reference/notify-api-quickstart
+    permanent: true
   - source: /alchemy/apis/optimism-api
     destination: /docs/reference/optimism-api-quickstart
+    permanent: true
   - source: /alchemy/enhanced-apis/nft-api/handling-errors
     destination: /docs/reference/nft-api-quickstart#handling-nft-api-errors
+    permanent: true
   - source: /documentation/alchemy-api-reference/transfers-api
     destination: /docs/reference/transfers-api
+    permanent: true
   - source: /documentation/alchemy-api-reference/json-rpc#eth_subscribe
     destination: /docs/reference/json-rpc#eth_subscribe
+    permanent: true
   - source: /alchemy/guides/nft-api-faq
     destination: /docs/reference/nft-api-quickstart#faqs
+    permanent: true
   - source: /enhanced-apis/nft-api/nft-image-caching
     destination: /docs/reference/nft-api-quickstart#faqs
+    permanent: true
   - source: /alchemy/apis/ethereum/eth_newpendingtransactionfilter
     destination: /docs/reference/eth-newpendingtransactionfilter
+    permanent: true
   - source: /alchemy/create-web3-dapp
     destination: /docs/nft-minter
+    permanent: true
   - source: /documentation/alchemy-api-reference/json-rpc#eth_subscribe
     destination: /docs/reference/eth-subscribe
+    permanent: true
   - source: /documentation/rate-limits.
     destination: /docs/reference/throughput
+    permanent: true
   - source: /docs/how-to-get-nft-ownership-information
     destination: /docs/how-to-check-the-owner-of-an-nft
+    permanent: true
   - source: /ether.js
     destination: /docs/what-is-ethers-js
+    permanent: true
   - source: /reference/how-to-query-events-occurred-on-the-blockchain
     destination: /docs/reference/eth-getlogs#use-cases-for-eth_getlogs
+    permanent: true
   - source: /alchemy/tutorials/hello-world-smart-contract/creating-a-full-stack-dapp
     destination: /docs/nft-minter
+    permanent: true
   - source: /reference/maxpriorityfeepergas
     destination: /docs/reference/eth-maxpriorityfeepergas
+    permanent: true
   - source: /reference/alchemyweb3js
     destination: /docs/web3-glossary
+    permanent: true
   - source: /docs/10-how-to-create-a-decentralized-twitter-with-lens-protocol
     destination: /docs/how-to-create-a-decentralized-twitter-with-lens-protocol
+    permanent: true
   - source: /documentation/alchemy-api-reference/debug-api
     destination: /docs/reference/debug-api-quickstart
+    permanent: true
   - source: /documentation/rate-limits
     destination: /docs/reference/throughput#-what-is-throughput
+    permanent: true
   - source: /docs/docs/how-to-build-a-betting-game-on-optimism
     destination: /docs/how-to-build-a-betting-game-on-optimism
+    permanent: true
   - source: /docs/weekly-hackathons
     destination: /docs/weekly-learning-challenges
+    permanent: true
   - source: /tutorials/how-to-write-and-deploy-a-nft-smart-contract/how-to-view-your-nft-in-your-wallet
     destination: /docs/how-to-view-your-nft-in-your-mobile-wallet
+    permanent: true
   - source: /alchemy/documentation/alchemy-api-reference/json-rpc
     destination: reference/error-reference#standard-json-rpc-errors
+    permanent: true
   - source: /documentation/alchemy-api-reference/notify-api
     destination: /docs/reference/notify-api-quickstart
+    permanent: true
   - source: /alchemy/documentation/apis/ethereum
     destination: /docs/reference/ethereum-api-quickstart
+    permanent: true
   - source: /alchemy/road-to-web3/weekly-learning-challenges/7.-how-to-an-nft-marketplace-from-scratch
     destination: /docs/how-to-build-an-nft-marketplace-from-scratch
+    permanent: true
   - source: /nft/v2/JFlD_ZfxP80cXwctyBv30gszKEg35gJF/getOwnersForCollection
     destination: /docs/reference/getownersforcollection
+    permanent: true
   - source: /docs/8-how-to-build-a-betting-game-on-optimism
     destination: /docs/how-to-build-a-betting-game-on-optimism
+    permanent: true
   - source: /alchemy/documentation/apis/ethereum/eth_getunclecountbyblocknumber
     destination: /docs/reference/eth-getunclecountbyblocknumber
+    permanent: true
   - source: /guides/rate-limits'
     destination: /docs/reference/throughput#-what-is-throughput
+    permanent: true
   - source: /alchemy/documentation/apis%22
     destination: /docs/reference/api-overview
+    permanent: true
   - source: /alchemy/guides/using-webhooks#address-activit
     destination: /docs/alchemy-notify#-address-activity
+    permanent: true
   - source: /alchemy/guides/v2-alchemy-notify
     destination: /docs/alchemy-notify
+    permanent: true
   - source: /reference/eth-sendrawtransaction
     destination: /docs/reference/eth-sendrawtransaction
+    permanent: true
   - source: /guides/using-websockets
     destination: /docs/reference/best-practices-for-using-websockets-in-web3
+    permanent: true
   - source: /reference/subscription-api-alchemy-sdk#pendingtransactions
     destination: /docs/reference/newpendingtransactions
+    permanent: true
   - source: /alchemy/road-to-web3/weekly-learning-challenges/10.-how-to-create-a-decentralized-twitter-with-lens-protocol
     destination: /docs/how-to-create-a-decentralized-twitter-with-lens-protocol
+    permanent: true
   - source: /alchemy/tutorials/how-to-write-and-deploy-a-nft-smart-contract
     destination: /docs/how-to-develop-an-nft-smart-contract-erc721-with-alchemy
+    permanent: true
   - source: /alchemy/enhanced-apis/nft-api/getnftmetadata/handling-errors
     destination: /docs/reference/getnftmetadata
+    permanent: true
   - source: /alchemy/guides/using-websockets#2-alchemy_filterednewfullpendingtransactions
     destination: /docs/how-to-subscribe-to-transactions-via-websocket-endpoints#step-6-filter-pending-transactions
+    permanent: true
   - source: /alchemy/documentation/apis
     destination: /docs/reference/api-overview
+    permanent: true
   - source: /docs/how-to-send-a-transaction
     destination: /docs/how-to-send-transactions-on-ethereum
+    permanent: true
   - source: /alchemy/apis/ethereum/eth_maxpriorityfeepergas
     destination: /docs/reference/eth-maxpriorityfeepergas
+    permanent: true
   - source: /alchemy/tutorials/how-to-write-and-deploy-a-nft-smart-contract
     destination: /docs/how-to-develop-an-nft-smart-contract-erc721-with-alchemy
+    permanent: true
   - source: /documentation/alchemy-api-reference/json-rpc#eth_sendrawtransaction
     destination: /docs/reference/eth-sendrawtransaction
+    permanent: true
   - source: /alchemy/enhanced-apis/nft-api/how-to-get-the-owner-s-of-an-nft
     destination: /docs/how-to-check-the-owner-of-an-nft
+    permanent: true
   - source: /alchemy/tutorials/how-to-write-and-deploy-an-nft/how-to-view-your-nft-in-your-wallet
     destination: /docs/how-to-view-your-nft-in-your-mobile-wallet
+    permanent: true
   - source: /alchemy/apis/ethereum/eth_newpendingtransactionfilter
     destination: /docs/reference/eth-newpendingtransactionfilter
+    permanent: true
   - source: /alchemy/enhanced-apis/nft-api/handling-errors
     destination: /docs/reference/nft-api-faq#handling-nft-api-errors
+    permanent: true
   - source: /alchemy/apis/polygon-api
     destination: /docs/reference/polygon-api-quickstart
+    permanent: true
   - source: /alchemy/road...
     destination: /docs/welcome-to-the-road-to-web3
+    permanent: true
   - source: /alchemy/road-to-web3/weekly-learning-challenges/4.-how-to-create-an-nft-gallery-alchemy-nft-api
     destination: /docs/how-to-create-an-nft-gallery
+    permanent: true
   - source: /documentation/alchemy-api-reference/transfers-api
     destination: /docs/reference/transfers-api-quickstart
+    permanent: true
   - source: /docs/welco
     destination: /docs
+    permanent: true
   - source: /alchemy/enhanced-apis/transfers-api/how-to-get-address-transaction-history-on-ethereum
     destination: /docs/how-to-get-transaction-history-for-an-address-on-ethereum
+    permanent: true
   - source: /alchemy/enhanced-apis/nft-api/nft-image-caching
     destination: /docs/reference/nft-api-faq#why-does-alchemy-cache-nft-media
+    permanent: true
   - source: /alchemy/documentation/subscription-api-websockets/how-to-listen-to-nft-mints
     destination: /docs/how-to-listen-to-nft-mints
+    permanent: true
   - source: /documentation/alchemy-api-reference/debug-api
     destination: /docs/reference/debug-api-quickstart
+    permanent: true
   - source: /resources/blockchain-glossary
     destination: /docs/web3-glossary
+    permanent: true
   - source: /tutorials/sending-transactions-using-web3-and-alchemy
     destination: /docs/sending-transactions
+    permanent: true
   - source: /guides/using-websockets
     destination: /docs/reference/best-practices-for-using-websockets-in-web3
+    permanent: true
   - source: /documentation/alchemy-api-reference
     destination: /docs/reference/api-overview
+    permanent: true
   - source: /alchemy/documentation/apis/ethereum/eth_feehistory
     destination: /docs/reference/eth-feehistory
+    permanent: true
   - source: /alchemy/documentation/alchemy-api-reference/token-api
     destination: /docs/reference/token-api-quickstart
+    permanent: true
   - source: /alchemy/apis/ethereum/eth_blocknumber
     destination: /docs/reference/eth-blocknumber
+    permanent: true
   - source: /alchemy/resources/blockchain-glossary
     destination: /docs/web3-glossary
+    permanent: true
   - source: /alchemy/guides/using-websockets
     destination: /docs/reference/best-practices-for-using-websockets-in-web3
+    permanent: true
   - source: /alchemy/documentation/alchemy-api-reference
     destination: /docs/reference/api-overview
+    permanent: true
   - source: /alchemy/documentation/alchemy-api-reference/trace-api
     destination: /docs/reference/trace-api-quickstart
+    permanent: true
   - source: /alchemy/documentation/alchemy-api-reference/debug-api
     destination: /docs/reference/debug-api-quickstart
+    permanent: true
   - source: /alchemy/documentation/alchemy-api-reference/notify-api
     destination: /docs/reference/notify-api-quickstart
+    permanent: true
   - source: /alchemy/tutorials/simple-web3-script
     destination: /docs/how-to-get-the-latest-block-on-ethereum
+    permanent: true
   - source: /alchemy/documentation/apis/arbitrum
     destination: /docs/reference/arbitrum-api-quickstart
+    permanent: true
   - source: /reference/eth-sendPrivateTransaction
     destination: /docs/reference/eth-sendprivatetransaction
+    permanent: true
   - source: /docs/alchemy-quickstart
     destination: /docs/alchemy-quickstart-guide
+    permanent: true
   - source: /alchemy/guides/alchemy-notify
     destination: /docs/alchemy-notify
+    permanent: true
   - source: /docs/alchemyweb3js
     destination: /docs/reference/use-alchemyweb3js
+    permanent: true
   - source: /docs/alchemyweb3
     destination: /docs/reference/use-alchemyweb3js
+    permanent: true
   - source: /reference/integrating-simulation-with-1-line-of-code
     destination: /docs/integrating-simulation-with-1-line-of-code
+    permanent: true
   - source: /reference/building-a-metamask-snap-from-scratch
     destination: /docs/building-a-metamask-snap-from-scratch
+    permanent: true
   - source: /reference/asset-changes-explained
     destination: /docs/asset-changes-explained
+    permanent: true
   - source: /reference/paymaster-api-quickstart
     destination: /docs/reference/gas-manager-coverage-api-quickstart
+    permanent: true
   - source: /reference/paymaster-admin-api-endpoints
     destination: /gas-manager-admin-api-endpoints
+    permanent: true
   - source: /docs/paymaster-services
     destination: /docs/gas-manager-services
+    permanent: true
   - source: /docs/setup-a-paymaster-policy
     destination: /docs/setup-a-gas-manager-policy
+    permanent: true
   - source: /docs/deployment-addresses
     destination: /docs/reference/gas-manager-deployment-addresses
+    permanent: true
   - source: /reference/account-abstraction-sdk
     destination: /docs/reference/aa-sdk
+    permanent: true
   - source: /reference/simple-account-factory-addresses
     destination: /docs/reference/factory-addresses
+    permanent: true
   - source: /reference/gnosis-api-quickstart
     destination: /docs/reference/gnosis-chain-api-quickstart
+    permanent: true
   - source: /reference/opbnb-api-quickstart
     destination: /docs/reference/opbnb-chain-api-quickstart
+    permanent: true
   - source: /reference/berachain-chain-api-quickstart
     destination: /docs/reference/berachain-api-quickstart
+    permanent: true
   - source: /reference/flow-chain-api-quickstart
     destination: /docs/reference/flow-api-quickstart
+    permanent: true
   - source: /reference/crossfi-api-quickstart
     destination: /docs/reference/crossfi-chain-api-quickstart
+    permanent: true
   - source: /reference/scroll-api-quickstart
     destination: /docs/reference/scroll-chain-api-quickstart
+    permanent: true
   - source: /discuss/66fe253fd93280003eea8a66
     destination: https://www.alchemy.com/support
+    permanent: true
   - source: /discuss/62e7a5a6e23dea00148f6ffd
     destination: https://www.alchemy.com/support/what-are-compute-units-cu-and-throughput-compute-units-cups
+    permanent: true
   - source: /discuss/66fa9e9a45dcf4001c852405
     destination: https://www.alchemy.com/support
+    permanent: true
   - source: /discuss/641b73fd62555c003787cbe5
     destination: https://www.alchemy.com/support/how-to-fix-account-registration-problem
+    permanent: true
   - source: /discuss/64dae197f35ac3002518fc1f
     destination: https://www.alchemy.com/support/how-to-fix-account-registration-problem
+    permanent: true
   - source: /discuss/65d43a5e7a84d00050658b0f
     destination: https://www.alchemy.com/support/how-to-fix-account-registration-problem
+    permanent: true
   - source: /discuss/6446da08add36600203e0fc0
     destination: https://www.alchemy.com/support/how-to-fix-account-registration-problem
+    permanent: true
   - source: /discuss/63e8ef371fee8b00672f3ab1
     destination: https://www.alchemy.com/support/how-can-i-delete-my-account
+    permanent: true
   - source: /discuss/6335c58a54d6b90088675304
     destination: https://www.alchemy.com/support/how-can-i-delete-my-account
+    permanent: true
   - source: /discuss/63eb49face3ff30366c6bd55
     destination: https://www.alchemy.com/support/what-are-compute-units-cu-and-throughput-compute-units-cups
+    permanent: true
   - source: /discuss/6307762d8ea0c40973b7f2eb
     destination: https://www.alchemy.com/support/how-are-webhooks-and-websockets-priced
+    permanent: true
   - source: /discuss/65bb92b0effc61005d1cff53
     destination: https://www.alchemy.com/support/how-to-fix-account-registration-problem
+    permanent: true
   - source: /discuss/65103ca89463fa09463c5ca4
     destination: https://www.alchemy.com/support/how-to-fix-account-registration-problem
+    permanent: true
   - source: /discuss/6545f5bf51079d000cb4382c
     destination: https://www.alchemy.com/support/how-to-fix-account-registration-problem
+    permanent: true
   - source: /discuss/6371f1e4781ef4006db78dcd
     destination: https://www.alchemy.com/support/what-are-compute-units-cu-and-throughput-compute-units-cups
+    permanent: true
   - source: /discuss/630ed6f51008080058e1e203
     destination: https://www.alchemy.com/support/how-can-i-update-the-nfts-metadata-using-alchemy-s-nft-api
+    permanent: true
   - source: /discuss/63b471e44ee8d5003f5ea0d0
     destination: https://www.alchemy.com/support/where-are-alchemys-servers-located
+    permanent: true
   - source: /discuss/(\w*)
     destination: https://www.alchemy.com/support
+    permanent: true
   - source: /docs/creating-a-smart-contract-account-and-sending-userops
     destination: /docs/how-to-create-a-modular-smart-contract-account-and-send-userops-with-account-kit
+    permanent: true


### PR DESCRIPTION
## Description

Redirects default to 302. But we can safely assume all of our redirects are meant to be permanent, which is better for SEO.

## Related Issues

[Slack thread](https://alchemyinsights.slack.com/archives/C03306R8XTL/p1747782858314479)

## Changes Made

- Change all redirects to 301

## Testing

<!-- Describe the tests that you ran to verify your changes -->

* \[x] I have tested these changes locally
* \[x] I have run the validation scripts (`pnpm run validate`)
* \[x] I have checked that the documentation builds correctly
