### PR TITLE
chore: remove all instances of x-readme in api specs

### DIFF
--- a/src/openapi/aptos/aptos.yaml
+++ b/src/openapi/aptos/aptos.yaml
@@ -24,12 +24,6 @@ paths:
         - Aptos API Endpoints
       security:
         - apiKey: []
-      x-readme:
-        samples-languages:
-          - javascript
-          - curl
-          - python
-          - go
       responses:
         "200":
           description: The latest ledger information.
@@ -99,9 +93,6 @@ paths:
         - Aptos API Endpoints
       security:
         - apiKey: []
-      x-readme:
-        samples-languages:
-          - curl
       responses:
         "200":
           description: HTML page with interactive API documentation.
@@ -145,12 +136,6 @@ paths:
         - Aptos API Endpoints
       security:
         - apiKey: []
-      x-readme:
-        samples-languages:
-          - curl
-          - javascript
-          - python
-          - go
       parameters:
         - name: duration_secs
           in: query
@@ -194,12 +179,6 @@ paths:
         - Aptos API Endpoints
       security:
         - apiKey: []
-      x-readme:
-        samples-languages:
-          - javascript
-          - curl
-          - python
-          - go
       parameters:
         - name: address
           in: path
@@ -248,12 +227,6 @@ paths:
         - Aptos API Endpoints
       security:
         - apiKey: []
-      x-readme:
-        samples-languages:
-          - javascript
-          - curl
-          - python
-          - go
       parameters:
         - name: address
           in: path
@@ -343,12 +316,6 @@ paths:
         - Aptos API Endpoints
       security:
         - apiKey: []
-      x-readme:
-        samples-languages:
-          - javascript
-          - curl
-          - python
-          - go
       parameters:
         - name: address
           in: path
@@ -428,12 +395,6 @@ paths:
         - Aptos API Endpoints
       security:
         - apiKey: []
-      x-readme:
-        samples-languages:
-          - javascript
-          - curl
-          - python
-          - go
       parameters:
         - name: address
           in: path
@@ -583,12 +544,6 @@ paths:
         - Aptos API Endpoints
       security:
         - apiKey: []
-      x-readme:
-        samples-languages:
-          - javascript
-          - curl
-          - python
-          - go
       parameters:
         - name: address
           in: path
@@ -730,12 +685,6 @@ paths:
         - Aptos API Endpoints
       security:
         - apiKey: []
-      x-readme:
-        samples-languages:
-          - javascript
-          - curl
-          - python
-          - go
       parameters:
         - name: address
           in: path
@@ -819,12 +768,6 @@ paths:
         - Aptos API Endpoints
       security:
         - apiKey: []
-      x-readme:
-        samples-languages:
-          - javascript
-          - curl
-          - python
-          - go
       parameters:
         - name: address
           in: path
@@ -913,12 +856,6 @@ paths:
         - Aptos API Endpoints
       security:
         - apiKey: []
-      x-readme:
-        samples-languages:
-          - javascript
-          - curl
-          - python
-          - go
       parameters:
         - name: block_height
           in: path
@@ -1038,12 +975,6 @@ paths:
         - Aptos API Endpoints
       security:
         - apiKey: []
-      x-readme:
-        samples-languages:
-          - javascript
-          - curl
-          - python
-          - go
       parameters:
         - name: version
           in: path
@@ -1234,12 +1165,6 @@ paths:
         - Aptos API Endpoints
       security:
         - apiKey: []
-      x-readme:
-        samples-languages:
-          - javascript
-          - curl
-          - python
-          - go
       parameters:
         - name: address
           in: path
@@ -1360,12 +1285,6 @@ paths:
         - Aptos API Endpoints
       security:
         - apiKey: []
-      x-readme:
-        samples-languages:
-          - javascript
-          - curl
-          - python
-          - go
       responses:
         "200":
           description: Estimated gas prices for deprioritized, standard, and prioritized transactions.
@@ -1409,12 +1328,6 @@ paths:
         - Aptos API Endpoints
       security:
         - apiKey: []
-      x-readme:
-        samples-languages:
-          - javascript
-          - curl
-          - python
-          - go
       parameters:
         - name: start
           in: query
@@ -1498,12 +1411,6 @@ paths:
         - Aptos API Endpoints
       security:
         - apiKey: []
-      x-readme:
-        samples-languages:
-          - javascript
-          - curl
-          - python
-          - go
       requestBody:
         required: true
         content:
@@ -1629,12 +1536,6 @@ paths:
         - Aptos API Endpoints
       security:
         - apiKey: []
-      x-readme:
-        samples-languages:
-          - javascript
-          - curl
-          - python
-          - go
       parameters:
         - name: txn_hash
           in: path
@@ -1727,12 +1628,6 @@ paths:
         - Aptos API Endpoints
       security:
         - apiKey: []
-      x-readme:
-        samples-languages:
-          - javascript
-          - curl
-          - python
-          - go
       parameters:
         - name: txn_version
           in: path
@@ -1803,12 +1698,6 @@ paths:
         - Aptos API Endpoints
       security:
         - apiKey: []
-      x-readme:
-        samples-languages:
-          - javascript
-          - curl
-          - python
-          - go
       requestBody:
         required: true
         content:

--- a/src/openapi/blocks/blocks.yaml
+++ b/src/openapi/blocks/blocks.yaml
@@ -15,12 +15,6 @@ paths:
       description: Fetches the first block before or after a given timestamp. Returns the block's number and on-chain timestamp.
       tags:
         - "Blocks API Endpoints"
-      x-readme:
-        samples-languages:
-          - javascript
-          - curl
-          - python
-          - go
       parameters:
         - $ref: "#/components/parameters/apiKey"
         - $ref: "#/components/parameters/networks"

