### PR TITLE
Revamp landing page with AI focus

### DIFF
--- a/fern/home/index.mdx
+++ b/fern/home/index.mdx
@@ -1,18 +1,18 @@
 ---
-title: The Alchemy Developer Hub
+title: The Alchemy AI Developer Hub
 layout: custom
 hide-feedback: true
 ---
 
 <div className="homepage-content">
   <div className="products">
-    <h2 id="build-anything-onchain" data-state="closed">Build anything onchain</h2>
+    <h2 id="build-anything-onchain" data-state="closed">Build AI-powered onchain apps</h2>
     <div className="my-6 grid gap-4 first:mt-0 sm:gap-6 grid-cols-1 sm:grid-cols-2">
       <a href="/docs/node">
         <div className="flex flex-col gap-2 justify-end product-card dark-blue-bg rounded-3">
             <span className="diamond" />
             <h2 className="product-card-title">Node</h2>
-            <span className="product-card-description">Build and scale your app on the most powerful web3 development platform.</span>
+            <span className="product-card-description">Build and scale your AI-enabled app on the most powerful web3 development platform.</span>
         </div>
       </a>
 
@@ -20,7 +20,7 @@ hide-feedback: true
         <div className="flex flex-col gap-2 justify-end product-card pink-bg rounded-3">
             <span className="arrow" />
             <h2 className="product-card-title">Data</h2>
-            <span className="product-card-description">Access complete blockchain data through one unified API that grows with you.</span>
+            <span className="product-card-description">Access complete blockchain data for training and running your AI models.</span>
         </div>
       </a>
 
@@ -28,7 +28,7 @@ hide-feedback: true
         <div className="flex flex-col gap-2 justify-end product-card yellow-bg rounded-3">
             <span className="star" />
             <h2 className="product-card-title">Wallets</h2>
-            <span className="product-card-description">Onboard users with secure, easy-to-use, wallets. No seed phrase or gas required.</span>
+            <span className="product-card-description">Onboard users with AI-enhanced wallets that are secure and easy to use.</span>
         </div>
       </a>
 
@@ -36,7 +36,7 @@ hide-feedback: true
         <div className="flex flex-col gap-2 justify-end product-card light-blue-bg rounded-3">
             <span className="circle" />
             <h2 className="product-card-title">Rollups</h2>
-            <span className="product-card-description">Launch a custom rollup with native developer tools and scale to millions.</span>
+            <span className="product-card-description">Launch a custom rollup with AI tooling and scale to millions.</span>
         </div>
       </a>
     </div>
@@ -46,7 +46,7 @@ hide-feedback: true
   </div>
 
   <div className="use-cases">
-    <h3 id="guides-to-get-started">Guides to get started</h3>
+    <h3 id="guides-to-get-started">AI Guides to get started</h3>
     <div className="my-6 grid gap-6 grid-cols-1 sm:grid-cols-2">
       <div className="use-case-card">
         <div className="use-case-icon-container">
@@ -119,10 +119,10 @@ hide-feedback: true
         </div>
         <div className="use-case-card-content">
           <div className="use-case-card-header">
-            <h3>Upgrade to EIP-7702</h3>
+            <h3>AI-driven insights</h3>
           </div>
-          <p className="description">Enable existing EOAs to benefit from batching actions, sponsoring transactions, and more.</p>
-          <p className="cta"><a href="https://www.alchemy.com/docs/wallets/react/using-7702" target="_self">Learn more <Icon icon="fa-regular fa-arrow-up-right" /></a></p>
+          <p className="description">Generate deeper analytics and predictions for your onchain data with our AI-powered APIs.</p>
+          <p className="cta"><a href="https://www.alchemy.com/docs/reference/ai" target="_self">Learn more <Icon icon="fa-regular fa-arrow-up-right" /></a></p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Description
- highlight AI in the landing page title and tagline
- mention AI use cases across product cards
- rename guides section to emphasize AI
- add a new use case for AI-driven insights

## Related Issues

## Changes Made
- updated `fern/home/index.mdx`

## Testing
- `pnpm exec lint-staged` *(failed: attempted network access)*
- `pnpm run validate` *(failed: attempted network access)*

------
https://chatgpt.com/codex/tasks/task_b_686c4b80e434832197c17e79931881f8