### PR TITLE
Fix typos in API reference docs

### DIFF
--- a/fern/api-reference/alchemy-sdk/sdk-core-methods/getbalance-sdk-v3.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-core-methods/getbalance-sdk-v3.mdx
@@ -70,7 +70,7 @@ Here is an example of how to make a `getBalance` request using the Alchemy SDK:
   const alchemy = new Alchemy(config);
 
   const main = async () => {
-    	// This response fetches the balance of the given address in the paramter as of the provided block.
+    	// This response fetches the balance of the given address in the parameter as of the provided block.
       let response = await alchemy.core.getBalance("vitalik.eth", "latest")
 
       //Logging the response to the console

--- a/fern/api-reference/alchemy-sdk/sdk-nft-methods/getnftmetadata-sdk-v3.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-nft-methods/getnftmetadata-sdk-v3.mdx
@@ -22,9 +22,9 @@ Get the NFT metadata associated with the provided parameters.
 | `tokenId`         | `string` | Token id of the NFT.                                                                                                |
 | `options`         | `object` | Options for the request. A null object should still be passed in params if no options are provided for the request. |
 
-### `options` paramters
+### `options` parameters
 
-| Parameter              | Type      | Deescription                                                                                                                                                                                                                                                             |
+| Parameter              | Type      | Description                                                                                                                                                                                                                                                             |
 | ---------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `tokenType?`           | `object`  | Optional field to specify the type of token to speed up the query. Available options include: \[`ERC721` = "ERC721", `ERC1155` = "ERC1155", `UNKNOWN` = "UNKNOWN"]                                                                                                       |
 | `tokenUriTimeoutInMs?` | `number`  | No set timeout by default - When metadata is requested, this parameter is the timeout (in milliseconds) for the website hosting the metadata to respond. If you want to only access the cache and not live fetch any metadata for cache misses then set this value to 0. |

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getassettransfers.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getassettransfers.mdx
@@ -50,7 +50,7 @@ See the [web documentation](/reference/alchemy-getassettransfers#alchemy_getasse
 
 ### `AssetTransfersResponse` response object parameters
 
-| paramter          | type                        | description                                                                                                                                      |
+| parameter          | type                        | description                                                                                                                                      |
 | ----------------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `uniqueId`        | `string`                    | The unique ID of the transfer.                                                                                                                   |
 | `category`        | `string`                    | The category of the transfer.                                                                                                                    |
@@ -67,7 +67,7 @@ See the [web documentation](/reference/alchemy-getassettransfers#alchemy_getasse
 
 ### `AssetTransfersWithMetadataResponse` object parameters
 
-| paramter          | type                        | description                                                                                                                                                                                    |
+| parameter          | type                        | description                                                                                                                                                                                    |
 | ----------------- | --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `uniqueId`        | `string`                    | The unique ID of the transfer.                                                                                                                                                                 |
 | `category`        | `string`                    | The category of the transfer.                                                                                                                                                                  |

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getbalance.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getbalance.mdx
@@ -70,7 +70,7 @@ Here is an example of how to make a `getBalance` request using the Alchemy SDK:
   const alchemy = new Alchemy(config);
 
   const main = async () => {
-    	// This response fetches the balance of the given address in the paramter as of the provided block.
+    	// This response fetches the balance of the given address in the parameter as of the provided block.
       let response = await alchemy.core.getBalance("vitalik.eth", "latest")
 
       //Logging the response to the console

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getnftmetadata.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getnftmetadata.mdx
@@ -22,9 +22,9 @@ Get the NFT metadata associated with the provided parameters.
 | `tokenId`         | `string` | Token id of the NFT.                                                                                                 |
 | `options`         | `object` | Options for the request. A null object should still be passed in the params if no options are given for the request. |
 
-### `options` paramters
+### `options` parameters
 
-| Parameter              | Type      | Deescription                                                                                                                                                                                                                                                             |
+| Parameter              | Type      | Description                                                                                                                                                                                                                                                             |
 | ---------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `tokenType?`           | `object`  | Optional field to specify the type of token to speed up the query. Available options include: \[`ERC721` = "ERC721", `ERC1155` = "ERC1155", `UNKNOWN` = "UNKNOWN"]                                                                                                       |
 | `tokenUriTimeoutInMs?` | `number`  | No set timeout by default - When metadata is requested, this parameter is the timeout (in milliseconds) for the website hosting the metadata to respond. If you want to only access the cache and not live fetch any metadata for cache misses then set this value to 0. |

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getnftsforcontract.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getnftsforcontract.mdx
@@ -27,7 +27,7 @@ This method returns the full NFTs in the contract. To get all NFTs without their
 | `contractAddress` | `string` | The contract address of the NFT contract. |
 | `options`         | `object` | The parameters to use for the request.    |
 
-#### `options` paramters
+#### `options` parameters
 
 | Property              | Type      | Description                                                                                                                                                                                                                                                                |
 | --------------------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getnftsforcontractiterator.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getnftsforcontractiterator.mdx
@@ -27,7 +27,7 @@ This method returns the full NFTs in the contract and pages through all page key
 | `contractAddress` | `string` | The contract address of the NFT contract.       |
 | `options`         | `object` | The optional parameters to use for the request. |
 
-### `options` paramters
+### `options` parameters
 
 | Property              | Type      | Description                                                                                                                                                                                                                                                                |
 | --------------------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getnftsforowneriterator.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getnftsforowneriterator.mdx
@@ -27,7 +27,7 @@ This method returns the full NFT for the owner and pages through all page keys u
 | `owner`   | `string` | The owner of the address.                       |
 | `options` | `object` | The optional parameters to use for the request. |
 
-### `options` paramters
+### `options` parameters
 
 | Property              | Type               | Description                                                                                                                                                                                                                                                                |
 | --------------------- | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getownersforcontract.mdx
+++ b/fern/api-reference/alchemy-sdk/sdk-v2-methods/sdk-getownersforcontract.mdx
@@ -21,9 +21,9 @@ Gets all the owners for a given NFT contract along with the token balance.
 | `contractAddress` | `string` | The NFT contract to get the owners for.     |
 | `options`         | `object` | Optional parameters to use for the request. |
 
-### `options` paramters
+### `options` parameters
 
-| Parameter           | Type      | Deescription                                                                                         |
+| Parameter           | Type      | Description                                                                                         |
 | ------------------- | --------- | ---------------------------------------------------------------------------------------------------- |
 | `withTokenBalances` | `boolean` | Whether to include the token balances per token id for each owner. Defaults to `false` when omitted. |
 | `pageKey?`          | `string`  | `Optional` page key to paginate the next page for large requests.                                    |

--- a/fern/api-reference/websockets/subscription-api-endpoints/alchemy-pendingtransactions.mdx
+++ b/fern/api-reference/websockets/subscription-api-endpoints/alchemy-pendingtransactions.mdx
@@ -96,7 +96,7 @@ With `hashesOnly` = `false`
   alchemy.ws.on(
     {
       method: AlchemySubscription.PENDING_TRANSACTIONS,
-      fromAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", // Replace with address to recieve pending transactions from this address
+      fromAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", // Replace with address to receive pending transactions from this address
       toAddress: "0xdAC17F958D2ee523a2206206994597C13D831ec7", // Replace with address to send  pending transactions to this address
     },
     (tx) => console.log(tx)

--- a/fern/api-reference/websockets/subscription-api-endpoints/logs.mdx
+++ b/fern/api-reference/websockets/subscription-api-endpoints/logs.mdx
@@ -26,7 +26,7 @@ The `logs` subscription type emits logs that match a specified topic filter and 
 
 An object with the following fields:
 
-* `adddress` (optional): `string`] or `[array of strings]` Singular address or array of addresses. Only logs created from one of these addresses will be emitted.
+* `address` (optional): `string`] or `[array of strings]` Singular address or array of addresses. Only logs created from one of these addresses will be emitted.
 
 * `topics`: an array of topic specifiers (**up to 4 topics allowed per address**).
 


### PR DESCRIPTION
## Summary
- correct `receive` spelling in `alchemy-pendingtransactions` example
- fix misspelled table headers and descriptions in several SDK docs
- correct `address` parameter in `logs` subscription docs

## Testing
- `pnpm run lint` *(fails: Request was cancelled due to missing internet access)*

------
https://chatgpt.com/codex/tasks/task_b_685c5120202483299d4ba55353eace89