### PR TITLE
Fix paths in chain directory doc to link to each of their respective API reference

### DIFF
--- a/fern/api-reference/introduction/alchemy-api-reference-overview/chain-apis-overview.mdx
+++ b/fern/api-reference/introduction/alchemy-api-reference-overview/chain-apis-overview.mdx
@@ -24,29 +24,29 @@ Welcome to the Chain APIs hub, your centralized location for accessing all our a
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_blocknumber`](/reference/eth-blocknumber)                                                 | [`eth_getBlockByHash`](/reference/eth-getblockbyhash)                                       |
-| [`eth_getBlockByNumber`](/reference/eth-getblockbynumber)                                       | [`eth_getBlockReceipts`](/reference/eth-getblockreceipts)                                   |
-| [`eth_getBlockTransactionCountByHash`](/reference/eth-getblocktransactioncountbyhash)           | [`eth_getBlockTransactionCountByNumber`](/reference/eth-getblocktransactioncountbynumber)   |
-| [`eth_getTransactionByHash`](/reference/eth-gettransactionbyhash)                               | [`eth_getTransactionByBlockHashAndIndex`](/reference/eth-gettransactionbyblockhashandindex) |
-| [`eth_getTransactionByBlockNumberAndIndex`](/reference/eth-gettransactionbyblocknumberandindex) | [`eth_getTransactionReceipt`](/reference/eth-gettransactionreceipt)                         |
-| [`eth_getTransactionCount`](/reference/eth-gettransactioncount)                                 | [`eth_sendRawTransaction`](/reference/eth-sendrawtransaction)                               |
-| [`eth_call`](/reference/eth-call)                                                               | [`eth_getCode`](/reference/eth-getcode)                                                     |
-| [`eth_getBalance`](/reference/eth-getbalance)                                                   | [`eth_accounts`](/reference/eth-accounts)                                                   |
-| [`eth_getStorageAt`](/reference/eth-getstorageat)                                               | [`eth_getProof`](/reference/eth-getproof)                                                   |
-| [`eth_getLogs`](/reference/eth-getlogs)                                                         | [`eth_newFilter`](/reference/eth-newfilter)                                                 |
-| [`eth_newPendingTransactionFilter`](/reference/eth-newpendingtransactionfilter)                 | [`eth_newBlockFilter`](/reference/eth-newblockfilter)                                       |
-| [`eth_getFilterChanges`](/reference/eth-getfilterchanges)                                       | [`eth_getFilterLogs`](/reference/eth-getfilterlogs)                                         |
-| [`eth_uninstallFilter`](/reference/eth-uninstallfilter)                                         | [`eth_chainId`](/reference/eth-chainid)                                                     |
-| [`eth_protocolVersion`](/reference/eth-protocolversion)                                         | [`net_listening`](/reference/net-listening)                                                 |
-| [`net_version`](/reference/net-version)                                                         | [`eth_getUncleCountByBlockHash`](/reference/eth-getunclecountbyblockhash)                   |
-| [`eth_getUncleByBlockNumberAndIndex`](/reference/eth-getunclebyblocknumberandindex)             | [`eth_getUncleByBlockHashAndIndex`](/reference/eth-getunclebyblockhashandindex)             |
-| [`eth_getUncleCountByBlockNumber`](/reference/eth-getunclecountbyblocknumber)                   | [`eth_estimateGas`](/reference/eth-estimategas)                                             |
-| [`eth_gasPrice`](/reference/eth-gasprice)                                                       | [`eth_feeHistory`](/reference/eth-feehistory)                                               |
-| [`eth_maxPriorityFeePerGas`](/reference/eth-maxpriorityfeepergas)                               | [`eth_createAccessList`](/reference/eth-createaccesslist)                                   |
-| [`web3_clientVersion`](/reference/web3-clientversion)                                           | [`web3_sha3`](/reference/web3-sha3)                                                         |
-| [`eth_subscribe`](/reference/eth-subscribe)                                                     | [`eth_unsubscribe`](/reference/eth-unsubscribe)                                             |
-| [`debug_getRawBlock`](/reference/debug-getrawblock)                                             | [`debug_getRawHeader`](/reference/debug-getrawheader)                                       |
-| [`debug_getRawReceipts`](/reference/debug-getrawreceipts)                                       |                                                                                             |
+| [`eth_blocknumber`](/docs/node/ethereum/ethereum-api-endpoints/eth-block-number)                 | [`eth_getBlockByHash`](/docs/node/ethereum/ethereum-api-endpoints/eth-get-block-by-hash)               |
+| [`eth_getBlockByNumber`](/docs/node/ethereum/ethereum-api-endpoints/eth-get-block-by-number)     | [`eth_getBlockReceipts`](/docs/node/ethereum/ethereum-api-endpoints/eth-get-block-receipts)           |
+| [`eth_getBlockTransactionCountByHash`](/docs/node/ethereum/ethereum-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/node/ethereum/ethereum-api-endpoints/eth-get-block-transaction-count-by-number) |
+| [`eth_getTransactionByHash`](/docs/node/ethereum/ethereum-api-endpoints/eth-get-transaction-by-hash) | [`eth_getTransactionByBlockHashAndIndex`](/docs/node/ethereum/ethereum-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
+| [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/ethereum/ethereum-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionReceipt`](/docs/node/ethereum/ethereum-api-endpoints/eth-get-transaction-receipt) |
+| [`eth_getTransactionCount`](/docs/node/ethereum/ethereum-api-endpoints/eth-get-transaction-count) | [`eth_sendRawTransaction`](/docs/node/ethereum/ethereum-api-endpoints/eth-send-raw-transaction)       |
+| [`eth_call`](/docs/node/ethereum/ethereum-api-endpoints/eth-call)                               | [`eth_getCode`](/docs/node/ethereum/ethereum-api-endpoints/eth-get-code)                             |
+| [`eth_getBalance`](/docs/node/ethereum/ethereum-api-endpoints/eth-get-balance)                   | [`eth_accounts`](/docs/node/ethereum/ethereum-api-endpoints/eth-accounts)                           |
+| [`eth_getStorageAt`](/docs/node/ethereum/ethereum-api-endpoints/eth-get-storage-at)               | [`eth_getProof`](/docs/node/ethereum/ethereum-api-endpoints/eth-get-proof)                           |
+| [`eth_getLogs`](/docs/node/ethereum/ethereum-api-endpoints/eth-get-logs)                         | [`eth_newFilter`](/docs/node/ethereum/ethereum-api-endpoints/eth-new-filter)                         |
+| [`eth_newPendingTransactionFilter`](/docs/node/ethereum/ethereum-api-endpoints/eth-new-pending-transaction-filter) | [`eth_newBlockFilter`](/docs/node/ethereum/ethereum-api-endpoints/eth-new-block-filter)             |
+| [`eth_getFilterChanges`](/docs/node/ethereum/ethereum-api-endpoints/eth-get-filter-changes)       | [`eth_getFilterLogs`](/docs/node/ethereum/ethereum-api-endpoints/eth-get-filter-logs)                 |
+| [`eth_uninstallFilter`](/docs/node/ethereum/ethereum-api-endpoints/eth-uninstall-filter)         | [`eth_chainId`](/docs/node/ethereum/ethereum-api-endpoints/eth-chain-id)                             |
+| [`eth_protocolVersion`](/docs/node/ethereum/ethereum-api-endpoints/eth-protocol-version)         | [`net_listening`](/docs/node/ethereum/ethereum-api-endpoints/net-listening)                           |
+| [`net_version`](/docs/node/ethereum/ethereum-api-endpoints/net-version)                         | [`eth_getUncleCountByBlockHash`](/docs/node/ethereum/ethereum-api-endpoints/eth-get-uncle-count-by-block-hash) |
+| [`eth_getUncleByBlockNumberAndIndex`](/docs/node/ethereum/ethereum-api-endpoints/eth-get-uncle-by-block-number-and-index) | [`eth_getUncleByBlockHashAndIndex`](/docs/node/ethereum/ethereum-api-endpoints/eth-get-uncle-by-block-hash-and-index) |
+| [`eth_getUncleCountByBlockNumber`](/docs/node/ethereum/ethereum-api-endpoints/eth-get-uncle-count-by-block-number) | [`eth_estimateGas`](/docs/node/ethereum/ethereum-api-endpoints/eth-estimate-gas)                     |
+| [`eth_gasPrice`](/docs/node/ethereum/ethereum-api-endpoints/eth-gas-price)                       | [`eth_feeHistory`](/docs/node/ethereum/ethereum-api-endpoints/eth-fee-history)                       |
+| [`eth_maxPriorityFeePerGas`](/docs/node/ethereum/ethereum-api-endpoints/eth-max-priority-fee-per-gas) | [`eth_createAccessList`](/docs/node/ethereum/ethereum-api-endpoints/eth-create-access-list)         |
+| [`web3_clientVersion`](/docs/node/ethereum/ethereum-api-endpoints/web3-client-version)           | [`web3_sha3`](/docs/node/ethereum/ethereum-api-endpoints/web3-sha3)                                   |
+| [`eth_subscribe`](/docs/node/ethereum/ethereum-api-endpoints/eth-subscribe)                     | [`eth_unsubscribe`](/docs/node/ethereum/ethereum-api-endpoints/eth-unsubscribe)                       |
+| [`debug_getRawBlock`](/docs/node/ethereum/ethereum-api-endpoints/debug-get-raw-block)           | [`debug_getRawHeader`](/docs/node/ethereum/ethereum-api-endpoints/debug-get-raw-header)               |
+| [`debug_getRawReceipts`](/docs/node/ethereum/ethereum-api-endpoints/debug-get-raw-receipts)     |                                                                                             |
 
 ***
 
@@ -56,29 +56,29 @@ Welcome to the Chain APIs hub, your centralized location for accessing all our a
 
 |                                                                                                   |                                                                                                         |
 | ------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
