### PR TITLE
Fix solana endpoint example

### DIFF
--- a/fern/api-reference/pricing-resources/resources/throughput.mdx
+++ b/fern/api-reference/pricing-resources/resources/throughput.mdx
@@ -24,7 +24,7 @@ In most instances, hitting your throughput limit will not affect your user's exp
 
 ## Elastic Throughput
 
-<Check />
+With Alchemy's elastic throughput system, users often experience higher throughput than their guaranteed limit outlined above.
 
 ***
 

--- a/src/openrpc/chains/solana/solana.yaml
+++ b/src/openrpc/chains/solana/solana.yaml
@@ -109,7 +109,7 @@ methods:
       - name: getTokenAccountBalance example
         params:
           - name: Token account Pubkey
-            value: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+            value: "7fUAJdStEuGbc3sM84cKRL6yYaaSstyLSU4ve5oovLS7"
     result:
       name: Token account balance
       description: The balance of the SPL Token account.

--- a/src/openrpc/chains/solana/solana.yaml
+++ b/src/openrpc/chains/solana/solana.yaml
@@ -145,7 +145,10 @@ methods:
       - name: getTokenAccountsByOwner example
         params:
           - name: Token owner Pubkey
-            value: "GwsPP9HHhCvEQeu3HTFzsVL6DEtnnYw4ALEtA3fMBC9Q"
+            value: "A1TMhSGzQxMr1TboBKtgixKz1sS6REASMxPo1qsyTSJd"
+          - name: Token filter
+            value:
+              programId: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
     result:
       name: Token accounts
       description: An array of JSON objects representing the token accounts owned by the specified Pubkey.

--- a/src/openrpc/chains/solana/solana.yaml
+++ b/src/openrpc/chains/solana/solana.yaml
@@ -149,6 +149,10 @@ methods:
           - name: Token filter
             value:
               programId: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+          - name: Configuration
+            value:
+              commitment: "finalized"
+              encoding: "jsonParsed"
     result:
       name: Token accounts
       description: An array of JSON objects representing the token accounts owned by the specified Pubkey.

--- a/src/openrpc/chains/solana/solana.yaml
+++ b/src/openrpc/chains/solana/solana.yaml
@@ -109,10 +109,7 @@ methods:
       - name: getTokenAccountBalance example
         params:
           - name: Token account Pubkey
-            value: "7fUAJdStEuGbc3sM84cKRL6yYaaSstyLSU4ve5oovLS7"
-          - name: Configuration
-            value:
-              commitment: "finalized"
+            value: "3emsAVdmGKERbHjmGfQ6oZ1e35dkf5iYcS6U4CPKFVaa"
     result:
       name: Token account balance
       description: The balance of the SPL Token account.

--- a/src/openrpc/chains/solana/solana.yaml
+++ b/src/openrpc/chains/solana/solana.yaml
@@ -145,7 +145,7 @@ methods:
       - name: getTokenAccountsByOwner example
         params:
           - name: Token owner Pubkey
-            value: "A1TMhSGzQxMr1TboBKtgixKz1sS6REASMxPo1qsyTSJd"
+            value: "7atgF8KQo4wJrD5ATGX7t1V2zVvykPJbFfNeVf1icFv1"
           - name: Token filter
             value:
               programId: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"

--- a/src/openrpc/chains/solana/solana.yaml
+++ b/src/openrpc/chains/solana/solana.yaml
@@ -110,6 +110,9 @@ methods:
         params:
           - name: Token account Pubkey
             value: "7fUAJdStEuGbc3sM84cKRL6yYaaSstyLSU4ve5oovLS7"
+          - name: Configuration
+            value:
+              commitment: "finalized"
     result:
       name: Token account balance
       description: The balance of the SPL Token account.


### PR DESCRIPTION
`gettokenaccountsbyowner` was failing in the example, asking for 2 params minimum. Added the second missing param.