### PR TITLE
feat: make alchemy logo link to Docs home rather than marketing site

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -12,7 +12,7 @@ layout:
 title: Alchemy Docs
 
 logo:
-  href: /
+  href: /docs
   light: assets/alchemy-light.svg
   dark: assets/alchemy-dark.svg
   height: 30


### PR DESCRIPTION
## Description

Self-explanatory

## Testing

<!-- Describe the tests that you ran to verify your changes -->

* \[x] I have tested these changes locally
* \[x] I have run the validation scripts (`pnpm run validate`)
* \[x] I have checked that the documentation builds correctly