--- a/src/openapi/nft/nft.yaml
+++ b/src/openapi/nft/nft.yaml
@@ -62,12 +62,6 @@ paths:
         - $ref: "#/components/parameters/apiKey"
         - $ref: "#/components/parameters/pageKey"
         - $ref: "#/components/parameters/pageSize"
-      x-readme:
-        samples-languages:
-          - javascript
-          - curl
-          - python
-          - go
       responses:
         "200":
           description: "Returns the list of all NFTs owned by the given address and satisfying the given input parameters."
@@ -109,12 +103,6 @@ paths:
         - $ref: "#/components/parameters/startToken"
         - $ref: "#/components/parameters/limit"
         - $ref: "#/components/parameters/tokenUriTimeoutInMs"
-      x-readme:
-        samples-languages:
-          - javascript
-          - curl
-          - python
-          - go
       responses:
         "200":
           description: "Returns a list of NFTs associated with the specified contract address."
@@ -145,31 +133,6 @@ paths:
         - $ref: "#/components/parameters/startToken"
         - $ref: "#/components/parameters/limit"
         - $ref: "#/components/parameters/tokenUriTimeoutInMs"
-      x-readme:
-        samples-languages:
-          - curl
-          - javascript
-          - python
-        code-samples:
-          - language: javascript
-            name: Alchemy SDK
-            code: |
-              // Github: https://github.com/alchemyplatform/alchemy-sdk-js
-              // Setup: npm install alchemy-sdk
-              import { Network, Alchemy } from "alchemy-sdk";
-
-              // Optional Config object, but defaults to demo api-key and eth-mainnet.
-              const settings = {
-                apiKey: "demo", // Replace with your Alchemy API Key.
-                network: Network.ETH_MAINNET, // Replace with your network.
-              };
-
-              const alchemy = new Alchemy(settings);
-
-              // Print total NFT collection returned in the response:
-              alchemy.nft
-                .getNftsForContract("0x61fce80d72363b731425c3a2a46a1a5fed9814b2")
-                .then(console.log);
       responses:
         "200":
           description: "Returns a list of NFTs associated with the specified collection."
@@ -211,12 +174,6 @@ paths:
         - $ref: "#/components/parameters/tokenType"
         - $ref: "#/components/parameters/tokenUriTimeoutInMs"
         - $ref: "#/components/parameters/refreshCache"
-      x-readme:
-        samples-languages:
-          - javascript
-          - curl
-          - python
-          - go
       responses:
         "200":
           description: "Returns the metadata of the specified NFT."
@@ -259,12 +216,6 @@ paths:
                   $ref: "#/components/schemas/tokenUriTimeoutInMs"
                 refreshCache:
                   $ref: "#/components/schemas/refreshCache"
-      x-readme:
-        samples-languages:
-          - javascript
-          - curl
-          - python
-          - go
       responses:
         "200":
           description: "Returns an array of NFT metadata corresponding to the batch query."
@@ -284,12 +235,6 @@ paths:
       parameters:
         - $ref: "#/components/parameters/apiKey"
         - $ref: "#/components/parameters/contractAddressRequired"
-      x-readme:
-        samples-languages:
-          - javascript
-          - curl
-          - python
-          - go
       responses:
         "200":
           description: "Returns the contract metadata for the specified address."
@@ -306,12 +251,6 @@ paths:
       parameters:
         - $ref: "#/components/parameters/apiKey"
         - $ref: "#/components/parameters/collectionSlugRequired"
-      x-readme:
-        samples-languages:
-          - javascript
-          - curl
-          - python
-          - go
       responses:
         "200":
           description: "Returns the collection metadata for the specified slug."
@@ -331,11 +270,6 @@ paths:
       parameters:
         - $ref: "#/components/parameters/apiKey"
         - $ref: "#/components/parameters/contractAddressRequired"
-      x-readme:
-        samples-languages:
-          - curl
-          - javascript
-          - python
       responses:
         "200":
           description: "Returns confirmation of cache invalidation along with the number of tokens invalidated."
@@ -375,12 +309,6 @@ paths:
                     ]
                   items:
                     $ref: "#/components/schemas/contractAddress"
-      x-readme:
-        samples-languages:
-          - javascript
-          - curl
-          - python
-          - go
       responses:
         "200":
           description: "Returns an array of contract metadata corresponding to the batch query."
@@ -401,12 +329,6 @@ paths:
         - $ref: "#/components/parameters/apiKey"
         - $ref: "#/components/parameters/contractAddressRequired"
         - $ref: "#/components/parameters/tokenId"
-      x-readme:
-        samples-languages:
-          - javascript
-          - curl
-          - python
-          - go
       responses:
         "200":
           description: "Returns the owner(s) of the specified NFT."
@@ -435,12 +357,6 @@ paths:
         # - $ref: '#/components/parameters/block'
         - $ref: "#/components/parameters/pageKey"
           description: String - used for contracts with >50,000 owners. `pageKey` field can be passed back as request parameter to get the next page of results.
-      x-readme:
-        samples-languages:
-          - javascript
-          - curl
-          - python
-          - go
       responses:
         "200":
           description: "Returns a list of all owners for the specified contract."
@@ -480,12 +396,6 @@ paths:
               default: eth-mainnet
       parameters:
         - $ref: "#/components/parameters/apiKey"
-      x-readme:
-        samples-languages:
-          - javascript
-          - curl
-          - python
-          - go
       responses:
         "200":
           description: "Returns a list of all spam contracts marked by Alchemy."
@@ -522,12 +432,6 @@ paths:
       parameters:
         - $ref: "#/components/parameters/apiKey"
         - $ref: "#/components/parameters/contractAddressRequired"
