### PR TITLE
Add Solana docs placeholders

### DIFF
--- a/fern/api-reference/solana/solana-grpc.mdx
+++ b/fern/api-reference/solana/solana-grpc.mdx
@@ -1,0 +1,9 @@
+---
+title: Solana gRPC
+description: How to use gRPC with the Solana API
+subtitle: Solana gRPC
+url: https://docs.alchemy.com/reference/solana-grpc
+slug: reference/solana-grpc
+---
+
+Content coming soon.

--- a/fern/api-reference/solana/solana-websockets.mdx
+++ b/fern/api-reference/solana/solana-websockets.mdx
@@ -1,0 +1,9 @@
+---
+title: Solana Websockets
+description: How to use Websockets with the Solana API
+subtitle: Solana Websockets
+url: https://docs.alchemy.com/reference/solana-websockets
+slug: reference/solana-websockets
+---
+
+Content coming soon.

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -1634,6 +1634,10 @@ navigation:
             path: api-reference/solana/solana-api-quickstart.mdx
           - page: Solana API FAQ
             path: api-reference/solana/solana-api-faq.mdx
+          - page: Solana Websockets
+            path: api-reference/solana/solana-websockets.mdx
+          - page: Solana gRPC
+            path: api-reference/solana/solana-grpc.mdx
           - api: Solana API Endpoints
             api-name: solana
         slug: solana


### PR DESCRIPTION
## Summary
- add placeholder docs for Solana Websockets and gRPC
- include new pages in docs navigation

## Testing
- `pnpm lint` *(fails: request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_b_687047193a5c8329a9ef4bdac37e2a39