### PR TITLE
Re-order Get Started docs sidebar

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -688,300 +688,8 @@ navigation:
                 path: tutorials/getting-started/dashboard/request-logs.mdx
               - page: Roles
                 path: tutorials/getting-started/dashboard/dashboard-roles.mdx
-      - section: Alchemy University
+      - section: Tutorials
         contents:
-          - section: Blockchain Basics
-            path: tutorials/alchemy-university/blockchain-basics.mdx
-            contents:
-              - page: What is a blockchain?
-                path: >-
-                  tutorials/alchemy-university/blockchain-basics/what-is-a-blockchain.mdx
-              - page: What is Proof of Work?
-                path: >-
-                  tutorials/alchemy-university/blockchain-basics/proof-of-work.mdx
-              - page: What are blockchain consensus mechanisms?
-                path: >-
-                  tutorials/alchemy-university/blockchain-basics/what-are-blockchain-consensus-mechanisms.mdx
-              - page: What does a blockchain network look like?
-                path: >-
-                  tutorials/alchemy-university/blockchain-basics/what-are-blockchain-networks.mdx
-              - page: What is a 51% attack?
-                path: >-
-                  tutorials/alchemy-university/blockchain-basics/51-percent-attack.mdx
-              - page: What is the Bitcoin genesis block?
-                path: >-
-                  tutorials/alchemy-university/blockchain-basics/bitcoin-genesis-block.mdx
-              - page: UTXO vs. Account Models
-                path: >-
-                  tutorials/alchemy-university/blockchain-basics/utxo-vs-account-models.mdx
-            slug: blockchain-basics
-          - section: Cryptography Basics
-            path: >-
-              tutorials/alchemy-university/cryptography-basics/cryptography-basics.mdx
-            contents:
-              - page: What is Public Key Cryptography?
-                path: >-
-                  tutorials/alchemy-university/cryptography-basics/public-key-cryptography.mdx
-              - page: What is a hashing algorithm?
-                path: >-
-                  tutorials/alchemy-university/cryptography-basics/hashing-algorithm.mdx
-              - page: How do tree data structures work?
-                path: >-
-                  tutorials/alchemy-university/cryptography-basics/tree-data-structures.mdx
-              - page: What are Merkle trees?
-                path: >-
-                  tutorials/alchemy-university/cryptography-basics/what-are-merkle-trees.mdx
-              - page: How are Merkle trees used in blockchains?
-                path: >-
-                  tutorials/alchemy-university/cryptography-basics/merkle-trees-in-blockchains.mdx
-              - page: What are Patricia Merkle Tries?
-                path: >-
-                  tutorials/alchemy-university/cryptography-basics/patricia-merkle-tries.mdx
-            slug: cryptography-basics
-          - section: Ethereum Basics
-            path: >-
-              tutorials/alchemy-university/ethereum-basics/ethereum-basics.mdx
-            contents:
-              - page: What is Ethereum?
-                path: >-
-                  tutorials/alchemy-university/ethereum-basics/what-is-ethereum.mdx
-              - page: What is Proof of Stake?
-                path: >-
-                  tutorials/alchemy-university/ethereum-basics/what-is-proof-of-stake.mdx
-              - page: How does Ethereum gas work?
-                path: tutorials/alchemy-university/ethereum-basics/ethereum-gas.mdx
-              - page: What are Ethereum Accounts?
-                path: >-
-                  tutorials/alchemy-university/ethereum-basics/ethereum-accounts.mdx
-              - page: How to Read Data with JSON-RPC
-                path: >-
-                  tutorials/alchemy-university/ethereum-basics/how-to-read-data-with-json-rpc.mdx
-              - page: How to create a JSON REST API for Ethereum
-                path: >-
-                  tutorials/alchemy-university/ethereum-basics/create-json-rest-api.mdx
-              - page: What are Ethereum nodes?
-                path: >-
-                  tutorials/alchemy-university/ethereum-basics/ethereum-nodes.mdx
-              - page: How do Ethereum transactions work?
-                path: >-
-                  tutorials/alchemy-university/ethereum-basics/how-ethereum-transactions-work.mdx
-              - page: Introduction to Ethereum Frontend Libraries
-                path: >-
-                  tutorials/alchemy-university/ethereum-basics/ethereum-frontend-libraries.mdx
-            slug: ethereum-basics
-          - section: Solidity Basics
-            path: >-
-              tutorials/alchemy-university/solidity-basics/solidity-basics.mdx
-            contents:
-              - page: What is Hardhat?
-                path: >-
-                  tutorials/alchemy-university/solidity-basics/what-is-hardhat.mdx
-              - page: What is Solidity Syntax?
-                path: >-
-                  tutorials/alchemy-university/solidity-basics/what-is-solidity-syntax.mdx
-              - page: How does Solidity work with the EVM?
-                path: >-
-                  tutorials/alchemy-university/solidity-basics/how-does-solidity-work.mdx
-              - page: "Solidity vs. JavaScript: Similarities & Differences"
-                path: >-
-                  tutorials/alchemy-university/solidity-basics/solidity-vs-javascript.mdx
-              - page: How do Solidity functions work?
-                path: >-
-                  tutorials/alchemy-university/solidity-basics/solidity-functions.mdx
-              - page: How to Modify State Variables
-                path: >-
-                  tutorials/alchemy-university/solidity-basics/how-to-modify-state-variables.mdx
-              - page: What does it mean to revert transactions?
-                path: >-
-                  tutorials/alchemy-university/solidity-basics/revert-transactions.mdx
-              - page: How do Solidity Mappings work?
-                path: >-
-                  tutorials/alchemy-university/solidity-basics/solidity-mappings.mdx
-              - page: What are Solidity events?
-                path: >-
-                  tutorials/alchemy-university/solidity-basics/solidity-events.mdx
-              - page: How do Solidity arrays work?
-                path: >-
-                  tutorials/alchemy-university/solidity-basics/how-solidity-arrays-work.mdx
-              - page: How do Solidity structs work?
-                path: >-
-                  tutorials/alchemy-university/solidity-basics/how-do-solidity-structs-work.mdx
-            slug: solidity-basics
-          - section: Smart Contract Basics
-            path: >-
-              tutorials/alchemy-university/smart-contract-basics/smart-contract-basics.mdx
-            contents:
-              - page: How do smart contracts communicate?
-                path: >-
-                  tutorials/alchemy-university/smart-contract-basics/smart-contract-communication.mdx
-              - page: How to Unit Test a Smart Contract
-                path: >-
-                  tutorials/alchemy-university/smart-contract-basics/how-to-unit-test-a-smart-contract.mdx
-              - page: How do smart contract ABIs work?
-                path: >-
-                  tutorials/alchemy-university/smart-contract-basics/smart-contract-abi.mdx
-              - page: What are multi-signature contracts?
-                path: >-
-                  tutorials/alchemy-university/smart-contract-basics/multi-sig-contracts.mdx
-              - page: What is Smart Contract inheritance?
-                path: >-
-                  tutorials/alchemy-university/smart-contract-basics/smart-contract-inheritance.mdx
-              - page: What is an ERC-20 token?
-                path: >-
-                  tutorials/alchemy-university/smart-contract-basics/what-is-erc-20.mdx
-              - page: What are NFTs?
-                path: >-
-                  tutorials/alchemy-university/smart-contract-basics/what-are-nfts.mdx
-              - page: What are upgradeable smart contracts?
-                path: >-
-                  tutorials/alchemy-university/smart-contract-basics/upgradeable-smart-contracts.mdx
-            slug: smart-contract-basics
-        slug: alchemy-university
-      - section: Web3 Tutorials
-        contents:
-          - section: Environment Setup
-            contents:
-              - page: How to Set Up Core Web3 Developer Tools
-                path: >-
-                  tutorials/getting-started/how-to-set-up-core-web3-developer-tools/how-to-set-up-core-web3-developer-tools.mdx
-              - page: How to Set Up Your Solana Development Environment
-                path: >-
-                  tutorials/getting-started/how-to-set-up-core-web3-developer-tools/how-to-setup-your-solana-development-environment.mdx
-                slug: environment-setup
-            slug: getting-started
-          - section: Learning Solidity
-            contents:
-              - page: What is Smart Contract Storage Layout?
-                path: tutorials/learning-solidity/smart-contract-storage-layout.mdx
-              - page: When to use Storage vs. Memory vs. Calldata in Solidity
-                path: >-
-                  tutorials/learning-solidity/when-to-use-storage-vs-memory-vs-calldata-in-solidity.mdx
-              - page: What is the difference between Memory and Calldata in Solidity?
-                path: >-
-                  tutorials/learning-solidity/what-is-the-difference-between-memory-and-calldata-in-solidity.mdx
-              - page: What are Payable Functions in Solidity?
-                path: tutorials/learning-solidity/solidity-payable-functions.mdx
-              - page: How to Get a Smart Contract's Balance in Solidity
-                path: >-
-                  tutorials/learning-solidity/how-to-get-a-smart-contracts-balance-in-solidity.mdx
-              - page: How to Send Value from Within a Smart Contract Using Solidity
-                path: >-
-                  tutorials/learning-solidity/how-to-send-value-from-within-a-smart-contract-using-solidity.mdx
-              - page: How to Interpret Binaries in Solidity
-                path: >-
-                  tutorials/learning-solidity/how-to-interpret-binaries-in-solidity.mdx
-              - page: How to Interact with ERC-20 tokens in Solidity
-                path: >-
-                  tutorials/learning-solidity/how-to-interact-with-erc-20-tokens-in-solidity.mdx
-              - page: How to Interact with ERC-721 Tokens in Solidity
-                path: >-
-                  tutorials/learning-solidity/how-to-interact-with-erc-721-tokens-in-solidity.mdx
-              - page: >-
-                  How to Make Your Dapp Compatible With Smart Contract Wallets Using
-                  ERC-1271
-                path: >-
-                  tutorials/learning-solidity/how-to-make-your-dapp-compatible-with-smart-contract-wallets.mdx
-              - section: How to Verify a Message Signature on Ethereum
-                path: >-
-                  tutorials/learning-solidity/how-to-verify-a-message-signature-on-ethereum/how-to-verify-a-message-signature-on-ethereum.mdx
-                contents:
-                  - page: How to Create a Signature Generator DApp
-                    path: >-
-                      tutorials/learning-solidity/how-to-verify-a-message-signature-on-ethereum/how-to-create-a-signature-generator-dapp.mdx
-                slug: how-to-verify-a-message-signature-on-ethereum
-            slug: learning-solidity
-          - section: Creating Smart Contracts
-            contents:
-              - section: Hello World Smart Contract
-                path: tutorials/creating-smart-contracts/hello-world-smart-contract.mdx
-                contents:
-                  - page: Interacting with a Smart Contract
-                    path: >-
-                      tutorials/creating-smart-contracts/hello-world-smart-contract/interacting-with-a-smart-contract.mdx
-                  - page: Submitting your Smart Contract to Etherscan
-                    path: >-
-                      tutorials/creating-smart-contracts/hello-world-smart-contract/submitting-your-smart-contract-to-etherscan.mdx
-                  - page: Integrating Your Smart Contract with the Frontend
-                    path: >-
-                      tutorials/creating-smart-contracts/hello-world-smart-contract/integrating-your-smart-contract-with-the-frontend.mdx
-                  - page: How to Code and Deploy a Polygon Smart Contract
-                    path: >-
-                      tutorials/creating-smart-contracts/hello-world-smart-contract/how-to-code-and-deploy-a-polygon-smart-contract.mdx
-                slug: hello-world-smart-contract
-              - section: Hello World Solana Program
-                path: >-
-                  tutorials/creating-smart-contracts/hello-world-solana-program/hello-world-solana-program.mdx
-                contents:
-                  - page: How to Integrate a Solana Program with a Web3 Application
-                    path: >-
-                      tutorials/creating-smart-contracts/hello-world-solana-program/integrating-your-solana-program-with-a-web3-application.mdx
-                slug: hello-world-solana-program
-              - section: "NFT Minter Tutorial: How to Create a Full Stack DApp"
-                path: >-
-                  tutorials/creating-smart-contracts/nft-minter-tutorial-how-to-create-a-full-stack-dapp/nft-minter.mdx
-                contents:
-                  - page: How to Build an NFT Website
-                    path: >-
-                      tutorials/creating-smart-contracts/nft-minter-tutorial-how-to-create-a-full-stack-dapp/how-to-build-an-nft-website.mdx
-                slug: nft-minter-tutorial-how-to-create-a-full-stack-dapp
-              - section: How to Create an NFT on Ethereum Tutorial
-                path: >-
-                  tutorials/creating-smart-contracts/how-to-create-an-nft-on-ethereum-tutorial/how-to-create-an-nft.mdx
-                contents:
-                  - page: How to Mint an NFT from Code
-                    path: >-
-                      tutorials/creating-smart-contracts/how-to-create-an-nft-on-ethereum-tutorial/how-to-mint-an-nft-from-code.mdx
-                  - page: How to View Your NFT in Your Mobile Wallet
-                    path: >-
-                      tutorials/creating-smart-contracts/how-to-create-an-nft-on-ethereum-tutorial/how-to-view-your-nft-in-your-mobile-wallet.mdx
-                  - page: How do I set a price on an NFT?
-                    path: >-
-                      tutorials/creating-smart-contracts/how-to-create-an-nft-on-ethereum-tutorial/how-do-i-set-a-price-on-an-nft.mdx
-                  - page: How to Create ERC-1155 Tokens
-                    path: >-
-                      tutorials/creating-smart-contracts/how-to-create-an-nft-on-ethereum-tutorial/how-to-create-erc-1155-tokens.mdx
-                slug: how-to-create-an-nft-on-ethereum-tutorial
-              - page: "Arbitrum NFTs: Creating and Deploying ERC-721"
-                path: >-
-                  tutorials/creating-smart-contracts/arbitrum-nfts-creating-and-deploying-erc-721.mdx
-              - page: How to Build a Solana NFT Collection
-                path: >-
-                  tutorials/creating-smart-contracts/how-to-build-a-solana-nft-collection.mdx
-              - page: How to Deploy a Smart Contract to the Sepolia Testnet
-                path: >-
-                  tutorials/creating-smart-contracts/how-to-deploy-a-smart-contract-to-the-sepolia-testnet.mdx
-            slug: creating-smart-contracts
-          - section: SDKs and Libraries
-            contents:
-              - page: How to set up Hardhat
-                path: tutorials/sdks-and-libraries/how-to-set-up-hardhat.mdx
-              - page: How to set up the MetaMask SDK
-                path: tutorials/sdks-and-libraries/how-to-set-up-the-metamask-sdk.mdx
-              - page: How to Fork Ethereum Mainnet
-                path: tutorials/sdks-and-libraries/how-to-fork-ethereum-mainnet.mdx
-              - page: Ethers.js vs Web3.js SDK Comparison
-                path: tutorials/sdks-and-libraries/ethersjs-vs-web3js-sdk-comparison.mdx
-              - page: How to Use ChatGPT to Power Your dapps
-                path: >-
-                  tutorials/sdks-and-libraries/how-to-use-chatgpt-to-power-your-dapps.mdx
-              - section: What is Ethers.js?
-                path: >-
-                  tutorials/sdks-and-libraries/what-is-ethersjs/what-is-ethers-js.mdx
-                contents:
-                  - page: How to Use a Signer in Ethers.js
-                    path: >-
-                      tutorials/sdks-and-libraries/what-is-ethersjs/ethers-js-signer.mdx
-                  - page: How to Use a Contract in Ethers.js
-                    path: >-
-                      tutorials/sdks-and-libraries/what-is-ethersjs/ethers-js-contract.mdx
-                  - page: How to Use a Provider in Ethers.js
-                    path: >-
-                      tutorials/sdks-and-libraries/what-is-ethersjs/ethers-js-provider.mdx
-                  - page: How to Use WebSockets in Ethers.js
-                    path: >-
-                      tutorials/sdks-and-libraries/what-is-ethersjs/ethers-js-websockets.mdx
-                slug: what-is-ethersjs
-            slug: sdks-and-libraries
           - section: NFTs
             contents:
               - page: NFT Project Code Templates