-      x-readme:
-        samples-languages:
-          - javascript
-          - curl
-          - python
-          - go
       responses:
         "200":
           description: "Returns whether the specified contract is marked as spam."
@@ -553,12 +457,6 @@ paths:
         - $ref: "#/components/parameters/apiKey"
         - $ref: "#/components/parameters/contractAddressRequired"
         - $ref: "#/components/parameters/tokenId"
-      x-readme:
-        samples-languages:
-          - javascript
-          - curl
-          - python
-          - go
       responses:
         "200":
           description: "Returns whether the specified token is marked as an airdrop."
@@ -591,12 +489,6 @@ paths:
       parameters:
         - $ref: "#/components/parameters/apiKey"
         - $ref: "#/components/parameters/contractAddressRequired"
-      x-readme:
-        samples-languages:
-          - javascript
-          - curl
-          - python
-          - go
       responses:
         "200":
           description: "Returns a summary of attribute prevalence for the specified NFT collection."
@@ -636,12 +528,6 @@ paths:
         - $ref: "#/components/parameters/apiKey"
         - $ref: "#/components/parameters/contractAddressDefault"
         - $ref: "#/components/parameters/collectionSlug"
-      x-readme:
-        samples-languages:
-          - javascript
-          - curl
-          - python
-          - go
       responses:
         "200":
           description: "Returns the floor prices of the specified NFT collection across different marketplaces."
@@ -685,12 +571,6 @@ paths:
       parameters:
         - $ref: "#/components/parameters/apiKey"
         - $ref: "#/components/parameters/query"
-      x-readme:
-        samples-languages:
-          - javascript
-          - curl
-          - python
-          - go
       responses:
         "200":
           description: "Returns the list of NFT contracts where the metadata has one or more keywords from the search string."
@@ -711,12 +591,6 @@ paths:
         - $ref: "#/components/parameters/apiKey"
         - $ref: "#/components/parameters/wallet"
         - $ref: "#/components/parameters/contractAddressRequired"
-      x-readme:
-        samples-languages:
-          - javascript
-          - curl
-          - python
-          - go
       responses:
         "200":
           description: "Returns whether the specified wallet holds any NFT from the given contract."
@@ -750,12 +624,6 @@ paths:
         - $ref: "#/components/parameters/apiKey"
         - $ref: "#/components/parameters/contractAddressRequired"
         - $ref: "#/components/parameters/tokenId"
-      x-readme:
-        samples-languages:
-          - javascript
-          - curl
-          - python
-          - go
       responses:
         "200":
           description: "Returns the rarity information for each attribute of the specified NFT."
@@ -814,12 +682,6 @@ paths:
         - $ref: "#/components/parameters/limit"
           description: Integer - The maximum number of NFT sales to return. Maximum and default values are 1000.
         - $ref: "#/components/parameters/pageKey"
-      x-readme:
-        samples-languages:
-          - javascript
-          - curl
-          - python
-          - go
       responses:
         "200":
           description: "Returns a list of NFT sales that match the query parameters."
@@ -945,12 +807,6 @@ paths:
         - $ref: "#/components/parameters/excludeFilters"
         - $ref: "#/components/parameters/orderBy"
         - $ref: "#/components/parameters/spamConfidenceLevel"
-      x-readme:
-        samples-languages:
-          - javascript
-          - curl
-          - python
-          - go
       responses:
         "200":
           description: "Returns a list of NFT contracts held by the specified owner address."
@@ -989,12 +845,6 @@ paths:
         - $ref: "#/components/parameters/withMetadata"
         - $ref: "#/components/parameters/includeFilters"
         - $ref: "#/components/parameters/excludeFilters"
-      x-readme:
-        samples-languages:
-          - javascript
-          - curl
-          - python
-          - go
       responses:
         "200":
           description: "Returns a list of NFT collections held by the specified owner address."
@@ -1036,12 +886,6 @@ paths:
             type: boolean
             description: "Whether the address is spam."
             default: true
-      x-readme:
-        samples-languages:
-          - javascript
-          - curl
-          - python
-          - go
       responses:
         "200":
           description: "Returns a confirmation message if the address was successfully reported as spam."
@@ -1061,12 +905,6 @@ paths:
       tags: ["NFT Metadata Endpoints"]
       parameters:
         - $ref: "#/components/parameters/apiKey"
-      x-readme:
-        samples-languages:
-          - javascript
-          - curl
-          - python
-          - go
       requestBody:
         content:
           application/json:
@@ -1124,30 +962,6 @@ paths:
         - $ref: "#/components/parameters/apiKey"
         - $ref: "#/components/parameters/pageKey"
         - $ref: "#/components/parameters/pageSize"
-      x-readme:
-        samples-languages:
-          - curl
-          - javascript
-          - python
-        code-samples:
-          - language: javascript
-            name: Alchemy SDK
-            code: |
-              // Setup: npm install alchemy-sdk
-              // Github: https://github.com/alchemyplatform/alchemy-sdk-js
-              import { Network, Alchemy } from "alchemy-sdk";
-
-              // Optional Config object, but defaults to demo api-key and eth-mainnet.
-              const settings = {
-                apiKey: demo, // Replace with your Alchemy API Key.
-                network: Network.ETH_MAINNET, // Replace with your network.
-
-              };
-
-              const alchemy = new Alchemy(settings);
-
-              // Print all NFTs returned in the response:
-              alchemy.nft.getNftsForOwner("vitalik.eth").then(console.log);
       responses:
         "200":
           description: "Returns the list of all NFTs owned by the given address and satisfying the given input parameters."