-| [`eth_blocknumber`](/reference/eth-blocknumber-polygon)                                           | [`eth_getBlockByNumber`](/reference/eth-getblockbynumber-polygon)                                       |
-| [`eth_getBlockByHash`](/reference/eth-getblockbyhash-polygon)                                     | [`eth_getTransactionByHash`](/reference/eth-gettransactionbyhash-polygon)                               |
-| [`eth_getTransactionCount`](/reference/eth-gettransactioncount-polygon)                           | [`eth_getTransactionByBlockHashAndIndex`](/reference/eth-gettransactionbyblockhashandindex-polygon)     |
-| [`eth_getBlockTransactionCountByNumber`](/reference/eth-getblocktransactioncountbynumber-polygon) | [`eth_getTransactionReceipt`](/reference/eth-gettransactionreceipt-polygon)                             |
-| [`eth_getBlockTransactionCountByHash`](/reference/eth-getblocktransactioncountbyhash-polygon)     | [`eth_getTransactionByBlockNumberAndIndex`](/reference/eth-gettransactionbyblocknumberandindex-polygon) |
-| [`eth_getTransactionReceiptsByBlock`](/reference/eth-gettransactionreceiptsbyblock-polygon)       | [`eth_sendRawTransaction`](/reference/eth-sendrawtransaction-polygon)                                   |
-| [`eth_call`](/reference/eth-call-polygon)                                                         | [`eth_getBalance`](/reference/eth-getbalance-polygon)                                                   |
-| [`eth_getStorageAt`](/reference/eth-getstorageat-polygon)                                         | [`eth_accounts`](/reference/eth-accounts-polygon)                                                       |
-| [`eth_getCode`](/reference/eth-getcode-polygon)                                                   | [`eth_getProof`](/reference/eth-getproof-polygon)                                                       |
-| [`eth_getLogs`](/reference/eth-getlogs-polygon)                                                   | [`eth_getFilterChanges`](/reference/eth-getfilterchanges-polygon)                                       |
-| [`eth_getFilterLogs`](/reference/eth-getfilterlogs-polygon)                                       | [`eth_newBlockFilter`](/reference/eth-newblockfilter-polygon)                                           |
-| [`eth_newFilter`](/reference/eth-newfilter-polygon)                                               | [`eth_newPendingTransactionFilter`](/reference/eth-newpendingtransactionfilter-polygon)                 |
-| [`eth_uninstallFilter`](/reference/eth-uninstallfilter-polygon)                                   | [`eth_getSignersAtHash`](/reference/eth-getsignersathash-polygon)                                       |
-| [`eth_chainId`](/reference/eth-chainid-polygon)                                                   | [`eth_getRootHash`](/reference/eth-getroothash-polygon)                                                 |
-| [`bor_getAuthor`](/reference/bor-getauthor-polygon)                                               | [`net_listening`](/reference/net-listening-polygon)                                                     |
-| [`net_version`](/reference/net-version-polygon)                                                   | [`getCurrentProposer`](/reference/bor-getcurrentproposer-polygon)                                       |
-| [`bor_getCurrentValidators`](/reference/bor-getcurrentvalidators-polygon)                         | [`bor_getRootHash`](/reference/bor-getroothash-polygon)                                                 |
-| [`eth_getUncleCountByBlockNumber`](/reference/eth-getunclecountbyblocknumber-polygon)             | [`eth_getUncleCountByBlockHash`](/reference/eth-getunclecountbyblockhash-polygon)                       |
-| [`eth_getUncleByBlockHashAndIndex`](/reference/eth-getunclebyblockhashandindex-polygon)           | [`eth_getUncleByBlockNumberAndIndex`](/reference/eth-getunclebyblocknumberandindex-polygon)             |
-| [`eth_createAccessList`](/reference/eth-createaccesslist-polygon)                                 | [`eth_gasPrice`](/reference/eth-gasprice-polygon)                                                       |
-| [`eth_estimateGas`](/reference/eth-estimategas-polygon)                                           | [`web3_clientVersion`](/reference/web3-clientversion-polygon)                                           |
-| [`web3_sha3`](/reference/web3-sha3-polygon)                                                       | [`eth_subscribe`](/reference/eth-subscribe-polygon)                                                     |
-| [`eth_unsubscribe`](/reference/eth-unsubscribe-polygon)                                           | [`eth_getBlockReceipts`](/reference/eth-getblockreceipts-polygon-pos)                                   |
+| [`eth_blocknumber`](/docs/node/polygon/polygon-api-endpoints/eth-block-number)                     | [`eth_getBlockByNumber`](/docs/node/polygon/polygon-api-endpoints/eth-get-block-by-number)             |
+| [`eth_getBlockByHash`](/docs/node/polygon/polygon-api-endpoints/eth-get-block-by-hash)             | [`eth_getTransactionByHash`](/docs/node/polygon/polygon-api-endpoints/eth-get-transaction-by-hash)     |
+| [`eth_getTransactionCount`](/docs/node/polygon/polygon-api-endpoints/eth-get-transaction-count)     | [`eth_getTransactionByBlockHashAndIndex`](/docs/node/polygon/polygon-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
+| [`eth_getBlockTransactionCountByNumber`](/docs/node/polygon/polygon-api-endpoints/eth-get-block-transaction-count-by-number) | [`eth_getTransactionReceipt`](/docs/node/polygon/polygon-api-endpoints/eth-get-transaction-receipt)   |
+| [`eth_getBlockTransactionCountByHash`](/docs/node/polygon/polygon-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/polygon/polygon-api-endpoints/eth-get-transaction-by-block-number-and-index) |
+| [`eth_getTransactionReceiptsByBlock`](/docs/node/polygon/polygon-api-endpoints/eth-get-transaction-receipts-by-block) | [`eth_sendRawTransaction`](/docs/node/polygon/polygon-api-endpoints/eth-send-raw-transaction)         |
+| [`eth_call`](/docs/node/polygon/polygon-api-endpoints/eth-call)                                   | [`eth_getBalance`](/docs/node/polygon/polygon-api-endpoints/eth-get-balance)                           |
+| [`eth_getStorageAt`](/docs/node/polygon/polygon-api-endpoints/eth-get-storage-at)                 | [`eth_accounts`](/docs/node/polygon/polygon-api-endpoints/eth-accounts)                                 |
+| [`eth_getCode`](/docs/node/polygon/polygon-api-endpoints/eth-get-code)                           | [`eth_getProof`](/docs/node/polygon/polygon-api-endpoints/eth-get-proof)                               |
+| [`eth_getLogs`](/docs/node/polygon/polygon-api-endpoints/eth-get-logs)                           | [`eth_getFilterChanges`](/docs/node/polygon/polygon-api-endpoints/eth-get-filter-changes)               |
+| [`eth_getFilterLogs`](/docs/node/polygon/polygon-api-endpoints/eth-get-filter-logs)               | [`eth_newBlockFilter`](/docs/node/polygon/polygon-api-endpoints/eth-new-block-filter)                   |
+| [`eth_newFilter`](/docs/node/polygon/polygon-api-endpoints/eth-new-filter)                       | [`eth_newPendingTransactionFilter`](/docs/node/polygon/polygon-api-endpoints/eth-new-pending-transaction-filter) |
+| [`eth_uninstallFilter`](/docs/node/polygon/polygon-api-endpoints/eth-uninstall-filter)           | [`eth_getSignersAtHash`](/docs/node/polygon/polygon-api-endpoints/eth-get-signers-at-hash)               |
+| [`eth_chainId`](/docs/node/polygon/polygon-api-endpoints/eth-chain-id)                           | [`eth_getRootHash`](/docs/node/polygon/polygon-api-endpoints/eth-get-root-hash)                         |
+| [`bor_getAuthor`](/docs/node/polygon/polygon-api-endpoints/bor-get-author)                       | [`net_listening`](/docs/node/polygon/polygon-api-endpoints/net-listening)                               |
+| [`net_version`](/docs/node/polygon/polygon-api-endpoints/net-version)                           | [`getCurrentProposer`](/docs/node/polygon/polygon-api-endpoints/bor-get-current-proposer)               |
+| [`bor_getCurrentValidators`](/docs/node/polygon/polygon-api-endpoints/bor-get-current-validators) | [`bor_getRootHash`](/docs/node/polygon/polygon-api-endpoints/bor-get-root-hash)                         |
+| [`eth_getUncleCountByBlockNumber`](/docs/node/polygon/polygon-api-endpoints/eth-get-uncle-count-by-block-number) | [`eth_getUncleCountByBlockHash`](/docs/node/polygon/polygon-api-endpoints/eth-get-uncle-count-by-block-hash) |
+| [`eth_getUncleByBlockHashAndIndex`](/docs/node/polygon/polygon-api-endpoints/eth-get-uncle-by-block-hash-and-index) | [`eth_getUncleByBlockNumberAndIndex`](/docs/node/polygon/polygon-api-endpoints/eth-get-uncle-by-block-number-and-index) |
+| [`eth_createAccessList`](/docs/node/polygon/polygon-api-endpoints/eth-create-access-list)         | [`eth_gasPrice`](/docs/node/polygon/polygon-api-endpoints/eth-gas-price)                               |
+| [`eth_estimateGas`](/docs/node/polygon/polygon-api-endpoints/eth-estimate-gas)                   | [`web3_clientVersion`](/docs/node/polygon/polygon-api-endpoints/web3-client-version)                   |
+| [`web3_sha3`](/docs/node/polygon/polygon-api-endpoints/web3-sha3)                               | [`eth_subscribe`](/docs/node/polygon/polygon-api-endpoints/eth-subscribe)                               |
+| [`eth_unsubscribe`](/docs/node/polygon/polygon-api-endpoints/eth-unsubscribe)                   | [`eth_getBlockReceipts`](/docs/node/polygon/polygon-api-endpoints/eth-get-block-receipts)               |
 
 ***
 
@@ -88,28 +88,31 @@ Welcome to the Chain APIs hub, your centralized location for accessing all our a
 
 |                                                                                                               |                                                                                                         |
 | ------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
-| [`zkevm_consolidatedBlockNumber`](/reference/zkevm-consolidatedblocknumber-polygon-zkevm)                     | [`zkevm_isBlockConsolidated`](/reference/zkevm-isblockconsolidated-polygon-zkevm)                       |
-| [`zkevm_isBlockVirtualized`](/reference/zkevm-isblockvirtualized-polygon-zkevm)                               | [`zkevm_batchNumberByBlockNumber`](/reference/zkevm-batchnumberbyblocknumber-polygon-zkevm)             |
-| [`zkevm_batchNumber`](/reference/zkevm-batchnumber-polygon-zkevm)                                             | [`zkevm_virtualBatchNumber`](/reference/zkevm-virtualbatchnumber-polygon-zkevm)                         |
-| [`zkevm_verifiedBatchNumber`](/reference/zkevm-verifiedbatchnumber-polygon-zkevm)                             | [`zkevm_getBatchByNumber`](/reference/zkevm-getbatchbynumber-polygon-zkevm)                             |
-| [`zkevm_getBroadcastURI`](/reference/zkevm-getbroadcasturi-polygon-zkevm)                                     | [`eth_blocknumber`](/reference/eth-blocknumber-polygon-zkevm)                                           |
-| [`eth_getBlockByNumber`](/reference/eth-getblockbynumber-polygon-zkevm)                                       | [`eth_getBlockByHash`](/reference/eth-getblockbyhash-polygon-zkevm)                                     |
-| [`eth_getTransactionByHash`](/reference/eth-gettransactionbyhash-polygon-zkevm)                               | [`eth_getTransactionCount`](/reference/eth-gettransactioncount-polygon-zkevm)                           |
-| [`eth_getTransactionByBlockHashAndIndex`](/reference/eth-gettransactionbyblockhashandindex-polygon-zkevm)     | [`eth_getBlockTransactionCountByNumber`](/reference/eth-getblocktransactioncountbynumber-polygon-zkevm) |
-| [`eth_getTransactionReceipt`](/reference/eth-gettransactionreceipt-polygon-zkevm)                             | [`eth_getBlockTransactionCountByHash`](/reference/eth-getblocktransactioncountbyhash-polygon-zkevm)     |
-| [`eth_getTransactionByBlockNumberAndIndex`](/reference/eth-gettransactionbyblocknumberandindex-polygon-zkevm) | [`eth_sendRawTransaction`](/reference/eth-sendrawtransaction-polygon-zkevm)                             |
-| [`eth_call`](/reference/eth-call-polygon-zkevm)                                                               | [`eth_getBalance`](/reference/eth-getbalance-polygon-zkevm)                                             |
-| [`eth_getStorageAt`](/reference/eth-getstorageat-polygon-zkevm)                                               | [`eth_getCode`](/reference/eth-getcode-polygon-zkevm)                                                   |
-| [`eth_getLogs`](/reference/eth-getlogs-polygon-zkevm)                                                         | [`eth_getFilterChanges`](/reference/eth-getfilterchanges-polygon-zkevm)                                 |
-| [`eth_getFilterLogs`](/reference/eth-getfilterlogs-polygon-zkevm)                                             | [`eth_newBlockFilter`](/reference/eth-newblockfilter-polygon-zkevm)                                     |
-| [`eth_newFilter`](/reference/eth-newfilter-polygon-zkevm)                                                     | [`eth_uninstallFilter`](/reference/eth-uninstallfilter-polygon-zkevm)                                   |
-| [`eth_getSignersAtHash`](/reference/eth-getsignersathash-polygon-zkevm)                                       | [`eth_chainId`](/reference/eth-chainid-polygon-zkevm)                                                   |
-| [`net_version`](/reference/net-version-polygon-zkevm)                                                         | [`eth_getCompilers`](/reference/eth-getcompilers-polygon-zkevm)                                         |
-| [`eth_protocolVersion`](/reference/eth-protocolversion-polygon-zkevm)                                         | [`eth_gasPrice`](/reference/eth-gasprice-polygon-zkevm)                                                 |
-| [`eth_estimateGas`](/reference/eth-estimategas-polygon-zkevm)                                                 | [`web3_clientVersion`](/reference/web3-clientversion-polygon-zkevm)                                     |
-| [`web3_sha3`](/reference/web3-sha3-polygon-zkevm)                                                             | [`eth_getUncleByBlockHashAndIndex`](/reference/eth-getunclebyblockhashandindex-polygon-zkevm)           |
-| [`eth_getUncleByBlockNumberAndIndex`](/reference/eth-getunclebyblocknumberandindex-polygon-zkevm)             | [`eth_getUncleCountByBlockHash`](/reference/eth-getunclecountbyblockhash-polygon-zkevm)                 |
-| [`eth_getUncleCountByBlockNumber`](/reference/eth-getunclecountbyblocknumber-polygon-zkevm)                   |                                                                                                         |
+| [`zkevm_consolidatedBlockNumber`](/docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/zkevm-consolidated-block-number) | [`zkevm_isBlockConsolidated`](/docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/zkevm-is-block-consolidated) |
+| [`zkevm_isBlockVirtualized`](/docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/zkevm-is-block-virtualized) | [`zkevm_batchNumberByBlockNumber`](/docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/zkevm-batch-number-by-block-number) |
+| [`zkevm_batchNumber`](/docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/zkevm-batch-number)                 | [`zkevm_virtualBatchNumber`](/docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/zkevm-virtual-batch-number) |
+| [`zkevm_verifiedBatchNumber`](/docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/zkevm-verified-batch-number) | [`zkevm_getBatchByNumber`](/docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/zkevm-get-batch-by-number) |
+| [`zkevm_getBroadcastURI`](/docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/zkevm-get-broadcast-uri)       | [`eth_blocknumber`](/docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-block-number)               |
+| [`eth_getBlockByNumber`](/docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-get-block-by-number)       | [`eth_getBlockByHash`](/docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-get-block-by-hash)       |
+| [`eth_getTransactionByHash`](/docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-get-transaction-by-hash) | [`eth_getTransactionCount`](/docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-get-transaction-count) |
+| [`eth_getTransactionByBlockHashAndIndex`](/docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-get-transaction-by-block-hash-and-index) | [`eth_getBlockTransactionCountByNumber`](/docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-get-block-transaction-count-by-number) |
+| [`eth_getTransactionReceipt`](/docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-get-transaction-receipt) | [`eth_getBlockTransactionCountByHash`](/docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-get-block-transaction-count-by-hash) |
+| [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_sendRawTransaction`](/docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-send-raw-transaction) |
+| [`eth_call`](/docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-call)                                   | [`eth_getBalance`](/docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-get-balance)                 |
+| [`eth_getStorageAt`](/docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-get-storage-at)                 | [`eth_getCode`](/docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-get-code)                       |
+| [`eth_getLogs`](/docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-get-logs)                           | [`eth_getFilterChanges`](/docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-get-filter-changes)   |
+| [`eth_getFilterLogs`](/docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-get-filter-logs)               | [`eth_newBlockFilter`](/docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-new-block-filter)       |
+| [`eth_newFilter`](/docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-new-filter)                       | [`eth_newPendingTransactionFilter`](/docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-new-pending-transaction-filter) |
+| [`eth_uninstallFilter`](/docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-uninstall-filter)           | [`eth_getSignersAtHash`](/docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-get-signers-at-hash)       |
+| [`eth_chainId`](/docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-chain-id)                       | [`eth_getRootHash`](/docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-get-root-hash)             |
+| [`net_version`](/docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/net-version)                       | [`eth_getCompilers`](/docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-get-compilers)             |
+| [`eth_newFilter`](/docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-new-filter)                       | [`eth_uninstallFilter`](/docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-uninstall-filter)       |
+| [`eth_getSignersAtHash`](/docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-get-signers-at-hash)       | [`eth_chainId`](/docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-chain-id)                       |
+| [`net_version`](/docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/net-version)                           | [`eth_getCompilers`](/docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-get-compilers)             |
+| [`eth_protocolVersion`](/docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-protocol-version)           | [`eth_gasPrice`](/docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-gas-price)                     |
+| [`eth_estimateGas`](/docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-estimate-gas)                   | [`web3_clientVersion`](/docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/web3-client-version)         |
+| [`web3_sha3`](/docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/web3-sha3)                               | [`eth_subscribe`](/docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-subscribe)                               |
+| [`eth_unsubscribe`](/docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-unsubscribe)                   | [`eth_getBlockReceipts`](/docs/node/polygon-zkevm/polygon-zkevm-api-endpoints/eth-get-block-receipts)               |
 
 ***
 
@@ -119,26 +122,26 @@ Welcome to the Chain APIs hub, your centralized location for accessing all our a
 
 |                                                                                                      |                                                                                                          |
 | ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| [`eth_blocknumber`](/reference/eth-blocknumber-arbitrum)                                             | [`eth_getBlockByHash`](/reference/eth-getblockbyhash-arbitrum)                                           |
-| [`eth_getBlockByNumber`](/reference/eth-getblockbynumber-arbitrum)                                   | [`eth_getBlockTransactionCountByHash`](/reference/eth-getblocktransactioncountbyhash-optimism)           |
-| [`eth_getBlockTransactionCountByNumber`](/reference/eth-getblocktransactioncountbynumber-optimism)   | [`eth_getTransactionByBlockNumberAndIndex`](/reference/eth-gettransactionbyblocknumberandindex-arbitrum) |
-| [`eth_getTransactionByBlockHashAndIndex`](/reference/eth-gettransactionbyblockhashandindex-arbitrum) | [`eth_getTransactionByHash`](/reference/eth-gettransactionbyhash-arbitrum)                               |
-| [`eth_getTransactionReceipt`](/reference/eth-gettransactionreceipt-arbitrum)                         | [`eth_getTransactionCount`](/reference/eth-gettransactioncount-arbitrum)                                 |
-| [`eth_call`](/reference/eth-call-arbitrum)                                                           | [`eth_sendRawTransaction`](/reference/eth-sendrawtransaction-arbitrum)                                   |
-| [`eth_accounts`](/reference/eth-accounts-arbitrum)                                                   | [`eth_getProof`](/reference/eth-getproof-arbitrum)                                                       |
-| [`eth_getBalance`](/reference/eth-getbalance-arbitrum)                                               | [`eth_getCode`](/reference/eth-getcode-arbitrum)                                                         |
-| [`eth_getStorageAt`](/reference/eth-getstorageat-arbitrum)                                           | [`eth_getLogs`](/reference/eth-getlogs-arbitrum)                                                         |
-| [`eth_newFilter`](/reference/eth-newfilter-arbitrum)                                                 | [`eth_newBlockFilter`](/reference/eth-newblockfilter-arbitrum)                                           |
-| [`eth_newPendingTransactionFilter`](/reference/eth-newpendingtransactionfilter-arbitrum)             | [`eth_getFilterChanges`](/reference/eth-getfilterchanges-arbitrum)                                       |
-| [`eth_getFilterLogs`](/reference/eth-getfilterlogs-arbitrum)                                         | [`eth_uninstallFilter`](/reference/eth-uninstallfilter-arbitrum)                                         |
-| [`eth_chainId`](/reference/eth-chainid-arbitrum)                                                     | [`net_version`](/reference/net-version-arbitrum)                                                         |
-| [`net_listening`](/reference/net-listening-arbitrum)                                                 | [`eth_getUncleByBlockNumberAndIndex`](/reference/eth-getunclebyblocknumberandindex-arbitrum)             |
-| [`eth_getUncleByBlockHashAndIndex`](/reference/eth-getunclebyblockhashandindex-arbitrum)             | [`eth_getUncleCountByBlockHash`](/reference/eth-getunclecountbyblockhash-arbitrum)                       |
-| [`eth_getUncleCountByBlockNumber`](/reference/eth-getunclecountbyblocknumber-arbitrum)               | [`eth_estimateGas`](/reference/eth-estimategas-arbitrum)                                                 |
-| [`eth_maxPriorityFeePerGas`](/reference/eth-maxpriorityfeepergas-arbitrum)                           | [`eth_gasPrice`](/reference/eth-gasprice-arbitrum)                                                       |
-| [`eth_feeHistory`](/reference/eth-feehistory-arbitrum)                                               | [`eth_createAccessList`](/reference/eth-createaccesslist-arbitrum)                                       |
-| [`web3_clientVersion`](/reference/web3-clientversion-arbitrum)                                       | [`web3_sha3`](/reference/web3-sha3-arbitrum)                                                             |
-| [`eth_getBlockReceipts`](/reference/eth-getblockreceipts-arbitrum)                                   | [`eth_unsubscribe`](/reference/eth-unsubscribe-arbitrum)                                                 |
+| [`eth_blocknumber`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-block-number)                     | [`eth_getBlockByHash`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-get-block-by-hash)               |
+| [`eth_getBlockByNumber`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-get-block-by-number)         | [`eth_getBlockTransactionCountByHash`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-get-block-transaction-count-by-hash) |
+| [`eth_getBlockTransactionCountByNumber`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-get-block-transaction-count-by-number) | [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-get-transaction-by-block-number-and-index) |
+| [`eth_getTransactionByBlockHashAndIndex`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-get-transaction-by-block-hash-and-index) | [`eth_getTransactionByHash`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-get-transaction-by-hash)   |
+| [`eth_getTransactionReceipt`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-get-transaction-receipt) | [`eth_getTransactionCount`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-get-transaction-count)       |
+| [`eth_call`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-call)                                     | [`eth_sendRawTransaction`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-send-raw-transaction)         |
+| [`eth_accounts`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-accounts)                             | [`eth_getProof`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-get-proof)                             |
+| [`eth_getBalance`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-get-balance)                       | [`eth_getCode`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-get-code)                               |
+| [`eth_getStorageAt`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-get-storage-at)                   | [`eth_getLogs`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-get-logs)                               |
+| [`eth_newFilter`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-new-filter)                         | [`eth_newBlockFilter`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-new-block-filter)                 |
+| [`eth_newPendingTransactionFilter`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-new-pending-transaction-filter) | [`eth_getFilterChanges`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-get-filter-changes)             |
+| [`eth_getFilterLogs`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-get-filter-logs)                 | [`eth_uninstallFilter`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-uninstall-filter)                 |
+| [`eth_chainId`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-chain-id)                             | [`net_version`](/docs/node/arbitrum/arbitrum-api-endpoints/net-version)                                 |
+| [`net_listening`](/docs/node/arbitrum/arbitrum-api-endpoints/net-listening)                           | [`eth_getUncleByBlockNumberAndIndex`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-get-uncle-by-block-number-and-index) |
+| [`eth_getUncleByBlockHashAndIndex`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-get-uncle-by-block-hash-and-index) | [`eth_getUncleCountByBlockHash`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-get-uncle-count-by-block-hash) |
+| [`eth_getUncleCountByBlockNumber`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-get-uncle-count-by-block-number) | [`eth_estimateGas`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-estimate-gas)                         |
+| [`eth_maxPriorityFeePerGas`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-max-priority-fee-per-gas) | [`eth_gasPrice`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-gas-price)                             |
+| [`eth_feeHistory`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-fee-history)                       | [`eth_createAccessList`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-create-access-list)             |
+| [`web3_clientVersion`](/docs/node/arbitrum/arbitrum-api-endpoints/web3-client-version)               | [`web3_sha3`](/docs/node/arbitrum/arbitrum-api-endpoints/web3-sha3)                                     |
+| [`eth_getBlockReceipts`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-get-block-receipts)           | [`eth_unsubscribe`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-unsubscribe)                         |
 
 ***
 
@@ -148,25 +151,25 @@ Welcome to the Chain APIs hub, your centralized location for accessing all our a
 
 |                                                                                                          |                                                                                                      |
 | -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| [`eth_blockNumber`](/reference/eth-blocknumber-optimism)                                                 | [`eth_getBlockByNumber`](/reference/eth-getblockbynumber-optimism)                                   |
-| [`eth_getBlockByHash`](/reference/eth-getblockbyhash-optimism)                                           | [`eth_getBlockTransactionCountByNumber`](/reference/eth-getblocktransactioncountbynumber-optimism)   |
-| [`eth_getBlockTransactionCountByHash`](/reference/getblocktransactioncountbyhash-optimism)               | [`eth_getTransactionByBlockHashAndIndex`](/reference/eth-gettransactionbyblockhashandindex-optimism) |
-| [`eth_getTransactionByBlockNumberAndIndex`](/reference/eth-gettransactionbyblocknumberandindex-optimism) | [`eth_getTransactionCount`](/reference/eth-gettransactioncount-optimism)                             |
-| [`eth_getTransactionByHash`](/reference/eth-gettransactionbyhash-optimism)                               | [`eth_getTransactionReceipt`](/reference/eth-gettransactionreceipt-optimism)                         |
-| [`eth_call`](/reference/eth-call-optimism)                                                               | [`eth_sendRawTransaction`](/reference/eth-sendrawtransaction-optimism)                               |
-| [`eth_getBalance`](/reference/eth-getbalance-optimism)                                                   | [`eth_accounts`](/reference/eth-accounts-optimism)                                                   |
-| [`eth_getProof`](/reference/eth-getproof-optimism)                                                       | [`eth_getCode`](/reference/eth-getcode-optimism)                                                     |
-| [`eth_getStorageAt`](/reference/eth-getstorageat-optimism)                                               | [`eth_getLogs`](/reference/eth-getlogs-optimism)                                                     |
-| [`eth_newFilter`](/reference/eth-newfilter-optimism)                                                     | [`eth_newBlockFilter`](/reference/eth-newblockfilter-optimism)                                       |
-| [`eth_newPendingTransactionFilter`](/reference/eth-newpendingtransactionfilter-optimism)                 | [`eth_getFilterLogs`](/reference/eth-getfilterlogs-optimism)                                         |
-| [`eth_getFilterChanges`](/reference/eth-getfilterchanges-optimism)                                       | [`eth_uninstallFilter`](/reference/eth-uninstallfilter-optimism-1)                                   |
-| [`eth_protocolVersion`](/reference/eth-protocolversion-optimism)                                         | [`eth_chainId`](/reference/eth-chainid-optimism)                                                     |
-| [`net_listening`](/reference/net-listening-optimism-1)                                                   | [`eth_syncing`](/reference/eth-syncing-optimism)                                                     |
-| [`net_version`](/reference/net-version-optimism-1)                                                       | [`eth_getUncleByBlockHashAndIndex`](/reference/eth-getunclebyblockhashandindex-optimism)             |
-| [`eth_getUncleByBlockNumberAndIndex`](/reference/eth-getunclebyblocknumberandindex-optimism)             | [`eth_getUncleCountByBlockHash`](/reference/eth-getunclecountbyblockhash-optimism)                   |
-| [`eth_getUncleCountByBlockNumber`](/reference/eth-getunclecountbyblocknumber-optimism)                   | [`eth_estimateGas`](/reference/eth-estimategas-optimism)                                             |
-| [`eth_gasPrice`](/reference/eth-gasprice-optimism)                                                       | [`eth_subscribe`](/reference/eth-subscribe-optimism)                                                 |
-| [`eth_unsubscribe`](/reference/eth-unsubscribe-optimism)                                                 | [`eth_getBlockReceipts`](/reference/eth-getblockreceipts-optimism)                                   |
+| [`eth_blockNumber`](/docs/node/optimism/optimism-api-endpoints/eth-block-number)                         | [`eth_getBlockByNumber`](/docs/node/optimism/optimism-api-endpoints/eth-get-block-by-number)         |
+| [`eth_getBlockByHash`](/docs/node/optimism/optimism-api-endpoints/eth-get-block-by-hash)                 | [`eth_getBlockTransactionCountByNumber`](/docs/node/optimism/optimism-api-endpoints/eth-get-block-transaction-count-by-number) |
+| [`eth_getBlockTransactionCountByHash`](/docs/node/optimism/optimism-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getTransactionByBlockHashAndIndex`](/docs/node/optimism/optimism-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
+| [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/optimism/optimism-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionCount`](/docs/node/optimism/optimism-api-endpoints/eth-get-transaction-count)   |
+| [`eth_getTransactionByHash`](/docs/node/optimism/optimism-api-endpoints/eth-get-transaction-by-hash)     | [`eth_getTransactionReceipt`](/docs/node/optimism/optimism-api-endpoints/eth-get-transaction-receipt) |
+| [`eth_call`](/docs/node/optimism/optimism-api-endpoints/eth-call)                                       | [`eth_sendRawTransaction`](/docs/node/optimism/optimism-api-endpoints/eth-send-raw-transaction)       |
+| [`eth_getBalance`](/docs/node/optimism/optimism-api-endpoints/eth-get-balance)                           | [`eth_accounts`](/docs/node/optimism/optimism-api-endpoints/eth-accounts)                           |
+| [`eth_getProof`](/docs/node/optimism/optimism-api-endpoints/eth-get-proof)                               | [`eth_getCode`](/docs/node/optimism/optimism-api-endpoints/eth-get-code)                             |
+| [`eth_getStorageAt`](/docs/node/optimism/optimism-api-endpoints/eth-get-storage-at)                     | [`eth_getLogs`](/docs/node/optimism/optimism-api-endpoints/eth-get-logs)                             |
+| [`eth_newFilter`](/docs/node/optimism/optimism-api-endpoints/eth-new-filter)                             | [`eth_newBlockFilter`](/docs/node/optimism/optimism-api-endpoints/eth-new-block-filter)               |
+| [`eth_newPendingTransactionFilter`](/docs/node/optimism/optimism-api-endpoints/eth-new-pending-transaction-filter) | [`eth_getFilterLogs`](/docs/node/optimism/optimism-api-endpoints/eth-get-filter-logs)               |
+| [`eth_getFilterChanges`](/docs/node/optimism/optimism-api-endpoints/eth-get-filter-changes)               | [`eth_uninstallFilter`](/docs/node/optimism/optimism-api-endpoints/eth-uninstall-filter)             |
+| [`eth_protocolVersion`](/docs/node/optimism/optimism-api-endpoints/eth-protocol-version)                 | [`eth_chainId`](/docs/node/optimism/optimism-api-endpoints/eth-chain-id)                             |
+| [`net_listening`](/docs/node/optimism/optimism-api-endpoints/net-listening)                               | [`eth_syncing`](/docs/node/optimism/optimism-api-endpoints/eth-syncing)                               |
+| [`net_version`](/docs/node/optimism/optimism-api-endpoints/net-version)                                   | [`eth_getUncleByBlockHashAndIndex`](/docs/node/optimism/optimism-api-endpoints/eth-get-uncle-by-block-hash-and-index) |
+| [`eth_getUncleByBlockNumberAndIndex`](/docs/node/optimism/optimism-api-endpoints/eth-get-uncle-by-block-number-and-index) | [`eth_getUncleCountByBlockHash`](/docs/node/optimism/optimism-api-endpoints/eth-get-uncle-count-by-block-hash) |
+| [`eth_getUncleCountByBlockNumber`](/docs/node/optimism/optimism-api-endpoints/eth-get-uncle-count-by-block-number) | [`eth_estimateGas`](/docs/node/optimism/optimism-api-endpoints/eth-estimate-gas)                     |
+| [`eth_gasPrice`](/docs/node/optimism/optimism-api-endpoints/eth-gas-price)                               | [`eth_subscribe`](/docs/node/optimism/optimism-api-endpoints/eth-subscribe)                           |
+| [`eth_unsubscribe`](/docs/node/optimism/optimism-api-endpoints/eth-unsubscribe)                           | [`eth_getBlockReceipts`](/docs/node/optimism/optimism-api-endpoints/eth-get-block-receipts)           |
 
 ***
 
@@ -176,33 +179,33 @@ Welcome to the Chain APIs hub, your centralized location for accessing all our a
 
 |                                                               |                                                                                     |
 | ------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
-| [`getBlockProduction`](/reference/getblockproduction)         | [`getBlock`](/reference/getblock)                                                   |
-| [`getBlockTime`](/reference/getblocktime)                     | [`getBlockCommitment`](/reference/getblockcommitment)                               |
-| [`getBlocksWithLimit`](/reference/getblockswithlimit)         | [`getBlockHeight`](/reference/getblockheight)                                       |
-| [`getBlocks`](/reference/getblocks)                           | [`isBlockhashValid`](/reference/isblockhashvalid)                                   |
-| [`getBalance`](/reference/getbalance)                         | [`getLargestAccounts`](/reference/getlargestaccounts)                               |
-| [`getAccountInfo`](/reference/getaccountinfo)                 | [`getVoteAccounts`](/reference/getvoteaccounts)                                     |
-| [`getMultipleAccounts`](/reference/getmultipleaccounts)       | [`getProgramAccounts`](/reference/getprogramaccounts)                               |
-| [`getClusterNodes`](/reference/getclusternodes)               | [`getHealth`](/reference/gethealth)                                                 |
-| [`getVersion`](/reference/getversion)                         | [`getIdentity`](/reference/getidentity)                                             |
-| [`getInflationGovernor`](/reference/getinflationgovernor)     | [`getInflationRate`](/reference/getinflationrate)                                   |
-| [`getInflationReward`](/reference/getinflationreward)         | [`getSupply`](/reference/getsupply)                                                 |
-| [`getEpochSchedule`](/reference/getepochschedule)             | [`getEpochInfo`](/reference/getepochinfo)                                           |
-| [`getFeeForMessage`](/reference/getfeeformessage)             | [`getHighestSnapshotSlot`](/reference/gethighestsnapshotslot)                       |
-| [`getGenesisHash`](/reference/getgenesishash)                 | [`getRecentPerformanceSamples`](/reference/getrecentperformancesamples)             |
-| [`getFirstAvailableBlock`](/reference/getfirstavailableblock) | [`getMinimumBalanceForRentExemption`](/reference/getminimumbalanceforrentexemption) |
-| [`getTransaction`](/reference/gettransaction)                 | [`sendTransaction`](/reference/sendtransaction)                                     |
-| [`getSignatureStatuses`](/reference/getsignaturestatuses)     | [`getSignaturesForAddress`](/reference/getsignaturesforaddress)                     |
-| [`simulateTransaction`](/reference/simulatetransaction)       | [`minimumLedgerSlot`](/reference/minimumledgerslot)                                 |
-| [`getMaxShredInsertSlot`](/reference/getmaxshredinsertslot)   | [`getSlot`](/reference/getslot)                                                     |
-| [`getSlotLeader`](/reference/getslotleader)                   | [`getSlotLeaders`](/reference/getslotleaders)                                       |
-| [`getMaxRetransmitSlot`](/reference/getmaxretransmitslot)     | [`getTokenAccountsByOwner`](/reference/gettokenaccountsbyowner)                     |
-| [`getTokenAccountBalance`](/reference/gettokenaccountbalance) | [`getTokenSupply`](/reference/gettokensupply)                                       |
-| [`signatureSubscribe`](/reference/signaturesubscribe)         | [`signatureUnsubscribe`](/reference/signatureunsubscribe)                           |
-| [`slotSubscribe`](/reference/slotsubscribe)                   | [`slotUnsubscribe`](/reference/slotunsubscribe)                                     |
-| [`slotUpdateSubscribe`](/reference/slotupdatesubscribe)       | [`blockSubscribe`](/reference/blocksubscribe)                                       |
-| [`blockUnsubscribe`](/reference/blockunsubscribe)             | [`logsSubscribe`](/reference/logssubscribe)                                         |
-| [`logsUnsubscribe`](/reference/logsunsubscribe)               |                                                                                     |
+| [`getBlockProduction`](/docs/node/solana/solana-api-endpoints/get-block-production)         | [`getBlock`](/docs/node/solana/solana-api-endpoints/get-block)                                                   |
+| [`getBlockTime`](/docs/node/solana/solana-api-endpoints/get-block-time)                     | [`getBlockCommitment`](/docs/node/solana/solana-api-endpoints/get-block-commitment)                               |
+| [`getBlocksWithLimit`](/docs/node/solana/solana-api-endpoints/get-blocks-with-limit)         | [`getBlockHeight`](/docs/node/solana/solana-api-endpoints/get-block-height)                                       |
+| [`getBlocks`](/docs/node/solana/solana-api-endpoints/get-blocks)                           | [`isBlockhashValid`](/docs/node/solana/solana-api-endpoints/is-blockhash-valid)                                   |
+| [`getBalance`](/docs/node/solana/solana-api-endpoints/get-balance)                         | [`getLargestAccounts`](/docs/node/solana/solana-api-endpoints/get-largest-accounts)                               |
+| [`getAccountInfo`](/docs/node/solana/solana-api-endpoints/get-account-info)                 | [`getVoteAccounts`](/docs/node/solana/solana-api-endpoints/get-vote-accounts)                                     |
+| [`getMultipleAccounts`](/docs/node/solana/solana-api-endpoints/get-multiple-accounts)       | [`getProgramAccounts`](/docs/node/solana/solana-api-endpoints/get-program-accounts)                               |
+| [`getClusterNodes`](/docs/node/solana/solana-api-endpoints/get-cluster-nodes)               | [`getHealth`](/docs/node/solana/solana-api-endpoints/get-health)                                                 |
+| [`getVersion`](/docs/node/solana/solana-api-endpoints/get-version)                         | [`getIdentity`](/docs/node/solana/solana-api-endpoints/get-identity)                                             |
+| [`getInflationGovernor`](/docs/node/solana/solana-api-endpoints/get-inflation-governor)     | [`getInflationRate`](/docs/node/solana/solana-api-endpoints/get-inflation-rate)                                   |
+| [`getInflationReward`](/docs/node/solana/solana-api-endpoints/get-inflation-reward)         | [`getSupply`](/docs/node/solana/solana-api-endpoints/get-supply)                                                 |
+| [`getEpochSchedule`](/docs/node/solana/solana-api-endpoints/get-epoch-schedule)             | [`getEpochInfo`](/docs/node/solana/solana-api-endpoints/get-epoch-info)                                           |
+| [`getFeeForMessage`](/docs/node/solana/solana-api-endpoints/get-fee-for-message)             | [`getHighestSnapshotSlot`](/docs/node/solana/solana-api-endpoints/get-highest-snapshot-slot)                       |
+| [`getGenesisHash`](/docs/node/solana/solana-api-endpoints/get-genesis-hash)                 | [`getRecentPerformanceSamples`](/docs/node/solana/solana-api-endpoints/get-recent-performance-samples)             |
+| [`getFirstAvailableBlock`](/docs/node/solana/solana-api-endpoints/get-first-available-block) | [`getMinimumBalanceForRentExemption`](/docs/node/solana/solana-api-endpoints/get-minimum-balance-for-rent-exemption) |
+| [`getTransaction`](/docs/node/solana/solana-api-endpoints/get-transaction)                 | [`sendTransaction`](/docs/node/solana/solana-api-endpoints/send-transaction)                                     |
+| [`getSignatureStatuses`](/docs/node/solana/solana-api-endpoints/get-signature-statuses)     | [`getSignaturesForAddress`](/docs/node/solana/solana-api-endpoints/get-signatures-for-address)                     |
+| [`simulateTransaction`](/docs/node/solana/solana-api-endpoints/simulate-transaction)       | [`minimumLedgerSlot`](/docs/node/solana/solana-api-endpoints/minimum-ledger-slot)                                 |
+| [`getMaxShredInsertSlot`](/docs/node/solana/solana-api-endpoints/get-max-shred-insert-slot)   | [`getSlot`](/docs/node/solana/solana-api-endpoints/get-slot)                                                     |
+| [`getSlotLeader`](/docs/node/solana/solana-api-endpoints/get-slot-leader)                   | [`getSlotLeaders`](/docs/node/solana/solana-api-endpoints/get-slot-leaders)                                       |
+| [`getMaxRetransmitSlot`](/docs/node/solana/solana-api-endpoints/get-max-retransmit-slot)     | [`getTokenAccountsByOwner`](/docs/node/solana/solana-api-endpoints/get-token-accounts-by-owner)                     |
+| [`getTokenAccountBalance`](/docs/node/solana/solana-api-endpoints/get-token-account-balance) | [`getTokenSupply`](/docs/node/solana/solana-api-endpoints/get-token-supply)                                       |
+| [`signatureSubscribe`](/docs/node/solana/solana-api-endpoints/signature-subscribe)         | [`signatureUnsubscribe`](/docs/node/solana/solana-api-endpoints/signature-unsubscribe)                           |
+| [`slotSubscribe`](/docs/node/solana/solana-api-endpoints/slot-subscribe)                   | [`slotUnsubscribe`](/docs/node/solana/solana-api-endpoints/slot-unsubscribe)                                     |
+| [`slotUpdateSubscribe`](/docs/node/solana/solana-api-endpoints/slot-update-subscribe)       | [`blockSubscribe`](/docs/node/solana/solana-api-endpoints/block-subscribe)                                       |
+| [`blockUnsubscribe`](/docs/node/solana/solana-api-endpoints/block-unsubscribe)             | [`logsSubscribe`](/docs/node/solana/solana-api-endpoints/logs-subscribe)                                         |
+| [`logsUnsubscribe`](/docs/node/solana/solana-api-endpoints/logs-unsubscribe)               |                                                                                     |
 
 ***
 
@@ -212,24 +215,24 @@ Welcome to the Chain APIs hub, your centralized location for accessing all our a
 
 |                                                                                                   |                                                                                                       |
 | ------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| [`eth_getBlockTransactionCountByHash`](/reference/eth-getblocktransactioncountbyhash-astar)       | [`eth_getBlockTransactionCountByNumber`](/reference/eth-getblocktransactioncountbynumber-astar)       |
-| [`eth_blocknumber`](/reference/eth-blocknumber-astar)                                             | [`eth_getBlockByNumber`](/reference/eth-getblockbynumber-astar)                                       |
-| [`eth_getBlockByHash`](/reference/eth-getblockbyhash-astar)                                       | [`eth_getTransactionByHash`](/reference/eth-gettransactionbyhash-astar)                               |
-| [`eth_getTransactionReceipt`](/reference/eth-gettransactionreceipt-astar)                         | [`eth_getTransactionCount`](/reference/eth-gettransactioncount-astar)                                 |
-| [`eth_getTransactionByBlockHashAndIndex`](/reference/eth-gettransactionbyblockhashandindex-astar) | [`eth_getTransactionByBlockNumberAndIndex`](/reference/eth-gettransactionbyblocknumberandindex-astar) |
-| [`eth_call`](/reference/eth-call-astar)                                                           | [`eth_sendRawTransaction`](/reference/eth-sendrawtransaction-astar)                                   |
-| [`eth_accounts`](/reference/eth-accounts-astar)                                                   | [`eth_getStorageAt`](/reference/eth-getstorageat-astar)                                               |
-| [`eth_getCode`](/reference/eth-getcode-astar)                                                     | [`eth_getBalance`](/reference/eth-getbalance-astar)                                                   |
-| [`eth_getLogs`](/reference/eth-getlogs-astar)                                                     | [`eth_newFilter`](/reference/eth-newfilter-astar)                                                     |
-| [`eth_newPendingTransactionFilter`](/reference/eth-newpendingtransactionfilter-astar)             | [`eth_newBlockFilter`](/reference/eth-newblockfilter-astar)                                           |
-| [`eth_getFilterChanges`](/reference/eth-getfilterchanges-astar)                                   | [`eth_getFilterLogs`](/reference/eth-getfilterlogs-astar)                                             |
-| [`eth_uninstallFilter`](/reference/eth-uninstallfilter-astar)                                     | [`net_version`](/reference/net-version-astar)                                                         |
-| [`eth_chainId`](/reference/eth-chainid-astar)                                                     | [`eth_getUncleByBlockNumberAndIndex`](/reference/eth-getunclebyblocknumberandindex-astar)             |
-| [`eth_estimateGas`](/reference/eth-estimategas-astar)                                             | [`eth_maxPriorityFeePerGas`](/reference/eth-maxpriorityfeepergas-astar)                               |
-| [`eth_gasPrice`](/reference/eth-gasprice-astar)                                                   | [`web3_clientVersion`](/reference/web3-clientversion-astar)                                           |
-| [`web3_sha3`](/reference/web3-sha3-astar)                                                         | [`eth_subscribe`](/reference/eth-subscribe-astar)                                                     |
-| [`eth_unsubscribe`](/reference/eth-unsubscribe-astar)                                             | [`newHeads`](/reference/newheads)                                                                     |
-| [`logs`](/reference/logs)                                                                         | [`eth_getBlockReceipts`](/reference/eth-getblockreceipts-astar)                                       |
+| [`eth_getBlockTransactionCountByHash`](/docs/node/astar/astar-api-endpoints/eth-get-block-transaction-count-by-hash)       | [`eth_getBlockTransactionCountByNumber`](/docs/node/astar/astar-api-endpoints/eth-get-block-transaction-count-by-number)       |
+| [`eth_blocknumber`](/docs/node/astar/astar-api-endpoints/eth-block-number)                                             | [`eth_getBlockByNumber`](/docs/node/astar/astar-api-endpoints/eth-get-block-by-number)                                       |
+| [`eth_getBlockByHash`](/docs/node/astar/astar-api-endpoints/eth-get-block-by-hash)                                       | [`eth_getTransactionByHash`](/docs/node/astar/astar-api-endpoints/eth-get-transaction-by-hash)                               |
+| [`eth_getTransactionReceipt`](/docs/node/astar/astar-api-endpoints/eth-get-transaction-receipt)                         | [`eth_getTransactionCount`](/docs/node/astar/astar-api-endpoints/eth-get-transaction-count)                                 |
+| [`eth_getTransactionByBlockHashAndIndex`](/docs/node/astar/astar-api-endpoints/eth-get-transaction-by-block-hash-and-index) | [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/astar/astar-api-endpoints/eth-get-transaction-by-block-number-and-index) |
+| [`eth_call`](/docs/node/astar/astar-api-endpoints/eth-call)                                                           | [`eth_sendRawTransaction`](/docs/node/astar/astar-api-endpoints/eth-send-raw-transaction)                                   |
+| [`eth_accounts`](/docs/node/astar/astar-api-endpoints/eth-accounts)                                                   | [`eth_getStorageAt`](/docs/node/astar/astar-api-endpoints/eth-get-storage-at)                                               |
+| [`eth_getCode`](/docs/node/astar/astar-api-endpoints/eth-get-code)                                                     | [`eth_getBalance`](/docs/node/astar/astar-api-endpoints/eth-get-balance)                                                   |
+| [`eth_getLogs`](/docs/node/astar/astar-api-endpoints/eth-get-logs)                                                     | [`eth_newFilter`](/docs/node/astar/astar-api-endpoints/eth-new-filter)                                                     |
+| [`eth_newPendingTransactionFilter`](/docs/node/astar/astar-api-endpoints/eth-new-pending-transaction-filter)             | [`eth_newBlockFilter`](/docs/node/astar/astar-api-endpoints/eth-new-block-filter)                                           |
+| [`eth_getFilterChanges`](/docs/node/astar/astar-api-endpoints/eth-get-filter-changes)                                   | [`eth_getFilterLogs`](/docs/node/astar/astar-api-endpoints/eth-get-filter-logs)                                             |
+| [`eth_uninstallFilter`](/docs/node/astar/astar-api-endpoints/eth-uninstall-filter)                                     | [`net_version`](/docs/node/astar/astar-api-endpoints/net-version)                                                         |
+| [`eth_chainId`](/docs/node/astar/astar-api-endpoints/eth-chain-id)                                                     | [`eth_getUncleByBlockNumberAndIndex`](/docs/node/astar/astar-api-endpoints/eth-get-uncle-by-block-number-and-index)             |
+| [`eth_estimateGas`](/docs/node/astar/astar-api-endpoints/eth-estimate-gas)                                             | [`eth_maxPriorityFeePerGas`](/docs/node/astar/astar-api-endpoints/eth-max-priority-fee-per-gas)                               |
+| [`eth_gasPrice`](/docs/node/astar/astar-api-endpoints/eth-gas-price)                                                   | [`web3_clientVersion`](/docs/node/astar/astar-api-endpoints/web3-client-version)                                           |
+| [`web3_sha3`](/docs/node/astar/astar-api-endpoints/web3-sha3)                                                         | [`eth_subscribe`](/docs/node/astar/astar-api-endpoints/eth-subscribe)                                                     |
+| [`eth_unsubscribe`](/docs/node/astar/astar-api-endpoints/eth-unsubscribe)                                             | [`newHeads`](/docs/node/astar/astar-api-endpoints/new-heads)                                                                     |
+| [`logs`](/docs/node/astar/astar-api-endpoints/logs)                                                                         | [`eth_getBlockReceipts`](/docs/node/astar/astar-api-endpoints/eth-get-block-receipts)                                       |
 
 ***
 
@@ -239,18 +242,18 @@ Welcome to the Chain APIs hub, your centralized location for accessing all our a
 
 |                                                                               |                                                                                                   |
 | ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| [`starknet_getClassHashAt`](/reference/starknet-getclasshashat)               | [`starknet_addDeployAccountTransaction`](/reference/starknet-add-deploy-account-transaction)         |
-| [`starknet_addDeclareTransaction`](/reference/starknet-add-declare-transaction) | [`starknet_blockHashAndNumber`](/reference/starknet-blockhashandnumber)                           |
-| [`starknet_getStorageAt`](starknet-getstorageat)                              | [`starknet_blockNumber`](/reference/starknet-blocknumber)                                         |
-| [`starknet_getStateUpdate`](/reference/starknet-getstateupdate)               | [`starknet_getTransactionByBlockIdAndIndex`](/reference/starknet-gettransactionbyblockidandindex) |
-| [`starknet_getTransactionReceipt`](/reference/starknet-gettransactionreceipt) | [`starknet_getBlockTransactionCount`](/reference/starknet-getblocktransactioncount)               |
-| [`starknet_call`](/reference/starknet-call)                                   | [`starknet_estimateFee`](/reference/starknet-estimatefee)                                         |
-| [`starknet_getNonce`](/reference/starknet-getnonce)                           | [`starknet_chainId`](/reference/starknet-chainid)                                                 |
-| [`starknet_getTransactionByHash`](/reference/starknet-gettransactionbyhash)   | [`starknet_syncing`](/reference/starknet-syncing)                                                 |
-| [`starknet_getBlockWithTxHashes`](/reference/starknet-getblockwithtxhashes)   | [`starknet_getEvents`](/reference/starknet-getevents)                                             |
-| [`starknet_pendingTransactions`](/reference/starknet-pending-transactions)     | [`starknet_getClass`](/reference/starknet-getclass)                                               |
-| [`starknet_getBlockWithTxs`](/reference/starknet-getblockwithtxs)             | [`starknet_addInvokeTransaction`](/reference/starknet-add-invoke-transaction)                       |
-| [`starknet_getClassAt`](/reference/starknet-getclassat)                       |                                                                                                   |
+| [`starknet_getClassHashAt`](/docs/node/starknet/starknet-api-endpoints/starknet-get-class-hash-at)               | [`starknet_addDeployAccountTransaction`](/docs/node/starknet/starknet-api-endpoints/starknet-add-deploy-account-transaction)         |
+| [`starknet_addDeclareTransaction`](/docs/node/starknet/starknet-api-endpoints/starknet-add-declare-transaction) | [`starknet_blockHashAndNumber`](/docs/node/starknet/starknet-api-endpoints/starknet-block-hash-and-number)                           |
+| [`starknet_getStorageAt`](/docs/node/starknet/starknet-api-endpoints/starknet-get-storage-at)                              | [`starknet_blockNumber`](/docs/node/starknet/starknet-api-endpoints/starknet-block-number)                                         |
+| [`starknet_getStateUpdate`](/docs/node/starknet/starknet-api-endpoints/starknet-get-state-update)               | [`starknet_getTransactionByBlockIdAndIndex`](/docs/node/starknet/starknet-api-endpoints/starknet-get-transaction-by-block-id-and-index) |
+| [`starknet_getTransactionReceipt`](/docs/node/starknet/starknet-api-endpoints/starknet-get-transaction-receipt) | [`starknet_getBlockTransactionCount`](/docs/node/starknet/starknet-api-endpoints/starknet-get-block-transaction-count)               |
+| [`starknet_call`](/docs/node/starknet/starknet-api-endpoints/starknet-call)                                   | [`starknet_estimateFee`](/docs/node/starknet/starknet-api-endpoints/starknet-estimate-fee)                                         |
+| [`starknet_getNonce`](/docs/node/starknet/starknet-api-endpoints/starknet-get-nonce)                           | [`starknet_chainId`](/docs/node/starknet/starknet-api-endpoints/starknet-chain-id)                                                 |
+| [`starknet_getTransactionByHash`](/docs/node/starknet/starknet-api-endpoints/starknet-get-transaction-by-hash)   | [`starknet_syncing`](/docs/node/starknet/starknet-api-endpoints/starknet-syncing)                                                 |
+| [`starknet_getBlockWithTxHashes`](/docs/node/starknet/starknet-api-endpoints/starknet-get-block-with-tx-hashes)   | [`starknet_getEvents`](/docs/node/starknet/starknet-api-endpoints/starknet-get-events)                                             |
+| [`starknet_pendingTransactions`](/docs/node/starknet/starknet-api-endpoints/starknet-pending-transactions)     | [`starknet_getClass`](/docs/node/starknet/starknet-api-endpoints/starknet-get-class)                                               |
+| [`starknet_getBlockWithTxs`](/docs/node/starknet/starknet-api-endpoints/starknet-get-block-with-txs)             | [`starknet_addInvokeTransaction`](/docs/node/starknet/starknet-api-endpoints/starknet-add-invoke-transaction)                       |
+| [`starknet_getClassAt`](/docs/node/starknet/starknet-api-endpoints/starknet-get-class-at)                       |                                                                                                   |
 
 ***
 
@@ -260,27 +263,27 @@ Welcome to the Chain APIs hub, your centralized location for accessing all our a
 
 |                                                                                                      |                                                                                                  |
 | ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
-| [`eth_blocknumber`](/reference/eth-blocknumber-base)                                                 | [`eth_getBlockByHash`](/reference/eth-getblockbyhash-base)                                       |
-| [`eth_getBlockByNumber`](/reference/eth-getblockbynumber-base)                                       | [`eth_getBlockReceipts`](/reference/eth-getblockreceipts-base)                                   |
-| [`eth_getBlockTransactionCountByHash`](/reference/eth-getblocktransactioncountbyhash-base)           | [`eth_getBlockTransactionCountByNumber`](/reference/eth-getblocktransactioncountbynumber-base)   |
-| [`eth_getTransactionByHash`](/reference/eth-gettransactionbyhash-base)                               | [`eth_getTransactionByBlockHashAndIndex`](/reference/eth-gettransactionbyblockhashandindex-base) |
-| [`eth_getTransactionByBlockNumberAndIndex`](/reference/eth-gettransactionbyblocknumberandindex-base) | [`eth_getTransactionReceipt`](/reference/eth-gettransactionreceipt-base)                         |
-| [`eth_getTransactionCount`](/reference/eth-gettransactioncount-base)                                 | [`eth_sendRawTransaction`](/reference/eth-sendrawtransaction-base)                               |
-| [`eth_call`](/reference/eth-call-base)                                                               | [`eth_getCode`](/reference/eth-getcode-base)                                                     |
-| [`eth_getBalance`](/reference/eth-getbalance-base)                                                   | [`eth_accounts`](/reference/eth-accounts-base)                                                   |
-| [`eth_getStorageAt`](/reference/eth-getstorageat-base)                                               | [`eth_getProof`](/reference/eth-getproof-base)                                                   |
-| [`eth_getLogs`](/reference/eth-getlogs-base)                                                         | [`eth_newFilter`](/reference/eth-newfilter-base)                                                 |
-| [`eth_newPendingTransactionFilter`](/reference/eth-newpendingtransactionfilter-base)                 | [`eth_newBlockFilter`](/reference/eth-newblockfilter-base)                                       |
-| [`eth_getFilterChanges`](/reference/eth-getfilterchanges-base)                                       | [`eth_getFilterLogs`](/reference/eth-getfilterlogs-base)                                         |
-| [`eth_uninstallFilter`](/reference/eth-uninstallfilter-base)                                         | [`eth_chainId`](/reference/eth-chainid-base)                                                     |
-| [`eth_protocolVersion`](/reference/eth-protocolversion-base)                                         | [`net_listening`](/reference/net-listening-base)                                                 |
-| [`net_version`](/reference/net-version-base)                                                         | [`eth_getUncleCountByBlockHash`](/reference/eth-getunclecountbyblockhash-base)                   |
-| [`eth_getUncleByBlockNumberAndIndex`](/reference/eth-getunclebyblocknumberandindex-base)             | [`eth_getUncleByBlockHashAndIndex`](/reference/eth-getunclebyblockhashandindex-base)             |
-| [`eth_getUncleCountByBlockNumber`](/reference/eth-getunclecountbyblocknumber-base)                   | [`eth_estimateGas`](/reference/eth-estimategas-base)                                             |
-| [`eth_gasPrice`](/reference/eth-gasprice-base)                                                       | [`eth_feeHistory`](/reference/eth-feehistory-base)                                               |
-| [`eth_maxPriorityFeePerGas`](/reference/eth-maxpriorityfeepergas-base)                               | [`eth_createAccessList`](/reference/eth-createaccesslist-base)                                   |
-| [`web3_clientVersion`](/reference/web3-clientversion-base)                                           | [`web3_sha3`](/reference/web3-sha3-base)                                                         |
-| [`eth_subscribe`](/reference/eth-subscribe-base)                                                     | [`eth_unsubscribe`](/reference/eth-unsubscribe-base)                                             |
+| [`eth_blocknumber`](/docs/node/base/base-api-endpoints/eth-block-number)                             | [`eth_getBlockByHash`](/docs/node/base/base-api-endpoints/eth-get-block-by-hash)                   |
+| [`eth_getBlockByNumber`](/docs/node/base/base-api-endpoints/eth-get-block-by-number)                 | [`eth_getBlockReceipts`](/docs/node/base/base-api-endpoints/eth-get-block-receipts)               |
+| [`eth_getBlockTransactionCountByHash`](/docs/node/base/base-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/node/base/base-api-endpoints/eth-get-block-transaction-count-by-number) |
+| [`eth_getTransactionByHash`](/docs/node/base/base-api-endpoints/eth-get-transaction-by-hash)         | [`eth_getTransactionByBlockHashAndIndex`](/docs/node/base/base-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
+| [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/base/base-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionReceipt`](/docs/node/base/base-api-endpoints/eth-get-transaction-receipt)     |
+| [`eth_getTransactionCount`](/docs/node/base/base-api-endpoints/eth-get-transaction-count)             | [`eth_sendRawTransaction`](/docs/node/base/base-api-endpoints/eth-send-raw-transaction)           |
+| [`eth_call`](/docs/node/base/base-api-endpoints/eth-call)                                           | [`eth_getCode`](/docs/node/base/base-api-endpoints/eth-get-code)                                   |
+| [`eth_getBalance`](/docs/node/base/base-api-endpoints/eth-get-balance)                               | [`eth_accounts`](/docs/node/base/base-api-endpoints/eth-accounts)                                   |
+| [`eth_getStorageAt`](/docs/node/base/base-api-endpoints/eth-get-storage-at)                         | [`eth_getProof`](/docs/node/base/base-api-endpoints/eth-get-proof)                                 |
+| [`eth_getLogs`](/docs/node/base/base-api-endpoints/eth-get-logs)                                     | [`eth_newFilter`](/docs/node/base/base-api-endpoints/eth-new-filter)                               |
+| [`eth_newPendingTransactionFilter`](/docs/node/base/base-api-endpoints/eth-new-pending-transaction-filter) | [`eth_newBlockFilter`](/docs/node/base/base-api-endpoints/eth-new-block-filter)                 |
+| [`eth_getFilterChanges`](/docs/node/base/base-api-endpoints/eth-get-filter-changes)                   | [`eth_getFilterLogs`](/docs/node/base/base-api-endpoints/eth-get-filter-logs)                       |
+| [`eth_uninstallFilter`](/docs/node/base/base-api-endpoints/eth-uninstall-filter)                     | [`eth_chainId`](/docs/node/base/base-api-endpoints/eth-chain-id)                                   |
+| [`eth_protocolVersion`](/docs/node/base/base-api-endpoints/eth-protocol-version)                     | [`net_listening`](/docs/node/base/base-api-endpoints/net-listening)                                 |
+| [`net_version`](/docs/node/base/base-api-endpoints/net-version)                                     | [`eth_getUncleCountByBlockHash`](/docs/node/base/base-api-endpoints/eth-get-uncle-count-by-block-hash) |
+| [`eth_getUncleByBlockNumberAndIndex`](/docs/node/base/base-api-endpoints/eth-get-uncle-by-block-number-and-index) | [`eth_getUncleByBlockHashAndIndex`](/docs/node/base/base-api-endpoints/eth-get-uncle-by-block-hash-and-index) |
+| [`eth_getUncleCountByBlockNumber`](/docs/node/base/base-api-endpoints/eth-get-uncle-count-by-block-number) | [`eth_estimateGas`](/docs/node/base/base-api-endpoints/eth-estimate-gas)                         |
+| [`eth_gasPrice`](/docs/node/base/base-api-endpoints/eth-gas-price)                                   | [`eth_feeHistory`](/docs/node/base/base-api-endpoints/eth-fee-history)                             |
+| [`eth_maxPriorityFeePerGas`](/docs/node/base/base-api-endpoints/eth-max-priority-fee-per-gas)         | [`eth_createAccessList`](/docs/node/base/base-api-endpoints/eth-create-access-list)               |
+| [`web3_clientVersion`](/docs/node/base/base-api-endpoints/web3-client-version)                       | [`web3_sha3`](/docs/node/base/base-api-endpoints/web3-sha3)                                         |
+| [`eth_subscribe`](/docs/node/base/base-api-endpoints/eth-subscribe)                                 | [`eth_unsubscribe`](/docs/node/base/base-api-endpoints/eth-unsubscribe)                             |
 
 ## zkSync APIs
 
@@ -288,34 +291,34 @@ Welcome to the Chain APIs hub, your centralized location for accessing all our a
 
 |                                                                                                        |                                                                                                    |
 | ------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------- |
-| [`eth_accounts`](/reference/eth-accounts-zksync)                                                       | [`eth_blockNumber`](/reference/eth-blocknumber-zksync)                                             |
-| [`eth_call`](/reference/eth-call-zksync)                                                               | [`eth_chainId`](/reference/eth-chainid-zksync)                                                     |
-| [`eth_createAccessList`](/reference/eth-createaccesslist-zksync)                                       | [`eth_estimateGas`](/reference/eth-estimategas-zksync)                                             |
-| [`eth_feeHistory`](/reference/eth-feehistory-zksync)                                                   | [`eth_gasPrice`](/reference/eth-gasprice-zksync)                                                   |
-| [`eth_getBalance`](/reference/eth-getbalance-zksync)                                                   | [`eth_getBlockByHash`](/reference/eth-getblockbyhash-zksync)                                       |
-| [`eth_getBlockByNumber`](/reference/eth-getblockbynumber-zksync)                                       | [`eth_getBlockTransactionCountByHash`](/reference/eth-getblocktransactioncountbyhash-zksync)       |
-| [`eth_getBlockTransactionCountByNumber`](/reference/eth-getblocktransactioncountbynumber-zksync)       | [`eth_getCode`](/reference/eth-getcode-zksync)                                                     |
-| [`eth_getFilterChanges`](/reference/eth-getfilterchanges-zksync)                                       | [`eth_getFilterLogs`](/reference/eth-getfilterlogs-zksync)                                         |
-| [`eth_getLogs`](/reference/eth-getlogs-zksync)                                                         | [`eth_getProof`](/reference/eth-getproof-zksync)                                                   |
-| [`eth_getStorageAt`](/reference/eth-getstorageat-zksync)                                               | [`eth_getTransactionByBlockHashAndIndex`](/reference/eth-gettransactionbyblockhashandindex-zksync) |
-| [`eth_getTransactionByBlockNumberAndIndex`](/reference/eth-gettransactionbyblocknumberandindex-zksync) | [`eth_getTransactionByHash`](/reference/eth-gettransactionbyhash-zksync)                           |
-| [`eth_getTransactionCount`](/reference/eth-gettransactioncount-zksync)                                 | [`eth_getTransactionReceipt`](/reference/eth-gettransactionreceipt-zksync)                         |
-| [`eth_getUncleByBlockHashAndIndex`](/reference/eth-getunclebyblockhashandindex-zksync)                 | [`eth_getUncleByBlockNumberAndIndex`](/reference/eth-getunclebyblocknumberandindex-zksync)         |
-| [`eth_getUncleCountByBlockHash`](/reference/eth-getunclecountbyblockhash-zksync)                       | [`eth_getUncleCountByBlockNumber`](/reference/eth-getunclecountbyblocknumber-zksync)               |
-| [`eth_getBlockReceipts`](/reference/eth-getblockreceipts-zksync)                                       | [`eth_newBlockFilter`](/reference/eth-newblockfilter-zksync)                                       |
-| [`eth_newFilter`](/reference/eth-newfilter-zksync)                                                     | [`eth_newPendingTransactionFilter`](/reference/eth-newpendingtransactionfilter-zksync)             |
-| [`eth_protocolVersion`](/reference/eth-protocolversion-zksync)                                         | [`eth_sendRawTransaction`](/reference/eth-sendrawtransaction-zksync)                               |
-| [`eth_uninstallFilter`](/reference/eth-uninstallfilter-zksync)                                         | [`net_listening`](/reference/net-listening-zksync)                                                 |
-| [`net_version`](/reference/net-version-zksync)                                                         | [`web3_clientVersion`](/reference/web3-clientversion-zksync)                                       |
-| [`web3_sha3`](/reference/web3-sha3-zksync)                                                             | [`zks_estimateFee`](/reference/zks-estimatefee-zksync)                                             |
-| [`zks_estimateGasL1ToL2`](/reference/zks-estimategasl1tol2-zksync)                                     | [`zks_getAllAccountBalances`](/reference/zks-getallaccountbalances-zksync)                         |
-| [`zks_getBlockDetails`](/reference/zks-getblockdetails-zksync)                                         | [`zks_getBridgeContracts`](/reference/zks-getbridgecontracts-zksync)                               |
-| [`zks_getBytecodeByHash`](/reference/zks-getbytecodebyhash-zksync)                                     | [`zks_getL1BatchBlockRange`](/reference/zks-getl1batchblockrange-zksync)                           |
-| [`zks_getL1BatchDetails`](/reference/zks-getl1batchdetails-zksync)                                     | [`zks_getL2ToL1LogProof`](/reference/zks-getl2tol1logproof-zksync)                                 |
-| [`zks_getL2ToL1MsgProof`](/reference/zks-getl2tol1msgproof-zksync)                                     | [`zks_getMainContract`](/reference/zks-getmaincontract-zksync)                                     |
-| [`zks_getProof`](/reference/zks-getproof-zksync)                                                       | [`zks_getRawBlockTransactions`](/reference/zks-getrawblocktransactions-zksync)                     |
-| [`zks_getTestnetPaymaster`](/reference/zks-gettestnetpaymaster-zksync)                                 | [`zks_getTransactionDetails`](/reference/zks-gettransactiondetails-zksync)                         |
-| [`zks_L1BatchNumber`](/reference/zks-l1batchnumber-zksync)                                             | [`zks_L1ChainId`](/reference/zks-l1chainid-zksync)                                                 |
+| [`eth_accounts`](/docs/node/zksync/zksync-api-endpoints/eth-accounts)                                   | [`eth_blockNumber`](/docs/node/zksync/zksync-api-endpoints/eth-block-number)                         |
+| [`eth_call`](/docs/node/zksync/zksync-api-endpoints/eth-call)                                           | [`eth_chainId`](/docs/node/zksync/zksync-api-endpoints/eth-chain-id)                                 |
+| [`eth_createAccessList`](/docs/node/zksync/zksync-api-endpoints/eth-create-access-list)                 | [`eth_estimateGas`](/docs/node/zksync/zksync-api-endpoints/eth-estimate-gas)                         |
+| [`eth_feeHistory`](/docs/node/zksync/zksync-api-endpoints/eth-fee-history)                             | [`eth_gasPrice`](/docs/node/zksync/zksync-api-endpoints/eth-gas-price)                               |
+| [`eth_getBalance`](/docs/node/zksync/zksync-api-endpoints/eth-get-balance)                             | [`eth_getBlockByHash`](/docs/node/zksync/zksync-api-endpoints/eth-get-block-by-hash)                 |
+| [`eth_getBlockByNumber`](/docs/node/zksync/zksync-api-endpoints/eth-get-block-by-number)               | [`eth_getBlockTransactionCountByHash`](/docs/node/zksync/zksync-api-endpoints/eth-get-block-transaction-count-by-hash) |
+| [`eth_getBlockTransactionCountByNumber`](/docs/node/zksync/zksync-api-endpoints/eth-get-block-transaction-count-by-number) | [`eth_getCode`](/docs/node/zksync/zksync-api-endpoints/eth-get-code)                               |
+| [`eth_getFilterChanges`](/docs/node/zksync/zksync-api-endpoints/eth-get-filter-changes)                 | [`eth_getFilterLogs`](/docs/node/zksync/zksync-api-endpoints/eth-get-filter-logs)                     |
+| [`eth_getLogs`](/docs/node/zksync/zksync-api-endpoints/eth-get-logs)                                   | [`eth_getProof`](/docs/node/zksync/zksync-api-endpoints/eth-get-proof)                               |
+| [`eth_getStorageAt`](/docs/node/zksync/zksync-api-endpoints/eth-get-storage-at)                       | [`eth_getTransactionByBlockHashAndIndex`](/docs/node/zksync/zksync-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
+| [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/zksync/zksync-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/node/zksync/zksync-api-endpoints/eth-get-transaction-by-hash)   |
+| [`eth_getTransactionCount`](/docs/node/zksync/zksync-api-endpoints/eth-get-transaction-count)           | [`eth_getTransactionReceipt`](/docs/node/zksync/zksync-api-endpoints/eth-get-transaction-receipt)     |
+| [`eth_getUncleByBlockHashAndIndex`](/docs/node/zksync/zksync-api-endpoints/eth-get-uncle-by-block-hash-and-index) | [`eth_getUncleByBlockNumberAndIndex`](/docs/node/zksync/zksync-api-endpoints/eth-get-uncle-by-block-number-and-index) |
+| [`eth_getUncleCountByBlockHash`](/docs/node/zksync/zksync-api-endpoints/eth-get-uncle-count-by-block-hash) | [`eth_getUncleCountByBlockNumber`](/docs/node/zksync/zksync-api-endpoints/eth-get-uncle-count-by-block-number) |
+| [`eth_getBlockReceipts`](/docs/node/zksync/zksync-api-endpoints/eth-get-block-receipts)                 | [`eth_newBlockFilter`](/docs/node/zksync/zksync-api-endpoints/eth-new-block-filter)                   |
+| [`eth_newFilter`](/docs/node/zksync/zksync-api-endpoints/eth-new-filter)                               | [`eth_newPendingTransactionFilter`](/docs/node/zksync/zksync-api-endpoints/eth-new-pending-transaction-filter) |
+| [`eth_protocolVersion`](/docs/node/zksync/zksync-api-endpoints/eth-protocol-version)                   | [`eth_sendRawTransaction`](/docs/node/zksync/zksync-api-endpoints/eth-send-raw-transaction)           |
+| [`eth_uninstallFilter`](/docs/node/zksync/zksync-api-endpoints/eth-uninstall-filter)                   | [`net_listening`](/docs/node/zksync/zksync-api-endpoints/net-listening)                               |
+| [`net_version`](/docs/node/zksync/zksync-api-endpoints/net-version)                                   | [`web3_clientVersion`](/docs/node/zksync/zksync-api-endpoints/web3-client-version)                   |
+| [`web3_sha3`](/docs/node/zksync/zksync-api-endpoints/web3-sha3)                                       | [`zks_estimateFee`](/docs/node/zksync/zksync-api-endpoints/zks-estimate-fee)                         |
+| [`zks_estimateGasL1ToL2`](/docs/node/zksync/zksync-api-endpoints/zks-estimate-gas-l1-to-l2)             | [`zks_getAllAccountBalances`](/docs/node/zksync/zksync-api-endpoints/zks-get-all-account-balances)     |
+| [`zks_getBlockDetails`](/docs/node/zksync/zksync-api-endpoints/zks-get-block-details)                   | [`zks_getBridgeContracts`](/docs/node/zksync/zksync-api-endpoints/zks-get-bridge-contracts)           |
+| [`zks_getBytecodeByHash`](/docs/node/zksync/zksync-api-endpoints/zks-get-bytecode-by-hash)             | [`zks_getL1BatchBlockRange`](/docs/node/zksync/zksync-api-endpoints/zks-get-l1-batch-block-range)     |
+| [`zks_getL1BatchDetails`](/docs/node/zksync/zksync-api-endpoints/zks-get-l1-batch-details)             | [`zks_getL2ToL1LogProof`](/docs/node/zksync/zksync-api-endpoints/zks-get-l2-to-l1-log-proof)         |
+| [`zks_getL2ToL1MsgProof`](/docs/node/zksync/zksync-api-endpoints/zks-get-l2-to-l1-msg-proof)           | [`zks_getMainContract`](/docs/node/zksync/zksync-api-endpoints/zks-get-main-contract)                 |
+| [`zks_getProof`](/docs/node/zksync/zksync-api-endpoints/zks-get-proof)                                 | [`zks_getRawBlockTransactions`](/docs/node/zksync/zksync-api-endpoints/zks-get-raw-block-transactions) |
+| [`zks_getTestnetPaymaster`](/docs/node/zksync/zksync-api-endpoints/zks-get-testnet-paymaster)           | [`zks_getTransactionDetails`](/docs/node/zksync/zksync-api-endpoints/zks-get-transaction-details)     |
+| [`zks_L1BatchNumber`](/docs/node/zksync/zksync-api-endpoints/zks-l1-batch-number)                       | [`zks_L1ChainId`](/docs/node/zksync/zksync-api-endpoints/zks-l1-chain-id)                             |
 
 ## BNB APIs
 
@@ -323,21 +326,21 @@ Welcome to the Chain APIs hub, your centralized location for accessing all our a
 
 |                                                                                                 |                                                                                                     |
 | ----------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| [`eth_blockNumber`](/reference/eth-blocknumber-bnb)                                             | [`eth_call`](/reference/eth-call-bnb)                                                               |
-| [`eth_chainId`](/reference/eth-chainid-bnb)                                                     | [`eth_estimateGas`](/reference/eth-estimategas-bnb)                                                 |
-| [`eth_gasPrice`](/reference/eth-gasprice-bnb)                                                   | [`eth_getBalance`](/reference/eth-getbalance-bnb)                                                   |
-| [`eth_getBlockByHash`](/reference/eth-getblockbyhash-bnb)                                       | [`eth_getBlockByNumber`](/reference/eth-getblockbynumber-bnb)                                       |
-| [`eth_getBlockTransactionCountByHash`](/reference/eth-getblocktransactioncountbyhash-bnb)       | [`eth_getBlockTransactionCountByNumber`](/reference/eth-getblocktransactioncountbynumber-bnb)       |
-| [`eth_getCode`](/reference/eth-getcode-bnb)                                                     | [`eth_getLogs`](/reference/eth-getlogs-bnb)                                                         |
-| [`eth_getProof`](/reference/eth-getproof-bnb)                                                   | [`eth_getStorageAt`](/reference/eth-getstorageat-bnb)                                               |
-| [`eth_getTransactionByBlockHashAndIndex`](/reference/eth-gettransactionbyblockhashandindex-bnb) | [`eth_getTransactionByBlockNumberAndIndex`](/reference/eth-gettransactionbyblocknumberandindex-bnb) |
-| [`eth_getTransactionByHash`](/reference/eth-gettransactionbyhash-bnb)                           | [`eth_getTransactionCount`](/reference/eth-gettransactioncount-bnb)                                 |
-| [`eth_getTransactionReceipt`](/reference/eth-gettransactionreceipt-bnb)                         | [`eth_getUncleByBlockHashAndIndex`](/reference/eth-getunclebyblockhashandindex-bnb)                 |
-| [`eth_getUncleByBlockNumberAndIndex`](/reference/eth-getunclebyblocknumberandindex-bnb)         | [`eth_getUncleCountByBlockHash`](/reference/eth-getunclecountbyblockhash-bnb)                       |
-| [`eth_getUncleCountByBlockNumber`](/reference/eth-getunclecountbyblocknumber-bnb)               | [`eth_sendRawTransaction`](/reference/eth-sendrawtransaction-bnb)                                   |
-| [`net_listening`](/reference/net-listening-bnb)                                                 | [`net_peerCount`](/reference/net-peercount-bnb)                                                     |
-| [`net_version`](/reference/net-version-bnb)                                                     | [`web3_clientVersion`](/reference/web3-clientversion-bnb)                                           |
-| [`web3_sha3`](/reference/web3-sha3-bnb)                                                         |                                                                                                     |
+| [`eth_blockNumber`](/docs/node/bnb/bnb-api-endpoints/eth-block-number)                         | [`eth_call`](/docs/node/bnb/bnb-api-endpoints/eth-call)                                           |
+| [`eth_chainId`](/docs/node/bnb/bnb-api-endpoints/eth-chain-id)                                 | [`eth_estimateGas`](/docs/node/bnb/bnb-api-endpoints/eth-estimate-gas)                             |
+| [`eth_gasPrice`](/docs/node/bnb/bnb-api-endpoints/eth-gas-price)                               | [`eth_getBalance`](/docs/node/bnb/bnb-api-endpoints/eth-get-balance)                               |
+| [`eth_getBlockByHash`](/docs/node/bnb/bnb-api-endpoints/eth-get-block-by-hash)                 | [`eth_getBlockByNumber`](/docs/node/bnb/bnb-api-endpoints/eth-get-block-by-number)                 |
+| [`eth_getBlockTransactionCountByHash`](/docs/node/bnb/bnb-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/node/bnb/bnb-api-endpoints/eth-get-block-transaction-count-by-number) |
+| [`eth_getCode`](/docs/node/bnb/bnb-api-endpoints/eth-get-code)                                 | [`eth_getLogs`](/docs/node/bnb/bnb-api-endpoints/eth-get-logs)                                     |
+| [`eth_getProof`](/docs/node/bnb/bnb-api-endpoints/eth-get-proof)                               | [`eth_getStorageAt`](/docs/node/bnb/bnb-api-endpoints/eth-get-storage-at)                           |
+| [`eth_getTransactionByBlockHashAndIndex`](/docs/node/bnb/bnb-api-endpoints/eth-get-transaction-by-block-hash-and-index) | [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/bnb/bnb-api-endpoints/eth-get-transaction-by-block-number-and-index) |
+| [`eth_getTransactionByHash`](/docs/node/bnb/bnb-api-endpoints/eth-get-transaction-by-hash)     | [`eth_getTransactionCount`](/docs/node/bnb/bnb-api-endpoints/eth-get-transaction-count)             |
+| [`eth_getTransactionReceipt`](/docs/node/bnb/bnb-api-endpoints/eth-get-transaction-receipt)     | [`eth_getUncleByBlockHashAndIndex`](/docs/node/bnb/bnb-api-endpoints/eth-get-uncle-by-block-hash-and-index) |
+| [`eth_getUncleByBlockNumberAndIndex`](/docs/node/bnb/bnb-api-endpoints/eth-get-uncle-by-block-number-and-index) | [`eth_getUncleCountByBlockHash`](/docs/node/bnb/bnb-api-endpoints/eth-get-uncle-count-by-block-hash) |
+| [`eth_getUncleCountByBlockNumber`](/docs/node/bnb/bnb-api-endpoints/eth-get-uncle-count-by-block-number) | [`eth_sendRawTransaction`](/docs/node/bnb/bnb-api-endpoints/eth-send-raw-transaction)               |
+| [`net_listening`](/docs/node/bnb/bnb-api-endpoints/net-listening)                               | [`net_peerCount`](/docs/node/bnb/bnb-api-endpoints/net-peer-count)                                 |
+| [`net_version`](/docs/node/bnb/bnb-api-endpoints/net-version)                                   | [`web3_clientVersion`](/docs/node/bnb/bnb-api-endpoints/web3-client-version)                       |
+| [`web3_sha3`](/docs/node/bnb/bnb-api-endpoints/web3-sha3)                                       |                                                                                                     |
 
 ## Avalanche-C-Chain APIs (Paid Tiers)
 
@@ -345,17 +348,17 @@ Welcome to the Chain APIs hub, your centralized location for accessing all our a
 
 |                                                                                             |                                                                                                 |
 | ------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| [`eth_getBlockByHash`](/reference/eth-getblockbyhash)                                       | [`eth_blockNumber`](/reference/eth-blocknumber)                                                 |
-| [`eth_getBlockByNumber`](/reference/eth-getblockbynumber)                                   | [`eth_getBlockTransactionCountByHash`](/reference/eth-getblocktransactioncountbyhash)           |
-| [`eth_getBlockTransactionCountByNumber`](/reference/eth-getblocktransactioncountbynumber)   | [`eth_getTransactionByHash`](/reference/eth-gettransactionbyhash)                               |
-| [`eth_getTransactionByBlockHashAndIndex`](/reference/eth-gettransactionbyblockhashandindex) | [`eth_getTransactionByBlockNumberAndIndex`](/reference/eth-gettransactionbyblocknumberandindex) |
-| [`eth_getTransactionReceipt`](/reference/eth-gettransactionreceipt)                         | [`eth_getTransactionCount`](/reference/eth-gettransactioncount)                                 |
-| [`eth_sendRawTransaction`](/reference/eth-sendrawtransaction)                               | [`eth_call`](/reference/eth-call)                                                               |
-| [`eth_getCode`](/reference/eth-getcode)                                                     | [`eth_getBalance`](/reference/eth-getbalance)                                                   |
-| [`eth_getStorageAt`](/reference/eth-getstorageat)                                           | [`eth_getLogs`](/reference/eth-getlogs)                                                         |
-| [`eth_chainId`](/reference/eth-chainid)                                                     | [`eth_estimateGas`](/reference/eth-estimategas)                                                 |
-| [`eth_gasPrice`](/reference/eth-gasprice)                                                   | [`web3_clientVersion`](/reference/web3-clientversion)                                           |
-| [`web3_sha3`](/reference/web3-sha3)                                                         |                                                                                                 |
+| [`eth_getBlockByHash`](/docs/node/avalanche/avalanche-api-endpoints/eth-get-block-by-hash) | [`eth_blockNumber`](/docs/node/avalanche/avalanche-api-endpoints/eth-block-number)                 |
+| [`eth_getBlockByNumber`](/docs/node/avalanche/avalanche-api-endpoints/eth-get-block-by-number) | [`eth_getBlockTransactionCountByHash`](/docs/node/avalanche/avalanche-api-endpoints/eth-get-block-transaction-count-by-hash) |
+| [`eth_getBlockTransactionCountByNumber`](/docs/node/avalanche/avalanche-api-endpoints/eth-get-block-transaction-count-by-number) | [`eth_getTransactionByHash`](/docs/node/avalanche/avalanche-api-endpoints/eth-get-transaction-by-hash) |
+| [`eth_getTransactionByBlockHashAndIndex`](/docs/node/avalanche/avalanche-api-endpoints/eth-get-transaction-by-block-hash-and-index) | [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/avalanche/avalanche-api-endpoints/eth-get-transaction-by-block-number-and-index) |
+| [`eth_getTransactionReceipt`](/docs/node/avalanche/avalanche-api-endpoints/eth-get-transaction-receipt) | [`eth_getTransactionCount`](/docs/node/avalanche/avalanche-api-endpoints/eth-get-transaction-count) |
+| [`eth_sendRawTransaction`](/docs/node/avalanche/avalanche-api-endpoints/eth-send-raw-transaction) | [`eth_call`](/docs/node/avalanche/avalanche-api-endpoints/eth-call)                               |
+| [`eth_getCode`](/docs/node/avalanche/avalanche-api-endpoints/eth-get-code)                 | [`eth_getBalance`](/docs/node/avalanche/avalanche-api-endpoints/eth-get-balance)                   |
+| [`eth_getStorageAt`](/docs/node/avalanche/avalanche-api-endpoints/eth-get-storage-at)       | [`eth_getLogs`](/docs/node/avalanche/avalanche-api-endpoints/eth-get-logs)                         |
+| [`eth_chainId`](/docs/node/avalanche/avalanche-api-endpoints/eth-chain-id)                 | [`eth_estimateGas`](/docs/node/avalanche/avalanche-api-endpoints/eth-estimate-gas)                 |
+| [`eth_gasPrice`](/docs/node/avalanche/avalanche-api-endpoints/eth-gas-price)               | [`web3_clientVersion`](/docs/node/avalanche/avalanche-api-endpoints/web3-client-version)           |
+| [`web3_sha3`](/docs/node/avalanche/avalanche-api-endpoints/web3-sha3)                     |                                                                                                 |
 
 ## Zetachain APIs
 
@@ -363,18 +366,18 @@ Welcome to the Chain APIs hub, your centralized location for accessing all our a
 
 |                                                                                             |                                                                                                 |
 | ------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| [`eth_getBlockByHash`](/reference/eth-getblockbyhash)                                       | [`eth_blockNumber`](/reference/eth-blocknumber)                                                 |
-| [`eth_getBlockByNumber`](/reference/eth-getblockbynumber)                                   | [`eth_getBlockTransactionCountByHash`](/reference/eth-getblocktransactioncountbyhash)           |
-| [`eth_getBlockTransactionCountByNumber`](/reference/eth-getblocktransactioncountbynumber)   | [`eth_getTransactionByHash`](/reference/eth-gettransactionbyhash)                               |
-| [`eth_getTransactionByBlockHashAndIndex`](/reference/eth-gettransactionbyblockhashandindex) | [`eth_getTransactionByBlockNumberAndIndex`](/reference/eth-gettransactionbyblocknumberandindex) |
-| [`eth_getTransactionReceipt`](/reference/eth-gettransactionreceipt)                         | [`eth_getTransactionCount`](/reference/eth-gettransactioncount)                                 |
-| [`eth_sendRawTransaction`](/reference/eth-sendrawtransaction)                               | [`eth_call`](/reference/eth-call)                                                               |
-| [`eth_getCode`](/reference/eth-getcode)                                                     | [`eth_getBalance`](/reference/eth-getbalance)                                                   |
-| [`eth_getStorageAt`](/reference/eth-getstorageat)                                           | [`eth_getProof`](/reference/eth-getproof)                                                       |
-| [`eth_getLogs`](/reference/eth-getlogs)                                                     | [`eth_chainId`](/reference/eth-chainid)                                                         |
-| [`net_version`](/reference/net-version)                                                     | [`eth_estimateGas`](/reference/eth-estimategas)                                                 |
-| [`eth_gasPrice`](/reference/eth-gasprice)                                                   | [`web3_clientVersion`](/reference/web3-clientversion)                                           |
-| [`web3_sha3`](/reference/web3-sha3)                                                         |                                                                                                 |
+| [`eth_getBlockByHash`](/docs/node/zetachain/zetachain-api-endpoints/eth-get-block-by-hash) | [`eth_blockNumber`](/docs/node/zetachain/zetachain-api-endpoints/eth-block-number)                 |
+| [`eth_getBlockByNumber`](/docs/node/zetachain/zetachain-api-endpoints/eth-get-block-by-number) | [`eth_getBlockTransactionCountByHash`](/docs/node/zetachain/zetachain-api-endpoints/eth-get-block-transaction-count-by-hash) |
+| [`eth_getBlockTransactionCountByNumber`](/docs/node/zetachain/zetachain-api-endpoints/eth-get-block-transaction-count-by-number) | [`eth_getTransactionByHash`](/docs/node/zetachain/zetachain-api-endpoints/eth-get-transaction-by-hash) |
+| [`eth_getTransactionByBlockHashAndIndex`](/docs/node/zetachain/zetachain-api-endpoints/eth-get-transaction-by-block-hash-and-index) | [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/zetachain/zetachain-api-endpoints/eth-get-transaction-by-block-number-and-index) |
+| [`eth_getTransactionReceipt`](/docs/node/zetachain/zetachain-api-endpoints/eth-get-transaction-receipt) | [`eth_getTransactionCount`](/docs/node/zetachain/zetachain-api-endpoints/eth-get-transaction-count) |
+| [`eth_sendRawTransaction`](/docs/node/zetachain/zetachain-api-endpoints/eth-send-raw-transaction) | [`eth_call`](/docs/node/zetachain/zetachain-api-endpoints/eth-call)                               |
+| [`eth_getCode`](/docs/node/zetachain/zetachain-api-endpoints/eth-get-code)                 | [`eth_getBalance`](/docs/node/zetachain/zetachain-api-endpoints/eth-get-balance)                   |
+| [`eth_getStorageAt`](/docs/node/zetachain/zetachain-api-endpoints/eth-get-storage-at)       | [`eth_getProof`](/docs/node/zetachain/zetachain-api-endpoints/eth-get-proof)                       |
+| [`eth_getLogs`](/docs/node/zetachain/zetachain-api-endpoints/eth-get-logs)                 | [`eth_chainId`](/docs/node/zetachain/zetachain-api-endpoints/eth-chain-id)                         |
+| [`net_version`](/docs/node/zetachain/zetachain-api-endpoints/net-version)                 | [`eth_estimateGas`](/docs/node/zetachain/zetachain-api-endpoints/eth-estimate-gas)                 |
+| [`eth_gasPrice`](/docs/node/zetachain/zetachain-api-endpoints/eth-gas-price)               | [`web3_clientVersion`](/docs/node/zetachain/zetachain-api-endpoints/web3-client-version)           |
+| [`web3_sha3`](/docs/node/zetachain/zetachain-api-endpoints/web3-sha3)                     |                                                                                                 |
 
 ## Blast APIs
 
@@ -382,18 +385,18 @@ Welcome to the Chain APIs hub, your centralized location for accessing all our a
 
 |                                                                                             |                                                                                                 |
 | ------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| [`eth_getBlockByHash`](/reference/eth-getblockbyhash)                                       | [`eth_blockNumber`](/reference/eth-blocknumber)                                                 |
-| [`eth_getBlockByNumber`](/reference/eth-getblockbynumber)                                   | [`eth_getBlockTransactionCountByHash`](/reference/eth-getblocktransactioncountbyhash)           |
-| [`eth_getBlockTransactionCountByNumber`](/reference/eth-getblocktransactioncountbynumber)   | [`eth_getTransactionByHash`](/reference/eth-gettransactionbyhash)                               |
-| [`eth_getTransactionByBlockHashAndIndex`](/reference/eth-gettransactionbyblockhashandindex) | [`eth_getTransactionByBlockNumberAndIndex`](/reference/eth-gettransactionbyblocknumberandindex) |
-| [`eth_getTransactionReceipt`](/reference/eth-gettransactionreceipt)                         | [`eth_getTransactionCount`](/reference/eth-gettransactioncount)                                 |
-| [`eth_sendRawTransaction`](/reference/eth-sendrawtransaction)                               | [`eth_call`](/reference/eth-call)                                                               |
-| [`eth_getCode`](/reference/eth-getcode)                                                     | [`eth_getBalance`](/reference/eth-getbalance)                                                   |
-| [`eth_getStorageAt`](/reference/eth-getstorageat)                                           | [`eth_getProof`](/reference/eth-getproof)                                                       |
-| [`eth_getLogs`](/reference/eth-getlogs)                                                     | [`eth_chainId`](/reference/eth-chainid)                                                         |
-| [`net_version`](/reference/net-version)                                                     | [`eth_estimateGas`](/reference/eth-estimategas)                                                 |
-| [`eth_gasPrice`](/reference/eth-gasprice)                                                   | [`web3_clientVersion`](/reference/web3-clientversion)                                           |
-| [`web3_sha3`](/reference/web3-sha3)                                                         |                                                                                                 |
+| [`eth_getBlockByHash`](/docs/node/blast/blast-api-endpoints/eth-get-block-by-hash)         | [`eth_blockNumber`](/docs/node/blast/blast-api-endpoints/eth-block-number)                         |
+| [`eth_getBlockByNumber`](/docs/node/blast/blast-api-endpoints/eth-get-block-by-number)     | [`eth_getBlockTransactionCountByHash`](/docs/node/blast/blast-api-endpoints/eth-get-block-transaction-count-by-hash) |
+| [`eth_getBlockTransactionCountByNumber`](/docs/node/blast/blast-api-endpoints/eth-get-block-transaction-count-by-number) | [`eth_getTransactionByHash`](/docs/node/blast/blast-api-endpoints/eth-get-transaction-by-hash) |
+| [`eth_getTransactionByBlockHashAndIndex`](/docs/node/blast/blast-api-endpoints/eth-get-transaction-by-block-hash-and-index) | [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/blast/blast-api-endpoints/eth-get-transaction-by-block-number-and-index) |
+| [`eth_getTransactionReceipt`](/docs/node/blast/blast-api-endpoints/eth-get-transaction-receipt) | [`eth_getTransactionCount`](/docs/node/blast/blast-api-endpoints/eth-get-transaction-count)     |
+| [`eth_sendRawTransaction`](/docs/node/blast/blast-api-endpoints/eth-send-raw-transaction)   | [`eth_call`](/docs/node/blast/blast-api-endpoints/eth-call)                                       |
+| [`eth_getCode`](/docs/node/blast/blast-api-endpoints/eth-get-code)                         | [`eth_getBalance`](/docs/node/blast/blast-api-endpoints/eth-get-balance)                           |
+| [`eth_getStorageAt`](/docs/node/blast/blast-api-endpoints/eth-get-storage-at)               | [`eth_getProof`](/docs/node/blast/blast-api-endpoints/eth-get-proof)                               |
+| [`eth_getLogs`](/docs/node/blast/blast-api-endpoints/eth-get-logs)                         | [`eth_chainId`](/docs/node/blast/blast-api-endpoints/eth-chain-id)                                 |
+| [`net_version`](/docs/node/blast/blast-api-endpoints/net-version)                         | [`eth_estimateGas`](/docs/node/blast/blast-api-endpoints/eth-estimate-gas)                         |
+| [`eth_gasPrice`](/docs/node/blast/blast-api-endpoints/eth-gas-price)                       | [`web3_clientVersion`](/docs/node/blast/blast-api-endpoints/web3-client-version)                   |
+| [`web3_sha3`](/docs/node/blast/blast-api-endpoints/web3-sha3)                             |                                                                                                 |
 
 ## Sonic APIs
 
@@ -401,18 +404,18 @@ Welcome to the Chain APIs hub, your centralized location for accessing all our a
 
 |                                                                                             |                                                                                                 |
 | ------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| [`eth_getBlockByHash`](/reference/eth-getblockbyhash)                                       | [`eth_blockNumber`](/reference/eth-blocknumber)                                                 |
-| [`eth_getBlockByNumber`](/reference/eth-getblockbynumber)                                   | [`eth_getBlockTransactionCountByHash`](/reference/eth-getblocktransactioncountbyhash)           |
-| [`eth_getBlockTransactionCountByNumber`](/reference/eth-getblocktransactioncountbynumber)   | [`eth_getTransactionByHash`](/reference/eth-gettransactionbyhash)                               |
-| [`eth_getTransactionByBlockHashAndIndex`](/reference/eth-gettransactionbyblockhashandindex) | [`eth_getTransactionByBlockNumberAndIndex`](/reference/eth-gettransactionbyblocknumberandindex) |
-| [`eth_getTransactionReceipt`](/reference/eth-gettransactionreceipt)                         | [`eth_getTransactionCount`](/reference/eth-gettransactioncount)                                 |
-| [`eth_sendRawTransaction`](/reference/eth-sendrawtransaction)                               | [`eth_call`](/reference/eth-call)                                                               |
-| [`eth_getCode`](/reference/eth-getcode)                                                     | [`eth_getBalance`](/reference/eth-getbalance)                                                   |
-| [`eth_getStorageAt`](/reference/eth-getstorageat)                                           | [`eth_getProof`](/reference/eth-getproof)                                                       |
-| [`eth_getLogs`](/reference/eth-getlogs)                                                     | [`eth_chainId`](/reference/eth-chainid)                                                         |
-| [`net_version`](/reference/net-version)                                                     | [`eth_estimateGas`](/reference/eth-estimategas)                                                 |
-| [`eth_gasPrice`](/reference/eth-gasprice)                                                   | [`web3_clientVersion`](/reference/web3-clientversion)                                           |
-| [`web3_sha3`](/reference/web3-sha3)                                                         |                                                                                                 |
+| [`eth_getBlockByHash`](/docs/node/sonic/sonic-api-endpoints/eth-get-block-by-hash)         | [`eth_blockNumber`](/docs/node/sonic/sonic-api-endpoints/eth-block-number)                         |
+| [`eth_getBlockByNumber`](/docs/node/sonic/sonic-api-endpoints/eth-get-block-by-number)     | [`eth_getBlockTransactionCountByHash`](/docs/node/sonic/sonic-api-endpoints/eth-get-block-transaction-count-by-hash) |
+| [`eth_getBlockTransactionCountByNumber`](/docs/node/sonic/sonic-api-endpoints/eth-get-block-transaction-count-by-number) | [`eth_getTransactionByHash`](/docs/node/sonic/sonic-api-endpoints/eth-get-transaction-by-hash) |
+| [`eth_getTransactionByBlockHashAndIndex`](/docs/node/sonic/sonic-api-endpoints/eth-get-transaction-by-block-hash-and-index) | [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/sonic/sonic-api-endpoints/eth-get-transaction-by-block-number-and-index) |
+| [`eth_getTransactionReceipt`](/docs/node/sonic/sonic-api-endpoints/eth-get-transaction-receipt) | [`eth_getTransactionCount`](/docs/node/sonic/sonic-api-endpoints/eth-get-transaction-count)     |
+| [`eth_sendRawTransaction`](/docs/node/sonic/sonic-api-endpoints/eth-send-raw-transaction)   | [`eth_call`](/docs/node/sonic/sonic-api-endpoints/eth-call)                                       |
+| [`eth_getCode`](/docs/node/sonic/sonic-api-endpoints/eth-get-code)                         | [`eth_getBalance`](/docs/node/sonic/sonic-api-endpoints/eth-get-balance)                           |
+| [`eth_getStorageAt`](/docs/node/sonic/sonic-api-endpoints/eth-get-storage-at)               | [`eth_getProof`](/docs/node/sonic/sonic-api-endpoints/eth-get-proof)                               |
+| [`eth_getLogs`](/docs/node/sonic/sonic-api-endpoints/eth-get-logs)                         | [`eth_chainId`](/docs/node/sonic/sonic-api-endpoints/eth-chain-id)                                 |
+| [`net_version`](/docs/node/sonic/sonic-api-endpoints/net-version)                         | [`eth_estimateGas`](/docs/node/sonic/sonic-api-endpoints/eth-estimate-gas)                         |
+| [`eth_gasPrice`](/docs/node/sonic/sonic-api-endpoints/eth-gas-price)                       | [`web3_clientVersion`](/docs/node/sonic/sonic-api-endpoints/web3-client-version)                   |
+| [`web3_sha3`](/docs/node/sonic/sonic-api-endpoints/web3-sha3)                             |                                                                                                 |
 
 ## Sei APIs
 
@@ -420,18 +423,18 @@ Welcome to the Chain APIs hub, your centralized location for accessing all our a
 
 |                                                                                             |                                                                                                 |
 | ------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| [`eth_getBlockByHash`](/reference/eth-getblockbyhash)                                       | [`eth_blockNumber`](/reference/eth-blocknumber)                                                 |
-| [`eth_getBlockByNumber`](/reference/eth-getblockbynumber)                                   | [`eth_getBlockTransactionCountByHash`](/reference/eth-getblocktransactioncountbyhash)           |
-| [`eth_getBlockTransactionCountByNumber`](/reference/eth-getblocktransactioncountbynumber)   | [`eth_getTransactionByHash`](/reference/eth-gettransactionbyhash)                               |
-| [`eth_getTransactionByBlockHashAndIndex`](/reference/eth-gettransactionbyblockhashandindex) | [`eth_getTransactionByBlockNumberAndIndex`](/reference/eth-gettransactionbyblocknumberandindex) |
-| [`eth_getTransactionReceipt`](/reference/eth-gettransactionreceipt)                         | [`eth_getTransactionCount`](/reference/eth-gettransactioncount)                                 |
-| [`eth_sendRawTransaction`](/reference/eth-sendrawtransaction)                               | [`eth_call`](/reference/eth-call)                                                               |
-| [`eth_getCode`](/reference/eth-getcode)                                                     | [`eth_getBalance`](/reference/eth-getbalance)                                                   |
-| [`eth_getStorageAt`](/reference/eth-getstorageat)                                           | [`eth_getProof`](/reference/eth-getproof)                                                       |
-| [`eth_getLogs`](/reference/eth-getlogs)                                                     | [`eth_chainId`](/reference/eth-chainid)                                                         |
-| [`net_version`](/reference/net-version)                                                     | [`eth_estimateGas`](/reference/eth-estimategas)                                                 |
-| [`eth_gasPrice`](/reference/eth-gasprice)                                                   | [`web3_clientVersion`](/reference/web3-clientversion)                                           |
-| [`web3_sha3`](/reference/web3-sha3)                                                         |                                                                                                 |
+| [`eth_getBlockByHash`](/docs/node/sei/sei-api-endpoints/eth-get-block-by-hash)             | [`eth_blockNumber`](/docs/node/sei/sei-api-endpoints/eth-block-number)                             |
+| [`eth_getBlockByNumber`](/docs/node/sei/sei-api-endpoints/eth-get-block-by-number)         | [`eth_getBlockTransactionCountByHash`](/docs/node/sei/sei-api-endpoints/eth-get-block-transaction-count-by-hash) |
+| [`eth_getBlockTransactionCountByNumber`](/docs/node/sei/sei-api-endpoints/eth-get-block-transaction-count-by-number) | [`eth_getTransactionByHash`](/docs/node/sei/sei-api-endpoints/eth-get-transaction-by-hash)     |
+| [`eth_getTransactionByBlockHashAndIndex`](/docs/node/sei/sei-api-endpoints/eth-get-transaction-by-block-hash-and-index) | [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/sei/sei-api-endpoints/eth-get-transaction-by-block-number-and-index) |
+| [`eth_getTransactionReceipt`](/docs/node/sei/sei-api-endpoints/eth-get-transaction-receipt) | [`eth_getTransactionCount`](/docs/node/sei/sei-api-endpoints/eth-get-transaction-count)         |
+| [`eth_sendRawTransaction`](/docs/node/sei/sei-api-endpoints/eth-send-raw-transaction)       | [`eth_call`](/docs/node/sei/sei-api-endpoints/eth-call)                                           |
+| [`eth_getCode`](/docs/node/sei/sei-api-endpoints/eth-get-code)                             | [`eth_getBalance`](/docs/node/sei/sei-api-endpoints/eth-get-balance)                               |
+| [`eth_getStorageAt`](/docs/node/sei/sei-api-endpoints/eth-get-storage-at)                   | [`eth_getProof`](/docs/node/sei/sei-api-endpoints/eth-get-proof)                                   |
+| [`eth_getLogs`](/docs/node/sei/sei-api-endpoints/eth-get-logs)                             | [`eth_chainId`](/docs/node/sei/sei-api-endpoints/eth-chain-id)                                     |
+| [`net_version`](/docs/node/sei/sei-api-endpoints/net-version)                             | [`eth_estimateGas`](/docs/node/sei/sei-api-endpoints/eth-estimate-gas)                             |
+| [`eth_gasPrice`](/docs/node/sei/sei-api-endpoints/eth-gas-price)                           | [`web3_clientVersion`](/docs/node/sei/sei-api-endpoints/web3-client-version)                       |
+| [`web3_sha3`](/docs/node/sei/sei-api-endpoints/web3-sha3)                                 |                                                                                                 |
 
 ## Metis APIs
 
@@ -439,18 +442,18 @@ Welcome to the Chain APIs hub, your centralized location for accessing all our a
 
 |                                                                                             |                                                                                                 |
 | ------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| [`eth_getBlockByHash`](/reference/eth-getblockbyhash)                                       | [`eth_blockNumber`](/reference/eth-blocknumber)                                                 |
-| [`eth_getBlockByNumber`](/reference/eth-getblockbynumber)                                   | [`eth_getBlockTransactionCountByHash`](/reference/eth-getblocktransactioncountbyhash)           |
-| [`eth_getBlockTransactionCountByNumber`](/reference/eth-getblocktransactioncountbynumber)   | [`eth_getTransactionByHash`](/reference/eth-gettransactionbyhash)                               |
-| [`eth_getTransactionByBlockHashAndIndex`](/reference/eth-gettransactionbyblockhashandindex) | [`eth_getTransactionByBlockNumberAndIndex`](/reference/eth-gettransactionbyblocknumberandindex) |
-| [`eth_getTransactionReceipt`](/reference/eth-gettransactionreceipt)                         | [`eth_getTransactionCount`](/reference/eth-gettransactioncount)                                 |
-| [`eth_sendRawTransaction`](/reference/eth-sendrawtransaction)                               | [`eth_call`](/reference/eth-call)                                                               |
-| [`eth_getCode`](/reference/eth-getcode)                                                     | [`eth_getBalance`](/reference/eth-getbalance)                                                   |
-| [`eth_getStorageAt`](/reference/eth-getstorageat)                                           | [`eth_getProof`](/reference/eth-getproof)                                                       |
-| [`eth_getLogs`](/reference/eth-getlogs)                                                     | [`eth_chainId`](/reference/eth-chainid)                                                         |
-| [`net_version`](/reference/net-version)                                                     | [`eth_estimateGas`](/reference/eth-estimategas)                                                 |
-| [`eth_gasPrice`](/reference/eth-gasprice)                                                   | [`web3_clientVersion`](/reference/web3-clientversion)                                           |
-| [`web3_sha3`](/reference/web3-sha3)                                                         |                                                                                                 |
+| [`eth_getBlockByHash`](/docs/node/metis/metis-api-endpoints/eth-get-block-by-hash)         | [`eth_blockNumber`](/docs/node/metis/metis-api-endpoints/eth-block-number)                         |
+| [`eth_getBlockByNumber`](/docs/node/metis/metis-api-endpoints/eth-get-block-by-number)     | [`eth_getBlockTransactionCountByHash`](/docs/node/metis/metis-api-endpoints/eth-get-block-transaction-count-by-hash) |
+| [`eth_getBlockTransactionCountByNumber`](/docs/node/metis/metis-api-endpoints/eth-get-block-transaction-count-by-number) | [`eth_getTransactionByHash`](/docs/node/metis/metis-api-endpoints/eth-get-transaction-by-hash) |
+| [`eth_getTransactionByBlockHashAndIndex`](/docs/node/metis/metis-api-endpoints/eth-get-transaction-by-block-hash-and-index) | [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/metis/metis-api-endpoints/eth-get-transaction-by-block-number-and-index) |
+| [`eth_getTransactionReceipt`](/docs/node/metis/metis-api-endpoints/eth-get-transaction-receipt) | [`eth_getTransactionCount`](/docs/node/metis/metis-api-endpoints/eth-get-transaction-count)     |
+| [`eth_sendRawTransaction`](/docs/node/metis/metis-api-endpoints/eth-send-raw-transaction)   | [`eth_call`](/docs/node/metis/metis-api-endpoints/eth-call)                                       |
+| [`eth_getCode`](/docs/node/metis/metis-api-endpoints/eth-get-code)                         | [`eth_getBalance`](/docs/node/metis/metis-api-endpoints/eth-get-balance)                           |
+| [`eth_getStorageAt`](/docs/node/metis/metis-api-endpoints/eth-get-storage-at)               | [`eth_getProof`](/docs/node/metis/metis-api-endpoints/eth-get-proof)                               |
+| [`eth_getLogs`](/docs/node/metis/metis-api-endpoints/eth-get-logs)                         | [`eth_chainId`](/docs/node/metis/metis-api-endpoints/eth-chain-id)                                 |
+| [`net_version`](/docs/node/metis/metis-api-endpoints/net-version)                         | [`eth_estimateGas`](/docs/node/metis/metis-api-endpoints/eth-estimate-gas)                         |
+| [`eth_gasPrice`](/docs/node/metis/metis-api-endpoints/eth-gas-price)                       | [`web3_clientVersion`](/docs/node/metis/metis-api-endpoints/web3-client-version)                   |
+| [`web3_sha3`](/docs/node/metis/metis-api-endpoints/web3-sha3)                             |                                                                                                 |
 
 ## Arbitrum Nova APIs
 
@@ -458,18 +461,18 @@ Welcome to the Chain APIs hub, your centralized location for accessing all our a
 
 |                                                                                             |                                                                                                 |
 | ------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| [`eth_getBlockByHash`](/reference/eth-getblockbyhash)                                       | [`eth_blockNumber`](/reference/eth-blocknumber)                                                 |
-| [`eth_getBlockByNumber`](/reference/eth-getblockbynumber)                                   | [`eth_getBlockTransactionCountByHash`](/reference/eth-getblocktransactioncountbyhash)           |
-| [`eth_getBlockTransactionCountByNumber`](/reference/eth-getblocktransactioncountbynumber)   | [`eth_getTransactionByHash`](/reference/eth-gettransactionbyhash)                               |
-| [`eth_getTransactionByBlockHashAndIndex`](/reference/eth-gettransactionbyblockhashandindex) | [`eth_getTransactionByBlockNumberAndIndex`](/reference/eth-gettransactionbyblocknumberandindex) |
-| [`eth_getTransactionReceipt`](/reference/eth-gettransactionreceipt)                         | [`eth_getTransactionCount`](/reference/eth-gettransactioncount)                                 |
-| [`eth_sendRawTransaction`](/reference/eth-sendrawtransaction)                               | [`eth_call`](/reference/eth-call)                                                               |
-| [`eth_getCode`](/reference/eth-getcode)                                                     | [`eth_getBalance`](/reference/eth-getbalance)                                                   |
-| [`eth_getStorageAt`](/reference/eth-getstorageat)                                           | [`eth_getProof`](/reference/eth-getproof)                                                       |
-| [`eth_getLogs`](/reference/eth-getlogs)                                                     | [`eth_chainId`](/reference/eth-chainid)                                                         |
-| [`net_version`](/reference/net-version)                                                     | [`eth_estimateGas`](/reference/eth-estimategas)                                                 |
-| [`eth_gasPrice`](/reference/eth-gasprice)                                                   | [`web3_clientVersion`](/reference/web3-clientversion)                                           |
-| [`web3_sha3`](/reference/web3-sha3)                                                         |                                                                                                 |
+| [`eth_getBlockByHash`](/docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/eth-get-block-by-hash) | [`eth_blockNumber`](/docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/eth-block-number)         |
+| [`eth_getBlockByNumber`](/docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/eth-get-block-by-number) | [`eth_getBlockTransactionCountByHash`](/docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/eth-get-block-transaction-count-by-hash) |
+| [`eth_getBlockTransactionCountByNumber`](/docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/eth-get-block-transaction-count-by-number) | [`eth_getTransactionByHash`](/docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/eth-get-transaction-by-hash) |
+| [`eth_getTransactionByBlockHashAndIndex`](/docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/eth-get-transaction-by-block-hash-and-index) | [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/eth-get-transaction-by-block-number-and-index) |
+| [`eth_getTransactionReceipt`](/docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/eth-get-transaction-receipt) | [`eth_getTransactionCount`](/docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/eth-get-transaction-count) |
+| [`eth_sendRawTransaction`](/docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/eth-send-raw-transaction) | [`eth_call`](/docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/eth-call)                       |
+| [`eth_getCode`](/docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/eth-get-code)           | [`eth_getBalance`](/docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/eth-get-balance)           |
+| [`eth_getStorageAt`](/docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/eth-get-storage-at) | [`eth_getProof`](/docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/eth-get-proof)               |
+| [`eth_getLogs`](/docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/eth-get-logs)           | [`eth_chainId`](/docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/eth-chain-id)                 |
+| [`net_version`](/docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/net-version)           | [`eth_estimateGas`](/docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/eth-estimate-gas)         |
+| [`eth_gasPrice`](/docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/eth-gas-price)         | [`web3_clientVersion`](/docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/web3-client-version)   |
+| [`web3_sha3`](/docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/web3-sha3)               |                                                                                                 |
 
 ## Linea APIs
 
@@ -477,18 +480,18 @@ Welcome to the Chain APIs hub, your centralized location for accessing all our a
 
 |                                                                                             |                                                                                                 |
 | ------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| [`eth_getBlockByHash`](/reference/eth-getblockbyhash)                                       | [`eth_blockNumber`](/reference/eth-blocknumber)                                                 |
-| [`eth_getBlockByNumber`](/reference/eth-getblockbynumber)                                   | [`eth_getBlockTransactionCountByHash`](/reference/eth-getblocktransactioncountbyhash)           |
-| [`eth_getBlockTransactionCountByNumber`](/reference/eth-getblocktransactioncountbynumber)   | [`eth_getTransactionByHash`](/reference/eth-gettransactionbyhash)                               |
-| [`eth_getTransactionByBlockHashAndIndex`](/reference/eth-gettransactionbyblockhashandindex) | [`eth_getTransactionByBlockNumberAndIndex`](/reference/eth-gettransactionbyblocknumberandindex) |
-| [`eth_getTransactionReceipt`](/reference/eth-gettransactionreceipt)                         | [`eth_getTransactionCount`](/reference/eth-gettransactioncount)                                 |
-| [`eth_sendRawTransaction`](/reference/eth-sendrawtransaction)                               | [`eth_call`](/reference/eth-call)                                                               |
-| [`eth_getCode`](/reference/eth-getcode)                                                     | [`eth_getBalance`](/reference/eth-getbalance)                                                   |
-| [`eth_getStorageAt`](/reference/eth-getstorageat)                                           | [`eth_getProof`](/reference/eth-getproof)                                                       |
-| [`eth_getLogs`](/reference/eth-getlogs)                                                     | [`eth_chainId`](/reference/eth-chainid)                                                         |
-| [`net_version`](/reference/net-version)                                                     | [`eth_estimateGas`](/reference/eth-estimategas)                                                 |
-| [`eth_gasPrice`](/reference/eth-gasprice)                                                   | [`web3_clientVersion`](/reference/web3-clientversion)                                           |
-| [`web3_sha3`](/reference/web3-sha3)                                                         | [`linea_estimateGas`](https://docs.linea.build/api/reference/linea-estimategas)                 |
+| [`eth_getBlockByHash`](/docs/node/linea/linea-api-endpoints/eth-get-block-by-hash)         | [`eth_blockNumber`](/docs/node/linea/linea-api-endpoints/eth-block-number)                         |
+| [`eth_getBlockByNumber`](/docs/node/linea/linea-api-endpoints/eth-get-block-by-number)     | [`eth_getBlockTransactionCountByHash`](/docs/node/linea/linea-api-endpoints/eth-get-block-transaction-count-by-hash) |
+| [`eth_getBlockTransactionCountByNumber`](/docs/node/linea/linea-api-endpoints/eth-get-block-transaction-count-by-number) | [`eth_getTransactionByHash`](/docs/node/linea/linea-api-endpoints/eth-get-transaction-by-hash) |
+| [`eth_getTransactionByBlockHashAndIndex`](/docs/node/linea/linea-api-endpoints/eth-get-transaction-by-block-hash-and-index) | [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/linea/linea-api-endpoints/eth-get-transaction-by-block-number-and-index) |
+| [`eth_getTransactionReceipt`](/docs/node/linea/linea-api-endpoints/eth-get-transaction-receipt) | [`eth_getTransactionCount`](/docs/node/linea/linea-api-endpoints/eth-get-transaction-count)     |
+| [`eth_sendRawTransaction`](/docs/node/linea/linea-api-endpoints/eth-send-raw-transaction)   | [`eth_call`](/docs/node/linea/linea-api-endpoints/eth-call)                                       |
+| [`eth_getCode`](/docs/node/linea/linea-api-endpoints/eth-get-code)                         | [`eth_getBalance`](/docs/node/linea/linea-api-endpoints/eth-get-balance)                           |
+| [`eth_getStorageAt`](/docs/node/linea/linea-api-endpoints/eth-get-storage-at)               | [`eth_getProof`](/docs/node/linea/linea-api-endpoints/eth-get-proof)                               |
+| [`eth_getLogs`](/docs/node/linea/linea-api-endpoints/eth-get-logs)                         | [`eth_chainId`](/docs/node/linea/linea-api-endpoints/eth-chain-id)                                 |
+| [`net_version`](/docs/node/linea/linea-api-endpoints/net-version)                         | [`eth_estimateGas`](/docs/node/linea/linea-api-endpoints/eth-estimate-gas)                         |
+| [`eth_gasPrice`](/docs/node/linea/linea-api-endpoints/eth-gas-price)                       | [`web3_clientVersion`](/docs/node/linea/linea-api-endpoints/web3-client-version)                   |
+| [`web3_sha3`](/docs/node/linea/linea-api-endpoints/web3-sha3)                             | [`linea_estimateGas`](https://docs.linea.build/api/reference/linea-estimategas)                   |
 
 ## Mantle APIs
 
@@ -496,18 +499,18 @@ Welcome to the Chain APIs hub, your centralized location for accessing all our a
 
 |                                                                                             |                                                                                                 |
 | ------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| [`eth_getBlockByHash`](/reference/eth-getblockbyhash)                                       | [`eth_blockNumber`](/reference/eth-blocknumber)                                                 |
-| [`eth_getBlockByNumber`](/reference/eth-getblockbynumber)                                   | [`eth_getBlockTransactionCountByHash`](/reference/eth-getblocktransactioncountbyhash)           |
-| [`eth_getBlockTransactionCountByNumber`](/reference/eth-getblocktransactioncountbynumber)   | [`eth_getTransactionByHash`](/reference/eth-gettransactionbyhash)                               |
-| [`eth_getTransactionByBlockHashAndIndex`](/reference/eth-gettransactionbyblockhashandindex) | [`eth_getTransactionByBlockNumberAndIndex`](/reference/eth-gettransactionbyblocknumberandindex) |
-| [`eth_getTransactionReceipt`](/reference/eth-gettransactionreceipt)                         | [`eth_getTransactionCount`](/reference/eth-gettransactioncount)                                 |
-| [`eth_sendRawTransaction`](/reference/eth-sendrawtransaction)                               | [`eth_call`](/reference/eth-call)                                                               |
-| [`eth_getCode`](/reference/eth-getcode)                                                     | [`eth_getBalance`](/reference/eth-getbalance)                                                   |
-| [`eth_getStorageAt`](/reference/eth-getstorageat)                                           | [`eth_getProof`](/reference/eth-getproof)                                                       |
-| [`eth_getLogs`](/reference/eth-getlogs)                                                     | [`eth_chainId`](/reference/eth-chainid)                                                         |
-| [`net_version`](/reference/net-version)                                                     | [`eth_estimateGas`](/reference/eth-estimategas)                                                 |
-| [`eth_gasPrice`](/reference/eth-gasprice)                                                   | [`web3_clientVersion`](/reference/web3-clientversion)                                           |
-| [`web3_sha3`](/reference/web3-sha3)                                                         |                                                                                                 |
+| [`eth_getBlockByHash`](/docs/node/mantle/mantle-api-endpoints/eth-get-block-by-hash)       | [`eth_blockNumber`](/docs/node/mantle/mantle-api-endpoints/eth-block-number)                       |
+| [`eth_getBlockByNumber`](/docs/node/mantle/mantle-api-endpoints/eth-get-block-by-number)   | [`eth_getBlockTransactionCountByHash`](/docs/node/mantle/mantle-api-endpoints/eth-get-block-transaction-count-by-hash) |
+| [`eth_getBlockTransactionCountByNumber`](/docs/node/mantle/mantle-api-endpoints/eth-get-block-transaction-count-by-number) | [`eth_getTransactionByHash`](/docs/node/mantle/mantle-api-endpoints/eth-get-transaction-by-hash) |
+| [`eth_getTransactionByBlockHashAndIndex`](/docs/node/mantle/mantle-api-endpoints/eth-get-transaction-by-block-hash-and-index) | [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/mantle/mantle-api-endpoints/eth-get-transaction-by-block-number-and-index) |
+| [`eth_getTransactionReceipt`](/docs/node/mantle/mantle-api-endpoints/eth-get-transaction-receipt) | [`eth_getTransactionCount`](/docs/node/mantle/mantle-api-endpoints/eth-get-transaction-count)   |
+| [`eth_sendRawTransaction`](/docs/node/mantle/mantle-api-endpoints/eth-send-raw-transaction) | [`eth_call`](/docs/node/mantle/mantle-api-endpoints/eth-call)                                     |
+| [`eth_getCode`](/docs/node/mantle/mantle-api-endpoints/eth-get-code)                       | [`eth_getBalance`](/docs/node/mantle/mantle-api-endpoints/eth-get-balance)                         |
+| [`eth_getStorageAt`](/docs/node/mantle/mantle-api-endpoints/eth-get-storage-at)             | [`eth_getProof`](/docs/node/mantle/mantle-api-endpoints/eth-get-proof)                             |
+| [`eth_getLogs`](/docs/node/mantle/mantle-api-endpoints/eth-get-logs)                       | [`eth_chainId`](/docs/node/mantle/mantle-api-endpoints/eth-chain-id)                               |
+| [`net_version`](/docs/node/mantle/mantle-api-endpoints/net-version)                       | [`eth_estimateGas`](/docs/node/mantle/mantle-api-endpoints/eth-estimate-gas)                       |
+| [`eth_gasPrice`](/docs/node/mantle/mantle-api-endpoints/eth-gas-price)                     | [`web3_clientVersion`](/docs/node/mantle/mantle-api-endpoints/web3-client-version)                 |
+| [`web3_sha3`](/docs/node/mantle/mantle-api-endpoints/web3-sha3)                           |                                                                                                 |
 
 ## Gnosis APIs
 
@@ -515,18 +518,18 @@ Welcome to the Chain APIs hub, your centralized location for accessing all our a
 
 |                                                                                             |                                                                                                 |
 | ------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| [`eth_getBlockByHash`](/reference/eth-getblockbyhash)                                       | [`eth_blockNumber`](/reference/eth-blocknumber)                                                 |
-| [`eth_getBlockByNumber`](/reference/eth-getblockbynumber)                                   | [`eth_getBlockTransactionCountByHash`](/reference/eth-getblocktransactioncountbyhash)           |
-| [`eth_getBlockTransactionCountByNumber`](/reference/eth-getblocktransactioncountbynumber)   | [`eth_getTransactionByHash`](/reference/eth-gettransactionbyhash)                               |
-| [`eth_getTransactionByBlockHashAndIndex`](/reference/eth-gettransactionbyblockhashandindex) | [`eth_getTransactionByBlockNumberAndIndex`](/reference/eth-gettransactionbyblocknumberandindex) |
-| [`eth_getTransactionReceipt`](/reference/eth-gettransactionreceipt)                         | [`eth_getTransactionCount`](/reference/eth-gettransactioncount)                                 |
-| [`eth_sendRawTransaction`](/reference/eth-sendrawtransaction)                               | [`eth_call`](/reference/eth-call)                                                               |
-| [`eth_getCode`](/reference/eth-getcode)                                                     | [`eth_getBalance`](/reference/eth-getbalance)                                                   |
-| [`eth_getStorageAt`](/reference/eth-getstorageat)                                           | [`eth_getProof`](/reference/eth-getproof)                                                       |
-| [`eth_getLogs`](/reference/eth-getlogs)                                                     | [`eth_chainId`](/reference/eth-chainid)                                                         |
-| [`net_version`](/reference/net-version)                                                     | [`eth_estimateGas`](/reference/eth-estimategas)                                                 |
-| [`eth_gasPrice`](/reference/eth-gasprice)                                                   | [`web3_clientVersion`](/reference/web3-clientversion)                                           |
-| [`web3_sha3`](/reference/web3-sha3)                                                         |                                                                                                 |
+| [`eth_getBlockByHash`](/docs/node/gnosis/gnosis-api-endpoints/eth-get-block-by-hash)       | [`eth_blockNumber`](/docs/node/gnosis/gnosis-api-endpoints/eth-block-number)                       |
+| [`eth_getBlockByNumber`](/docs/node/gnosis/gnosis-api-endpoints/eth-get-block-by-number)   | [`eth_getBlockTransactionCountByHash`](/docs/node/gnosis/gnosis-api-endpoints/eth-get-block-transaction-count-by-hash) |
+| [`eth_getBlockTransactionCountByNumber`](/docs/node/gnosis/gnosis-api-endpoints/eth-get-block-transaction-count-by-number) | [`eth_getTransactionByHash`](/docs/node/gnosis/gnosis-api-endpoints/eth-get-transaction-by-hash) |
+| [`eth_getTransactionByBlockHashAndIndex`](/docs/node/gnosis/gnosis-api-endpoints/eth-get-transaction-by-block-hash-and-index) | [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/gnosis/gnosis-api-endpoints/eth-get-transaction-by-block-number-and-index) |
+| [`eth_getTransactionReceipt`](/docs/node/gnosis/gnosis-api-endpoints/eth-get-transaction-receipt) | [`eth_getTransactionCount`](/docs/node/gnosis/gnosis-api-endpoints/eth-get-transaction-count)   |
+| [`eth_sendRawTransaction`](/docs/node/gnosis/gnosis-api-endpoints/eth-send-raw-transaction) | [`eth_call`](/docs/node/gnosis/gnosis-api-endpoints/eth-call)                                     |
+| [`eth_getCode`](/docs/node/gnosis/gnosis-api-endpoints/eth-get-code)                       | [`eth_getBalance`](/docs/node/gnosis/gnosis-api-endpoints/eth-get-balance)                         |
+| [`eth_getStorageAt`](/docs/node/gnosis/gnosis-api-endpoints/eth-get-storage-at)             | [`eth_getProof`](/docs/node/gnosis/gnosis-api-endpoints/eth-get-proof)                             |
+| [`eth_getLogs`](/docs/node/gnosis/gnosis-api-endpoints/eth-get-logs)                       | [`eth_chainId`](/docs/node/gnosis/gnosis-api-endpoints/eth-chain-id)                               |
+| [`net_version`](/docs/node/gnosis/gnosis-api-endpoints/net-version)                       | [`eth_estimateGas`](/docs/node/gnosis/gnosis-api-endpoints/eth-estimate-gas)                       |
+| [`eth_gasPrice`](/docs/node/gnosis/gnosis-api-endpoints/eth-gas-price)                     | [`web3_clientVersion`](/docs/node/gnosis/gnosis-api-endpoints/web3-client-version)                 |
+| [`web3_sha3`](/docs/node/gnosis/gnosis-api-endpoints/web3-sha3)                           |                                                                                                 |
 
 ## opBNB APIs
 
@@ -534,18 +537,18 @@ Welcome to the Chain APIs hub, your centralized location for accessing all our a
 
 |                                                                                             |                                                                                                 |
 | ------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| [`eth_getBlockByHash`](/reference/eth-getblockbyhash)                                       | [`eth_blockNumber`](/reference/eth-blocknumber)                                                 |
-| [`eth_getBlockByNumber`](/reference/eth-getblockbynumber)                                   | [`eth_getBlockTransactionCountByHash`](/reference/eth-getblocktransactioncountbyhash)           |
-| [`eth_getBlockTransactionCountByNumber`](/reference/eth-getblocktransactioncountbynumber)   | [`eth_getTransactionByHash`](/reference/eth-gettransactionbyhash)                               |
-| [`eth_getTransactionByBlockHashAndIndex`](/reference/eth-gettransactionbyblockhashandindex) | [`eth_getTransactionByBlockNumberAndIndex`](/reference/eth-gettransactionbyblocknumberandindex) |
-| [`eth_getTransactionReceipt`](/reference/eth-gettransactionreceipt)                         | [`eth_getTransactionCount`](/reference/eth-gettransactioncount)                                 |
-| [`eth_sendRawTransaction`](/reference/eth-sendrawtransaction)                               | [`eth_call`](/reference/eth-call)                                                               |
-| [`eth_getCode`](/reference/eth-getcode)                                                     | [`eth_getBalance`](/reference/eth-getbalance)                                                   |
-| [`eth_getStorageAt`](/reference/eth-getstorageat)                                           | [`eth_getProof`](/reference/eth-getproof)                                                       |
-| [`eth_getLogs`](/reference/eth-getlogs)                                                     | [`eth_chainId`](/reference/eth-chainid)                                                         |
-| [`net_version`](/reference/net-version)                                                     | [`eth_estimateGas`](/reference/eth-estimategas)                                                 |
-| [`eth_gasPrice`](/reference/eth-gasprice)                                                   | [`web3_clientVersion`](/reference/web3-clientversion)                                           |
-| [`web3_sha3`](/reference/web3-sha3)                                                         |                                                                                                 |
+| [`eth_getBlockByHash`](/docs/node/opbnb/opbnb-api-endpoints/eth-get-block-by-hash)         | [`eth_blockNumber`](/docs/node/opbnb/opbnb-api-endpoints/eth-block-number)                         |
+| [`eth_getBlockByNumber`](/docs/node/opbnb/opbnb-api-endpoints/eth-get-block-by-number)     | [`eth_getBlockTransactionCountByHash`](/docs/node/opbnb/opbnb-api-endpoints/eth-get-block-transaction-count-by-hash) |
+| [`eth_getBlockTransactionCountByNumber`](/docs/node/opbnb/opbnb-api-endpoints/eth-get-block-transaction-count-by-number) | [`eth_getTransactionByHash`](/docs/node/opbnb/opbnb-api-endpoints/eth-get-transaction-by-hash) |
+| [`eth_getTransactionByBlockHashAndIndex`](/docs/node/opbnb/opbnb-api-endpoints/eth-get-transaction-by-block-hash-and-index) | [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/opbnb/opbnb-api-endpoints/eth-get-transaction-by-block-number-and-index) |
+| [`eth_getTransactionReceipt`](/docs/node/opbnb/opbnb-api-endpoints/eth-get-transaction-receipt) | [`eth_getTransactionCount`](/docs/node/opbnb/opbnb-api-endpoints/eth-get-transaction-count)     |
+| [`eth_sendRawTransaction`](/docs/node/opbnb/opbnb-api-endpoints/eth-send-raw-transaction)   | [`eth_call`](/docs/node/opbnb/opbnb-api-endpoints/eth-call)                                       |
+| [`eth_getCode`](/docs/node/opbnb/opbnb-api-endpoints/eth-get-code)                         | [`eth_getBalance`](/docs/node/opbnb/opbnb-api-endpoints/eth-get-balance)                           |
+| [`eth_getStorageAt`](/docs/node/opbnb/opbnb-api-endpoints/eth-get-storage-at)               | [`eth_getProof`](/docs/node/opbnb/opbnb-api-endpoints/eth-get-proof)                               |
+| [`eth_getLogs`](/docs/node/opbnb/opbnb-api-endpoints/eth-get-logs)                         | [`eth_chainId`](/docs/node/opbnb/opbnb-api-endpoints/eth-chain-id)                                 |
+| [`net_version`](/docs/node/opbnb/opbnb-api-endpoints/net-version)                         | [`eth_estimateGas`](/docs/node/opbnb/opbnb-api-endpoints/eth-estimate-gas)                         |
+| [`eth_gasPrice`](/docs/node/opbnb/opbnb-api-endpoints/eth-gas-price)                       | [`web3_clientVersion`](/docs/node/opbnb/opbnb-api-endpoints/web3-client-version)                   |
+| [`web3_sha3`](/docs/node/opbnb/opbnb-api-endpoints/web3-sha3)                             |                                                                                                 |
 
 ## Berachain APIs
 
@@ -553,18 +556,18 @@ Welcome to the Chain APIs hub, your centralized location for accessing all our a
 
 |                                                                                             |                                                                                                 |
 | ------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| [`eth_getBlockByHash`](/reference/eth-getblockbyhash)                                       | [`eth_blockNumber`](/reference/eth-blocknumber)                                                 |
-| [`eth_getBlockByNumber`](/reference/eth-getblockbynumber)                                   | [`eth_getBlockTransactionCountByHash`](/reference/eth-getblocktransactioncountbyhash)           |
-| [`eth_getBlockTransactionCountByNumber`](/reference/eth-getblocktransactioncountbynumber)   | [`eth_getTransactionByHash`](/reference/eth-gettransactionbyhash)                               |
-| [`eth_getTransactionByBlockHashAndIndex`](/reference/eth-gettransactionbyblockhashandindex) | [`eth_getTransactionByBlockNumberAndIndex`](/reference/eth-gettransactionbyblocknumberandindex) |
-| [`eth_getTransactionReceipt`](/reference/eth-gettransactionreceipt)                         | [`eth_getTransactionCount`](/reference/eth-gettransactioncount)                                 |
-| [`eth_sendRawTransaction`](/reference/eth-sendrawtransaction)                               | [`eth_call`](/reference/eth-call)                                                               |
-| [`eth_getCode`](/reference/eth-getcode)                                                     | [`eth_getBalance`](/reference/eth-getbalance)                                                   |
-| [`eth_getStorageAt`](/reference/eth-getstorageat)                                           | [`eth_getProof`](/reference/eth-getproof)                                                       |
-| [`eth_getLogs`](/reference/eth-getlogs)                                                     | [`eth_chainId`](/reference/eth-chainid)                                                         |
-| [`net_version`](/reference/net-version)                                                     | [`eth_estimateGas`](/reference/eth-estimategas)                                                 |
-| [`eth_gasPrice`](/reference/eth-gasprice)                                                   | [`web3_clientVersion`](/reference/web3-clientversion)                                           |
-| [`web3_sha3`](/reference/web3-sha3)                                                         |                                                                                                 |
+| [`eth_getBlockByHash`](/docs/node/berachain/berachain-api-endpoints/eth-get-block-by-hash) | [`eth_blockNumber`](/docs/node/berachain/berachain-api-endpoints/eth-block-number)                 |
+| [`eth_getBlockByNumber`](/docs/node/berachain/berachain-api-endpoints/eth-get-block-by-number) | [`eth_getBlockTransactionCountByHash`](/docs/node/berachain/berachain-api-endpoints/eth-get-block-transaction-count-by-hash) |
+| [`eth_getBlockTransactionCountByNumber`](/docs/node/berachain/berachain-api-endpoints/eth-get-block-transaction-count-by-number) | [`eth_getTransactionByHash`](/docs/node/berachain/berachain-api-endpoints/eth-get-transaction-by-hash) |
+| [`eth_getTransactionByBlockHashAndIndex`](/docs/node/berachain/berachain-api-endpoints/eth-get-transaction-by-block-hash-and-index) | [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/berachain/berachain-api-endpoints/eth-get-transaction-by-block-number-and-index) |
+| [`eth_getTransactionReceipt`](/docs/node/berachain/berachain-api-endpoints/eth-get-transaction-receipt) | [`eth_getTransactionCount`](/docs/node/berachain/berachain-api-endpoints/eth-get-transaction-count) |
+| [`eth_sendRawTransaction`](/docs/node/berachain/berachain-api-endpoints/eth-send-raw-transaction) | [`eth_call`](/docs/node/berachain/berachain-api-endpoints/eth-call)                               |
+| [`eth_getCode`](/docs/node/berachain/berachain-api-endpoints/eth-get-code)                 | [`eth_getBalance`](/docs/node/berachain/berachain-api-endpoints/eth-get-balance)                   |
+| [`eth_getStorageAt`](/docs/node/berachain/berachain-api-endpoints/eth-get-storage-at)       | [`eth_getProof`](/docs/node/berachain/berachain-api-endpoints/eth-get-proof)                       |
+| [`eth_getLogs`](/docs/node/berachain/berachain-api-endpoints/eth-get-logs)                 | [`eth_chainId`](/docs/node/berachain/berachain-api-endpoints/eth-chain-id)                         |
+| [`net_version`](/docs/node/berachain/berachain-api-endpoints/net-version)                 | [`eth_estimateGas`](/docs/node/berachain/berachain-api-endpoints/eth-estimate-gas)                 |
+| [`eth_gasPrice`](/docs/node/berachain/berachain-api-endpoints/eth-gas-price)               | [`web3_clientVersion`](/docs/node/berachain/berachain-api-endpoints/web3-client-version)           |
+| [`web3_sha3`](/docs/node/berachain/berachain-api-endpoints/web3-sha3)                     |                                                                                                 |
 
 ## Flow APIs
 
@@ -572,18 +575,18 @@ Welcome to the Chain APIs hub, your centralized location for accessing all our a
 
 |                                                                                             |                                                                                                 |
 | ------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| [`eth_getBlockByHash`](/reference/eth-getblockbyhash)                                       | [`eth_blockNumber`](/reference/eth-blocknumber)                                                 |
-| [`eth_getBlockByNumber`](/reference/eth-getblockbynumber)                                   | [`eth_getBlockTransactionCountByHash`](/reference/eth-getblocktransactioncountbyhash)           |
-| [`eth_getBlockTransactionCountByNumber`](/reference/eth-getblocktransactioncountbynumber)   | [`eth_getTransactionByHash`](/reference/eth-gettransactionbyhash)                               |
-| [`eth_getTransactionByBlockHashAndIndex`](/reference/eth-gettransactionbyblockhashandindex) | [`eth_getTransactionByBlockNumberAndIndex`](/reference/eth-gettransactionbyblocknumberandindex) |
-| [`eth_getTransactionReceipt`](/reference/eth-gettransactionreceipt)                         | [`eth_getTransactionCount`](/reference/eth-gettransactioncount)                                 |
-| [`eth_sendRawTransaction`](/reference/eth-sendrawtransaction)                               | [`eth_call`](/reference/eth-call)                                                               |
-| [`eth_getCode`](/reference/eth-getcode)                                                     | [`eth_getBalance`](/reference/eth-getbalance)                                                   |
-| [`eth_getStorageAt`](/reference/eth-getstorageat)                                           | [`eth_getProof`](/reference/eth-getproof)                                                       |
-| [`eth_getLogs`](/reference/eth-getlogs)                                                     | [`eth_chainId`](/reference/eth-chainid)                                                         |
-| [`net_version`](/reference/net-version)                                                     | [`eth_estimateGas`](/reference/eth-estimategas)                                                 |
-| [`eth_gasPrice`](/reference/eth-gasprice)                                                   | [`web3_clientVersion`](/reference/web3-clientversion)                                           |
-| [`web3_sha3`](/reference/web3-sha3)                                                         |                                                                                                 |
+| [`eth_getBlockByHash`](/docs/node/flow/flow-api-endpoints/eth-get-block-by-hash)           | [`eth_blockNumber`](/docs/node/flow/flow-api-endpoints/eth-block-number)                           |
+| [`eth_getBlockByNumber`](/docs/node/flow/flow-api-endpoints/eth-get-block-by-number)       | [`eth_getBlockTransactionCountByHash`](/docs/node/flow/flow-api-endpoints/eth-get-block-transaction-count-by-hash) |
+| [`eth_getBlockTransactionCountByNumber`](/docs/node/flow/flow-api-endpoints/eth-get-block-transaction-count-by-number) | [`eth_getTransactionByHash`](/docs/node/flow/flow-api-endpoints/eth-get-transaction-by-hash)   |
+| [`eth_getTransactionByBlockHashAndIndex`](/docs/node/flow/flow-api-endpoints/eth-get-transaction-by-block-hash-and-index) | [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/flow/flow-api-endpoints/eth-get-transaction-by-block-number-and-index) |
+| [`eth_getTransactionReceipt`](/docs/node/flow/flow-api-endpoints/eth-get-transaction-receipt) | [`eth_getTransactionCount`](/docs/node/flow/flow-api-endpoints/eth-get-transaction-count)       |
+| [`eth_sendRawTransaction`](/docs/node/flow/flow-api-endpoints/eth-send-raw-transaction)     | [`eth_call`](/docs/node/flow/flow-api-endpoints/eth-call)                                         |
+| [`eth_getCode`](/docs/node/flow/flow-api-endpoints/eth-get-code)                           | [`eth_getBalance`](/docs/node/flow/flow-api-endpoints/eth-get-balance)                             |
+| [`eth_getStorageAt`](/docs/node/flow/flow-api-endpoints/eth-get-storage-at)                 | [`eth_getProof`](/docs/node/flow/flow-api-endpoints/eth-get-proof)                                 |
+| [`eth_getLogs`](/docs/node/flow/flow-api-endpoints/eth-get-logs)                           | [`eth_chainId`](/docs/node/flow/flow-api-endpoints/eth-chain-id)                                   |
+| [`net_version`](/docs/node/flow/flow-api-endpoints/net-version)                           | [`eth_estimateGas`](/docs/node/flow/flow-api-endpoints/eth-estimate-gas)                           |
+| [`eth_gasPrice`](/docs/node/flow/flow-api-endpoints/eth-gas-price)                         | [`web3_clientVersion`](/docs/node/flow/flow-api-endpoints/web3-client-version)                     |
+| [`web3_sha3`](/docs/node/flow/flow-api-endpoints/web3-sha3)                               |                                                                                                 |
 
 ## CrossFi APIs
 
@@ -591,17 +594,17 @@ Welcome to the Chain APIs hub, your centralized location for accessing all our a
 
 |                                                                                             |                                                                                                 |
 | ------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| [`eth_getBlockByHash`](/reference/eth-getblockbyhash)                                       | [`eth_blockNumber`](/reference/eth-blocknumber)                                                 |
-| [`eth_getBlockByNumber`](/reference/eth-getblockbynumber)                                   | [`eth_getBlockTransactionCountByHash`](/reference/eth-getblocktransactioncountbyhash)           |
-| [`eth_getBlockTransactionCountByNumber`](/reference/eth-getblocktransactioncountbynumber)   | [`eth_getTransactionByHash`](/reference/eth-gettransactionbyhash)                               |
-| [`eth_getTransactionByBlockHashAndIndex`](/reference/eth-gettransactionbyblockhashandindex) | [`eth_getTransactionByBlockNumberAndIndex`](/reference/eth-gettransactionbyblocknumberandindex) |
-| [`eth_getTransactionReceipt`](/reference/eth-gettransactionreceipt)                         | [`eth_getTransactionCount`](/reference/eth-gettransactioncount)                                 |
-| [`eth_sendRawTransaction`](/reference/eth-sendrawtransaction)                               | [`eth_call`](/reference/eth-call)                                                               |
-| [`eth_getCode`](/reference/eth-getcode)                                                     | [`eth_getBalance`](/reference/eth-getbalance)                                                   |
-| [`eth_getLogs`](/reference/eth-getlogs)                                                     | [`eth_chainId`](/reference/eth-chainid)                                                         |
-| [`net_version`](/reference/net-version)                                                     | [`eth_estimateGas`](/reference/eth-estimategas)                                                 |
-| [`eth_gasPrice`](/reference/eth-gasprice)                                                   | [`web3_clientVersion`](/reference/web3-clientversion)                                           |
-| [`web3_sha3`](/reference/web3-sha3)                                                         |                                                                                                 |
+| [`eth_getBlockByHash`](/docs/node/crossfi/crossfi-api-endpoints/eth-get-block-by-hash)     | [`eth_blockNumber`](/docs/node/crossfi/crossfi-api-endpoints/eth-block-number)                     |
+| [`eth_getBlockByNumber`](/docs/node/crossfi/crossfi-api-endpoints/eth-get-block-by-number) | [`eth_getBlockTransactionCountByHash`](/docs/node/crossfi/crossfi-api-endpoints/eth-get-block-transaction-count-by-hash) |
+| [`eth_getBlockTransactionCountByNumber`](/docs/node/crossfi/crossfi-api-endpoints/eth-get-block-transaction-count-by-number) | [`eth_getTransactionByHash`](/docs/node/crossfi/crossfi-api-endpoints/eth-get-transaction-by-hash) |
+| [`eth_getTransactionByBlockHashAndIndex`](/docs/node/crossfi/crossfi-api-endpoints/eth-get-transaction-by-block-hash-and-index) | [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/crossfi/crossfi-api-endpoints/eth-get-transaction-by-block-number-and-index) |
+| [`eth_getTransactionReceipt`](/docs/node/crossfi/crossfi-api-endpoints/eth-get-transaction-receipt) | [`eth_getTransactionCount`](/docs/node/crossfi/crossfi-api-endpoints/eth-get-transaction-count) |
+| [`eth_sendRawTransaction`](/docs/node/crossfi/crossfi-api-endpoints/eth-send-raw-transaction) | [`eth_call`](/docs/node/crossfi/crossfi-api-endpoints/eth-call)                                   |
+| [`eth_getCode`](/docs/node/crossfi/crossfi-api-endpoints/eth-get-code)                     | [`eth_getBalance`](/docs/node/crossfi/crossfi-api-endpoints/eth-get-balance)                       |
+| [`eth_getLogs`](/docs/node/crossfi/crossfi-api-endpoints/eth-get-logs)                     | [`eth_chainId`](/docs/node/crossfi/crossfi-api-endpoints/eth-chain-id)                             |
+| [`net_version`](/docs/node/crossfi/crossfi-api-endpoints/net-version)                     | [`eth_estimateGas`](/docs/node/crossfi/crossfi-api-endpoints/eth-estimate-gas)                     |
+| [`eth_gasPrice`](/docs/node/crossfi/crossfi-api-endpoints/eth-gas-price)                   | [`web3_clientVersion`](/docs/node/crossfi/crossfi-api-endpoints/web3-client-version)               |
+| [`web3_sha3`](/docs/node/crossfi/crossfi-api-endpoints/web3-sha3)                         |                                                                                                 |
 
 ## Scroll APIs
 
@@ -609,17 +612,17 @@ Welcome to the Chain APIs hub, your centralized location for accessing all our a
 
 |                                                                                             |                                                                                                 |
 | ------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| [`eth_getBlockByHash`](/reference/eth-getblockbyhash)                                       | [`eth_blockNumber`](/reference/eth-blocknumber)                                                 |
-| [`eth_getBlockByNumber`](/reference/eth-getblockbynumber)                                   | [`eth_getBlockTransactionCountByHash`](/reference/eth-getblocktransactioncountbyhash)           |
-| [`eth_getBlockTransactionCountByNumber`](/reference/eth-getblocktransactioncountbynumber)   | [`eth_getTransactionByHash`](/reference/eth-gettransactionbyhash)                               |
-| [`eth_getTransactionByBlockHashAndIndex`](/reference/eth-gettransactionbyblockhashandindex) | [`eth_getTransactionByBlockNumberAndIndex`](/reference/eth-gettransactionbyblocknumberandindex) |
-| [`eth_getTransactionReceipt`](/reference/eth-gettransactionreceipt)                         | [`eth_getTransactionCount`](/reference/eth-gettransactioncount)                                 |
-| [`eth_sendRawTransaction`](/reference/eth-sendrawtransaction)                               | [`eth_call`](/reference/eth-call)                                                               |
-| [`eth_getCode`](/reference/eth-getcode)                                                     | [`eth_getBalance`](/reference/eth-getbalance)                                                   |
-| [`eth_getLogs`](/reference/eth-getlogs)                                                     | [`eth_chainId`](/reference/eth-chainid)                                                         |
-| [`net_version`](/reference/net-version)                                                     | [`eth_estimateGas`](/reference/eth-estimategas)                                                 |
-| [`eth_gasPrice`](/reference/eth-gasprice)                                                   | [`web3_clientVersion`](/reference/web3-clientversion)                                           |
-| [`web3_sha3`](/reference/web3-sha3)                                                         |                                                                                                 |
+| [`eth_getBlockByHash`](/docs/node/scroll/scroll-api-endpoints/eth-get-block-by-hash)       | [`eth_blockNumber`](/docs/node/scroll/scroll-api-endpoints/eth-block-number)                       |
+| [`eth_getBlockByNumber`](/docs/node/scroll/scroll-api-endpoints/eth-get-block-by-number)   | [`eth_getBlockTransactionCountByHash`](/docs/node/scroll/scroll-api-endpoints/eth-get-block-transaction-count-by-hash) |
+| [`eth_getBlockTransactionCountByNumber`](/docs/node/scroll/scroll-api-endpoints/eth-get-block-transaction-count-by-number) | [`eth_getTransactionByHash`](/docs/node/scroll/scroll-api-endpoints/eth-get-transaction-by-hash) |
+| [`eth_getTransactionByBlockHashAndIndex`](/docs/node/scroll/scroll-api-endpoints/eth-get-transaction-by-block-hash-and-index) | [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/scroll/scroll-api-endpoints/eth-get-transaction-by-block-number-and-index) |
+| [`eth_getTransactionReceipt`](/docs/node/scroll/scroll-api-endpoints/eth-get-transaction-receipt) | [`eth_getTransactionCount`](/docs/node/scroll/scroll-api-endpoints/eth-get-transaction-count)   |
+| [`eth_sendRawTransaction`](/docs/node/scroll/scroll-api-endpoints/eth-send-raw-transaction) | [`eth_call`](/docs/node/scroll/scroll-api-endpoints/eth-call)                                     |
+| [`eth_getCode`](/docs/node/scroll/scroll-api-endpoints/eth-get-code)                       | [`eth_getBalance`](/docs/node/scroll/scroll-api-endpoints/eth-get-balance)                         |
+| [`eth_getLogs`](/docs/node/scroll/scroll-api-endpoints/eth-get-logs)                       | [`eth_chainId`](/docs/node/scroll/scroll-api-endpoints/eth-chain-id)                               |
+| [`net_version`](/docs/node/scroll/scroll-api-endpoints/net-version)                       | [`eth_estimateGas`](/docs/node/scroll/scroll-api-endpoints/eth-estimate-gas)                       |
+| [`eth_gasPrice`](/docs/node/scroll/scroll-api-endpoints/eth-gas-price)                     | [`web3_clientVersion`](/docs/node/scroll/scroll-api-endpoints/web3-client-version)                 |
+| [`web3_sha3`](/docs/node/scroll/scroll-api-endpoints/web3-sha3)                           |                                                                                                 |
 
 ## Soneium APIs
 
@@ -627,17 +630,17 @@ Welcome to the Chain APIs hub, your centralized location for accessing all our a
 
 |                                                                                             |                                                                                                 |
 | ------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| [`eth_getBlockByHash`](/reference/eth-getblockbyhash)                                       | [`eth_blockNumber`](/reference/eth-blocknumber)                                                 |
-| [`eth_getBlockByNumber`](/reference/eth-getblockbynumber)                                   | [`eth_getBlockTransactionCountByHash`](/reference/eth-getblocktransactioncountbyhash)           |
-| [`eth_getBlockTransactionCountByNumber`](/reference/eth-getblocktransactioncountbynumber)   | [`eth_getTransactionByHash`](/reference/eth-gettransactionbyhash)                               |
-| [`eth_getTransactionByBlockHashAndIndex`](/reference/eth-gettransactionbyblockhashandindex) | [`eth_getTransactionByBlockNumberAndIndex`](/reference/eth-gettransactionbyblocknumberandindex) |
-| [`eth_getTransactionReceipt`](/reference/eth-gettransactionreceipt)                         | [`eth_getTransactionCount`](/reference/eth-gettransactioncount)                                 |
-| [`eth_sendRawTransaction`](/reference/eth-sendrawtransaction)                               | [`eth_call`](/reference/eth-call)                                                               |
-| [`eth_getCode`](/reference/eth-getcode)                                                     | [`eth_getBalance`](/reference/eth-getbalance)                                                   |
-| [`eth_getLogs`](/reference/eth-getlogs)                                                     | [`eth_chainId`](/reference/eth-chainid)                                                         |
-| [`net_version`](/reference/net-version)                                                     | [`eth_estimateGas`](/reference/eth-estimategas)                                                 |
-| [`eth_gasPrice`](/reference/eth-gasprice)                                                   | [`web3_clientVersion`](/reference/web3-clientversion)                                           |
-| [`web3_sha3`](/reference/web3-sha3)                                                         |                                                                                                 |
+| [`eth_getBlockByHash`](/docs/node/soneium/soneium-api-endpoints/eth-get-block-by-hash)     | [`eth_blockNumber`](/docs/node/soneium/soneium-api-endpoints/eth-block-number)                     |
+| [`eth_getBlockByNumber`](/docs/node/soneium/soneium-api-endpoints/eth-get-block-by-number) | [`eth_getBlockTransactionCountByHash`](/docs/node/soneium/soneium-api-endpoints/eth-get-block-transaction-count-by-hash) |
+| [`eth_getBlockTransactionCountByNumber`](/docs/node/soneium/soneium-api-endpoints/eth-get-block-transaction-count-by-number) | [`eth_getTransactionByHash`](/docs/node/soneium/soneium-api-endpoints/eth-get-transaction-by-hash) |
+| [`eth_getTransactionByBlockHashAndIndex`](/docs/node/soneium/soneium-api-endpoints/eth-get-transaction-by-block-hash-and-index) | [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/soneium/soneium-api-endpoints/eth-get-transaction-by-block-number-and-index) |
+| [`eth_getTransactionReceipt`](/docs/node/soneium/soneium-api-endpoints/eth-get-transaction-receipt) | [`eth_getTransactionCount`](/docs/node/soneium/soneium-api-endpoints/eth-get-transaction-count) |
+| [`eth_sendRawTransaction`](/docs/node/soneium/soneium-api-endpoints/eth-send-raw-transaction) | [`eth_call`](/docs/node/soneium/soneium-api-endpoints/eth-call)                                   |
+| [`eth_getCode`](/docs/node/soneium/soneium-api-endpoints/eth-get-code)                     | [`eth_getBalance`](/docs/node/soneium/soneium-api-endpoints/eth-get-balance)                       |
+| [`eth_getLogs`](/docs/node/soneium/soneium-api-endpoints/eth-get-logs)                     | [`eth_chainId`](/docs/node/soneium/soneium-api-endpoints/eth-chain-id)                             |
+| [`net_version`](/docs/node/soneium/soneium-api-endpoints/net-version)                     | [`eth_estimateGas`](/docs/node/soneium/soneium-api-endpoints/eth-estimate-gas)                     |
+| [`eth_gasPrice`](/docs/node/soneium/soneium-api-endpoints/eth-gas-price)                   | [`web3_clientVersion`](/docs/node/soneium/soneium-api-endpoints/web3-client-version)               |
+| [`web3_sha3`](/docs/node/soneium/soneium-api-endpoints/web3-sha3)                         |                                                                                                 |
 
 ## Unichain APIs
 
@@ -645,17 +648,17 @@ Welcome to the Chain APIs hub, your centralized location for accessing all our a
 
 |                                                                                             |                                                                                                 |
 | ------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| [`eth_getBlockByHash`](/reference/eth-getblockbyhash)                                       | [`eth_blockNumber`](/reference/eth-blocknumber)                                                 |
-| [`eth_getBlockByNumber`](/reference/eth-getblockbynumber)                                   | [`eth_getBlockTransactionCountByHash`](/reference/eth-getblocktransactioncountbyhash)           |
-| [`eth_getBlockTransactionCountByNumber`](/reference/eth-getblocktransactioncountbynumber)   | [`eth_getTransactionByHash`](/reference/eth-gettransactionbyhash)                               |
-| [`eth_getTransactionByBlockHashAndIndex`](/reference/eth-gettransactionbyblockhashandindex) | [`eth_getTransactionByBlockNumberAndIndex`](/reference/eth-gettransactionbyblocknumberandindex) |
-| [`eth_getTransactionReceipt`](/reference/eth-gettransactionreceipt)                         | [`eth_getTransactionCount`](/reference/eth-gettransactioncount)                                 |
-| [`eth_sendRawTransaction`](/reference/eth-sendrawtransaction)                               | [`eth_call`](/reference/eth-call)                                                               |
-| [`eth_getCode`](/reference/eth-getcode)                                                     | [`eth_getBalance`](/reference/eth-getbalance)                                                   |
-| [`eth_getLogs`](/reference/eth-getlogs)                                                     | [`eth_chainId`](/reference/eth-chainid)                                                         |
-| [`net_version`](/reference/net-version)                                                     | [`eth_estimateGas`](/reference/eth-estimategas)                                                 |
-| [`eth_gasPrice`](/reference/eth-gasprice)                                                   | [`web3_clientVersion`](/reference/web3-clientversion)                                           |
-| [`web3_sha3`](/reference/web3-sha3)                                                         |                                                                                                 |
+| [`eth_getBlockByHash`](/docs/node/unichain/unichain-api-endpoints/eth-get-block-by-hash)   | [`eth_blockNumber`](/docs/node/unichain/unichain-api-endpoints/eth-block-number)                   |
+| [`eth_getBlockByNumber`](/docs/node/unichain/unichain-api-endpoints/eth-get-block-by-number) | [`eth_getBlockTransactionCountByHash`](/docs/node/unichain/unichain-api-endpoints/eth-get-block-transaction-count-by-hash) |
+| [`eth_getBlockTransactionCountByNumber`](/docs/node/unichain/unichain-api-endpoints/eth-get-block-transaction-count-by-number) | [`eth_getTransactionByHash`](/docs/node/unichain/unichain-api-endpoints/eth-get-transaction-by-hash) |
+| [`eth_getTransactionByBlockHashAndIndex`](/docs/node/unichain/unichain-api-endpoints/eth-get-transaction-by-block-hash-and-index) | [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/unichain/unichain-api-endpoints/eth-get-transaction-by-block-number-and-index) |
+| [`eth_getTransactionReceipt`](/docs/node/unichain/unichain-api-endpoints/eth-get-transaction-receipt) | [`eth_getTransactionCount`](/docs/node/unichain/unichain-api-endpoints/eth-get-transaction-count) |
+| [`eth_sendRawTransaction`](/docs/node/unichain/unichain-api-endpoints/eth-send-raw-transaction) | [`eth_call`](/docs/node/unichain/unichain-api-endpoints/eth-call)                                 |
+| [`eth_getCode`](/docs/node/unichain/unichain-api-endpoints/eth-get-code)                   | [`eth_getBalance`](/docs/node/unichain/unichain-api-endpoints/eth-get-balance)                     |
+| [`eth_getLogs`](/docs/node/unichain/unichain-api-endpoints/eth-get-logs)                   | [`eth_chainId`](/docs/node/unichain/unichain-api-endpoints/eth-chain-id)                           |
+| [`net_version`](/docs/node/unichain/unichain-api-endpoints/net-version)                   | [`eth_estimateGas`](/docs/node/unichain/unichain-api-endpoints/eth-estimate-gas)                   |
+| [`eth_gasPrice`](/docs/node/unichain/unichain-api-endpoints/eth-gas-price)                 | [`web3_clientVersion`](/docs/node/unichain/unichain-api-endpoints/web3-client-version)             |
+| [`web3_sha3`](/docs/node/unichain/unichain-api-endpoints/web3-sha3)                       |                                                                                                 |
 
 ## World Chain APIs
 
@@ -663,26 +666,26 @@ Welcome to the Chain APIs hub, your centralized location for accessing all our a
 
 |                                                                                             |                                                                                                 |
 | ------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| [`eth_getBlockByHash`](/reference/eth-getblockbyhash)                                       | [`eth_getBlockByNumber`](/reference/eth-getblockbynumber)                                       |
-| [`eth_blockNumber`](/reference/eth-blocknumber)                                             | [`eth_getBlockTransactionCountByHash`](/reference/eth-getblocktransactioncountbyhash)           |
-| [`eth_getBlockTransactionCountByNumber`](/reference/eth-getblocktransactioncountbynumber)   | [`eth_getTransactionByHash`](/reference/eth-gettransactionbyhash)                               |
-| [`eth_getTransactionByBlockHashAndIndex`](/reference/eth-gettransactionbyblockhashandindex) | [`eth_getTransactionByBlockNumberAndIndex`](/reference/eth-gettransactionbyblocknumberandindex) |
-| [`eth_getTransactionReceipt`](/reference/eth-gettransactionreceipt)                         | [`eth_getTransactionCount`](/reference/eth-gettransactioncount)                                 |
-| [`eth_sendRawTransaction`](/reference/eth-sendrawtransaction)                               | [`eth_call`](/reference/eth-call)                                                               |
-| [`eth_getCode`](/reference/eth-getcode)                                                     | [`eth_getBalance`](/reference/eth-getbalance)                                                   |
-| [`eth_getStorageAt`](/reference/eth-getstorageat)                                           | [`eth_getLogs`](/reference/eth-getlogs)                                                         |
-| [`eth_getFilterLogs`](/reference/eth-getfilterlogs)                                         | [`eth_getFilterChanges`](/reference/eth-getfilterchanges)                                       |
-| [`eth_newBlockFilter`](/reference/eth-newblockfilter)                                       | [`eth_newFilter`](/reference/eth-newfilter)                                                     |
-| [`eth_uninstallFilter`](/reference/eth-uninstallfilter)                                     | [`eth_chainId`](/reference/eth-chainid)                                                         |
-| [`net_version`](/reference/net-version)                                                     | [`eth_estimateGas`](/reference/eth-estimategas)                                                 |
-| [`eth_gasPrice`](/reference/eth-gasprice)                                                   | [`web3_clientVersion`](/reference/web3-clientversion)                                           |
-| [`web3_sha3`](/reference/web3-sha3)                                                         | [`eth_getUserOperationReceipt`](/reference/eth-getuseroperationreceipt)                         |
-| [`eth_sendUserOperation`](/reference/eth-senduseroperation)                                 | [`eth_estimateUserOperationGas`](/reference/eth-estimateuseroperationgas)                       |
-| [`eth_getUserOperationByHash`](/reference/eth-getuseroperationbyhash)                       | [`eth_supportedEntryPoints`](/reference/eth-supportedentrypoints)                               |
-| [`alchemy_requestGasAndPaymasterAndData`](/reference/alchemy-requestgasandpaymasteranddata) | [`alchemy_requestPaymasterAndData`](/reference/alchemy-requestpaymasteranddata)                 |
-| [`pm_getPaymasterStubData`](/reference/pm-getpaymasterstubdata)                             | [`pm_getPaymasterData`](/reference/pm-getpaymasterdata)                                         |
-| [`alchemy_getTokenBalances`](/reference/alchemy-gettokenbalances)                           | [`alchemy_getTokenAllowance`](/reference/alchemy-gettokenallowance)                             |
-| [`alchemy_getTokenMetadata`](/reference/alchemy-gettokenmetadata)                           | [`alchemy_getAssetTransfers`](/reference/alchemy-getassettransfers)                             |
+| [`eth_getBlockByHash`](/docs/node/world-chain/world-chain-api-endpoints/eth-get-block-by-hash)                                       | [`eth_getBlockByNumber`](/docs/node/world-chain/world-chain-api-endpoints/eth-get-block-by-number)                                       |
+| [`eth_blockNumber`](/docs/node/world-chain/world-chain-api-endpoints/eth-block-number)                                             | [`eth_getBlockTransactionCountByHash`](/docs/node/world-chain/world-chain-api-endpoints/eth-get-block-transaction-count-by-hash)           |
+| [`eth_getBlockTransactionCountByNumber`](/docs/node/world-chain/world-chain-api-endpoints/eth-get-block-transaction-count-by-number)   | [`eth_getTransactionByHash`](/docs/node/world-chain/world-chain-api-endpoints/eth-get-transaction-by-hash)                               |
+| [`eth_getTransactionByBlockHashAndIndex`](/docs/node/world-chain/world-chain-api-endpoints/eth-get-transaction-by-block-hash-and-index) | [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/world-chain/world-chain-api-endpoints/eth-get-transaction-by-block-number-and-index) |
+| [`eth_getTransactionReceipt`](/docs/node/world-chain/world-chain-api-endpoints/eth-get-transaction-receipt)                         | [`eth_getTransactionCount`](/docs/node/world-chain/world-chain-api-endpoints/eth-get-transaction-count)                                 |
+| [`eth_sendRawTransaction`](/docs/node/world-chain/world-chain-api-endpoints/eth-send-raw-transaction)                               | [`eth_call`](/docs/node/world-chain/world-chain-api-endpoints/eth-call)                                                               |
+| [`eth_getCode`](/docs/node/world-chain/world-chain-api-endpoints/eth-get-code)                                                     | [`eth_getBalance`](/docs/node/world-chain/world-chain-api-endpoints/eth-get-balance)                                                   |
+| [`eth_getStorageAt`](/docs/node/world-chain/world-chain-api-endpoints/eth-get-storage-at)                                           | [`eth_getLogs`](/docs/node/world-chain/world-chain-api-endpoints/eth-get-logs)                                                         |
+| [`eth_getFilterLogs`](/docs/node/world-chain/world-chain-api-endpoints/eth-get-filter-logs)                                         | [`eth_getFilterChanges`](/docs/node/world-chain/world-chain-api-endpoints/eth-get-filter-changes)                                       |
+| [`eth_newBlockFilter`](/docs/node/world-chain/world-chain-api-endpoints/eth-new-block-filter)                                       | [`eth_newFilter`](/docs/node/world-chain/world-chain-api-endpoints/eth-new-filter)                                                     |
+| [`eth_uninstallFilter`](/docs/node/world-chain/world-chain-api-endpoints/eth-uninstall-filter)                                     | [`eth_chainId`](/docs/node/world-chain/world-chain-api-endpoints/eth-chain-id)                                                         |
+| [`net_version`](/docs/node/world-chain/world-chain-api-endpoints/net-version)                                                     | [`eth_estimateGas`](/docs/node/world-chain/world-chain-api-endpoints/eth-estimate-gas)                                                 |
+| [`eth_gasPrice`](/docs/node/world-chain/world-chain-api-endpoints/eth-gas-price)                                                   | [`web3_clientVersion`](/docs/node/world-chain/world-chain-api-endpoints/web3-client-version)                                           |
+| [`web3_sha3`](/docs/node/world-chain/world-chain-api-endpoints/web3-sha3)                                                         | [`eth_getUserOperationReceipt`](/docs/node/world-chain/world-chain-api-endpoints/eth-get-user-operation-receipt)                         |
+| [`eth_sendUserOperation`](/docs/node/world-chain/world-chain-api-endpoints/eth-send-user-operation)                                 | [`eth_estimateUserOperationGas`](/docs/node/world-chain/world-chain-api-endpoints/eth-estimate-user-operation-gas)                       |
+| [`eth_getUserOperationByHash`](/docs/node/world-chain/world-chain-api-endpoints/eth-get-user-operation-by-hash)                     | [`eth_supportedEntryPoints`](/docs/node/world-chain/world-chain-api-endpoints/eth-supported-entry-points)                               |
+| [`alchemy_requestGasAndPaymasterAndData`](/docs/node/world-chain/world-chain-api-endpoints/alchemy-request-gas-and-paymaster-and-data) | [`alchemy_requestPaymasterAndData`](/docs/node/world-chain/world-chain-api-endpoints/alchemy-request-paymaster-and-data)                 |
+| [`pm_getPaymasterStubData`](/docs/node/world-chain/world-chain-api-endpoints/pm-get-paymaster-stub-data)                             | [`pm_getPaymasterData`](/docs/node/world-chain/world-chain-api-endpoints/pm-get-paymaster-data)                                         |
+| [`alchemy_getTokenBalances`](/docs/node/world-chain/world-chain-api-endpoints/alchemy-get-token-balances)                           | [`alchemy_getTokenAllowance`](/docs/node/world-chain/world-chain-api-endpoints/alchemy-get-token-allowance)                             |
+| [`alchemy_getTokenMetadata`](/docs/node/world-chain/world-chain-api-endpoints/alchemy-get-token-metadata)                           | [`alchemy_getAssetTransfers`](/docs/node/world-chain/world-chain-api-endpoints/alchemy-get-asset-transfers)                             |
 
 ## Rootstock APIs
 
@@ -690,26 +693,26 @@ Welcome to the Chain APIs hub, your centralized location for accessing all our a
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_getBlockByHash`](/reference/eth-getblockbyhash)                                           | [`eth_getBlockByNumber`](/reference/eth-getblockbynumber)                                   |
-| [`eth_blockNumber`](/reference/eth-blocknumber)                                                 | [`eth_getBlockTransactionCountByHash`](/reference/eth-getblocktransactioncountbyhash)       |
-| [`eth_getTransactionByHash`](/reference/eth-gettransactionbyhash)                               | [`eth_getTransactionByBlockHashAndIndex`](/reference/eth-gettransactionbyblockhashandindex) |
-| [`eth_getTransactionByBlockNumberAndIndex`](/reference/eth-gettransactionbyblocknumberandindex) | [`eth_getTransactionReceipt`](/reference/eth-gettransactionreceipt)                         |
-| [`eth_getTransactionCount`](/reference/eth-gettransactioncount)                                 | [`eth_call`](/reference/eth-call)                                                           |
-| [`eth_getCode`](/reference/eth-getcode)                                                         | [`eth_getBalance`](/reference/eth-getbalance)                                               |
-| [`eth_accounts`](/reference/eth-accounts)                                                       | [`eth_getStorageAt`](/reference/eth-getstorageat)                                           |
-| [`eth_getLogs`](/reference/eth-getlogs)                                                         | [`eth_newFilter`](/reference/eth-newfilter)                                                 |
-| [`eth_newPendingTransactionFilter`](/reference/eth-newpendingtransactionfilter)                 | [`eth_newBlockFilter`](/reference/eth-newblockfilter)                                       |
-| [`eth_getFilterChanges`](/reference/eth-getfilterchanges)                                       | [`eth_getFilterLogs`](/reference/eth-getfilterlogs)                                         |
-| [`eth_uninstallFilter`](/reference/eth-uninstallfilter)                                         | [`eth_chainId`](/reference/eth-chainid)                                                     |
-| [`eth_protocolVersion`](/reference/eth-protocolversion)                                         | [`net_listening`](/reference/net-listening)                                                 |
-| [`net_version`](/reference/net-version)                                                         | [`eth_getUncleByBlockNumberAndIndex`](/reference/eth-getunclebyblocknumberandindex)         |
-| [`eth_getUncleByBlockHashAndIndex`](/reference/eth-getunclebyblockhashandindex)                 | [`eth_getUncleCountByBlockNumber`](/reference/eth-getunclecountbyblocknumber)               |
-| [`eth_estimateGas`](/reference/eth-estimategas)                                                 | [`eth_gasPrice`](/reference/eth-gasprice)                                                   |
-| [`web3_clientVersion`](/reference/web3-clientversion)                                           | [`web3_sha3`](/reference/web3-sha3)                                                         |
-| [`net_peerCount`](/reference/net-peercount)                                                     | [`eth_syncing`](/reference/eth-syncing)                                                     |
-| [`eth_coinbase`](/reference/eth-coinbase)                                                       | [`eth_mining`](/reference/eth-mining)                                                       |
-| [`eth_hashrate`](/reference/eth-hashrate)                                                       | [`debug_traceTransaction`](/reference/debug-tracetransaction)                               |
-| [`debug_traceBlockByHash`](/reference/debug-traceblockbyhash)                                   |                                                                                             |
+| [`eth_getBlockByHash`](/docs/node/rootstock/rootstock-api-endpoints/eth-get-block-by-hash)     | [`eth_getBlockByNumber`](/docs/node/rootstock/rootstock-api-endpoints/eth-get-block-by-number) |
+| [`eth_blockNumber`](/docs/node/rootstock/rootstock-api-endpoints/eth-block-number)             | [`eth_getBlockTransactionCountByHash`](/docs/node/rootstock/rootstock-api-endpoints/eth-get-block-transaction-count-by-hash) |
+| [`eth_getTransactionByHash`](/docs/node/rootstock/rootstock-api-endpoints/eth-get-transaction-by-hash) | [`eth_getTransactionByBlockHashAndIndex`](/docs/node/rootstock/rootstock-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
+| [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/rootstock/rootstock-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionReceipt`](/docs/node/rootstock/rootstock-api-endpoints/eth-get-transaction-receipt) |
+| [`eth_getTransactionCount`](/docs/node/rootstock/rootstock-api-endpoints/eth-get-transaction-count) | [`eth_call`](/docs/node/rootstock/rootstock-api-endpoints/eth-call)                         |
+| [`eth_getCode`](/docs/node/rootstock/rootstock-api-endpoints/eth-get-code)                     | [`eth_getBalance`](/docs/node/rootstock/rootstock-api-endpoints/eth-get-balance)             |
+| [`eth_accounts`](/docs/node/rootstock/rootstock-api-endpoints/eth-accounts)                   | [`eth_getStorageAt`](/docs/node/rootstock/rootstock-api-endpoints/eth-get-storage-at)       |
+| [`eth_getLogs`](/docs/node/rootstock/rootstock-api-endpoints/eth-get-logs)                     | [`eth_newFilter`](/docs/node/rootstock/rootstock-api-endpoints/eth-new-filter)               |
+| [`eth_newPendingTransactionFilter`](/docs/node/rootstock/rootstock-api-endpoints/eth-new-pending-transaction-filter) | [`eth_newBlockFilter`](/docs/node/rootstock/rootstock-api-endpoints/eth-new-block-filter) |
+| [`eth_getFilterChanges`](/docs/node/rootstock/rootstock-api-endpoints/eth-get-filter-changes) | [`eth_getFilterLogs`](/docs/node/rootstock/rootstock-api-endpoints/eth-get-filter-logs)     |
+| [`eth_uninstallFilter`](/docs/node/rootstock/rootstock-api-endpoints/eth-uninstall-filter)     | [`eth_chainId`](/docs/node/rootstock/rootstock-api-endpoints/eth-chain-id)                   |
+| [`eth_protocolVersion`](/docs/node/rootstock/rootstock-api-endpoints/eth-protocol-version)     | [`net_listening`](/docs/node/rootstock/rootstock-api-endpoints/net-listening)               |
+| [`net_version`](/docs/node/rootstock/rootstock-api-endpoints/net-version)                     | [`eth_getUncleByBlockNumberAndIndex`](/docs/node/rootstock/rootstock-api-endpoints/eth-get-uncle-by-block-number-and-index) |
+| [`eth_getUncleByBlockHashAndIndex`](/docs/node/rootstock/rootstock-api-endpoints/eth-get-uncle-by-block-hash-and-index) | [`eth_getUncleCountByBlockHash`](/docs/node/rootstock/rootstock-api-endpoints/eth-get-uncle-count-by-block-hash) |
+| [`eth_getUncleCountByBlockNumber`](/docs/node/rootstock/rootstock-api-endpoints/eth-get-uncle-count-by-block-number) | [`eth_estimateGas`](/docs/node/rootstock/rootstock-api-endpoints/eth-estimate-gas)         |
+| [`web3_clientVersion`](/docs/node/rootstock/rootstock-api-endpoints/web3-client-version)       | [`web3_sha3`](/docs/node/rootstock/rootstock-api-endpoints/web3-sha3)                       |
+| [`net_peerCount`](/docs/node/rootstock/rootstock-api-endpoints/net-peer-count)                 | [`eth_syncing`](/docs/node/rootstock/rootstock-api-endpoints/eth-syncing)                   |
+| [`eth_coinbase`](/docs/node/rootstock/rootstock-api-endpoints/eth-coinbase)                   | [`eth_mining`](/docs/node/rootstock/rootstock-api-endpoints/eth-mining)                     |
+| [`eth_hashrate`](/docs/node/rootstock/rootstock-api-endpoints/eth-hashrate)                   | [`debug_traceTransaction`](/docs/node/rootstock/rootstock-api-endpoints/debug-trace-transaction) |
+| [`debug_traceBlockByHash`](/docs/node/rootstock/rootstock-api-endpoints/debug-trace-block-by-hash) |                                                                                             |
 
 ## Shape APIs
 
@@ -717,285 +720,23 @@ Welcome to the Chain APIs hub, your centralized location for accessing all our a
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_getBlockByHash`](/reference/eth-getblockbyhash)                                           | [`eth_blockNumber`](/reference/eth-blocknumber)                                             |
-| [`eth_getBlockByNumber`](/reference/eth-getblockbynumber)                                       | [`eth_getBlockReceipts`](/reference/eth-getblockreceipts)                                   |
-| [`eth_getBlockTransactionCountByHash`](/reference/eth-getblocktransactioncountbyhash)           | [`eth_getBlockTransactionCountByNumber`](/reference/eth-getblocktransactioncountbynumber)   |
-| [`eth_getTransactionByHash`](/reference/eth-gettransactionbyhash)                               | [`eth_getTransactionByBlockHashAndIndex`](/reference/eth-gettransactionbyblockhashandindex) |
-| [`eth_getTransactionByBlockNumberAndIndex`](/reference/eth-gettransactionbyblocknumberandindex) | [`eth_getTransactionReceipt`](/reference/eth-gettransactionreceipt)                         |
-| [`eth_getTransactionCount`](/reference/eth-gettransactioncount)                                 | [`eth_call`](/reference/eth-call)                                                           |
-| [`eth_getCode`](/reference/eth-getcode)                                                         | [`eth_getBalance`](/reference/eth-getbalance)                                               |
-| [`eth_accounts`](/reference/eth-accounts)                                                       | [`eth_getStorageAt`](/reference/eth-getstorageat)                                           |
-| [`eth_getProof`](/reference/eth-getproof)                                                       | [`eth_getLogs`](/reference/eth-getlogs)                                                     |
-| [`eth_newFilter`](/reference/eth-newfilter)                                                     | [`eth_newPendingTransactionFilter`](/reference/eth-newpendingtransactionfilter)             |
-| [`eth_newBlockFilter`](/reference/eth-newblockfilter)                                           | [`eth_getFilterChanges`](/reference/eth-getfilterchanges)                                   |
-| [`eth_getFilterLogs`](/reference/eth-getfilterlogs)                                             | [`eth_uninstallFilter`](/reference/eth-uninstallfilter)                                     |
-| [`eth_chainId`](/reference/eth-chainid)                                                         | [`net_listening`](/reference/net-listening)                                                 |
-| [`net_version`](/reference/net-version)                                                         | [`eth_getUncleCountByBlockHash`](/reference/eth-getunclecountbyblockhash)                   |
-| [`eth_getUncleByBlockNumberAndIndex`](/reference/eth-getunclebyblocknumberandindex)             | [`eth_getUncleByBlockHashAndIndex`](/reference/eth-getunclebyblockhashandindex)             |
-| [`eth_getUncleCountByBlockNumber`](/reference/eth-getunclecountbyblocknumber)                   | [`eth_estimateGas`](/reference/eth-estimategas)                                             |
-| [`eth_gasPrice`](/reference/eth-gasprice)                                                       | [`eth_feeHistory`](/reference/eth-feehistory)                                               |
-| [`eth_maxPriorityFeePerGas`](/reference/eth-maxpriorityfeepergas)                               | [`eth_createAccessList`](/reference/eth-createaccesslist)                                   |
-| [`web3_clientVersion`](/reference/web3-clientversion)                                           | [`web3_sha3`](/reference/web3-sha3)                                                         |
-| [`debug_traceCall`](/reference/debug-tracecall)                                                 | [`debug_traceTransaction`](/reference/debug-tracetransaction)                               |
-| [`debug_traceBlockByNumber`](/reference/debug-traceblockbynumber)                               | [`debug_traceBlockByHash`](/reference/debug-traceblockbyhash)                               |
-| [`trace_block`](/reference/trace-block)                                                         | [`eth_syncing`](/reference/eth-syncing)                                                     |
-
-## ApeChain APIs
-
-📙 Get started with our [ApeChain API Quickstart](/reference/apechain-api-quickstart)
-
-|                                                                                                 |                                                                                             |
-| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_getBlockByHash`](/reference/eth-getblockbyhash)                                           | [`eth_blockNumber`](/reference/eth-blocknumber)                                             |
-| [`eth_getBlockByNumber`](/reference/eth-getblockbynumber)                                       | [`eth_getBlockReceipts`](/reference/eth-getblockreceipts)                                   |
-| [`eth_getBlockTransactionCountByHash`](/reference/eth-getblocktransactioncountbyhash)           | [`eth_getBlockTransactionCountByNumber`](/reference/eth-getblocktransactioncountbynumber)   |
-| [`eth_getTransactionByHash`](/reference/eth-gettransactionbyhash)                               | [`eth_getTransactionByBlockHashAndIndex`](/reference/eth-gettransactionbyblockhashandindex) |
-| [`eth_getTransactionByBlockNumberAndIndex`](/reference/eth-gettransactionbyblocknumberandindex) | [`eth_getTransactionReceipt`](/reference/eth-gettransactionreceipt)                         |
-| [`eth_getTransactionCount`](/reference/eth-gettransactioncount)                                 | [`eth_call`](/reference/eth-call)                                                           |
-| [`eth_getCode`](/reference/eth-getcode)                                                         | [`eth_getBalance`](/reference/eth-getbalance)                                               |
-| [`eth_getStorageAt`](/reference/eth-getstorageat)                                               | [`eth_getProof`](/reference/eth-getproof)                                                   |
-| [`eth_getLogs`](/reference/eth-getlogs)                                                         | [`eth_chainId`](/reference/eth-chainid)                                                     |
-| [`net_version`](/reference/net-version)                                                         | [`eth_getUncleCountByBlockHash`](/reference/eth-getunclecountbyblockhash)                   |
-| [`eth_getUncleByBlockNumberAndIndex`](/reference/eth-getunclebyblocknumberandindex)             | [`eth_getUncleByBlockHashAndIndex`](/reference/eth-getunclebyblockhashandindex)             |
-| [`eth_getUncleCountByBlockNumber`](/reference/eth-getunclecountbyblocknumber)                   | [`eth_estimateGas`](/reference/eth-estimategas)                                             |
-| [`eth_gasPrice`](/reference/eth-gasprice)                                                       | [`eth_feeHistory`](/reference/eth-feehistory)                                               |
-| [`eth_maxPriorityFeePerGas`](/reference/eth-maxpriorityfeepergas)                               | [`eth_createAccessList`](/reference/eth-createaccesslist)                                   |
-| [`web3_clientVersion`](/reference/web3-clientversion)                                           | [`web3_sha3`](/reference/web3-sha3)                                                         |
-| [`debug_traceCall`](/reference/debug-tracecall)                                                 | [`debug_traceTransaction`](/reference/debug-tracetransaction)                               |
-| [`debug_traceBlockByNumber`](/reference/debug-traceblockbynumber)                               | [`debug_traceBlockByHash`](/reference/debug-traceblockbyhash)                               |
-| [`eth_syncing`](/reference/eth-syncing)                                                         | [`eth_accounts`](/reference/eth-accounts)                                                   |
-| [`eth_newFilter`](/reference/eth-newfilter)                                                     | [`eth_newPendingTransactionFilter`](/reference/eth-newpendingtransactionfilter)             |
-| [`eth_newBlockFilter`](/reference/eth-newblockfilter)                                           | [`eth_getFilterChanges`](/reference/eth-getfilterchanges)                                   |
-| [`eth_getFilterLogs`](/reference/eth-getfilterlogs)                                             | [`eth_uninstallFilter`](/reference/eth-uninstallfilter)                                     |
-
-## Geist APIs
-
-📙 Get started with our [Geist API Quickstart](/reference/geist-api-quickstart)
-
-|                                                                                                 |                                                                                             |
-| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_getBlockByHash`](/reference/eth-getblockbyhash)                                           | [`eth_blockNumber`](/reference/eth-blocknumber)                                             |
-| [`eth_getBlockByNumber`](/reference/eth-getblockbynumber)                                       | [`eth_getBlockReceipts`](/reference/eth-getblockreceipts)                                   |
-| [`eth_getBlockTransactionCountByHash`](/reference/eth-getblocktransactioncountbyhash)           | [`eth_getBlockTransactionCountByNumber`](/reference/eth-getblocktransactioncountbynumber)   |
-| [`eth_getTransactionByHash`](/reference/eth-gettransactionbyhash)                               | [`eth_getTransactionByBlockHashAndIndex`](/reference/eth-gettransactionbyblockhashandindex) |
-| [`eth_getTransactionByBlockNumberAndIndex`](/reference/eth-gettransactionbyblocknumberandindex) | [`eth_getTransactionReceipt`](/reference/eth-gettransactionreceipt)                         |
-| [`eth_getTransactionCount`](/reference/eth-gettransactioncount)                                 | [`eth_call`](/reference/eth-call)                                                           |
-| [`eth_getCode`](/reference/eth-getcode)                                                         | [`eth_getBalance`](/reference/eth-getbalance)                                               |
-| [`eth_getStorageAt`](/reference/eth-getstorageat)                                               | [`eth_getProof`](/reference/eth-getproof)                                                   |
-| [`eth_getLogs`](/reference/eth-getlogs)                                                         | [`eth_chainId`](/reference/eth-chainid)                                                     |
-| [`net_version`](/reference/net-version)                                                         | [`eth_getUncleCountByBlockHash`](/reference/eth-getunclecountbyblockhash)                   |
-| [`eth_getUncleByBlockNumberAndIndex`](/reference/eth-getunclebyblocknumberandindex)             | [`eth_getUncleByBlockHashAndIndex`](/reference/eth-getunclebyblockhashandindex)             |
-| [`eth_getUncleCountByBlockNumber`](/reference/eth-getunclecountbyblocknumber)                   | [`eth_estimateGas`](/reference/eth-estimategas)                                             |
-| [`eth_gasPrice`](/reference/eth-gasprice)                                                       | [`eth_feeHistory`](/reference/eth-feehistory)                                               |
-| [`eth_maxPriorityFeePerGas`](/reference/eth-maxpriorityfeepergas)                               | [`eth_createAccessList`](/reference/eth-createaccesslist)                                   |
-| [`web3_clientVersion`](/reference/web3-clientversion)                                           | [`web3_sha3`](/reference/web3-sha3)                                                         |
-| [`debug_traceCall`](/reference/debug-tracecall)                                                 | [`debug_traceTransaction`](/reference/debug-tracetransaction)                               |
-| [`debug_traceBlockByNumber`](/reference/debug-traceblockbynumber)                               | [`debug_traceBlockByHash`](/reference/debug-traceblockbyhash)                               |
-| [`eth_syncing`](/reference/eth-syncing)                                                         | [`eth_accounts`](/reference/eth-accounts)                                                   |
-| [`eth_newFilter`](/reference/eth-newfilter)                                                     | [`eth_newPendingTransactionFilter`](/reference/eth-newpendingtransactionfilter)             |
-| [`eth_newBlockFilter`](/reference/eth-newblockfilter)                                           | [`eth_getFilterChanges`](/reference/eth-getfilterchanges)                                   |
-| [`eth_getFilterLogs`](/reference/eth-getfilterlogs)                                             | [`eth_uninstallFilter`](/reference/eth-uninstallfilter)                                     |
-
-## Lens APIs
-
-📙 Get started with our [Lens API Quickstart](/reference/lens-api-quickstart)
-
-|                                                                                                 |                                                                                             |
-| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_getBlockByHash`](/reference/eth-getblockbyhash)                                           | [`eth_blockNumber`](/reference/eth-blocknumber)                                             |
-| [`eth_getBlockByNumber`](/reference/eth-getblockbynumber)                                       | [`eth_getBlockReceipts`](/reference/eth-getblockreceipts)                                   |
-| [`eth_getBlockTransactionCountByHash`](/reference/eth-getblocktransactioncountbyhash)           | [`eth_getBlockTransactionCountByNumber`](/reference/eth-getblocktransactioncountbynumber)   |
-| [`eth_getTransactionByHash`](/reference/eth-gettransactionbyhash)                               | [`eth_getTransactionByBlockHashAndIndex`](/reference/eth-gettransactionbyblockhashandindex) |
-| [`eth_getTransactionByBlockNumberAndIndex`](/reference/eth-gettransactionbyblocknumberandindex) | [`eth_getTransactionReceipt`](/reference/eth-gettransactionreceipt)                         |
-| [`eth_getTransactionCount`](/reference/eth-gettransactioncount)                                 | [`eth_call`](/reference/eth-call)                                                           |
-| [`eth_getCode`](/reference/eth-getcode)                                                         | [`eth_getBalance`](/reference/eth-getbalance)                                               |
-| [`eth_getStorageAt`](/reference/eth-getstorageat)                                               | [`eth_getLogs`](/reference/eth-getlogs)                                                     |
-| [`eth_chainId`](/reference/eth-chainid)                                                         | [`net_version`](/reference/net-version)                                                     |
-| [`eth_getUncleCountByBlockHash`](/reference/eth-getunclecountbyblockhash)                       | [`eth_getUncleCountByBlockNumber`](/reference/eth-getunclecountbyblocknumber)               |
-| [`eth_estimateGas`](/reference/eth-estimategas)                                                 | [`eth_gasPrice`](/reference/eth-gasprice)                                                   |
-| [`eth_feeHistory`](/reference/eth-feehistory)                                                   | [`web3_clientVersion`](/reference/web3-clientversion)                                       |
-| [`web3_sha3`](/reference/web3-sha3)                                                             | [`debug_traceCall`](/reference/debug-tracecall)                                             |
-| [`debug_traceTransaction`](/reference/debug-tracetransaction)                                   | [`debug_traceBlockByNumber`](/reference/debug-traceblockbynumber)                           |
-| [`debug_traceBlockByHash`](/reference/debug-traceblockbyhash)                                   | [`eth_syncing`](/reference/eth-syncing)                                                     |
-| [`eth_accounts`](/reference/eth-accounts)                                                       | [`eth_newFilter`](/reference/eth-newfilter)                                                 |
-| [`eth_newPendingTransactionFilter`](/reference/eth-newpendingtransactionfilter)                 | [`eth_newBlockFilter`](/reference/eth-newblockfilter)                                       |
-| [`eth_getFilterChanges`](/reference/eth-getfilterchanges)                                       | [`eth_getFilterLogs`](/reference/eth-getfilterlogs)                                         |
-| [`eth_uninstallFilter`](/reference/eth-uninstallfilter)                                         |                                                                                             |
-
-## Ink APIs
-
-📙 Get started with our [Ink API Quickstart](/reference/ink-api-quickstart)
-
-|                                                                                                 |                                                                                             |
-| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_getBlockByHash`](/reference/eth-getblockbyhash)                                           | [`eth_blockNumber`](/reference/eth-blocknumber)                                             |
-| [`eth_getBlockByNumber`](/reference/eth-getblockbynumber)                                       | [`eth_getBlockReceipts`](/reference/eth-getblockreceipts)                                   |
-| [`eth_getBlockTransactionCountByHash`](/reference/eth-getblocktransactioncountbyhash)           | [`eth_getBlockTransactionCountByNumber`](/reference/eth-getblocktransactioncountbynumber)   |
-| [`eth_getTransactionByHash`](/reference/eth-gettransactionbyhash)                               | [`eth_getTransactionByBlockHashAndIndex`](/reference/eth-gettransactionbyblockhashandindex) |
-| [`eth_getTransactionByBlockNumberAndIndex`](/reference/eth-gettransactionbyblocknumberandindex) | [`eth_getTransactionReceipt`](/reference/eth-gettransactionreceipt)                         |
-| [`eth_getTransactionCount`](/reference/eth-gettransactioncount)                                 | [`eth_sendRawTransaction`](/reference/eth-sendrawtransaction)                               |
-| [`eth_call`](/reference/eth-call)                                                               | [`eth_getCode`](/reference/eth-getcode)                                                     |
-| [`eth_getBalance`](/reference/eth-getbalance)                                                   | [`eth_accounts`](/reference/eth-accounts)                                                   |
-| [`eth_getStorageAt`](/reference/eth-getstorageat)                                               | [`eth_getProof`](/reference/eth-getproof)                                                   |
-| [`eth_getLogs`](/reference/eth-getlogs)                                                         | [`eth_newFilter`](/reference/eth-newfilter)                                                 |
-| [`eth_newPendingTransactionFilter`](/reference/eth-newpendingtransactionfilter)                 | [`eth_newBlockFilter`](/reference/eth-newblockfilter)                                       |
-| [`eth_getFilterChanges`](/reference/eth-getfilterchanges)                                       | [`eth_getFilterLogs`](/reference/eth-getfilterlogs)                                         |
-| [`eth_uninstallFilter`](/reference/eth-uninstallfilter)                                         | [`eth_chainId`](/reference/eth-chainid)                                                     |
-| [`net_listening`](/reference/net-listening)                                                     | [`net_version`](/reference/net-version)                                                     |
-| [`eth_getUncleCountByBlockHash`](/reference/eth-getunclecountbyblockhash)                       | [`eth_getUncleByBlockNumberAndIndex`](/reference/eth-getunclebyblocknumberandindex)         |
-| [`eth_getUncleByBlockHashAndIndex`](/reference/eth-getunclebyblockhashandindex)                 | [`eth_getUncleCountByBlockNumber`](/reference/eth-getunclecountbyblocknumber)               |
-| [`eth_estimateGas`](/reference/eth-estimategas)                                                 | [`eth_gasPrice`](/reference/eth-gasprice)                                                   |
-| [`eth_feeHistory`](/reference/eth-feehistory)                                                   | [`eth_maxPriorityFeePerGas`](/reference/eth-maxpriorityfeepergas)                           |
-| [`eth_createAccessList`](/reference/eth-createaccesslist)                                       | [`web3_clientVersion`](/reference/web3-clientversion)                                       |
-| [`web3_sha3`](/reference/web3-sha3)                                                             | [`debug_traceCall`](/reference/debug-tracecall)                                             |
-| [`debug_traceTransaction`](/reference/debug-tracetransaction)                                   | [`debug_traceBlockByNumber`](/reference/debug-traceblockbynumber)                           |
-| [`debug_traceBlockByHash`](/reference/debug-traceblockbyhash)                                   | [`net_peerCount`](/reference/net-peercount-bnb)                                             |
-| [`eth_syncing`](/reference/eth-syncing-base)                                                    |                                                                                             |
-
-## Abstract APIs
-
-📙 Get started with our [Abstract API Quickstart](/reference/abstract-api-quickstart)
-
-|                                                                                                 |                                                                                             |
-| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_getBlockByHash`](/reference/eth-getblockbyhash)                                           | [`eth_blockNumber`](/reference/eth-blocknumber)                                             |
-| [`eth_getBlockByNumber`](/reference/eth-getblockbynumber)                                       | [`eth_getBlockReceipts`](/reference/eth-getblockreceipts)                                   |
-| [`eth_getBlockTransactionCountByHash`](/reference/eth-getblocktransactioncountbyhash)           | [`eth_getTransactionByBlockHashAndIndex`](/reference/eth-gettransactionbyblockhashandindex) |
-| [`eth_getTransactionByHash`](/reference/eth-gettransactionbyhash)                               | [`eth_getTransactionReceipt`](/reference/eth-gettransactionreceipt)                         |
-| [`eth_getTransactionByBlockNumberAndIndex`](/reference/eth-gettransactionbyblocknumberandindex) | [`eth_call`](/reference/eth-call)                                                           |
-| [`eth_getTransactionCount`](/reference/eth-gettransactioncount)                                 | [`eth_getBalance`](/reference/eth-getbalance)                                               |
-| [`eth_getCode`](/reference/eth-getcode)                                                         | [`eth_getLogs`](/reference/eth-getlogs)                                                     |
-| [`eth_getStorageAt`](/reference/eth-getstorageat)                                               | [`net_version`](/reference/net-version)                                                     |
-| [`eth_chainId`](/reference/eth-chainid)                                                         | [`eth_getUncleCountByBlockNumber`](/reference/eth-getunclecountbyblocknumber)               |
-| [`eth_getUncleCountByBlockHash`](/reference/eth-getunclecountbyblockhash)                       | [`eth_gasPrice`](/reference/eth-gasprice)                                                   |
-| [`eth_feeHistory`](/reference/eth-feehistory)                                                   | [`eth_protocolVersion`](/reference/eth-protocolversion)                                     |
-| [`web3_clientVersion`](/reference/web3-clientversion)                                           | [`net_listening`](/reference/net-listening)                                                 |
-| [`eth_accounts`](/reference/eth-accounts)                                                       | [`eth_newFilter`](/reference/eth-newfilter)                                                 |
-| [`eth_newPendingTransactionFilter`](/reference/eth-newpendingtransactionfilter)                 | [`eth_newBlockFilter`](/reference/eth-newblockfilter)                                       |
-| [`eth_uninstallFilter`](/reference/eth-uninstallfilter)                                         | [`eth_getFilterLogs`](/reference/eth-getfilterlogs)                                         |
-| [`debug_traceTransaction`](/reference/debug-tracetransaction)                                   |                                                                                             |
-
-## Celo APIs
-
-📙 Get started with our [Celo API Quickstart](/reference/celo-chain-api-quickstart)
-
-|                                                                                                  |                                                                                                      |
-| ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| [`eth_getBlockByHash`](/reference/eth-getblockbyhash-base)                                       | [`eth_blocknumber`](/reference/eth-blocknumber-base)                                                 |
-| [`eth_getBlockReceipts`](/reference/eth-getblockreceipts-base)                                   | [`eth_getBlockByNumber`](/reference/eth-getblockbynumber-base)                                       |
-| [`eth_getBlockTransactionCountByNumber`](/reference/eth-getblocktransactioncountbynumber-base)   | [`eth_getBlockTransactionCountByHash`](/reference/eth-getblocktransactioncountbyhash-base)           |
-| [`eth_getTransactionByBlockHashAndIndex`](/reference/eth-gettransactionbyblockhashandindex-base) | [`eth_getTransactionByHash`](/reference/eth-gettransactionbyhash-base)                               |
-| [`eth_getTransactionReceipt`](/reference/eth-gettransactionreceipt-base)                         | [`eth_getTransactionByBlockNumberAndIndex`](/reference/eth-gettransactionbyblocknumberandindex-base) |
-| [`eth_sendRawTransaction`](/reference/eth-sendrawtransaction-base)                               | [`eth_getTransactionCount`](/reference/eth-gettransactioncount-base)                                 |
-| [`eth_getCode`](/reference/eth-getcode-base)                                                     | [`eth_call`](/reference/eth-call-base)                                                               |
-| [`eth_accounts`](/reference/eth-accounts-base)                                                   | [`eth_getBalance`](/reference/eth-getbalance-base)                                                   |
-| [`eth_getProof`](/reference/eth-getproof-base)                                                   | [`eth_getStorageAt`](/reference/eth-getstorageat-base)                                               |
-| [`eth_newFilter`](/reference/eth-newfilter-base)                                                 | [`eth_getLogs`](/reference/eth-getlogs-base)                                                         |
-| [`eth_newBlockFilter`](/reference/eth-newblockfilter-base)                                       | [`eth_newPendingTransactionFilter`](/reference/eth-newpendingtransactionfilter-base)                 |
-| [`eth_getFilterLogs`](/reference/eth-getfilterlogs-base)                                         | [`eth_getFilterChanges`](/reference/eth-getfilterchanges-base)                                       |
-| [`eth_chainId`](/reference/eth-chainid-base)                                                     | [`eth_uninstallFilter`](/reference/eth-uninstallfilter-base)                                         |
-| [`net_listening`](/reference/net-listening-base)                                                 | [`eth_protocolVersion`](/reference/eth-protocolversion-base)                                         |
-| [`eth_getUncleCountByBlockHash`](/reference/eth-getunclecountbyblockhash-base)                   | [`net_version`](/reference/net-version-base)                                                         |
-| [`eth_getUncleByBlockHashAndIndex`](/reference/eth-getunclebyblockhashandindex-base)             | [`eth_getUncleByBlockNumberAndIndex`](/reference/eth-getunclebyblocknumberandindex-base)             |
-| [`eth_estimateGas`](/reference/eth-estimategas-base)                                             | [`eth_getUncleCountByBlockNumber`](/reference/eth-getunclecountbyblocknumber-base)                   |
-| [`eth_feeHistory`](/reference/eth-feehistory-base)                                               | [`eth_gasPrice`](/reference/eth-gasprice-base)                                                       |
-| [`eth_createAccessList`](/reference/eth-createaccesslist-base)                                   | [`eth_maxPriorityFeePerGas`](/reference/eth-maxpriorityfeepergas-base)                               |
-| [`web3_sha3`](/reference/web3-sha3-base)                                                         | [`web3_clientVersion`](/reference/web3-clientversion-base)                                           |
-| [`eth_unsubscribe`](/reference/eth-unsubscribe-base)                                             | [`eth_subscribe`](/reference/eth-subscribe-base)                                                     |
-
-## Anime APIs
-
-📙 Get started with our [Anime API Quickstart](https://www.alchemy.com/docs/reference/anime-api-quickstart)
-
-| Method | Method |
-| ------ | ------ |
-| [eth_accounts](https://www.alchemy.com/docs/node/anime/anime-api-endpoints/eth-accounts) | [eth_blockNumber](https://www.alchemy.com/docs/node/anime/anime-api-endpoints/eth-block-number) |
-| [eth_call](https://www.alchemy.com/docs/node/anime/anime-api-endpoints/eth-call) | [eth_chainId](https://www.alchemy.com/docs/node/anime/anime-api-endpoints/eth-chain-id) |
-| [eth_createAccessList](https://www.alchemy.com/docs/node/anime/anime-api-endpoints/eth-create-access-list) | [eth_estimateGas](https://www.alchemy.com/docs/node/anime/anime-api-endpoints/eth-estimate-gas) |
-| [eth_feeHistory](https://www.alchemy.com/docs/node/anime/anime-api-endpoints/eth-fee-history) | [eth_gasPrice](https://www.alchemy.com/docs/node/anime/anime-api-endpoints/eth-gas-price) |
-| [eth_getBalance](https://www.alchemy.com/docs/node/anime/anime-api-endpoints/eth-get-balance) | [eth_getBlockByHash](https://www.alchemy.com/docs/node/anime/anime-api-endpoints/eth-get-block-by-hash) |
-| [eth_getBlockByNumber](https://www.alchemy.com/docs/node/anime/anime-api-endpoints/eth-get-block-by-number) | [eth_getBlockReceipts](https://www.alchemy.com/docs/node/anime/anime-api-endpoints/eth-get-block-receipts) |
-| [eth_getBlockTransactionCountByHash](https://www.alchemy.com/docs/node/anime/anime-api-endpoints/eth-get-block-transaction-count-by-hash) | [eth_getBlockTransactionCountByNumber](https://www.alchemy.com/docs/node/anime/anime-api-endpoints/eth-get-block-transaction-count-by-number) |
-| [eth_getCode](https://www.alchemy.com/docs/node/anime/anime-api-endpoints/eth-get-code) | [eth_getFilterChanges](https://www.alchemy.com/docs/node/anime/anime-api-endpoints/eth-get-filter-changes) |
-| [eth_getFilterLogs](https://www.alchemy.com/docs/node/anime/anime-api-endpoints/eth-get-filter-logs) | [eth_getLogs](https://www.alchemy.com/docs/node/anime/anime-api-endpoints/eth-get-logs) |
-| [eth_getProof](https://www.alchemy.com/docs/node/anime/anime-api-endpoints/eth-get-proof) | [eth_getStorageAt](https://www.alchemy.com/docs/node/anime/anime-api-endpoints/eth-get-storage-at) |
-| [eth_getTransactionByBlockHashAndIndex](https://www.alchemy.com/docs/node/anime/anime-api-endpoints/eth-get-transaction-by-block-hash-and-index) | [eth_getTransactionByBlockNumberAndIndex](https://www.alchemy.com/docs/node/anime/anime-api-endpoints/eth-get-transaction-by-block-number-and-index) |
-| [eth_getTransactionByHash](https://www.alchemy.com/docs/node/anime/anime-api-endpoints/eth-get-transaction-by-hash) | [eth_getTransactionCount](https://www.alchemy.com/docs/node/anime/anime-api-endpoints/eth-get-transaction-count) |
-| [eth_getTransactionReceipt](https://www.alchemy.com/docs/node/anime/anime-api-endpoints/eth-get-transaction-receipt) | [eth_getUncleByBlockHashAndIndex](https://www.alchemy.com/docs/node/anime/anime-api-endpoints/eth-get-uncle-by-block-hash-and-index) |
-| [eth_getUncleByBlockNumberAndIndex](https://www.alchemy.com/docs/node/anime/anime-api-endpoints/eth-get-uncle-by-block-number-and-index) | [eth_getUncleCountByBlockHash](https://www.alchemy.com/docs/node/anime/anime-api-endpoints/eth-get-uncle-count-by-block-hash) |
-| [eth_getUncleCountByBlockNumber](https://www.alchemy.com/docs/node/anime/anime-api-endpoints/eth-get-uncle-count-by-block-number) | [eth_maxPriorityFeePerGas](https://www.alchemy.com/docs/node/anime/anime-api-endpoints/eth-max-priority-fee-per-gas) |
-| [eth_newBlockFilter](https://www.alchemy.com/docs/node/anime/anime-api-endpoints/eth-new-block-filter) | [eth_newFilter](https://www.alchemy.com/docs/node/anime/anime-api-endpoints/eth-new-filter) |
-| [eth_newPendingTransactionFilter](https://www.alchemy.com/docs/node/anime/anime-api-endpoints/eth-new-pending-transaction-filter) | [eth_protocolVersion](https://www.alchemy.com/docs/node/anime/anime-api-endpoints/eth-protocol-version) |
-| [eth_sendRawTransaction](https://www.alchemy.com/docs/node/anime/anime-api-endpoints/eth-send-raw-transaction) | [eth_simulateV1](https://www.alchemy.com/docs/node/anime/anime-api-endpoints/eth-simulate-v-1) |
-| [eth_syncing](https://www.alchemy.com/docs/node/anime/anime-api-endpoints/eth-syncing) | [eth_uninstallFilter](https://www.alchemy.com/docs/node/anime/anime-api-endpoints/eth-uninstall-filter) |
-| [net_listening](https://www.alchemy.com/docs/node/anime/anime-api-endpoints/net-listening) | [net_version](https://www.alchemy.com/docs/node/anime/anime-api-endpoints/net-version) |
-| [web3_clientVersion](https://www.alchemy.com/docs/node/anime/anime-api-endpoints/web-3-client-version) | [web3_sha3](https://www.alchemy.com/docs/node/anime/anime-api-endpoints/web-3-sha3) |
-
-## Story APIs
-
-📙 Get started with our [Story API Quickstart](https://www.alchemy.com/docs/reference/story-api-quickstart)
-
-| Method | Method |
-| ------ | ------ |
-| [eth_accounts](https://www.alchemy.com/docs/node/story/story-api-endpoints/eth-accounts) | [eth_blockNumber](https://www.alchemy.com/docs/node/story/story-api-endpoints/eth-block-number) |
-| [eth_call](https://www.alchemy.com/docs/node/story/story-api-endpoints/eth-call) | [eth_chainId](https://www.alchemy.com/docs/node/story/story-api-endpoints/eth-chain-id) |
-| [eth_createAccessList](https://www.alchemy.com/docs/node/story/story-api-endpoints/eth-create-access-list) | [eth_estimateGas](https://www.alchemy.com/docs/node/story/story-api-endpoints/eth-estimate-gas) |
-| [eth_feeHistory](https://www.alchemy.com/docs/node/story/story-api-endpoints/eth-fee-history) | [eth_gasPrice](https://www.alchemy.com/docs/node/story/story-api-endpoints/eth-gas-price) |
-| [eth_getBalance](https://www.alchemy.com/docs/node/story/story-api-endpoints/eth-get-balance) | [eth_getBlockByHash](https://www.alchemy.com/docs/node/story/story-api-endpoints/eth-get-block-by-hash) |
-| [eth_getBlockByNumber](https://www.alchemy.com/docs/node/story/story-api-endpoints/eth-get-block-by-number) | [eth_getBlockReceipts](https://www.alchemy.com/docs/node/story/story-api-endpoints/eth-get-block-receipts) |
-| [eth_getBlockTransactionCountByHash](https://www.alchemy.com/docs/node/story/story-api-endpoints/eth-get-block-transaction-count-by-hash) | [eth_getBlockTransactionCountByNumber](https://www.alchemy.com/docs/node/story/story-api-endpoints/eth-get-block-transaction-count-by-number) |
-| [eth_getCode](https://www.alchemy.com/docs/node/story/story-api-endpoints/eth-get-code) | [eth_getFilterChanges](https://www.alchemy.com/docs/node/story/story-api-endpoints/eth-get-filter-changes) |
-| [eth_getFilterLogs](https://www.alchemy.com/docs/node/story/story-api-endpoints/eth-get-filter-logs) | [eth_getLogs](https://www.alchemy.com/docs/node/story/story-api-endpoints/eth-get-logs) |
-| [eth_getProof](https://www.alchemy.com/docs/node/story/story-api-endpoints/eth-get-proof) | [eth_getStorageAt](https://www.alchemy.com/docs/node/story/story-api-endpoints/eth-get-storage-at) |
-| [eth_getTransactionByBlockHashAndIndex](https://www.alchemy.com/docs/node/story/story-api-endpoints/eth-get-transaction-by-block-hash-and-index) | [eth_getTransactionByBlockNumberAndIndex](https://www.alchemy.com/docs/node/story/story-api-endpoints/eth-get-transaction-by-block-number-and-index) |
-| [eth_getTransactionByHash](https://www.alchemy.com/docs/node/story/story-api-endpoints/eth-get-transaction-by-hash) | [eth_getTransactionCount](https://www.alchemy.com/docs/node/story/story-api-endpoints/eth-get-transaction-count) |
-| [eth_getTransactionReceipt](https://www.alchemy.com/docs/node/story/story-api-endpoints/eth-get-transaction-receipt) | [eth_getUncleByBlockHashAndIndex](https://www.alchemy.com/docs/node/story/story-api-endpoints/eth-get-uncle-by-block-hash-and-index) |
-| [eth_getUncleByBlockNumberAndIndex](https://www.alchemy.com/docs/node/story/story-api-endpoints/eth-get-uncle-by-block-number-and-index) | [eth_getUncleCountByBlockHash](https://www.alchemy.com/docs/node/story/story-api-endpoints/eth-get-uncle-count-by-block-hash) |
-| [eth_getUncleCountByBlockNumber](https://www.alchemy.com/docs/node/story/story-api-endpoints/eth-get-uncle-count-by-block-number) | [eth_maxPriorityFeePerGas](https://www.alchemy.com/docs/node/story/story-api-endpoints/eth-max-priority-fee-per-gas) |
-| [eth_newBlockFilter](https://www.alchemy.com/docs/node/story/story-api-endpoints/eth-new-block-filter) | [eth_newFilter](https://www.alchemy.com/docs/node/story/story-api-endpoints/eth-new-filter) |
-| [eth_newPendingTransactionFilter](https://www.alchemy.com/docs/node/story/story-api-endpoints/eth-new-pending-transaction-filter) | [eth_protocolVersion](https://www.alchemy.com/docs/node/story/story-api-endpoints/eth-protocol-version) |
-| [eth_sendRawTransaction](https://www.alchemy.com/docs/node/story/story-api-endpoints/eth-send-raw-transaction) | [eth_simulateV1](https://www.alchemy.com/docs/node/story/story-api-endpoints/eth-simulate-v-1) |
-| [eth_syncing](https://www.alchemy.com/docs/node/story/story-api-endpoints/eth-syncing) | [eth_uninstallFilter](https://www.alchemy.com/docs/node/story/story-api-endpoints/eth-uninstall-filter) |
-| [net_listening](https://www.alchemy.com/docs/node/story/story-api-endpoints/net-listening) | [net_version](https://www.alchemy.com/docs/node/story/story-api-endpoints/net-version) |
-| [web3_clientVersion](https://www.alchemy.com/docs/node/story/story-api-endpoints/web-3-client-version) | [web3_sha3](https://www.alchemy.com/docs/node/story/story-api-endpoints/web-3-sha3) |
-
-## Botanix APIs
-
-📙 Get started with our [Botanix API Quickstart](https://www.alchemy.com/docs/reference/botanix-api-quickstart)
-
-| Method | Method |
-| ------ | ------ |
-| [eth_accounts](https://www.alchemy.com/docs/node/botanix/botanix-api-endpoints/eth-accounts) | [eth_blockNumber](https://www.alchemy.com/docs/node/botanix/botanix-api-endpoints/eth-block-number) |
-| [eth_call](https://www.alchemy.com/docs/node/botanix/botanix-api-endpoints/eth-call) | [eth_chainId](https://www.alchemy.com/docs/node/botanix/botanix-api-endpoints/eth-chain-id) |
-| [eth_createAccessList](https://www.alchemy.com/docs/node/botanix/botanix-api-endpoints/eth-create-access-list) | [eth_estimateGas](https://www.alchemy.com/docs/node/botanix/botanix-api-endpoints/eth-estimate-gas) |
-| [eth_feeHistory](https://www.alchemy.com/docs/node/botanix/botanix-api-endpoints/eth-fee-history) | [eth_gasPrice](https://www.alchemy.com/docs/node/botanix/botanix-api-endpoints/eth-gas-price) |
-| [eth_getBalance](https://www.alchemy.com/docs/node/botanix/botanix-api-endpoints/eth-get-balance) | [eth_getBlockByHash](https://www.alchemy.com/docs/node/botanix/botanix-api-endpoints/eth-get-block-by-hash) |
-| [eth_getBlockByNumber](https://www.alchemy.com/docs/node/botanix/botanix-api-endpoints/eth-get-block-by-number) | [eth_getBlockReceipts](https://www.alchemy.com/docs/node/botanix/botanix-api-endpoints/eth-get-block-receipts) |
-| [eth_getBlockTransactionCountByHash](https://www.alchemy.com/docs/node/botanix/botanix-api-endpoints/eth-get-block-transaction-count-by-hash) | [eth_getBlockTransactionCountByNumber](https://www.alchemy.com/docs/node/botanix/botanix-api-endpoints/eth-get-block-transaction-count-by-number) |
-| [eth_getCode](https://www.alchemy.com/docs/node/botanix/botanix-api-endpoints/eth-get-code) | [eth_getFilterChanges](https://www.alchemy.com/docs/node/botanix/botanix-api-endpoints/eth-get-filter-changes) |
-| [eth_getFilterLogs](https://www.alchemy.com/docs/node/botanix/botanix-api-endpoints/eth-get-filter-logs) | [eth_getLogs](https://www.alchemy.com/docs/node/botanix/botanix-api-endpoints/eth-get-logs) |
-| [eth_getProof](https://www.alchemy.com/docs/node/botanix/botanix-api-endpoints/eth-get-proof) | [eth_getStorageAt](https://www.alchemy.com/docs/node/botanix/botanix-api-endpoints/eth-get-storage-at) |
-| [eth_getTransactionByBlockHashAndIndex](https://www.alchemy.com/docs/node/botanix/botanix-api-endpoints/eth-get-transaction-by-block-hash-and-index) | [eth_getTransactionByBlockNumberAndIndex](https://www.alchemy.com/docs/node/botanix/botanix-api-endpoints/eth-get-transaction-by-block-number-and-index) |
-| [eth_getTransactionByHash](https://www.alchemy.com/docs/node/botanix/botanix-api-endpoints/eth-get-transaction-by-hash) | [eth_getTransactionCount](https://www.alchemy.com/docs/node/botanix/botanix-api-endpoints/eth-get-transaction-count) |
-| [eth_getTransactionReceipt](https://www.alchemy.com/docs/node/botanix/botanix-api-endpoints/eth-get-transaction-receipt) | [eth_getUncleByBlockHashAndIndex](https://www.alchemy.com/docs/node/botanix/botanix-api-endpoints/eth-get-uncle-by-block-hash-and-index) |
-| [eth_getUncleByBlockNumberAndIndex](https://www.alchemy.com/docs/node/botanix/botanix-api-endpoints/eth-get-uncle-by-block-number-and-index) | [eth_getUncleCountByBlockHash](https://www.alchemy.com/docs/node/botanix/botanix-api-endpoints/eth-get-uncle-count-by-block-hash) |
-| [eth_getUncleCountByBlockNumber](https://www.alchemy.com/docs/node/botanix/botanix-api-endpoints/eth-get-uncle-count-by-block-number) | [eth_maxPriorityFeePerGas](https://www.alchemy.com/docs/node/botanix/botanix-api-endpoints/eth-max-priority-fee-per-gas) |
-| [eth_newBlockFilter](https://www.alchemy.com/docs/node/botanix/botanix-api-endpoints/eth-new-block-filter) | [eth_newFilter](https://www.alchemy.com/docs/node/botanix/botanix-api-endpoints/eth-new-filter) |
-| [eth_newPendingTransactionFilter](https://www.alchemy.com/docs/node/botanix/botanix-api-endpoints/eth-new-pending-transaction-filter) | [eth_protocolVersion](https://www.alchemy.com/docs/node/botanix/botanix-api-endpoints/eth-protocol-version) |
-| [eth_sendRawTransaction](https://www.alchemy.com/docs/node/botanix/botanix-api-endpoints/eth-send-raw-transaction) | [eth_simulateV1](https://www.alchemy.com/docs/node/botanix/botanix-api-endpoints/eth-simulate-v-1) |
-| [eth_syncing](https://www.alchemy.com/docs/node/botanix/botanix-api-endpoints/eth-syncing) | [eth_uninstallFilter](https://www.alchemy.com/docs/node/botanix/botanix-api-endpoints/eth-uninstall-filter) |
-| [net_listening](https://www.alchemy.com/docs/node/botanix/botanix-api-endpoints/net-listening) | [net_version](https://www.alchemy.com/docs/node/botanix/botanix-api-endpoints/net-version) |
-| [web3_clientVersion](https://www.alchemy.com/docs/node/botanix/botanix-api-endpoints/web-3-client-version) | [web3_sha3](https://www.alchemy.com/docs/node/botanix/botanix-api-endpoints/web-3-sha3) |
-
-## Debug and Trace APIs
-
-The *debug* and *trace* API methods are used to debug and inspect transactions. You can get detailed insights into transactions using these APIs. They are supported on all networks except Astar and Solana. Get started with our [Debug API Quickstart](/reference/debug-api-quickstart) and [Trace API Quickstart](/reference/trace-api-quickstart) guides.
-
-|                                                                   |                                                               |
-| ----------------------------------------------------------------- | ------------------------------------------------------------- |
-| [`debug_traceCall`](/reference/debug-tracecall)                   | [`debug_traceBlockByHash`](/reference/debug-traceblockbyhash) |
-| [`debug_traceBlockByNumber`](/reference/debug-traceblockbynumber) | [`debug_traceTransaction`](/reference/debug-tracetransaction) |
-| [`trace_call`](/reference/trace-call)                             | [`trace_block`](/reference/trace-block)                       |
-| [`trace_get`](/reference/trace-get)                               | [`trace_filter`](/reference/trace-filter)                     |
-| [`trace_transaction`](/reference/trace-transaction)               | [`trace_rawTransaction`](/reference/trace-rawtransaction)     |
-| [`trace_replayTransaction`](/reference/trace-replaytransaction)   |                                                               |
+| [`eth_getBlockByHash`](/docs/node/shape/shape-api-endpoints/eth-get-block-by-hash)             | [`eth_blockNumber`](/docs/node/shape/shape-api-endpoints/eth-block-number)                   |
+| [`eth_getBlockByNumber`](/docs/node/shape/shape-api-endpoints/eth-get-block-by-number)         | [`eth_getBlockReceipts`](/docs/node/shape/shape-api-endpoints/eth-get-block-receipts)       |
+| [`eth_getBlockTransactionCountByHash`](/docs/node/shape/shape-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/node/shape/shape-api-endpoints/eth-get-block-transaction-count-by-number) |
+| [`eth_getTransactionByHash`](/docs/node/shape/shape-api-endpoints/eth-get-transaction-by-hash) | [`eth_getTransactionByBlockHashAndIndex`](/docs/node/shape/shape-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
+| [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/shape/shape-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionReceipt`](/docs/node/shape/shape-api-endpoints/eth-get-transaction-receipt) |
+| [`eth_getTransactionCount`](/docs/node/shape/shape-api-endpoints/eth-get-transaction-count)     | [`eth_call`](/docs/node/shape/shape-api-endpoints/eth-call)                                 |
+| [`eth_getCode`](/docs/node/shape/shape-api-endpoints/eth-get-code)                             | [`eth_getBalance`](/docs/node/shape/shape-api-endpoints/eth-get-balance)                     |
+| [`eth_accounts`](/docs/node/shape/shape-api-endpoints/eth-accounts)                           | [`eth_getStorageAt`](/docs/node/shape/shape-api-endpoints/eth-get-storage-at)               |
+| [`eth_getProof`](/docs/node/shape/shape-api-endpoints/eth-get-proof)                           | [`eth_getLogs`](/docs/node/shape/shape-api-endpoints/eth-get-logs)                           |
+| [`eth_newFilter`](/docs/node/shape/shape-api-endpoints/eth-new-filter)                         | [`eth_newPendingTransactionFilter`](/docs/node/shape/shape-api-endpoints/eth-new-pending-transaction-filter) |
+| [`eth_newBlockFilter`](/docs/node/shape/shape-api-endpoints/eth-new-block-filter)               | [`eth_getFilterChanges`](/docs/node/shape/shape-api-endpoints/eth-get-filter-changes)       |
+| [`eth_getFilterLogs`](/docs/node/shape/shape-api-endpoints/eth-get-filter-logs)                 | [`eth_uninstallFilter`](/docs/node/shape/shape-api-endpoints/eth-uninstall-filter)         |
+| [`eth_chainId`](/docs/node/shape/shape-api-endpoints/eth-chain-id)                             | [`net_listening`](/docs/node/shape/shape-api-endpoints/net-listening)                       |
+| [`net_version`](/docs/node/shape/shape-api-endpoints/net-version)                             | [`eth_getUncleCountByBlockHash`](/docs/node/shape/shape-api-endpoints/eth-get-uncle-count-by-block-hash) |
+| [`eth_getUncleByBlockNumberAndIndex`](/docs/node/shape/shape-api-endpoints/eth-get-uncle-by-block-number-and-index) | [`eth_getUncleByBlockHashAndIndex`](/docs/node/shape/shape-api-endpoints/eth-get-uncle-by-block-hash-and-index) |
+| [`eth_getUncleCountByBlockNumber`](/docs/node/shape/shape-api-endpoints/eth-get-uncle-count-by-block-number) | [`eth_estimateGas`](/docs/node/shape/shape-api-endpoints/eth-estimate-gas)                 |
+| [`eth_gasPrice`](/docs/node/shape/shape-api-endpoints/eth-gas-price)                           | [`eth_feeHistory`](/docs/node/shape/shape-api-endpoints/eth-fee-history)                     |
+| [`eth_maxPriorityFeePerGas`](/docs/node/shape/shape-api-endpoints/eth-max-priority-fee-per-gas) | [`eth_createAccessList`](/docs/node/shape/shape-api-endpoints/eth-create-access-list)       |
+| [`web3_clientVersion`](/docs/node/shape/shape-api-endpoints/web3-client-version)               | [`web3_sha3`](/docs/node/shape/shape-api-endpoints/web3-sha3)                               |
+| \[\`


### PR DESCRIPTION
Before we migrated to Fern, we would piggyback all docs off the `Ethereum` parent section, but now that we have pages for each API endpoint under each chain, we are linking to each one directly.