### PR TITLE
add redirect for wrongly indexed nft api pages

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -6202,3 +6202,6 @@ redirects:
   - source: /docs/wallets/api/gas-manager-admin-api/gas-coverage-api-endpoints/:method
     destination: /docs/wallets/api/gas-manager-admin-api/gas-abstraction-api-endpoints/:method
     permanent: true
+  - source: /docs/data/nft-api/api-reference/:folder/:method
+    destination: /docs/reference/nft-api-endpoints/nft-api-endpoints/:folder/:method
+    permanent: true


### PR DESCRIPTION
* \[x] I have tested these changes locally
* \[x] I have run the validation scripts (`pnpm run validate`)
* \[x] I have checked that the documentation builds correctly
