### PR TITLE
Fix duplicate titles and unwanted content

### DIFF
--- a/fern/api-reference/alchemy-rollups/customizations-integrations.mdx
+++ b/fern/api-reference/alchemy-rollups/customizations-integrations.mdx
@@ -6,8 +6,6 @@ url: https://docs.alchemy.com/reference/customizations-integrations
 slug: reference/customizations-integrations
 ---
 
-List of available customizations & add-on integrations for your rollup.
-
 This page explains how you can tailor your rollup environment with three key components: configuring your own chain, leveraging our instant developer tools, and integrating with our partner ecosystem.
 
 ***

--- a/fern/api-reference/alchemy-rollups/operating-your-rollup.mdx
+++ b/fern/api-reference/alchemy-rollups/operating-your-rollup.mdx
@@ -6,10 +6,6 @@ url: https://docs.alchemy.com/reference/operating-your-rollup
 slug: reference/operating-your-rollup
 ---
 
-How to monitor & keep your rollup running smoothly after launching with Alchemy.
-
-# Operations & Maintenance
-
 Keep your rollup running smoothly with robust operational practices. This guide covers reliability, upgrades, security, and monitoring.
 
 ## Reliability & Uptime

--- a/fern/api-reference/alchemy-rollups/quickstart-deploy-a-rollup.mdx
+++ b/fern/api-reference/alchemy-rollups/quickstart-deploy-a-rollup.mdx
@@ -6,8 +6,6 @@ url: https://docs.alchemy.com/reference/quickstart-deploy-a-rollup
 slug: reference/quickstart-deploy-a-rollup
 ---
 
-# Quickstart: Deploy a Rollup
-
 This guide will help you deploy a testnet rollup using the Alchemy Rollups dashboard. Follow these steps to launch your own Layer-2 blockchain quickly.
 
 ## Prerequisites

--- a/fern/api-reference/alchemy-rollups/rollup-basics.mdx
+++ b/fern/api-reference/alchemy-rollups/rollup-basics.mdx
@@ -1,12 +1,8 @@
 ---
 title: Rollup Basics
-description: Background knowledge about Ethereum rollups to help you get started.
-subtitle: Background knowledge about Ethereum rollups to help you get started.
 url: https://docs.alchemy.com/reference/rollup-basics
 slug: reference/rollup-basics
 ---
-
-# Rollup Basics
 
 Before diving in, it’s important to understand what rollups are and the two primary types available. Alchemy Rollups supports both Optimistic Rollups and Zero-Knowledge (ZK) Rollups.
 

--- a/fern/api-reference/alchemy-rollups/rollups-faq.mdx
+++ b/fern/api-reference/alchemy-rollups/rollups-faq.mdx
@@ -6,8 +6,6 @@ url: https://docs.alchemy.com/reference/rollups-faq
 slug: reference/rollups-faq
 ---
 
-# FAQ & Troubleshooting
-
 This section addresses frequently asked questions and common troubleshooting topics for your Alchemy Rollup.
 
 **Q: How is a rollup different from a sidechain or appchain?**

--- a/fern/api-reference/alchemy-rollups/rollups-quickstart.mdx
+++ b/fern/api-reference/alchemy-rollups/rollups-quickstart.mdx
@@ -6,8 +6,6 @@ url: https://docs.alchemy.com/reference/rollups-quickstart
 slug: reference/rollups-quickstart
 ---
 
-# Introduction to Alchemy Rollups
-
 ![](0fd597603aed1b6b4d7e18de93b91204790f8af904984181b417a3d55fb09def-image.png)
 
 Launching a rollup helps you make more money by unlocking new revenue streams, enabling novel use cases, and providing a better user experience.

--- a/fern/api-reference/alchemy-rollups/supported-stacks.mdx
+++ b/fern/api-reference/alchemy-rollups/supported-stacks.mdx
@@ -6,8 +6,6 @@ url: https://docs.alchemy.com/reference/supported-stacks
 slug: reference/supported-stacks
 ---
 
-# Supported Rollup Frameworks
-
 Alchemy Rollups supports multiple rollup frameworks. This guide provides an overview of each framework to help you choose the best option for your project.
 
 ## Optimism OP Stack

--- a/fern/api-reference/alchemy-rollups/using-your-rollup.mdx
+++ b/fern/api-reference/alchemy-rollups/using-your-rollup.mdx
@@ -6,10 +6,6 @@ url: https://docs.alchemy.com/reference/using-your-rollup
 slug: reference/using-your-rollup
 ---
 
-# Using Your Rollup
-
-After deployment, learn how to interact with your rollup. This guide covers connecting via RPC, bridging assets, and exploring the blockchain.
-
 ## RPC Endpoints & API Access
 
 * Your rollup’s RPC URL is available in the Alchemy dashboard.


### PR DESCRIPTION
## Summary
- remove duplicate headings and intro text from several rollups docs

## Testing
- `pnpm run lint` *(fails: network access needed to download packages)*

------
https://chatgpt.com/codex/tasks/task_b_685eefb756e0832998101202b667ef59