### PR TITLE
Fix wallets react quickstart link

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -5875,6 +5875,9 @@ redirects:
   - source: /docs/setup-a-gas-manager-policy
     destination: /docs/reference/how-to-sponsor-gas-on-evm
     permanent: true
+  - source: /docs/wallets/react/quickstart
+    destination: /docs/wallets/react/quickstart/new-project
+    permanent: true
   # Dynamic Redirect MUST be at the end of the redirects list. This is because redirects are processed in order
   # and we want static redirects to take precedence over dynamic redirects.
   # ======================================= Dynamic Redirects ========================================


### PR DESCRIPTION
## Summary
- add redirect from `/docs/wallets/react/quickstart` to `/docs/wallets/react/quickstart/new-project`

## Testing
- `pnpm run lint` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_b_686f4ae6560483208084fff98df4dcfe