### PR TITLE
fix: run insert-wallets-tab composite as part of gh-pages-deploy

### DIFF
--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Setup pnpm
         uses: ./.github/actions/setup-pnpm
 
+      - name: Add aa-sdk docs to fern
+        uses: ./.github/actions/insert-wallets-tab
+
       - name: Run build script
         id: build
         run: pnpm generate && pnpm generate:metadata


### PR DESCRIPTION
## Description

API specs in wallets tab aren't getting included in the GitHub Pages deploy because they weren't being pulled in from aa-sdk during the GH Pages deploy action
[Slack thread](https://alchemyinsights.slack.com/archives/C03JX8DJP40/p1751584875229749)

## Related Issues

<!-- Link to any related issues or Asana tasks this PR addresses (e.g., "Fixes #123") -->

## Changes Made

<!-- List the specific changes made in this PR -->

## Testing

<!-- Describe the tests that you ran to verify your changes -->

* \[x] I have tested these changes locally
* \[x] I have run the validation scripts (`pnpm run validate`)
* \[x] I have checked that the documentation builds correctly