@@ -1387,10 +1095,6 @@ navigation:
               - page: How to Calculate Ethereum Miner Rewards
                 path: >-
                   tutorials/understanding-the-evm/how-to-calculate-ethereum-miner-rewards.mdx
-              - page: Web3 Glossary
-                path: tutorials/understanding-the-evm/web3-glossary.mdx
-              - page: Blockchain 101
-                path: tutorials/understanding-the-evm/blockchain-101.mdx
               - section: How to Deploy a Contract to the Same Address on Multiple Networks
                 path: >-
                   tutorials/understanding-the-evm/how-to-deploy-a-contract-to-the-same-address-on-multiple-networks/how-to-deploy-a-contract-to-the-same-address-on-multiple-networks.mdx
@@ -1400,8 +1104,307 @@ navigation:
                       tutorials/understanding-the-evm/how-to-deploy-a-contract-to-the-same-address-on-multiple-networks/create2-an-alternative-to-deriving-contract-addresses.mdx
                 slug: how-to-deploy-a-contract-to-the-same-address-on-multiple-networks
             slug: understanding-the-evm
-        slug: web3-tutorials
-
+        slug: tutorials
+      - section: New to Web3
+        contents:
+          - section: Alchemy University
+            contents:
+              - section: Blockchain Basics
+                path: tutorials/alchemy-university/blockchain-basics.mdx
+                contents:
+                  - page: What is a blockchain?
+                    path: >-
+                      tutorials/alchemy-university/blockchain-basics/what-is-a-blockchain.mdx
+                  - page: What is Proof of Work?
+                    path: >-
+                      tutorials/alchemy-university/blockchain-basics/proof-of-work.mdx
+                  - page: What are blockchain consensus mechanisms?
+                    path: >-
+                      tutorials/alchemy-university/blockchain-basics/what-are-blockchain-consensus-mechanisms.mdx
+                  - page: What does a blockchain network look like?
+                    path: >-
+                      tutorials/alchemy-university/blockchain-basics/what-are-blockchain-networks.mdx
+                  - page: What is a 51% attack?
+                    path: >-
+                      tutorials/alchemy-university/blockchain-basics/51-percent-attack.mdx
+                  - page: What is the Bitcoin genesis block?
+                    path: >-
+                      tutorials/alchemy-university/blockchain-basics/bitcoin-genesis-block.mdx
+                  - page: UTXO vs. Account Models
+                    path: >-
+                      tutorials/alchemy-university/blockchain-basics/utxo-vs-account-models.mdx
+                  - page: Web3 Glossary
+                    path: tutorials/understanding-the-evm/web3-glossary.mdx
+                  - page: Blockchain 101
+                    path: tutorials/understanding-the-evm/blockchain-101.mdx
+                slug: blockchain-basics
+              - section: Cryptography Basics
+                path: >-
+                  tutorials/alchemy-university/cryptography-basics/cryptography-basics.mdx
+                contents:
+                  - page: What is Public Key Cryptography?
+                    path: >-
+                      tutorials/alchemy-university/cryptography-basics/public-key-cryptography.mdx
+                  - page: What is a hashing algorithm?
+                    path: >-
+                      tutorials/alchemy-university/cryptography-basics/hashing-algorithm.mdx
+                  - page: How do tree data structures work?
+                    path: >-
+                      tutorials/alchemy-university/cryptography-basics/tree-data-structures.mdx
+                  - page: What are Merkle trees?
+                    path: >-
+                      tutorials/alchemy-university/cryptography-basics/what-are-merkle-trees.mdx
+                  - page: How are Merkle trees used in blockchains?
+                    path: >-
+                      tutorials/alchemy-university/cryptography-basics/merkle-trees-in-blockchains.mdx
+                  - page: What are Patricia Merkle Tries?
+                    path: >-
+                      tutorials/alchemy-university/cryptography-basics/patricia-merkle-tries.mdx
+                slug: cryptography-basics
+              - section: Ethereum Basics
+                path: >-
+                  tutorials/alchemy-university/ethereum-basics/ethereum-basics.mdx
+                contents:
+                  - page: What is Ethereum?
+                    path: >-
+                      tutorials/alchemy-university/ethereum-basics/what-is-ethereum.mdx
+                  - page: What is Proof of Stake?
+                    path: >-
+                      tutorials/alchemy-university/ethereum-basics/what-is-proof-of-stake.mdx
+                  - page: How does Ethereum gas work?
+                    path: tutorials/alchemy-university/ethereum-basics/ethereum-gas.mdx
+                  - page: What are Ethereum Accounts?
+                    path: >-
+                      tutorials/alchemy-university/ethereum-basics/ethereum-accounts.mdx
+                  - page: How to Read Data with JSON-RPC
+                    path: >-
+                      tutorials/alchemy-university/ethereum-basics/how-to-read-data-with-json-rpc.mdx
+                  - page: How to create a JSON REST API for Ethereum
+                    path: >-
+                      tutorials/alchemy-university/ethereum-basics/create-json-rest-api.mdx
+                  - page: What are Ethereum nodes?
+                    path: >-
+                      tutorials/alchemy-university/ethereum-basics/ethereum-nodes.mdx
+                  - page: How do Ethereum transactions work?
+                    path: >-
+                      tutorials/alchemy-university/ethereum-basics/how-ethereum-transactions-work.mdx
+                  - page: Introduction to Ethereum Frontend Libraries
+                    path: >-
+                      tutorials/alchemy-university/ethereum-basics/ethereum-frontend-libraries.mdx
+                slug: ethereum-basics
+              - section: Solidity Basics
+                path: >-
+                  tutorials/alchemy-university/solidity-basics/solidity-basics.mdx
+                contents:
+                  - page: What is Hardhat?
+                    path: >-
+                      tutorials/alchemy-university/solidity-basics/what-is-hardhat.mdx
+                  - page: What is Solidity Syntax?
+                    path: >-
+                      tutorials/alchemy-university/solidity-basics/what-is-solidity-syntax.mdx
+                  - page: How does Solidity work with the EVM?
+                    path: >-
+                      tutorials/alchemy-university/solidity-basics/how-does-solidity-work.mdx
+                  - page: "Solidity vs. JavaScript: Similarities & Differences"
+                    path: >-
+                      tutorials/alchemy-university/solidity-basics/solidity-vs-javascript.mdx
+                  - page: How do Solidity functions work?
+                    path: >-
+                      tutorials/alchemy-university/solidity-basics/solidity-functions.mdx
+                  - page: How to Modify State Variables
+                    path: >-
+                      tutorials/alchemy-university/solidity-basics/how-to-modify-state-variables.mdx
+                  - page: What does it mean to revert transactions?
+                    path: >-
+                      tutorials/alchemy-university/solidity-basics/revert-transactions.mdx
+                  - page: How do Solidity Mappings work?
+                    path: >-
+                      tutorials/alchemy-university/solidity-basics/solidity-mappings.mdx
+                  - page: What are Solidity events?
+                    path: >-
+                      tutorials/alchemy-university/solidity-basics/solidity-events.mdx
+                  - page: How do Solidity arrays work?
+                    path: >-
+                      tutorials/alchemy-university/solidity-basics/how-solidity-arrays-work.mdx
+                  - page: How do Solidity structs work?
+                    path: >-
+                      tutorials/alchemy-university/solidity-basics/how-do-solidity-structs-work.mdx
+                slug: solidity-basics
+              - section: Smart Contract Basics
+                path: >-
+                  tutorials/alchemy-university/smart-contract-basics/smart-contract-basics.mdx
+                contents:
+                  - page: How do smart contracts communicate?
+                    path: >-
+                      tutorials/alchemy-university/smart-contract-basics/smart-contract-communication.mdx
+                  - page: How to Unit Test a Smart Contract
+                    path: >-
+                      tutorials/alchemy-university/smart-contract-basics/how-to-unit-test-a-smart-contract.mdx
+                  - page: How do smart contract ABIs work?
+                    path: >-
+                      tutorials/alchemy-university/smart-contract-basics/smart-contract-abi.mdx
+                  - page: What are multi-signature contracts?
+                    path: >-
+                      tutorials/alchemy-university/smart-contract-basics/multi-sig-contracts.mdx
+                  - page: What is Smart Contract inheritance?
+                    path: >-
+                      tutorials/alchemy-university/smart-contract-basics/smart-contract-inheritance.mdx
+                  - page: What is an ERC-20 token?
+                    path: >-
+                      tutorials/alchemy-university/smart-contract-basics/what-is-erc-20.mdx
+                  - page: What are NFTs?
+                    path: >-
+                      tutorials/alchemy-university/smart-contract-basics/what-are-nfts.mdx
+                  - page: What are upgradeable smart contracts?
+                    path: >-
+                      tutorials/alchemy-university/smart-contract-basics/upgradeable-smart-contracts.mdx
+                slug: smart-contract-basics
+            slug: alchemy-university
+          - section: Developer Basics
+            contents:
+              - section: Environment Setup
+                contents:
+                  - page: How to Set Up Core Web3 Developer Tools
+                    path: >-
+                      tutorials/getting-started/how-to-set-up-core-web3-developer-tools/how-to-set-up-core-web3-developer-tools.mdx
+                  - page: How to Set Up Your Solana Development Environment
+                    path: >-
+                      tutorials/getting-started/how-to-set-up-core-web3-developer-tools/how-to-setup-your-solana-development-environment.mdx
+                slug: environment-setup
+              - section: Learning Solidity
+                contents:
+                  - page: What is Smart Contract Storage Layout?
+                    path: tutorials/learning-solidity/smart-contract-storage-layout.mdx
+                  - page: When to use Storage vs. Memory vs. Calldata in Solidity
+                    path: >-
+                      tutorials/learning-solidity/when-to-use-storage-vs-memory-vs-calldata-in-solidity.mdx
+                  - page: What is the difference between Memory and Calldata in Solidity?
+                    path: >-
+                      tutorials/learning-solidity/what-is-the-difference-between-memory-and-calldata-in-solidity.mdx
+                  - page: What are Payable Functions in Solidity?
+                    path: tutorials/learning-solidity/solidity-payable-functions.mdx
+                  - page: How to Get a Smart Contract's Balance in Solidity
+                    path: >-
+                      tutorials/learning-solidity/how-to-get-a-smart-contracts-balance-in-solidity.mdx
+                  - page: How to Send Value from Within a Smart Contract Using Solidity
+                    path: >-
+                      tutorials/learning-solidity/how-to-send-value-from-within-a-smart-contract-using-solidity.mdx
+                  - page: How to Interpret Binaries in Solidity
+                    path: >-
+                      tutorials/learning-solidity/how-to-interpret-binaries-in-solidity.mdx
+                  - page: How to Interact with ERC-20 tokens in Solidity
+                    path: >-
+                      tutorials/learning-solidity/how-to-interact-with-erc-20-tokens-in-solidity.mdx
+                  - page: How to Interact with ERC-721 Tokens in Solidity
+                    path: >-
+                      tutorials/learning-solidity/how-to-interact-with-erc-721-tokens-in-solidity.mdx
+                  - page: >-
+                      How to Make Your Dapp Compatible With Smart Contract Wallets Using
+                      ERC-1271
+                    path: >-
+                      tutorials/learning-solidity/how-to-make-your-dapp-compatible-with-smart-contract-wallets.mdx
+                  - section: How to Verify a Message Signature on Ethereum
+                    path: >-
+                      tutorials/learning-solidity/how-to-verify-a-message-signature-on-ethereum/how-to-verify-a-message-signature-on-ethereum.mdx
+                    contents:
+                      - page: How to Create a Signature Generator DApp
+                        path: >-
+                          tutorials/learning-solidity/how-to-verify-a-message-signature-on-ethereum/how-to-create-a-signature-generator-dapp.mdx
+                    slug: how-to-verify-a-message-signature-on-ethereum
+                slug: learning-solidity
+              - section: Creating Smart Contracts
+                contents:
+                  - section: Hello World Smart Contract
+                    path: tutorials/creating-smart-contracts/hello-world-smart-contract.mdx
+                    contents:
+                      - page: Interacting with a Smart Contract
+                        path: >-
+                          tutorials/creating-smart-contracts/hello-world-smart-contract/interacting-with-a-smart-contract.mdx
+                      - page: Submitting your Smart Contract to Etherscan
+                        path: >-
+                          tutorials/creating-smart-contracts/hello-world-smart-contract/submitting-your-smart-contract-to-etherscan.mdx
+                      - page: Integrating Your Smart Contract with the Frontend
+                        path: >-
+                          tutorials/creating-smart-contracts/hello-world-smart-contract/integrating-your-smart-contract-with-the-frontend.mdx
+                      - page: How to Code and Deploy a Polygon Smart Contract
+                        path: >-
+                          tutorials/creating-smart-contracts/hello-world-smart-contract/how-to-code-and-deploy-a-polygon-smart-contract.mdx
+                    slug: hello-world-smart-contract
+                  - section: Hello World Solana Program
+                    path: >-
+                      tutorials/creating-smart-contracts/hello-world-solana-program/hello-world-solana-program.mdx
+                    contents:
+                      - page: How to Integrate a Solana Program with a Web3 Application
+                        path: >-
+                          tutorials/creating-smart-contracts/hello-world-solana-program/integrating-your-solana-program-with-a-web3-application.mdx
+                    slug: hello-world-solana-program
+                  - section: "NFT Minter Tutorial: How to Create a Full Stack DApp"
+                    path: >-
+                      tutorials/creating-smart-contracts/nft-minter-tutorial-how-to-create-a-full-stack-dapp/nft-minter.mdx
+                    contents:
+                      - page: How to Build an NFT Website
+                        path: >-
+                          tutorials/creating-smart-contracts/nft-minter-tutorial-how-to-create-a-full-stack-dapp/how-to-build-an-nft-website.mdx
+                    slug: nft-minter-tutorial-how-to-create-a-full-stack-dapp
+                  - section: How to Create an NFT on Ethereum Tutorial
+                    path: >-
+                      tutorials/creating-smart-contracts/how-to-create-an-nft-on-ethereum-tutorial/how-to-create-an-nft.mdx
+                    contents:
+                      - page: How to Mint an NFT from Code
+                        path: >-
+                          tutorials/creating-smart-contracts/how-to-create-an-nft-on-ethereum-tutorial/how-to-mint-an-nft-from-code.mdx
+                      - page: How to View Your NFT in Your Mobile Wallet
+                        path: >-
+                          tutorials/creating-smart-contracts/how-to-create-an-nft-on-ethereum-tutorial/how-to-view-your-nft-in-your-mobile-wallet.mdx
+                      - page: How do I set a price on an NFT?
+                        path: >-
+                          tutorials/creating-smart-contracts/how-to-create-an-nft-on-ethereum-tutorial/how-do-i-set-a-price-on-an-nft.mdx
+                      - page: How to Create ERC-1155 Tokens
+                        path: >-
+                          tutorials/creating-smart-contracts/how-to-create-an-nft-on-ethereum-tutorial/how-to-create-erc-1155-tokens.mdx
+                    slug: how-to-create-an-nft-on-ethereum-tutorial
+                  - page: "Arbitrum NFTs: Creating and Deploying ERC-721"
+                    path: >-
+                      tutorials/creating-smart-contracts/arbitrum-nfts-creating-and-deploying-erc-721.mdx
+                  - page: How to Build a Solana NFT Collection
+                    path: >-
+                      tutorials/creating-smart-contracts/how-to-build-a-solana-nft-collection.mdx
+                  - page: How to Deploy a Smart Contract to the Sepolia Testnet
+                    path: >-
+                      tutorials/creating-smart-contracts/how-to-deploy-a-smart-contract-to-the-sepolia-testnet.mdx
+                slug: creating-smart-contracts
+              - section: SDKs and Libraries
+                contents:
+                  - page: How to set up Hardhat
+                    path: tutorials/sdks-and-libraries/how-to-set-up-hardhat.mdx
+                  - page: How to set up the MetaMask SDK
+                    path: tutorials/sdks-and-libraries/how-to-set-up-the-metamask-sdk.mdx
+                  - page: How to Fork Ethereum Mainnet
+                    path: tutorials/sdks-and-libraries/how-to-fork-ethereum-mainnet.mdx
+                  - page: Ethers.js vs Web3.js SDK Comparison
+                    path: tutorials/sdks-and-libraries/ethersjs-vs-web3js-sdk-comparison.mdx
+                  - page: How to Use ChatGPT to Power Your dapps
+                    path: >-
+                      tutorials/sdks-and-libraries/how-to-use-chatgpt-to-power-your-dapps.mdx
+                  - section: What is Ethers.js?
+                    path: >-
+                      tutorials/sdks-and-libraries/what-is-ethersjs/what-is-ethers-js.mdx
+                    contents:
+                      - page: How to Use a Signer in Ethers.js
+                        path: >-
+                          tutorials/sdks-and-libraries/what-is-ethersjs/ethers-js-signer.mdx
+                      - page: How to Use a Contract in Ethers.js
+                        path: >-
+                          tutorials/sdks-and-libraries/what-is-ethersjs/ethers-js-contract.mdx
+                      - page: How to Use a Provider in Ethers.js
+                        path: >-
+                          tutorials/sdks-and-libraries/what-is-ethersjs/ethers-js-provider.mdx
+                      - page: How to Use WebSockets in Ethers.js
+                        path: >-
+                          tutorials/sdks-and-libraries/what-is-ethersjs/ethers-js-websockets.mdx
+                    slug: what-is-ethersjs
+                slug: sdks-and-libraries
+            slug: developer-basics
   - tab: wallets
     layout:
       - page: Wallets Placeholder
