### PR TITLE
Update throughput reference

### DIFF
--- a/fern/api-reference/pricing-resources/resources/throughput.mdx
+++ b/fern/api-reference/pricing-resources/resources/throughput.mdx
@@ -6,25 +6,19 @@ url: https://docs.alchemy.com/reference/throughput
 slug: reference/throughput
 ---
 
-<Info>
-  Getting hit with rate limits?
-
-  [Talk to our team](https://www.alchemy.com/contact-sales) to increase your throughput.
-</Info>
-
 ## What is throughput?
 
-Throughput is a measure of the number of requests your application can send per second. It is often known as the applications "rate limit".
-
-If a large number of requests are sent at the same time, you may hit your throughput capacity. However, under Alchemy's elastic throughput system, users are *guaranteed* their given throughput limit (measured in [compute units per second](/reference/throughput#scroll-what-are-compute-units-per-second-cups)), but will often experience higher throughput in practice.
-
-In most instances, hitting your throughput limit will not affect your user's experience engaging with your application. As long as retries are implemented, the requests will go through in the following second. As a general rule of thumb, if you are experiencing **under 30%** rate limited requests, [using retries](/reference/throughput#retries) is the best solution.
+Throughput refers to the volume of requests your app can successfully send to Alchemy's infrastructure within a given time frame — and is configured by throughput limits set for your account.
 
 ***
 
-## Elastic Throughput
+## How throughput at Alchemy works
 
-<Check />
+On Alchemy, throughput is defined in terms of CUPS (Compute Units Per Second), and throughput limits vary depending on account tier.
+
+- Throughput is now set at the account level (no longer at the app level). This means limits apply to all your apps in aggregate.
+- The Throughput Page is where you can find your current account throughput and throughput limit. Enterprise customers can also use this page to set custom throughput overrides for specific apps.
+- Limits are evaluated over a 10s rolling window via a token bucket algorithm with strict refill rates. For example, Free tier customers with 500 CU/s throughput limit can access up to 5000 CU over a 10s period. This structure allows us to gracefully handle spikes in traffic.
 
 ***
 
@@ -115,22 +109,17 @@ To test out your implementation of retries, we created a test app on each networ
 
 ### Ethereum Goerli, Polygon Mumbai (and other testnets)
 
-<Warning>
-  While you can use the Goerli testnet, we caution against it as the Ethereum Foundation has announced that [Goerli will soon be deprecated](https://www.alchemy.com/blog/goerli-faucet-deprecation).
-
-  We therefore recommend using [Sepolia](https://www.alchemy.com/overviews/sepolia-testnet) testnet as Alchemy has full Sepolia support and a free [Sepolia faucet](https://sepoliafaucet.com/) also.
-</Warning>
 
 #### HTTP
 
-[https://eth-goerli.g.alchemy.com/v2/AxnmGEYn7VDkC4KqfNSFbSW9pHFR7PDO](https://eth-goerli.g.alchemy.com/v2/AxnmGEYn7VDkC4KqfNSFbSW9pHFR7PDO)
+[https://eth-sepolia.g.alchemy.com/v2/AxnmGEYn7VDkC4KqfNSFbSW9pHFR7PDO](https://eth-sepolia.g.alchemy.com/v2/AxnmGEYn7VDkC4KqfNSFbSW9pHFR7PDO)
 
 #### WebSocket
 
-[\<wss://eth-goerli.g.alchemy.com/v2/AxnmGEYn7VDkC4KqfNSFbSW9pHFR7PDO>]()
+[\<wss://eth-sepolia.g.alchemy.com/v2/AxnmGEYn7VDkC4KqfNSFbSW9pHFR7PDO>]()
 
 ***
 
 ## Final Tips
 
-Use a different key for each part of your project (e.g., frontend, backend, development) to isolate throughput usage to each use case. This also splits monitoring across different parts of your project, making it easier to debug issues and monitor usage.
+Reach out to support@alchemy.com with any questions you have!


### PR DESCRIPTION
## Summary
- revise the "What is throughput" description
- add a new section explaining throughput at Alchemy
- remove old rate limit info block and Goerli deprecation notice
- update example URLs to use `eth-sepolia`
- streamline final tips message

## Testing
- `pnpm run lint` *(fails: network access required)*

------
https://chatgpt.com/codex/tasks/task_b_6879903adfcc83298afd739f00e8a5e0