### PR TITLE
Fix update webhook filter requirements

### DIFF
--- a/src/openapi/notify/notify.yaml
+++ b/src/openapi/notify/notify.yaml
@@ -498,8 +498,6 @@ components:
       type: object
       required:
         - webhook_id
-        - nft_metadata_filters_to_add
-        - nft_metadata_filters_to_remove
       properties:
         webhook_id:
           type: string


### PR DESCRIPTION
## Summary
- remove `nft_metadata_filters_to_add` and `nft_metadata_filters_to_remove` from the list of required fields in the Update NFT metadata webhook filters schema

## Testing
- `pnpm run validate` *(fails: RequestAbortedError due to network)*
- `pnpm run lint` *(fails: RequestAbortedError due to network)*

------
https://chatgpt.com/codex/tasks/task_b_6866f84b25088320976d5e1b7d56670b