### PR TITLE
Docs on call: fix outdated links

### DIFF
--- a/fern/tutorials/defi/erc-20-tokens/how-to-get-token-metadata.mdx
+++ b/fern/tutorials/defi/erc-20-tokens/how-to-get-token-metadata.mdx
@@ -85,7 +85,7 @@ You should see the below output:
   TOKEN METADATA->
   {
     decimals: 6,
-    logo: 'https://static.alchemyapi.com/images/assets/825.png',
+    logo: 'https://static.alchemyapi.io/images/assets/825.png',
     name: 'Tether',
     symbol: 'USDT'
    }
@@ -161,7 +161,7 @@ You should see the below output
   TOKEN METADATA->
   {
     decimals: 6,
-    logo: 'https://static.alchemyapi.com/images/assets/825.png',
+    logo: 'https://static.alchemyapi.io/images/assets/825.png',
     name: 'Tether',
     symbol: 'USDT'
    }
@@ -239,7 +239,7 @@ You should see the below output
   TOKEN METADATA->
   {
     decimals: 6,
-    logo: 'https://static.alchemyapi.com/images/assets/825.png',
+    logo: 'https://static.alchemyapi.io/images/assets/825.png',
     name: 'Tether',
     symbol: 'USDT'
   }
@@ -258,7 +258,7 @@ You should see the below output
   ```shell shell
   {
     decimals: 6,
-    logo: 'https://static.alchemyapi.com/images/assets/825.png',
+    logo: 'https://static.alchemyapi.io/images/assets/825.png',
     name: 'Tether',
     symbol: 'USDT'
   }
@@ -272,6 +272,6 @@ You should see the below output
 
 With this, you're all set to fetch token metadata using TokenAPI!
 
-If you enjoyed this tutorial for getting address transaction history on Ethereum, give us a tweet [@Alchemy](https://twitter.com/Alchemy)! (Or if you have any questions/feedback give the author [@ankg404](https://twitter.com/ankg404) a shoutout!)
+If you enjoyed this tutorial for getting address transaction history on Ethereum, give us a tweet [@Alchemy](https://twitter.com/Alchemy)!
 
 If you have any questions or feedback, please contact us at <Markdown src="../../../../snippets/support-email.mdx" /> or open a ticket in the dashboard.

--- a/fern/tutorials/defi/token-balances/how-to-get-all-tokens-owned-by-an-address.mdx
+++ b/fern/tutorials/defi/token-balances/how-to-get-all-tokens-owned-by-an-address.mdx
@@ -557,7 +557,7 @@ You should obtain an output that looks something like this:
 
 Congratulations! You now know how to use the [Alchemy Token API](/reference/token-api) to get all tokens and token balances of any address on the Ethereum blockchain.
 
-If you enjoyed this tutorial on how to get all tokens owned by an address, give us a tweet [@Alchemy](https://twitter.com/Alchemy), or shoutout feedback to the authors [@rounak\_banik](https://twitter.com/Rounak_Banik) and [@ankg404](https://twitter.com/ankg404)!
+If you enjoyed this tutorial on how to get all tokens owned by an address, give us a tweet [@Alchemy](https://twitter.com/Alchemy).
 
 If you have any questions or feedback, please contact us at <Markdown src="../../../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
 

--- a/fern/tutorials/defi/token-balances/how-to-get-token-balance-for-an-address.mdx
+++ b/fern/tutorials/defi/token-balances/how-to-get-token-balance-for-an-address.mdx
@@ -494,6 +494,6 @@ The output that you would see from running the above code is
   ```
 </CodeGroup>
 
