### PR TITLE
fix: add placeholder file to wallets/components folder

### DIFF
--- a/fern/wallets/components/placeholder.md
+++ b/fern/wallets/components/placeholder.md
@@ -1,0 +1,1 @@
+This directly is replaced by it's equivalent in the [aa-sdk repository](https://github.com/alchemyplatform/aa-sdk). It only exists here to prevent local dev from failing if the components folder is not found.


### PR DESCRIPTION
## Description

## Related Issues

[Slack message](https://alchemyinsights.slack.com/archives/C08801YNZG9/p1750266093067559?thread_ts=1750231891.909669&cid=C08801YNZG9). The wallets/components folder was empty which was causing some people's local dev to fail in the docs repo. Empty folders aren't added to git so `fern docs dev` errored out when a folder referenced in docs.yml wasn't there.

## Changes Made

<!-- List the specific changes made in this PR -->

## Testing

<!-- Describe the tests that you ran to verify your changes -->

* \[ ] I have tested these changes locally
* \[ ] I have run the validation scripts (`pnpm run validate`)
* \[ ] I have checked that the documentation builds correctly
