### PR TITLE
feat: move changelog to the right end of top nav

### DIFF
--- a/fern/assets/styles.css
+++ b/fern/assets/styles.css
@@ -749,3 +749,15 @@ header#fern-header a.fern-button.filled.normal.primary:hover {
     }
   }
 }
+
+@media (min-width: 768px) {
+  .fern-header-tabs > div {
+    display: flex;
+    justify-content: flex-start;
+    width: 100%;
+
+    & > :last-child {
+      margin-left: auto !important;
+    }
+  }
+}


### PR DESCRIPTION
## Description

<img width="767" height="179" alt="Screenshot 2025-07-18 at 11 54 12 AM" src="https://github.com/user-attachments/assets/a4fc6053-8577-4285-9db3-661918ea7930" />

## Related Issues

[Slack convo](https://alchemyinsights.slack.com/archives/C06FF51281M/p1752848894710839)

## Changes Made

- Move changelog to the right end of top nav

## Testing

<!-- Describe the tests that you ran to verify your changes -->

* \[ ] I have tested these changes locally
* \[ ] I have run the validation scripts (`pnpm run validate`)
* \[ ] I have checked that the documentation builds correctly