-With this, you're all set to fetch token balances from TokenAPI. This can also be extended to fetching the balance for multiple tokens by passing in an array of token addresses, or using the default list (see example [here](https://composer.alchemyapi.io/?share=eJwti00PwUAQQP.LnHsY1qr2RtSF1EG5iDSz22Gl_yG1goj.rpG_03uH9wFt6OohxwQ8x2fo2r87jiY0JTmGHMhqw_5dXzhWoWW.IEte8x0SuFFH7kD20Vd_BHzhwHiUkZITFHKqlZqJTCtGKVA0aYryTP27LFbz.aaqq_26KHdw_v4AtWQrlQ--))! If you enjoyed this tutorial for getting address transaction history on Ethereum, give us a tweet [@Alchemy](https://twitter.com/Alchemy)! (Or if you have any questions/feedback give the author [@ankg404](https://twitter.com/ankg404) a shoutout!)
+With this, you're all set to fetch token balances from TokenAPI. This can also be extended to fetching the balance for multiple tokens by passing in an array of token addresses, or using the default list (see example [here](https://composer.alchemyapi.io/?share=eJwti00PwUAQQP.LnHsY1qr2RtSF1EG5iDSz22Gl_yG1goj.rpG_03uH9wFt6OohxwQ8x2fo2r87jiY0JTmGHMhqw_5dXzhWoWW.IEte8x0SuFFH7kD20Vd_BHzhwHiUkZITFHKqlZqJTCtGKVA0aYryTP27LFbz.aaqq_26KHdw_v4AtWQrlQ--))! If you enjoyed this tutorial for getting address transaction history on Ethereum, give us a tweet [@Alchemy](https://twitter.com/Alchemy)!
 
 If you have any questions or feedback, please contact us at <Markdown src="../../../../snippets/support-email.mdx" /> or open a ticket in the dashboard.

--- a/fern/tutorials/getting-started/how-to-set-up-core-web3-developer-tools/how-to-set-up-core-web3-developer-tools.mdx
+++ b/fern/tutorials/getting-started/how-to-set-up-core-web3-developer-tools/how-to-set-up-core-web3-developer-tools.mdx
@@ -311,6 +311,6 @@ Similarly, other chains and L2's have their own explorers:
 
 Congrats! You have now set up your web3 environment and are ready to begin programming smart contracts like a professional blockchain developer!
 
