### PR TITLE
fix: skip preview docs job if from fork

### DIFF
--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -11,6 +11,12 @@ jobs:
       deployments: write
       pull-requests: write
     steps:
+      - name: Skip if from fork
+        run: |
+          if [[ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]]; then
+            echo "PR is from a fork and cannot access Fern token — exiting early."
+            exit 0  # Early exit successfully
+          fi
       - name: Checkout repository
         uses: actions/checkout@v4
 


### PR DESCRIPTION
## Description

PRs generated from [forks only have read access](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/about-permissions-and-visibility-of-forks#important-security-considerations) and can't get secrets. That means they'll never be able to run the Generate Fern Preview GHA job. This PR skips that job only for forked PRs. These PRs should have extra scrutiny at code review stage.

## Related Issues

Fixes errors like [this one](https://github.com/alchemyplatform/docs/actions/runs/16354055491/job/46208117752?pr=373)

## Changes Made

- early return the Fern preview job if the PR generated from a fork

## Testing

<!-- Describe the tests that you ran to verify your changes -->

* \[ ] I have tested these changes locally
* \[ ] I have run the validation scripts (`pnpm run validate`)
* \[ ] I have checked that the documentation builds correctly
