### PR TITLE
Fix broken retries link

### DIFF
--- a/fern/api-reference/pricing-resources/resources/throughput.mdx
+++ b/fern/api-reference/pricing-resources/resources/throughput.mdx
@@ -60,7 +60,7 @@ You will receive a JSON-RPC error response with error code 429. For example, the
 
 ## Retries
 
-There are several options for implementing retries. For a deep dive into each option, check out **[How to Implement Retries](/reference/how-to-implement-retries)**.
+There are several options for implementing retries. For a deep dive into each option, check out **[How to Implement Retries](/docs/how-to-implement-retries)**.
 
 All you need to do to easily handle 429 errors is to retry the request. This will ensure a great user experiences with any API even if you aren't hitting rate limits. Once you've implemented retries, [test out the behavior](/reference/throughput#test-rate-limits-retries) to make sure they work as expected.
 


### PR DESCRIPTION
## Summary
- fix link to How to Implement Retries page

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.9.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_b_686ed6e78c548329b74221f9e6761cc2