@@ -3131,7 +3134,8 @@ redirects:
   - source: /reference/eth-getblockreceipts-base
     destination: /docs/node/base/base-api-endpoints/eth-get-block-receipts
   - source: /reference/eth-getblocktransactioncountbyhash-base
-    destination: /docs/node/base/base-api-endpoints/eth-get-block-transaction-count-by-hash
+    destination: >-
+      /docs/node/base/base-api-endpoints/eth-get-block-transaction-count-by-hash
   - source: /reference/eth-getblocktransactioncountbynumber-base
     destination: >-
       /docs/node/base/base-api-endpoints/eth-get-block-transaction-count-by-number
@@ -5123,10 +5127,6 @@ redirects:
     destination: /docs/reference/trace-get
   - source: /enhanced-apis/trace-api/trace_rawtransaction
     destination: /docs/reference/trace-rawtransaction
-  - source: /enhanced-apis/trace-api/trace_replayblocktransactions
-    destination: /docs/reference/trace-replayblocktransaction
-  - source: /enhanced-apis/trace-api/trace_replaytransaction
-    destination: /docs/reference/trace-replaytransaction
   - source: /enhanced-apis/trace-api/trace_transaction
     destination: /docs/reference/trace-transaction
   - source: /enhanced-apis/transaction-receipts-api


### PR DESCRIPTION
1. Replace AU section with new New to Web3 section
Create 2 collapsible sub-sections for New to Web3
Alchemy University (→ include all current AU items under this section)
Developer basics
Environment Setup
Learning Solidity
Creating Smart Contracts
SDKs and Libraries

2. Rename Web3 Tutorials section to just Tutorials
NFTs
DeFi
Transactions
Streaming Data
API Security and Authentication
Developer Best Practices
Understanding the EVM

3. Move some items from Understanding the EVM to the new New to Web3 section
Web3 Glossary
Blockchain 101

4. Put new Tutorials section above New to Web3 section