@@ -1189,32 +1003,6 @@ paths:
         - $ref: "#/components/parameters/tokenType"
         - $ref: "#/components/parameters/tokenUriTimeoutInMs"
         - $ref: "#/components/parameters/refreshCache"
-      x-readme:
-        samples-languages:
-          - curl
-          - javascript
-          - python
-        code-samples:
-          - language: javascript
-            name: Alchemy SDK
-            code: |
-              // Github: https://github.com/alchemyplatform/alchemy-sdk-js
-              // Setup: npm install alchemy-sdk
-              import { Network, Alchemy } from "alchemy-sdk";
-
-              // Optional Config object, but defaults to demo api-key and eth-mainnet.
-              const settings = {
-                apiKey: "demo", // Replace with your Alchemy API Key.
-                network: Network.ETH_MAINNET, // Replace with your network.
-              };
-
-              const alchemy = new Alchemy(settings);
-
-              // Print NFT metadata returned in the response:
-              alchemy.nft.getNftMetadata(
-                "0x5180db8F5c931aaE63c74266b211F580155ecac8",
-                "1590"
-              ).then(console.log);
       responses:
         "200":
           description: ""
@@ -1257,32 +1045,6 @@ paths:
                   $ref: "#/components/schemas/tokenUriTimeoutInMs"
                 refreshCache:
                   $ref: "#/components/schemas/refreshCache"
-      x-readme:
-        samples-languages:
-          - curl
-          - javascript
-          - python
-        code-samples:
-          - language: javascript
-            name: Alchemy SDK
-            code: |
-              // Github: https://github.com/alchemyplatform/alchemy-sdk-js
-              // Setup: npm install alchemy-sdk
-              import { Network, Alchemy } from "alchemy-sdk";
-
-              // Optional Config object, but defaults to demo api-key and eth-mainnet.
-              const settings = {
-                apiKey: "demo", // Replace with your Alchemy API Key.
-                network: Network.ETH_MAINNET, // Replace with your network.
-              };
-
-              const alchemy = new Alchemy(settings);
-
-              // Print NFT metadata returned in the response:
-              alchemy.nft.getNftMetadata(
-                "0x5180db8F5c931aaE63c74266b211F580155ecac8",
-                "1590"
-              ).then(console.log);
       responses:
         "200":
           description: ""
@@ -1301,30 +1063,6 @@ paths:
       parameters:
         - $ref: "#/components/parameters/apiKey"
         - $ref: "#/components/parameters/contractAddressRequired"
-      x-readme:
-        samples-languages:
-          - curl
-          - javascript
-          - python
-        code-samples:
-          - language: javascript
-            name: Alchemy SDK
-            code: |
-              // Github: https://github.com/alchemyplatform/alchemy-sdk-js
-              // Setup: npm install alchemy-sdk
-              import { Network, Alchemy } from "alchemy-sdk";
-
-              // Optional Config object, but defaults to demo api-key and eth-mainnet.
-              const settings = {
-                apiKey: "demo", // Replace with your Alchemy API Key.
-                network: Network.ETH_MAINNET, // Replace with your network.
-              };
-
-              const alchemy = new Alchemy(settings);
-
-              alchemy.nft
-                .getContractMetadata("0x61fce80d72363b731425c3a2a46a1a5fed9814b2")
-                .then(console.log);
       responses:
         "200":
           description: ""
@@ -1390,31 +1128,6 @@ paths:
         - $ref: "#/components/parameters/startToken"
         - $ref: "#/components/parameters/limit"
         - $ref: "#/components/parameters/tokenUriTimeoutInMs"
-      x-readme:
-        samples-languages:
-          - curl
-          - javascript
-          - python
-        code-samples:
-          - language: javascript
-            name: Alchemy SDK
-            code: |
-              // Github: https://github.com/alchemyplatform/alchemy-sdk-js
-              // Setup: npm install alchemy-sdk
-              import { Network, Alchemy } from "alchemy-sdk";
-
-              // Optional Config object, but defaults to demo api-key and eth-mainnet.
-              const settings = {
-                apiKey: "demo", // Replace with your Alchemy API Key.
-                network: Network.ETH_MAINNET, // Replace with your network.
-              };
-
-              const alchemy = new Alchemy(settings);
-
-              // Print total NFT collection returned in the response:
-              alchemy.nft
-                .getNftsForContract("0x61fce80d72363b731425c3a2a46a1a5fed9814b2")
-                .then(console.log);
       responses:
         "200":
           description: ""
@@ -1455,31 +1168,6 @@ paths:
         - $ref: "#/components/parameters/tokenId"
         - $ref: "#/components/parameters/pageKey"
         - $ref: "#/components/parameters/getOwnersForTokenPageSize"
-      x-readme:
-        samples-languages:
-          - curl
-          - javascript
-          - python
-        code-samples:
-          - language: javascript
-            name: Alchemy SDK
-            code: |
-              // Github: https://github.com/alchemyplatform/alchemy-sdk-js
-              // Setup: npm install alchemy-sdk
-              import { Network, Alchemy } from "alchemy-sdk";
-
-              // Optional Config object, but defaults to demo api-key and eth-mainnet.
-              const settings = {
-                apiKey: "demo", // Replace with your Alchemy API Key.
-                network: Network.ETH_MAINNET, // Replace with your network.
-              };
-
-              const alchemy = new Alchemy(settings);
-
-              // Print total NFT count returned in the response:
-              alchemy.nft.getOwnersForNft("0x5180db8F5c931aaE63c74266b211F580155ecac8", "1590").then(
-                console.log
-              );
       responses:
         "200":
           description: ""
