### PR TITLE
Fix faucet test parsing

### DIFF
--- a/fern/tutorials/alchemy-university/smart-contract-basics/how-to-unit-test-a-smart-contract.mdx
+++ b/fern/tutorials/alchemy-university/smart-contract-basics/how-to-unit-test-a-smart-contract.mdx
@@ -219,7 +219,7 @@ As opposed to the first unit test, we will the [**Revert** Chai Matcher](https:/
 
 <CodeGroup>
   ```javascript javascript
-  let withdrawAmount = ethers.utils.parseUnits("1", "ether");
+  let withdrawAmount = ethers.parseUnits("1", "ether");
   ```
 </CodeGroup>
 
@@ -255,7 +255,7 @@ Go ahead and change the value to be less than .1 ETH and see the terminal get an
 
       const [owner] = await ethers.getSigners();
 
-      let withdrawAmount = ethers.utils.parseUnits('1', 'ether');
+      let withdrawAmount = ethers.parseUnits('1', 'ether');
 
       return { faucet, owner, withdrawAmount };
     }


### PR DESCRIPTION
## Description
- fix withdrawAmount variable by removing `utils` property

## Related Issues
- n/a

## Changes Made
- corrected ethers parseUnits usage in `how-to-unit-test-a-smart-contract.mdx`

## Testing
- `pnpm run lint` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_b_686c4501dbbc83209a0589e17b5f602a