-If you enjoyed this tutorial for setting up your web3 environment, give us a tweet [@Alchemy](https://twitter.com/Alchemy), or shout out the author [@ankg404](https://twitter.com/ankg404) on Twitter!
+If you enjoyed this tutorial for setting up your web3 environment, give us a tweet [@Alchemy](https://twitter.com/Alchemy)!
 
 If you have any questions or feedback, please contact us at <Markdown src="../../../../snippets/support-email.mdx" /> or open a ticket in the dashboard.

--- a/fern/tutorials/nfts/nft-api-tutorials/how-to-check-the-owner-of-an-nft.mdx
+++ b/fern/tutorials/nfts/nft-api-tutorials/how-to-check-the-owner-of-an-nft.mdx
@@ -226,6 +226,6 @@ If we were retrieving information for an ERC-1155 NFT, which can have multiple o
 
 You now know how to [use the Alchemy NFT API to check the owner of an NFT](https://www.alchemy.com/nft-api?a=d3d4c6ebf1).
 
-If you enjoyed this tutorial about how to get all NFTs owned by an address, tweet us at **@Alchemy** and give the authors **@rounak\_banik** and **@ankg404** a shoutout!
+If you enjoyed this tutorial about how to get all NFTs owned by an address, tweet us at **@Alchemy**!
 
 Don't forget to join our [Discord server](https://www.alchemy.com/discord) to meet other blockchain devs, builders, and entrepreneurs!

--- a/fern/tutorials/nfts/nft-api-tutorials/how-to-get-all-nfts-in-a-collection.mdx
+++ b/fern/tutorials/nfts/nft-api-tutorials/how-to-get-all-nfts-in-a-collection.mdx
@@ -421,7 +421,7 @@ You should obtain output that looks like this:
 
 Congratulations! You now know how to use the Alchemy NFT API to retrieve all NFTs in a collection or at an address. You can adapt this for any network (e.g., Ethereum, Polygon, etc.).
 
-If you enjoyed this tutorial about how to get all NFTs owned by an address, tweet us at [@Alchemy](https://twitter.com/Alchemy) and give the authors [@rounak\_banik](https://twitter.com/Rounak_Banik) and [@ankg404](https://twitter.com/ankg404) a shoutout!
+If you enjoyed this tutorial about how to get all NFTs owned by an address, tweet us at [@Alchemy](https://twitter.com/Alchemy)!
 
 Don't forget to join our [Discord server](https://www.alchemy.com/discord) to meet other blockchain devs, builders, and entrepreneurs!
 

--- a/fern/tutorials/nfts/nft-api-tutorials/how-to-get-all-nfts-owned-by-an-address.mdx
+++ b/fern/tutorials/nfts/nft-api-tutorials/how-to-get-all-nfts-owned-by-an-address.mdx
@@ -418,7 +418,7 @@ Total NFTs owned by elanhalpern.eth: 18
 
 Congratulations! You now know how to use the Alchemy NFT API to get all NFTs owned by a user on a blockchain (whether that be Ethereum or Polygon).
 
-If you enjoyed this tutorial on how to get all NFTs owned by an address, tweet us at [@AlchemyPlatform](https://twitter.com/AlchemyPlatform) and give the authors [@rounak\_banik](https://twitter.com/Rounak_Banik) and [@ankg404](https://twitter.com/ankg404) a shoutout!
+If you enjoyed this tutorial on how to get all NFTs owned by an address, tweet us at [@AlchemyPlatform](https://twitter.com/AlchemyPlatform)!
 
 Don't forget to join our [Discord server](https://www.alchemy.com/discord) to meet other blockchain devs, builders, and entrepreneurs!
 

--- a/fern/tutorials/streaming-data/transaction-notifications/building-a-dapp-with-real-time-transaction-notifications.mdx
+++ b/fern/tutorials/streaming-data/transaction-notifications/building-a-dapp-with-real-time-transaction-notifications.mdx
@@ -687,7 +687,7 @@ Fork 🍴, build 🏗️, and design 📝off [this repo](https://github.com/alch
 
 And that's it! You now know how to use Alchemy Notify v2 to add notifications to your dApp!
 
-If you enjoyed this tutorial for setting Alchemy Notify on your dApp, give us a tweet [@Alchemy](https://twitter.com/Alchemy)*,* or share questions/feedback with the authors [@crypt0zeke](https://twitter.com/crypt0zeke) and [@ankg404](https://twitter.com/ankg404).
+If you enjoyed this tutorial for setting Alchemy Notify on your dApp, give us a tweet [@Alchemy](https://twitter.com/Alchemy)*,* or share questions/feedback with the authors [@crypt0zeke](https://twitter.com/crypt0zeke).
 
 If you have any questions or feedback, please contact us at <Markdown src="../../../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
 

--- a/fern/tutorials/streaming-data/transaction-notifications/how-to-track-mined-and-pending-ethereum-transactions.mdx
+++ b/fern/tutorials/streaming-data/transaction-notifications/how-to-track-mined-and-pending-ethereum-transactions.mdx
@@ -835,7 +835,7 @@ Similarly, upon miner confirmation of that transaction, the Heroku webapp also s
 
 And that's it! You now know how to use Alchemy Notify to add notifications to your dApp! You also know where to go if you want to send SMS notifications for an addresses' activity.
 
-If you enjoyed this tutorial for setting Alchemy Notify on your dApp, give us a tweet [@Alchemy](https://twitter.com/Alchemy)! (Or if you have any questions/feedback give the authors [@crypt0zeke](https://twitter.com/crypt0zeke) and [@ankg404](https://twitter.com/ankg404) a shoutout!)
+If you enjoyed this tutorial for setting Alchemy Notify on your dApp, give us a tweet [@Alchemy](https://twitter.com/Alchemy)!
 
 If you have any questions or feedback, please contact us at <Markdown src="../../../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
 


### PR DESCRIPTION
This PR addresses a reported issue in the [token metadata tutorial](https://www.alchemy.com/docs/how-to-get-token-metadata). The tutorial previously included a URL (https://static.alchemyapi.com/) that leads to a domain with invalid SSL certificates and inappropriate content. Additionally, the tutorial referenced a former teammate's outdated Twitter handle. This update removes or replaces the problematic URL and updates or removes outdated author references to maintain professionalism and accuracy in our docs.