@@ -1503,31 +1191,6 @@ paths:
         # - $ref: '#/components/parameters/block'
         - $ref: "#/components/parameters/pageKey"
           description: String - used for collections with >50,000 owners. `pageKey` field can be passed back as request parameter to get the next page of results.
-      x-readme:
-        samples-languages:
-          - curl
-          - javascript
-          - python
-        code-samples:
-          - language: javascript
-            name: Alchemy SDK
-            code: |
-              // Github: https://github.com/alchemyplatform/alchemy-sdk-js
-              // Setup: npm install alchemy-sdk
-              import { Network, Alchemy } from "alchemy-sdk";
-
-              // Optional Config object, but defaults to demo api-key and eth-mainnet.
-              const settings = {
-                apiKey: "demo", // Replace with your Alchemy API Key.
-                network: Network.ETH_MAINNET, // Replace with your network.
-              };
-
-              const alchemy = new Alchemy(settings);
-
-              // Print total NFT count returned in the response:
-              alchemy.nft
-                .getOwnersForContract("0x61fce80d72363b731425c3a2a46a1a5fed9814b2")
-                .then(console.log);
       responses:
         "200":
           description: ""
@@ -1551,29 +1214,6 @@ paths:
               default: eth-mainnet
       parameters:
         - $ref: "#/components/parameters/apiKey"
-      x-readme:
-        samples-languages:
-          - curl
-          - javascript
-          - python
-        code-samples:
-          - language: javascript
-            name: Alchemy SDK
-            code: |
-              // Github: https://github.com/alchemyplatform/alchemy-sdk-js
-              // Setup: npm install alchemy-sdk
-              import { Network, Alchemy } from "alchemy-sdk";
-
-              // Optional Config object, but defaults to demo api-key and eth-mainnet.
-              const settings = {
-                apiKey: "demo", // Replace with your Alchemy API Key.
-                network: Network.ETH_MAINNET, // Replace with your network.
-              };
-
-              const alchemy = new Alchemy(settings);
-
-              // Print all spam NFT contracts returned in the response:
-              alchemy.nft.getSpamContracts().then(console.log);
       responses:
         "200":
           description: ""
@@ -1605,31 +1245,6 @@ paths:
       parameters:
         - $ref: "#/components/parameters/apiKey"
         - $ref: "#/components/parameters/contractAddressRequired"
-      x-readme:
-        samples-languages:
-          - curl
-          - javascript
-          - python
-        code-samples:
-          - language: javascript
-            name: Alchemy SDK
-            code: |
-              // Github: https://github.com/alchemyplatform/alchemy-sdk-js
-              // Setup: npm install alchemy-sdk
-              import { Network, Alchemy } from "alchemy-sdk";
-
-              // Optional Config object, but defaults to demo api-key and eth-mainnet.
-              const settings = {
-                apiKey: "demo", // Replace with your Alchemy API Key.
-                network: Network.ETH_MAINNET, // Replace with your network.
-              };
-
-              const alchemy = new Alchemy(settings);
-
-              // Print whether an NFT contract is spam
-              alchemy.nft
-                .isSpamContract("0x000440f08436a7b866d1ae42db5e0be801da722a")
-                .then(console.log);
       responses:
         "200":
           description: ""
@@ -1648,11 +1263,6 @@ paths:
         - $ref: "#/components/parameters/apiKey"
         - $ref: "#/components/parameters/contractAddressRequired"
         - $ref: "#/components/parameters/tokenId"
-      x-readme:
-        samples-languages:
-          - curl
-          - javascript
-          - python
       responses:
         "200":
           description: ""
@@ -1670,11 +1280,6 @@ paths:
       parameters:
         - $ref: "#/components/parameters/apiKey"
         - $ref: "#/components/parameters/contractAddressRequired"
-      x-readme:
-        samples-languages:
-          - curl
-          - javascript
-          - python
       responses:
         "200":
           description: ""
@@ -1706,31 +1311,6 @@ paths:
       parameters:
         - $ref: "#/components/parameters/apiKey"
         - $ref: "#/components/parameters/contractAddressRequired"
-      x-readme:
-        samples-languages:
-          - curl
-          - javascript
-          - python
-        code-samples:
-          - language: javascript
-            name: Alchemy SDK
-            code: |
-              // Github: https://github.com/alchemyplatform/alchemy-sdk-js
-              // Setup: npm install alchemy-sdk
-              import { Network, Alchemy } from "alchemy-sdk";
-
-              // Optional Config object, but defaults to demo api-key and eth-mainnet.
-              const settings = {
-                apiKey: "demo", // Replace with your Alchemy API Key.
-                network: Network.ETH_MAINNET, // Replace with your network.
-              };
-
-              const alchemy = new Alchemy(settings);
-
-              // Print the NFT floor price for a contract
-              alchemy.nft
-                .getFloorPrice("0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d")
-                .then(console.log);
       responses:
         "200":
           description: ""
@@ -1778,11 +1358,6 @@ paths:
         - $ref: "#/components/parameters/apiKey"
         - $ref: "#/components/parameters/contractAddressRequired"
         - $ref: "#/components/parameters/tokenId"
-      x-readme:
-        samples-languages:
-          - curl
-          - javascript
-          - python
       responses:
         "200":
           description: ""
@@ -1823,11 +1398,6 @@ paths:
       parameters:
         - $ref: "#/components/parameters/apiKey"
         - $ref: "#/components/parameters/query"
-      x-readme:
-        samples-languages:
-          - curl
-          - javascript
-          - python
       responses:
         "200":
           description: "Returns the list of NFT contracts where the metadata has one or more keywords from the search string."
@@ -1860,11 +1430,6 @@ paths:
       parameters:
         - $ref: "#/components/parameters/apiKey"
         - $ref: "#/components/parameters/contractAddressRequired"
