### PR TITLE
feat: add repo dispatch trigger for gh pages deploy

### DIFF
--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -8,7 +8,8 @@ on:
       - main
     types:
       - completed
-
+  repository_dispatch:
+    types: [trigger-gh-pages-deploy]
 concurrency:
   group: "pages"
   cancel-in-progress: false
@@ -16,7 +17,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'repository_dispatch' }}
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
## Description

From Asana:
> Currently we publish all API specs to GitHub Pages. This is useful for directly querying the specs for customers to reference as well as for our own services like the sandbox in dashboard. The definitions for these specs live in both docs repo and aa-sdk repo.
Problem:
The GHA that deploys the GitHub Pages site only lives in docs, so changes to the API specs in aa-sdk won't update the GitHub Pages until there's another docs repo PR merged.

> Solution:
Allow the deploy workflow to be triggered via workflow_dispatch and trigger it programmatically from aa-sdk on relevant pushes.

## Related Issues

Asana Ticket:
https://app.asana.com/1/1129441638109975/project/1208969177908953/task/1210721107097049?focus=true

## Changes Made

- add repo dispatch trigger for gh pages deploy

## Testing

<!-- Describe the tests that you ran to verify your changes -->

* \[ ] I have tested these changes locally
* \[ ] I have run the validation scripts (`pnpm run validate`)
* \[ ] I have checked that the documentation builds correctly
