### PR TITLE
Fix NFT API V2 methods tag

### DIFF
--- a/src/openapi/nft/nft.yaml
+++ b/src/openapi/nft/nft.yaml
@@ -43,6 +43,10 @@ servers: # servers are also specified at the method level, if there isn't a spec
           - abstract-testnet
           - apechain-mainnet
         default: eth-mainnet
+
+tags:
+  - name: "NFT API V2 Methods (Older Version)"
+    description: "Deprecated NFT API V2 endpoints."
 paths:
   ## Below are all the v3 methods
   "/v3/{apiKey}/getNFTsForOwner":


### PR DESCRIPTION
## Summary
- add a tag definition for NFT API V2 methods with the correct label

## Testing
- `pnpm run lint` *(fails: Request was cancelled - no internet)*

------
https://chatgpt.com/codex/tasks/task_b_6865545be3308320915a6e5146459969