-      x-readme:
-        samples-languages:
-          - curl
-          - javascript
-          - python
       responses:
         "200":
           description: ""
@@ -1896,11 +1461,6 @@ paths:
           in: query
           required: true
         - $ref: "#/components/parameters/contractAddressRequired"
-      x-readme:
-        samples-languages:
-          - curl
-          - javascript
-          - python
       responses:
         "200":
           description: ""
@@ -1944,11 +1504,6 @@ paths:
         - $ref: "#/components/parameters/limit"
           description: Integer - The maximum number of NFT sales to return. Maximum and default values are 1000.
         - $ref: "#/components/parameters/pageKey"
-      x-readme:
-        samples-languages:
-          - curl
-          - javascript
-          - python
       responses:
         "200":
           description: ""
@@ -2060,11 +1615,6 @@ paths:
         - $ref: "#/components/parameters/excludeFilters"
         - $ref: "#/components/parameters/orderBy"
         - $ref: "#/components/parameters/spamConfidenceLevel"
-      x-readme:
-        samples-languages:
-          - curl
-          - javascript
-          - python
       responses:
         "200":
           description: ""
@@ -2095,11 +1645,6 @@ paths:
       parameters:
         - $ref: "#/components/parameters/apiKey"
         - $ref: "#/components/parameters/addressRequired"
-      x-readme:
-        samples-languages:
-          - curl
-          - javascript
-          - python
       responses:
         "200":
           description: ""

--- a/src/openapi/notify/notify.yaml
+++ b/src/openapi/notify/notify.yaml
@@ -20,24 +20,6 @@ paths:
         - $ref: "#/components/parameters/limit"
         - $ref: "#/components/parameters/after"
         - $ref: "#/components/parameters/pageKey"
-      x-readme:
-        samples-languages:
-          - curl
-          - python
-        code-samples:
-          - language: javascript
-            name: Alchemy SDK
-            code: |
-              // Setup: npm install alchemy-sdk
-              // Github: https://github.com/alchemyplatform/alchemy-sdk-js
-              import { Alchemy, Network } from "alchemy-sdk";
-
-              const settings = {
-                authToken: "your-notify-auth-token",
-                network: Network.ETH_MAINNET,
-              };
-              const alchemy = new Alchemy(settings);
-              alchemy.notify.getAllWebhooks().then(console.log);
       responses:
         "200":
           description: OK- Successful query of Custom Webhook variable
@@ -66,10 +48,6 @@ paths:
           application/json:
             schema:
               $ref: "#/components/schemas/create_custom_webhook"
-      x-readme:
-        samples-languages:
-          - curl
-          - python
       responses:
         "201":
           description: OK- Successful creation of a Custom Webhook variable
@@ -85,10 +63,6 @@ paths:
       parameters:
         - $ref: "#/components/parameters/X-Alchemy-Token"
         - $ref: "#/components/parameters/variable"
-      x-readme:
-        samples-languages:
-          - curl
-          - python
       responses:
         "201":
           description: OK- Successful deletion of a Custom Webhook variable
@@ -114,10 +88,6 @@ paths:
           application/json:
             schema:
               $ref: "#/components/schemas/update_custom_webhook_variable"
-      x-readme:
-        samples-languages:
-          - curl
-          - python
       responses:
         "200":
           description: OK- Successful update to Custom Webhook variable
@@ -135,11 +105,6 @@ paths:
       tags: ["Notify API Methods"]
       parameters:
         - $ref: "#/components/parameters/X-Alchemy-Token"
-      x-readme:
-        samples-languages:
-          - curl
-          - javascript
-          - python
       responses:
         "200":
           description: Returns list of webhook objects.
@@ -163,12 +128,6 @@ paths:
         - $ref: "#/components/parameters/limit"
         - $ref: "#/components/parameters/after"
         - $ref: "#/components/parameters/pageKey"
-      x-readme:
-        explorer-enabled: false
-        samples-languages:
-          - curl
-          - javascript
-          - python
       responses:
         "200":
           description: "List of addresses and pagination info."
@@ -191,11 +150,6 @@ paths:
           application/json:
             schema:
               $ref: "#/components/schemas/create_webhook"
-      x-readme:
-        samples-languages:
-          - curl
-          - javascript
-          - python
       responses:
         "200":
           description: "Returns webhook creation data."
@@ -220,11 +174,6 @@ paths:
           application/json:
             schema:
               $ref: "#/components/schemas/update_webhook_addresses"
-      x-readme:
-        samples-languages:
-          - curl
-          - javascript
-          - python
       responses:
         "200":
           description: "Returns empty object."
@@ -246,11 +195,6 @@ paths:
           application/json:
             schema:
               $ref: "#/components/schemas/replace_webhook_addresses"
-      x-readme:
-        samples-languages:
-          - curl
-          - javascript
-          - python
       responses:
         "200":
           description: "Returns empty object."
@@ -273,11 +217,6 @@ paths:
           application/json:
             schema:
               $ref: "#/components/schemas/update_webhook"
-      x-readme:
-        samples-languages:
-          - curl
-          - javascript
-          - python
       responses:
         "200":
           description: "Returns updated webhook status."
@@ -300,11 +239,6 @@ paths:
           application/json:
             schema:
               $ref: "#/components/schemas/update_webhook_nft_filters"
-      x-readme:
-        samples-languages:
-          - curl
-          - javascript
-          - python
       responses:
         "200":
           description: "Returns empty object."
@@ -348,11 +282,6 @@ paths:
         - $ref: "#/components/parameters/limit"
         - $ref: "#/components/parameters/after"
         - $ref: "#/components/parameters/pageKey"
