### PR TITLE
docs: correct AlchemyProvider usage in example

### DIFF
--- a/fern/tutorials/creating-smart-contracts/how-to-create-an-nft-on-ethereum-tutorial/how-to-mint-an-nft-from-code.mdx
+++ b/fern/tutorials/creating-smart-contracts/how-to-create-an-nft-on-ethereum-tutorial/how-to-mint-an-nft-from-code.mdx
@@ -29,7 +29,7 @@ Open the repository from Part 1 in your favorite code editor (e.g. VSCode), and 
   const API_KEY = process.env.API_KEY;
 
   // Define an Alchemy Provider
-  const provider = new ethers.AlchemyProvider('sepolia', API_KEY)
+  const provider = new ethers.providers.AlchemyProvider('sepolia', API_KEY)
   ```
 </CodeGroup>
 


### PR DESCRIPTION
## Description

<!-- Provide a brief summary of the changes in this PR -->
Fix incorrect usage of `AlchemyProvider` in documentation example by adding the `.providers` namespace.


## Changes Made

<!-- List the specific changes made in this PR -->
- Updated the example code to use `ethers.providers.AlchemyProvider` instead of `ethers.AlchemyProvider`.

## Testing

<!-- Describe the tests that you ran to verify your changes -->

* [x] I have tested these changes locally
* [ ] I have run the validation scripts (`pnpm run validate`)
* [x] I have checked that the documentation builds correctly
