### PR TITLE
Update compute unit costs page

### DIFF
--- a/fern/api-reference/pricing-resources/pricing/compute-unit-costs.mdx
+++ b/fern/api-reference/pricing-resources/pricing/compute-unit-costs.mdx
@@ -5,31 +5,9 @@ url: "https://docs.alchemy.com/reference/compute-unit-costs"
 slug: "reference/compute-unit-costs"
 ---
 
-### New CU Costs
-
-Build and scale apps with lower CU costs on key APIs
-
-[Get started for free](https://dashboard.alchemy.com/signup/?utm_source=docs\&utm_medium=website\&utm_campaign=build)
-
-# Table of Contents
-
-* [What are Compute Units](#what-are-compute-units-and-throughput-compute-units)
-* [EVM API](/reference/compute-unit-costs#standard-evm-json-rpc-methods)
-* [NFT API](/reference/compute-unit-costs#nft-api)
-* [Transfers API](/reference/compute-unit-costs#transfers-api)
-* [Token API](/reference/compute-unit-costs#token-api)
-* [Transact](/reference/compute-unit-costs#transact)
-* [Debug API](/reference/compute-unit-costs#debug-api)
-* [Trace API](/reference/compute-unit-costs#trace-api)
-* [Polygon PoS API](/reference/compute-unit-costs#polygon-pos-specific-methods)
-* [Polygon zkEVM API](/reference/compute-unit-costs#polygon-zkevm-specific-methods)
-* [Gas Manager & Bundler APIs](#gas-manager--bundler-apis)
-* [Wallet APIs](#wallet-apis)
-* [Embedded Account APIs](/reference/compute-unit-costs#embedded-account-apis)
-* [Starknet JSON-RPC APIs](/reference/compute-unit-costs#standard-starknet-json-rpc-methods)
-* [Solana API](/reference/compute-unit-costs#standard-solana-json-rpc-methods)
-* [Notify & Subscription APIs](/reference/compute-unit-costs#notify-and-subscription-apis)
-* [Error Codes](/reference/compute-unit-costs#compute-unit-cost-for-error-codes)
+<Tip title="Don't have an API key?" icon="star">
+  Unlock millions of requests and free archive data on all chains. [Get started for free](https://dashboard.alchemy.com/signup/)
+</Tip>
 
 ## What are Compute Units and Throughput Compute Units?
 

--- a/fern/api-reference/pricing-resources/pricing/compute-unit-costs.mdx
+++ b/fern/api-reference/pricing-resources/pricing/compute-unit-costs.mdx
@@ -11,11 +11,7 @@ slug: "reference/compute-unit-costs"
 
 ## What are Compute Units and Throughput Compute Units?
 
-For more details, please check out the [Compute Units](/reference/compute-units#what-are-compute-units) section.
-
-## What are Throughput Compute Units?
-
-For more details, please check out the [Throughput Compute Units](/reference/compute-units#what-are-throughput-compute-units) section.
+For more details, please check out the [Compute Units](/reference/compute-units#what-are-compute-units) section and the [Throughput Compute Units](/reference/compute-units#what-are-throughput-compute-units) section.
 
 # Standard EVM JSON-RPC Methods
 


### PR DESCRIPTION
## Summary
- remove manual table of contents from the compute unit costs page
- replace the "New CU Costs" section with a tip about getting an API key

## Testing
- `pnpm lint` *(fails: network access needed)*

------
https://chatgpt.com/codex/tasks/task_b_686c98f6848c8329aacb9270b65e5687