-      x-readme:
-        samples-languages:
-          - curl
-          - javascript
-          - python
       responses:
         "200":
           description: Returns a list of nft filter objects.
@@ -371,11 +300,6 @@ paths:
       parameters:
         - $ref: "#/components/parameters/X-Alchemy-Token"
         - $ref: "#/components/parameters/webhook_id"
-      x-readme:
-        samples-languages:
-          - curl
-          - javascript
-          - python
       responses:
         "200":
           description: "Returns empty object."

--- a/src/openapi/portfolio/assets/nfts/by-address.yaml
+++ b/src/openapi/portfolio/assets/nfts/by-address.yaml
@@ -2,12 +2,6 @@ summary: NFTs By Wallet
 description: >
   Fetches NFTs for multiple wallet addresses and networks. Returns a list of NFTs and metadata for each wallet/network combination. This endpoint is supported on Ethereum and many L2s, including Polygon, Arbitrum, Optimism, Base, World Chain and more. See the full list of supported networks [here](https://dashboard.alchemy.com/chains?service=token-api&utm_source=readme&utm_medium=link&utm_campaign=docs_method_chains_link_v1_tokens).
 tags: ["Portfolio API Endpoints"]
-x-readme:
-  samples-languages:
-    - javascript
-    - curl
-    - python
-    - go
 parameters:
   - $ref: "./../../portfolio.yaml#/components/parameters/apiKey"
 requestBody:

--- a/src/openapi/portfolio/assets/nfts/contracts/by-address.yaml
+++ b/src/openapi/portfolio/assets/nfts/contracts/by-address.yaml
@@ -2,12 +2,6 @@ summary: NFT Collections By Wallet
 description: >
   Fetches NFT collections (contracts) for multiple wallet addresses and networks. Returns a list of collections and metadata for each wallet/network combination. This endpoint is supported on Ethereum and many L2s, including Polygon, Arbitrum, Optimism, Base, World Chain and more. See the full list of supported networks [here](https://dashboard.alchemy.com/chains?service=token-api&utm_source=readme&utm_medium=link&utm_campaign=docs_method_chains_link_v1_tokens).
 tags: ["Portfolio API Endpoints"]
-x-readme:
-  samples-languages:
-    - javascript
-    - curl
-    - python
-    - go
 parameters:
   - $ref: "./../../../portfolio.yaml#/components/parameters/apiKey"
 requestBody:

--- a/src/openapi/portfolio/assets/tokens/balances/by-address.yaml
+++ b/src/openapi/portfolio/assets/tokens/balances/by-address.yaml
@@ -2,12 +2,6 @@ summary: Token Balances By Wallet
 description: >
   Fetches fungible tokens (native and ERC-20) for multiple wallet addresses and networks. Returns a list of tokens with balances for each wallet/network combination. This endpoint is supported on Ethereum, Solana, and 30+ EVM chains. See the full list of supported networks [here](https://dashboard.alchemy.com/chains?service=token-api&utm_source=readme&utm_medium=link&utm_campaign=docs_method_chains_link_v1_tokens)
 tags: ["Portfolio API Endpoints"]
-x-readme:
-  samples-languages:
-    - javascript
-    - curl
-    - python
-    - go
 parameters:
   - $ref: "./../../../portfolio.yaml#/components/parameters/apiKey"
 requestBody:

--- a/src/openapi/portfolio/assets/tokens/by-address.yaml
+++ b/src/openapi/portfolio/assets/tokens/by-address.yaml
@@ -2,12 +2,6 @@ summary: Tokens By Wallet
 description: >
   Fetches fungible tokens (native and ERC-20) for multiple wallet addresses and networks. Returns a list of tokens with balances, prices, and metadata for each wallet/network combination. This endpoint is supported on Ethereum, Solana, and 30+ EVM chains. See the full list of supported networks [here](https://dashboard.alchemy.com/chains?service=token-api&utm_source=readme&utm_medium=link&utm_campaign=docs_method_chains_link_v1_tokens).
 tags: ["Portfolio API Endpoints"]
-x-readme:
-  samples-languages:
-    - javascript
-    - curl
-    - python
-    - go
 parameters:
   - $ref: "./../../portfolio.yaml#/components/parameters/apiKey"
 requestBody:

--- a/src/openapi/portfolio/portfolio.yaml
+++ b/src/openapi/portfolio/portfolio.yaml
@@ -42,12 +42,6 @@ paths:
   #     description: >
   #       Placeholder for the NFT API - in order to update this you'll need to move it back and forth.
   #     tags: ["🎨 NFT API"]
-  #     x-readme:
-  #       samples-languages:
-  #         - javascript
-  #         - curl
-  #         - python
-  #         - go
   #     parameters:
   #       - $ref: "#/components/parameters/apiKey"
   #     requestBody:
@@ -74,12 +68,6 @@ paths:
   #     description: >
   #       Placeholder for the Prices API - in order to update this you'll need to move it back and forth.
   #     tags: ["🪙 Token API"]
-  #     x-readme:
-  #       samples-languages:
-  #         - javascript
-  #         - curl
-  #         - python
-  #         - go
   #     parameters:
   #       - $ref: "#/components/parameters/apiKey"
   #     requestBody:
@@ -106,12 +94,6 @@ paths:
   #     description: >
   #       Placeholder for the Prices API - in order to update this you'll need to move it back and forth.
   #     tags: ["📈 Prices API"]
-  #     x-readme:
-  #       samples-languages:
-  #         - javascript
-  #         - curl
-  #         - python
-  #         - go
   #     parameters:
   #       - $ref: "#/components/parameters/apiKey"
   #     requestBody:
@@ -150,12 +132,6 @@ paths:
   #     description: >
   #       Placeholder for the Transfers API - in order to update this you'll need to move it back and forth.
   #     tags: ["💸 Transfers API"]
-  #     x-readme:
-  #       samples-languages:
-  #         - javascript
-  #         - curl
-  #         - python
-  #         - go
   #     parameters:
   #       - $ref: "#/components/parameters/apiKey"
   #     requestBody:
@@ -192,12 +168,6 @@ paths:
   #     summary: Blocks by Timestamp
   #     description: Fetches the first block before or after a given timestamp. Returns the block's number and on-chain timestamp.
   #     tags: ["🛠️ Utility APIs"]
-  #     x-readme:
-  #       samples-languages:
-  #         - javascript
-  #         - curl
-  #         - python
-  #         - go
   #     parameters:
   #       - $ref: "#/components/parameters/apiKey"
   #       - $ref: "#/components/parameters/networks"
@@ -233,12 +203,6 @@ paths:
   #     description: >
   #       Placeholder for the Subgraphs - in order to update this you'll need to move it back and forth.
   #     tags: ["🍊 Subgraphs"]
-  #     x-readme:
-  #       samples-languages:
-  #         - javascript
-  #         - curl
-  #         - python
-  #         - go
   #     parameters:
   #       - $ref: "#/components/parameters/apiKey"
   #     requestBody:
@@ -265,12 +229,6 @@ paths:
   #     description: >
   #       Placeholder for the Webhooks - in order to update this you'll need to move it back and forth.
   #     tags: ["🔔 Webhooks"]
-  #     x-readme:
-  #       samples-languages:
-  #         - javascript
-  #         - curl
-  #         - python
-  #         - go
   #     parameters:
   #       - $ref: "#/components/parameters/apiKey"
   #     requestBody:

--- a/src/openapi/portfolio/transactions/history/by-address.yaml
+++ b/src/openapi/portfolio/transactions/history/by-address.yaml
@@ -2,12 +2,6 @@ summary: Transactions By Wallet
 description: >
   Fetches all historical transactions (internal & external) for multiple wallet addresses and networks. Returns a list of transaction objects with metadata and log information. This endpoint will be supported on Ethereum, Solana, and 30+ EVM chains (Beta: currently limited to Ethereum and Base with a limit of 1 address)
 tags: ["Portfolio API Endpoints"]
-x-readme:
-  samples-languages:
-    - javascript
-    - curl
-    - python
-    - go
 parameters:
   - $ref: "./../../portfolio.yaml#/components/parameters/apiKey"
 requestBody:

--- a/src/openapi/prices/prices.yaml
+++ b/src/openapi/prices/prices.yaml
@@ -13,12 +13,6 @@ paths:
       description: >
         Fetches current prices for multiple tokens using their symbols. Returns a list of token prices, each containing the symbol, prices, and an optional error field.
       tags: ["Prices API Endpoints"]
-      x-readme:
-        samples-languages:
-          - javascript
-          - curl
-          - python
-          - go
       parameters:
         - $ref: "#/components/parameters/apiKey"
         - in: query
@@ -61,12 +55,6 @@ paths:
       description: >
         Fetches current prices for multiple tokens using network and address pairs. Returns a list of token prices, each containing the network, address, prices, and an optional error field.
       tags: ["Prices API Endpoints"]
-      x-readme:
-        samples-languages:
-          - javascript
-          - curl
-          - python
-          - go
       parameters:
         - $ref: "#/components/parameters/apiKey"
       requestBody:
@@ -102,12 +90,6 @@ paths:
       description: >
         Provides historical price data for a single token over a time range. You can identify the token by symbol or by network and contract address.
       tags: ["Prices API Endpoints"]
-      x-readme:
-        samples-languages:
-          - javascript
-          - curl
-          - python
-          - go
       parameters:
         - $ref: "#/components/parameters/apiKey"
       requestBody:

--- a/src/openapi/transactions/transactions.yaml
+++ b/src/openapi/transactions/transactions.yaml
@@ -15,12 +15,6 @@ paths:
       description: >
         Fetches current prices for multiple tokens using their symbols. Returns a list of token prices, each containing the symbol, prices, and an optional error field.
       tags: ["Prices API Endpoints"]
-      x-readme:
-        samples-languages:
-          - javascript
-          - curl
-          - python
-          - go
       parameters:
         - $ref: "#/components/parameters/apiKey"
         - in: query
@@ -63,12 +57,6 @@ paths:
       description: >
         Fetches current prices for multiple tokens using network and address pairs. Returns a list of token prices, each containing the network, address, prices, and an optional error field.
       tags: ["Prices API Endpoints"]
-      x-readme:
-        samples-languages:
-          - javascript
-          - curl
-          - python
-          - go
       parameters:
         - $ref: "#/components/parameters/apiKey"
       requestBody:
@@ -104,12 +92,6 @@ paths:
       description: >
         Provides historical price data for a single token over a time range. You can identify the token by symbol or by network and contract address.
       tags: ["Prices API Endpoints"]
-      x-readme:
-        samples-languages:
-          - javascript
-          - curl
-          - python
-          - go
       parameters:
         - $ref: "#/components/parameters/apiKey"
       requestBody:


### PR DESCRIPTION
## Description

These lines are left-over from when specs were consumed by Readme. Now that this is no longer the case we can clean them up.

## Changes Made

- remove all instances of x-readme in api specs

## Testing

<!-- Describe the tests that you ran to verify your changes -->

* \[x] I have tested these changes locally
* \[x] I have run the validation scripts (`pnpm run validate`)
* \[x] I have checked that the documentation builds correctly
