### PR TITLE
add solana methods part 2 and 3

### DIFF
--- a/src/openrpc/chains/solana/components/account.yaml
+++ b/src/openrpc/chains/solana/components/account.yaml
@@ -147,3 +147,126 @@ components:
       items:
         $ref: "#/components/schemas/LargestAccount"
       description: List of the 20 largest accounts.
+    StakeActivationConfig:
+      title: StakeActivation Configuration
+      type: object
+      properties:
+        commitment:
+          $ref: "./base-types.yaml#/components/schemas/Commitment"
+        epoch:
+          type: integer
+          description: Epoch for which to calculate activation details.
+        minContextSlot:
+          $ref: "./base-types.yaml#/components/schemas/MinContextSlot"
+    StakeActivation:
+      title: Stake Activation
+      type: object
+      properties:
+        state:
+          type: string
+          enum:
+            - active
+            - inactive
+            - activating
+            - deactivating
+          description: The stake account's activation state.
+        active:
+          type: integer
+          description: Stake active during the epoch.
+        inactive:
+          type: integer
+          description: Stake inactive during the epoch.
+    GetTokenAccountsByDelegateConfig:
+      title: GetTokenAccountsByDelegate Configuration
+      type: object
+      properties:
+        commitment:
+          $ref: "./base-types.yaml#/components/schemas/Commitment"
+        minContextSlot:
+          $ref: "./base-types.yaml#/components/schemas/MinContextSlot"
+        dataSlice:
+          $ref: "./base-types.yaml#/components/schemas/DataSlice"
+        encoding:
+          $ref: "./base-types.yaml#/components/schemas/Encoding"
+          description: Encoding format for account data.
+    GetTokenLargestAccountsConfig:
+      title: GetTokenLargestAccounts Configuration
+      type: object
+      properties:
+        commitment:
+          $ref: "./base-types.yaml#/components/schemas/Commitment"
+    TokenLargestAccount:
+      title: Token Largest Account
+      type: object
+      properties:
+        address:
+          $ref: "./base-types.yaml#/components/schemas/Pubkey"
+          description: Address of the token account.
+        amount:
+          type: string
+          description: Raw amount in the account, without decimals.
+        decimals:
+          type: integer
+          description: Number of decimals configured for the token's mint.
+        uiAmount:
+          type: number
+          nullable: true
+          description: Token amount using mint-prescribed decimals. **DEPRECATED**
+        uiAmountString:
+          type: string
+          description: Token amount as a string, using mint-prescribed decimals.
+    TokenLargestAccountsList:
+      title: Token Largest Accounts List
+      type: array
+      items:
+        $ref: "#/components/schemas/TokenLargestAccount"
+      description: List of the 20 largest token accounts.
+    GetTokenAccountsConfig:
+      title: GetTokenAccounts Configuration
+      type: object
+      properties:
+        mint:
+          $ref: "./base-types.yaml#/components/schemas/Pubkey"
+          description: The mint address to filter token accounts by.
+        owner:
+          $ref: "./base-types.yaml#/components/schemas/Pubkey"
+          description: The owner address to filter token accounts by.
+        programId:
+          $ref: "./base-types.yaml#/components/schemas/Pubkey"
+          description: The program ID to filter accounts by.
+        commitment:
+          $ref: "./base-types.yaml#/components/schemas/Commitment"
+        minContextSlot:
+          $ref: "./base-types.yaml#/components/schemas/MinContextSlot"
+        dataSlice:
+          $ref: "./base-types.yaml#/components/schemas/DataSlice"
+        encoding:
+          $ref: "./base-types.yaml#/components/schemas/Encoding"
+          description: Encoding format for account data.
+        limit:
+          type: integer
+          description: The maximum number of token accounts to retrieve.
+          maximum: 1000
+          default: 100
+        cursor:
+          type: string
+          description: Cursor for pagination.
+    TokenAccountsList:
+      title: Token Accounts List
+      type: object
+      properties:
+        total:
+          type: integer
+          description: Total number of token accounts.
+        limit:
+          type: integer
+          description: Number of token accounts returned.
+        cursor:
+          type: string
+          nullable: true
+          description: Cursor for pagination.
+        token_accounts:
+          type: array
+          items:
+            $ref: "#/components/schemas/TokenAccount"
+          description: Array of token accounts.

--- a/src/openrpc/chains/solana/components/asset.yaml
+++ b/src/openrpc/chains/solana/components/asset.yaml
@@ -1,0 +1,795 @@
+components:
+  schemas:
+    AssetId:
+      title: Asset ID
+      type: string
+      description: The ID of the asset, typically a base-58 encoded string.
+
+    DisplayOptions:
+      title: Display Options
+      type: object
+      description: Options for display formatting.
+      properties:
+        showFungible:
+          type: boolean
+          description: Display all fungible tokens.
+          default: false
+        showNativeBalance:
+          type: boolean
+          description: Display native SOL balance.
+          default: false
+        showInscriptions:
+          type: boolean
+          description: Display inscriptions.
+          default: false
+        showZeroBalance:
+          type: boolean
+          description: Display assets with zero balance.
+          default: false
+        showGrandTotal:
+          type: boolean
+          description: Display grand total.
+          default: false
+
+    GetAssetConfig:
+      title: GetAsset Configuration
+      type: object
+      properties:
+        displayOptions:
+          $ref: "#/components/schemas/DisplayOptions"
+
+    GetAssetsConfig:
+      title: GetAssets Configuration
+      type: object
+      properties:
+        sortBy:
+          type: object
+          description: Sorting criteria for assets.
+          properties:
+            sortBy:
+              type: string
+              enum:
+                - created
+                - updated
+                - recentAction
+                - none
+              description: The field to sort by.
+            sortDirection:
+              type: string
+              enum:
+                - asc
+                - desc
+              description: Sort direction.
+        limit:
+          type: integer
+          description: The maximum number of assets to retrieve.
+          maximum: 1000
+          default: 100
+        page:
+          type: integer
+          description: The index of the "page" to retrieve.
+          default: 1
+        before:
+          type: string
+          description: Retrieve assets before this cursor.
+        after:
+          type: string
+          description: Retrieve assets after this cursor.
+        displayOptions:
+          $ref: "#/components/schemas/DisplayOptions"
+
+    AssetInterface:
+      title: Asset Interface
+      type: string
+      enum:
+        - V1_NFT
+        - V1_PRINT
+        - LEGACY_NFT
+        - V2_NFT
+        - FungibleAsset
+        - Custom
+        - Identity
+        - Executable
+        - ProgrammableNFT
+      description: The interface of the asset.
+
+    AssetOwnership:
+      title: Asset Ownership
+      type: object
+      properties:
+        frozen:
+          type: boolean
+          description: Whether the asset is frozen.
+        delegated:
+          type: boolean
+          description: Whether the asset is delegated.
+        delegate:
+          type: string
+          nullable: true
+          description: The delegate of the asset, if any.
+        ownership_model:
+          type: string
+          enum:
+            - single
+            - token
+          description: The ownership model.
+        owner:
+          $ref: "./base-types.yaml#/components/schemas/Pubkey"
+          description: The owner of the asset.
+
+    AssetRoyalty:
+      title: Asset Royalty
+      type: object
+      properties:
+        royalty_model:
+          type: string
+          enum:
+            - creators
+            - fanout
+            - single
+          description: The royalty model.
+        target:
+          type: string
+          nullable: true
+          description: The target of the royalty.
+        percent:
+          type: number
+          description: The royalty percentage.
+        basis_points:
+          type: integer
+          description: The royalty in basis points.
+        primary_sale_happened:
+          type: boolean
+          description: Whether the primary sale has happened.
+        locked:
+          type: boolean
+          description: Whether the royalty is locked.
+
+    AssetCreator:
+      title: Asset Creator
+      type: object
+      properties:
+        address:
+          $ref: "./base-types.yaml#/components/schemas/Pubkey"
+          description: The address of the creator.
+        share:
+          type: integer
+          description: The creator's share percentage.
+        verified:
+          type: boolean
+          description: Whether the creator is verified.
+
+    AssetGrouping:
+      title: Asset Grouping
+      type: object
+      properties:
+        group_key:
+          type: string
+          description: The key of the group.
+        group_value:
+          type: string
+          description: The value of the group.
+
+    AssetAuthority:
+      title: Asset Authority
+      type: object
+      properties:
+        address:
+          $ref: "./base-types.yaml#/components/schemas/Pubkey"
+          description: The address of the authority.
+        scopes:
+          type: array
+          items:
+            type: string
+          description: The scopes of the authority.
+
+    AssetCompression:
+      title: Asset Compression
+      type: object
+      properties:
+        eligible:
+          type: boolean
+          description: Whether the asset is eligible for compression.
+        compressed:
+          type: boolean
+          description: Whether the asset is compressed.
+        data_hash:
+          type: string
+          nullable: true
+          description: The data hash of the compressed asset.
+        creator_hash:
+          type: string
+          nullable: true
+          description: The creator hash of the compressed asset.
+        asset_hash:
+          type: string
+          nullable: true
+          description: The asset hash of the compressed asset.
+        tree:
+          $ref: "./base-types.yaml#/components/schemas/Pubkey"
+          nullable: true
+          description: The merkle tree address.
+        seq:
+          type: integer
+          nullable: true
+          description: The sequence number.
+        leaf_id:
+          type: integer
+          nullable: true
+          description: The leaf ID in the merkle tree.
+
+    AssetContent:
+      title: Asset Content
+      type: object
+      properties:
+        $schema:
+          type: string
+          description: The schema version.
+        json_uri:
+          type: string
+          description: The URI of the JSON metadata.
+        files:
+          type: array
+          items:
+            type: object
+            properties:
+              uri:
+                type: string
+                description: The URI of the file.
+              cdn_uri:
+                type: string
+                nullable: true
+                description: The CDN URI of the file.
+              mime:
+                type: string
+                description: The MIME type of the file.
+        metadata:
+          type: object
+          properties:
+            attributes:
+              type: array
+              items:
+                type: object
+                properties:
+                  value:
+                    oneOf:
+                      - type: string
+                      - type: number
+                    description: The value of the attribute.
+                  trait_type:
+                    type: string
+                    description: The trait type of the attribute.
+            description:
+              type: string
+              description: The description of the asset.
+            name:
+              type: string
+              description: The name of the asset.
+            symbol:
+              type: string
+              description: The symbol of the asset.
+        links:
+          type: object
+          nullable: true
+          description: External links related to the asset.
+
+    Asset:
+      title: Asset
+      type: object
+      properties:
+        interface:
+          $ref: "#/components/schemas/AssetInterface"
+        id:
+          $ref: "#/components/schemas/AssetId"
+        content:
+          $ref: "#/components/schemas/AssetContent"
+        authorities:
+          type: array
+          items:
+            $ref: "#/components/schemas/AssetAuthority"
+        compression:
+          $ref: "#/components/schemas/AssetCompression"
+        grouping:
+          type: array
+          items:
+            $ref: "#/components/schemas/AssetGrouping"
+        royalty:
+          $ref: "#/components/schemas/AssetRoyalty"
+        creators:
+          type: array
+          items:
+            $ref: "#/components/schemas/AssetCreator"
+        ownership:
+          $ref: "#/components/schemas/AssetOwnership"
+        mutable:
+          type: boolean
+          description: Whether the asset is mutable.
+        burnt:
+          type: boolean
+          description: Whether the asset is burnt.
+        supply:
+          type: object
+          properties:
+            print_max_supply:
+              type: integer
+              nullable: true
+              description: The maximum print supply.
+            print_current_supply:
+              type: integer
+              nullable: true
+              description: The current print supply.
+            edition_nonce:
+              type: integer
+              nullable: true
+              description: The edition nonce.
+
+    AssetList:
+      title: Asset List
+      type: object
+      properties:
+        total:
+          type: integer
+          description: Total number of assets.
+        limit:
+          type: integer
+          description: Number of assets returned.
+        page:
+          type: integer
+          nullable: true
+          description: Current page number.
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/Asset"
+          description: Array of assets.
+
+    AssetProof:
+      title: Asset Proof
+      type: object
+      properties:
+        root:
+          type: string
+          description: The merkle tree root.
+        proof:
+          type: array
+          items:
+            type: string
+          description: The merkle proof path.
+        node_index:
+          type: integer
+          description: The node index in the tree.
+        leaf:
+          type: string
+          description: The leaf hash.
+        tree_id:
+          $ref: "./base-types.yaml#/components/schemas/Pubkey"
+          description: The merkle tree address.
+
+    AssetProofList:
+      title: Asset Proof List
+      type: array
+      items:
+        $ref: "#/components/schemas/AssetProof"
+      description: Array of asset proofs.
+
+    GetAssetsByAuthorityConfig:
+      title: GetAssetsByAuthority Configuration
+      type: object
+      properties:
+        sortBy:
+          type: object
+          description: Sorting criteria for assets.
+          properties:
+            sortBy:
+              type: string
+              enum:
+                - created
+                - updated
+                - recentAction
+                - none
+              description: The field to sort by.
+            sortDirection:
+              type: string
+              enum:
+                - asc
+                - desc
+              description: Sort direction.
+        limit:
+          type: integer
+          description: The maximum number of assets to retrieve.
+          maximum: 1000
+          default: 100
+        page:
+          type: integer
+          description: The index of the "page" to retrieve.
+          default: 1
+        before:
+          type: string
+          description: Retrieve assets before this cursor.
+        after:
+          type: string
+          description: Retrieve assets after this cursor.
+        authorityAddress:
+          $ref: "./base-types.yaml#/components/schemas/Pubkey"
+          description: The authority address to filter by.
+
+    GetAssetsByOwnerConfig:
+      title: GetAssetsByOwner Configuration
+      type: object
+      properties:
+        sortBy:
+          type: object
+          description: Sorting criteria for assets.
+          properties:
+            sortBy:
+              type: string
+              enum:
+                - created
+                - updated
+                - recentAction
+                - none
+              description: The field to sort by.
+            sortDirection:
+              type: string
+              enum:
+                - asc
+                - desc
+              description: Sort direction.
+        limit:
+          type: integer
+          description: The maximum number of assets to retrieve.
+          maximum: 1000
+          default: 100
+        page:
+          type: integer
+          description: The index of the "page" to retrieve.
+          default: 1
+        before:
+          type: string
+          description: Retrieve assets before this cursor.
+        after:
+          type: string
+          description: Retrieve assets after this cursor.
+        displayOptions:
+          $ref: "#/components/schemas/DisplayOptions"
+
+    GetAssetsByGroupConfig:
+      title: GetAssetsByGroup Configuration
+      type: object
+      properties:
+        sortBy:
+          type: object
+          description: Sorting criteria for assets.
+          properties:
+            sortBy:
+              type: string
+              enum:
+                - created
+                - updated
+                - recentAction
+                - none
+              description: The field to sort by.
+            sortDirection:
+              type: string
+              enum:
+                - asc
+                - desc
+              description: Sort direction.
+        limit:
+          type: integer
+          description: The maximum number of assets to retrieve.
+          maximum: 1000
+          default: 100
+        page:
+          type: integer
+          description: The index of the "page" to retrieve.
+          default: 1
+        before:
+          type: string
+          description: Retrieve assets before this cursor.
+        after:
+          type: string
+          description: Retrieve assets after this cursor.
+        groupKey:
+          type: string
+          description: The group key to filter by.
+        groupValue:
+          type: string
+          description: The group value to filter by.
+
+    GetAssetsByCreatorConfig:
+      title: GetAssetsByCreator Configuration
+      type: object
+      properties:
+        sortBy:
+          type: object
+          description: Sorting criteria for assets.
+          properties:
+            sortBy:
+              type: string
+              enum:
+                - created
+                - updated
+                - recentAction
+                - none
+              description: The field to sort by.
+            sortDirection:
+              type: string
+              enum:
+                - asc
+                - desc
+              description: Sort direction.
+        limit:
+          type: integer
+          description: The maximum number of assets to retrieve.
+          maximum: 1000
+          default: 100
+        page:
+          type: integer
+          description: The index of the "page" to retrieve.
+          default: 1
+        before:
+          type: string
+          description: Retrieve assets before this cursor.
+        after:
+          type: string
+          description: Retrieve assets after this cursor.
+        creatorAddress:
+          $ref: "./base-types.yaml#/components/schemas/Pubkey"
+          description: The creator address to filter by.
+        onlyVerified:
+          type: boolean
+          description: Only return assets where the creator is verified.
+          default: false
+
+    SearchAssetsConfig:
+      title: SearchAssets Configuration
+      type: object
+      properties:
+        sortBy:
+          type: object
+          description: Sorting criteria for assets.
+          properties:
+            sortBy:
+              type: string
+              enum:
+                - created
+                - updated
+                - recentAction
+                - none
+              description: The field to sort by.
+            sortDirection:
+              type: string
+              enum:
+                - asc
+                - desc
+              description: Sort direction.
+        limit:
+          type: integer
+          description: The maximum number of assets to retrieve.
+          maximum: 1000
+          default: 100
+        page:
+          type: integer
+          description: The index of the "page" to retrieve.
+          default: 1
+        before:
+          type: string
+          description: Retrieve assets before this cursor.
+        after:
+          type: string
+          description: Retrieve assets after this cursor.
+        negate:
+          type: boolean
+          description: Invert the search filter.
+          default: false
+        conditionType:
+          type: string
+          enum:
+            - all
+            - any
+          description: Condition type for multiple filters.
+          default: all
+        interface:
+          $ref: "#/components/schemas/AssetInterface"
+        ownerAddress:
+          $ref: "./base-types.yaml#/components/schemas/Pubkey"
+          description: The owner address to filter by.
+        ownerType:
+          type: string
+          enum:
+            - single
+            - token
+          description: The ownership model.
+        creatorAddress:
+          $ref: "./base-types.yaml#/components/schemas/Pubkey"
+          description: The creator address to filter by.
+        creatorVerified:
+          type: boolean
+          description: Only include verified creators.
+        authorityAddress:
+          $ref: "./base-types.yaml#/components/schemas/Pubkey"
+          description: The authority address to filter by.
+        grouping:
+          type: array
+          items:
+            type: string
+          description: Grouping criteria for assets.
+        delegateAddress:
+          $ref: "./base-types.yaml#/components/schemas/Pubkey"
+          description: The delegate address to filter by.
+        frozen:
+          type: boolean
+          description: Filter by frozen status.
+        supply:
+          type: object
+          properties:
+            printMaxSupply:
+              type: integer
+              description: Maximum print supply filter.
+            printCurrentSupply:
+              type: integer
+              description: Current print supply filter.
+        mutable:
+          type: boolean
+          description: Filter by mutable status.
+        burnt:
+          type: boolean
+          description: Filter by burnt status.
+        jsonUri:
+          type: string
+          description: Filter by JSON URI.
+
+    GetAssetSignaturesConfig:
+      title: GetAssetSignatures Configuration
+      type: object
+      properties:
+        limit:
+          type: integer
+          description: The maximum number of signatures to retrieve.
+          maximum: 1000
+          default: 100
+        page:
+          type: integer
+          description: The index of the "page" to retrieve.
+          default: 1
+        before:
+          type: string
+          description: Retrieve signatures before this cursor.
+        after:
+          type: string
+          description: Retrieve signatures after this cursor.
+        tree:
+          $ref: "./base-types.yaml#/components/schemas/Pubkey"
+          description: The merkle tree address to filter by.
+
+    AssetSignature:
+      title: Asset Signature
+      type: object
+      properties:
+        signature:
+          type: string
+          description: The transaction signature.
+        slot:
+          type: integer
+          description: The slot number.
+        blockTime:
+          type: integer
+          nullable: true
+          description: The block time as a Unix timestamp.
+        instruction:
+          type: string
+          description: The instruction type.
+        tree:
+          $ref: "./base-types.yaml#/components/schemas/Pubkey"
+          description: The merkle tree address.
+        leafIndex:
+          type: integer
+          nullable: true
+          description: The leaf index in the merkle tree.
+        seq:
+          type: integer
+          nullable: true
+          description: The sequence number.
+
+    AssetSignatureList:
+      title: Asset Signature List
+      type: object
+      properties:
+        total:
+          type: integer
+          description: Total number of signatures.
+        limit:
+          type: integer
+          description: Number of signatures returned.
+        page:
+          type: integer
+          nullable: true
+          description: Current page number.
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/AssetSignature"
+          description: Array of asset signatures.
+
+    GetNftEditionsConfig:
+      title: GetNftEditions Configuration
+      type: object
+      properties:
+        limit:
+          type: integer
+          description: The maximum number of editions to retrieve.
+          maximum: 1000
+          default: 100
+        page:
+          type: integer
+          description: The index of the "page" to retrieve.
+          default: 1
+        before:
+          type: string
+          description: Retrieve editions before this cursor.
+        after:
+          type: string
+          description: Retrieve editions after this cursor.
+
+    NftEdition:
+      title: NFT Edition
+      type: object
+      properties:
+        interface:
+          $ref: "#/components/schemas/AssetInterface"
+        id:
+          $ref: "#/components/schemas/AssetId"
+        content:
+          $ref: "#/components/schemas/AssetContent"
+        authorities:
+          type: array
+          items:
+            $ref: "#/components/schemas/AssetAuthority"
+        compression:
+          $ref: "#/components/schemas/AssetCompression"
+        grouping:
+          type: array
+          items:
+            $ref: "#/components/schemas/AssetGrouping"
+        royalty:
+          $ref: "#/components/schemas/AssetRoyalty"
+        creators:
+          type: array
+          items:
+            $ref: "#/components/schemas/AssetCreator"
+        ownership:
+          $ref: "#/components/schemas/AssetOwnership"
+        supply:
+          type: object
+          properties:
+            edition_nonce:
+              type: integer
+              nullable: true
+              description: The edition nonce.
+        mutable:
+          type: boolean
+          description: Whether the edition is mutable.
+        burnt:
+          type: boolean
+          description: Whether the edition is burnt.
+
+    NftEditionList:
+      title: NFT Edition List
+      type: object
+      properties:
+        total:
+          type: integer
+          description: Total number of editions.
+        limit:
+          type: integer
+          description: Number of editions returned.
+        page:
+          type: integer
+          nullable: true
+          description: Current page number.
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/NftEdition"
+          description: Array of NFT editions.

--- a/src/openrpc/chains/solana/components/state.yaml
+++ b/src/openrpc/chains/solana/components/state.yaml
@@ -82,3 +82,15 @@ components:
         feature-set:
           type: integer
           description: Unique identifier of the current software's feature set.
+    GetTransactionCountConfig:
+      title: GetTransactionCount Configuration
+      type: object
+      properties:
+        commitment:
+          $ref: "./base-types.yaml#/components/schemas/Commitment"
+        minContextSlot:
+          $ref: "./base-types.yaml#/components/schemas/MinContextSlot"
+    TransactionCount:
+      title: Transaction Count
+      type: integer
+      description: The current transaction count from the ledger.

--- a/src/openrpc/chains/solana/solana.yaml
+++ b/src/openrpc/chains/solana/solana.yaml
@@ -161,6 +161,71 @@ methods:
         items:
           $ref: "./components/account.yaml#/components/schemas/TokenAccount"
 
+  - name: getTokenAccountsByDelegate
+    description: Returns all SPL Token accounts delegated to the provided account.
+    params:
+      - name: Delegate Pubkey
+        required: true
+        description: The Pubkey of the account delegate to query.
+        schema:
+          $ref: "./components/base-types.yaml#/components/schemas/Pubkey"
+      - name: Token filter
+        required: false
+        description: A filter object containing either the Mint Pubkey or the Token program Pubkey.
+        schema:
+          type: object
+          properties:
+            mint:
+              $ref: "./components/base-types.yaml#/components/schemas/Pubkey"
+              description: The Pubkey of the specific token Mint to limit accounts to.
+            programId:
+              $ref: "./components/base-types.yaml#/components/schemas/Pubkey"
+              description: The Pubkey of the Token program that owns the accounts.
+      - name: Configuration
+        required: false
+        description: Optional configuration object containing additional settings.
+        schema:
+          $ref: "./components/account.yaml#/components/schemas/GetTokenAccountsByDelegateConfig"
+    examples:
+      - name: getTokenAccountsByDelegate example
+        params:
+          - name: Delegate Pubkey
+            value: "4Nd1mBQtrMJVYVfKf2PJy9NZUZdTAsp7D4xWLs4gDB4T"
+          - name: Token filter
+            value:
+              programId: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+    result:
+      name: Token accounts
+      description: An array of JSON objects representing the token accounts delegated to the specified Pubkey.
+      schema:
+        type: array
+        items:
+          $ref: "./components/account.yaml#/components/schemas/TokenAccount"
+
+  - name: getTokenLargestAccounts
+    description: Returns the 20 largest accounts of a particular SPL Token type.
+    params:
+      - name: Token Mint Pubkey
+        required: true
+        description: The Pubkey of the token Mint to query.
+        schema:
+          $ref: "./components/base-types.yaml#/components/schemas/Pubkey"
+      - name: Configuration
+        required: false
+        description: Optional configuration object.
+        schema:
+          $ref: "./components/account.yaml#/components/schemas/GetTokenLargestAccountsConfig"
+    examples:
+      - name: getTokenLargestAccounts example
+        params:
+          - name: Token Mint Pubkey
+            value: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+    result:
+      name: Largest token accounts
+      description: An array of the 20 largest accounts of the specified token type.
+      schema:
+        $ref: "./components/account.yaml#/components/schemas/TokenLargestAccountsList"
+
   - name: getLargestAccounts
     description: Returns the 20 largest accounts, by lamport balance.
     params:
@@ -174,6 +239,30 @@ methods:
       description: An array of objects containing the address of the account and its lamport balance.
       schema:
         $ref: "./components/account.yaml#/components/schemas/LargestAccountsList"
+
+  - name: getStakeActivation
+    description: Returns epoch activation information for a stake account.
+    params:
+      - name: Stake account Pubkey
+        required: true
+        description: Pubkey of the stake account to query.
+        schema:
+          $ref: "./components/base-types.yaml#/components/schemas/Pubkey"
+      - name: Configuration
+        required: false
+        description: Optional configuration object.
+        schema:
+          $ref: "./components/account.yaml#/components/schemas/StakeActivationConfig"
+    examples:
+      - name: getStakeActivation example
+        params:
+          - name: Stake account Pubkey
+            value: "CYRJWqiSjLitBAcRxPvWpgX3s5TvmN2SuRY3eEYypFvT"
+    result:
+      name: Stake activation info
+      description: Returns epoch activation information for the stake account.
+      schema:
+        $ref: "./components/account.yaml#/components/schemas/StakeActivation"
 
   # Airdrop methods
   - name: requestAirdrop
@@ -705,6 +794,23 @@ methods:
       schema:
         $ref: "./components/state.yaml#/components/schemas/VersionInfo"
 
+  - name: getTransactionCount
+    description: Returns the current transaction count from the ledger.
+    params:
+      - name: Configuration
+        required: false
+        description: Optional configuration object.
+        schema:
+          $ref: "./components/state.yaml#/components/schemas/GetTransactionCountConfig"
+    examples:
+      - name: getTransactionCount example
+        params: []
+    result:
+      name: Transaction count
+      description: The current transaction count from the ledger.
+      schema:
+        $ref: "./components/state.yaml#/components/schemas/TransactionCount"
+
   # Supply methods
   - name: getSupply
     description: Returns information about the current supply of lamports.
@@ -840,3 +946,291 @@ methods:
       description: The details of a confirmed transaction.
       schema:
         $ref: "./components/transaction.yaml#/components/schemas/TransactionDetails"
+
+  - name: getAsset
+    description: Returns information about a single digital asset.
+    params:
+      - name: Asset ID
+        required: true
+        description: The ID of the asset to retrieve.
+        schema:
+          $ref: "./components/asset.yaml#/components/schemas/AssetId"
+      - name: Configuration
+        required: false
+        description: Optional configuration object for display formatting.
+        schema:
+          $ref: "./components/asset.yaml#/components/schemas/GetAssetConfig"
+    examples:
+      - name: getAsset example
+        params:
+          - name: Asset ID
+            value: "Bu1DEKeawy7txbnCEJE4BU3BKLXaNAKCYcHR4XhndGss"
+    result:
+      name: Asset information
+      description: Returns detailed information about the specified digital asset.
+      schema:
+        $ref: "./components/asset.yaml#/components/schemas/Asset"
+
+  - name: getAssets
+    description: Returns information about multiple digital assets.
+    params:
+      - name: Asset IDs
+        required: true
+        description: An array of asset IDs to retrieve.
+        schema:
+          type: array
+          items:
+            $ref: "./components/asset.yaml#/components/schemas/AssetId"
+      - name: Configuration
+        required: false
+        description: Optional configuration object for sorting and pagination.
+        schema:
+          $ref: "./components/asset.yaml#/components/schemas/GetAssetsConfig"
+    examples:
+      - name: getAssets example
+        params:
+          - name: Asset IDs
+            value:
+              - "Bu1DEKeawy7txbnCEJE4BU3BKLXaNAKCYcHR4XhndGss"
+              - "8vw7tdLGE3FBjaetsJrZAbbyssUrXai1aBJbUnj5S5uo"
+    result:
+      name: Assets list
+      description: Returns detailed information about the specified digital assets.
+      schema:
+        $ref: "./components/asset.yaml#/components/schemas/AssetList"
+
+  - name: getAssetProof
+    description: Returns the merkle proof for a compressed digital asset.
+    params:
+      - name: Asset ID
+        required: true
+        description: The ID of the compressed asset to get proof for.
+        schema:
+          $ref: "./components/asset.yaml#/components/schemas/AssetId"
+    examples:
+      - name: getAssetProof example
+        params:
+          - name: Asset ID
+            value: "Bu1DEKeawy7txbnCEJE4BU3BKLXaNAKCYcHR4XhndGss"
+    result:
+      name: Asset proof
+      description: Returns the merkle proof for the specified compressed asset.
+      schema:
+        $ref: "./components/asset.yaml#/components/schemas/AssetProof"
+
+  - name: getAssetProofs
+    description: Returns merkle proofs for multiple compressed digital assets.
+    params:
+      - name: Asset IDs
+        required: true
+        description: An array of compressed asset IDs to get proofs for.
+        schema:
+          type: array
+          items:
+            $ref: "./components/asset.yaml#/components/schemas/AssetId"
+    examples:
+      - name: getAssetProofs example
+        params:
+          - name: Asset IDs
+            value:
+              - "Bu1DEKeawy7txbnCEJE4BU3BKLXaNAKCYcHR4XhndGss"
+              - "8vw7tdLGE3FBjaetsJrZAbbyssUrXai1aBJbUnj5S5uo"
+    result:
+      name: Asset proofs
+      description: Returns merkle proofs for the specified compressed assets.
+      schema:
+        $ref: "./components/asset.yaml#/components/schemas/AssetProofList"
+
+  - name: getAssetsByAuthority
+    description: Returns assets filtered by their authority.
+    params:
+      - name: Authority address
+        required: true
+        description: The authority address to filter assets by.
+        schema:
+          $ref: "./components/base-types.yaml#/components/schemas/Pubkey"
+      - name: Configuration
+        required: false
+        description: Optional configuration object for sorting and pagination.
+        schema:
+          $ref: "./components/asset.yaml#/components/schemas/GetAssetsByAuthorityConfig"
+    examples:
+      - name: getAssetsByAuthority example
+        params:
+          - name: Authority address
+            value: "7atgF8KQo4wJrD5ATGX7t1V2zVvykPJbFfNeVf1icFv1"
+    result:
+      name: Assets by authority
+      description: Returns assets filtered by the specified authority.
+      schema:
+        $ref: "./components/asset.yaml#/components/schemas/AssetList"
+
+  - name: getAssetsByOwner
+    description: Returns assets owned by the specified address.
+    params:
+      - name: Owner address
+        required: true
+        description: The owner address to filter assets by.
+        schema:
+          $ref: "./components/base-types.yaml#/components/schemas/Pubkey"
+      - name: Configuration
+        required: false
+        description: Optional configuration object for sorting and pagination.
+        schema:
+          $ref: "./components/asset.yaml#/components/schemas/GetAssetsByOwnerConfig"
+    examples:
+      - name: getAssetsByOwner example
+        params:
+          - name: Owner address
+            value: "N4f6zftYsuu4yT7icsjLwh4i6pB1zvvKbseHj2NmSQw"
+    result:
+      name: Assets by owner
+      description: Returns assets owned by the specified address.
+      schema:
+        $ref: "./components/asset.yaml#/components/schemas/AssetList"
+
+  - name: getAssetsByGroup
+    description: Returns assets filtered by their group information.
+    params:
+      - name: Group key
+        required: true
+        description: The group key to filter assets by.
+        schema:
+          type: string
+      - name: Group value
+        required: true
+        description: The group value to filter assets by.
+        schema:
+          type: string
+      - name: Configuration
+        required: false
+        description: Optional configuration object for sorting and pagination.
+        schema:
+          $ref: "./components/asset.yaml#/components/schemas/GetAssetsByGroupConfig"
+    examples:
+      - name: getAssetsByGroup example
+        params:
+          - name: Group key
+            value: "collection"
+          - name: Group value
+            value: "J1S9H3QjnRtBbbuD4HjPV6RpRhwuk4zKbxsnCHuTgh9w"
+    result:
+      name: Assets by group
+      description: Returns assets filtered by the specified group.
+      schema:
+        $ref: "./components/asset.yaml#/components/schemas/AssetList"
+
+  - name: getAssetsByCreator
+    description: Returns assets created by the specified address.
+    params:
+      - name: Creator address
+        required: true
+        description: The creator address to filter assets by.
+        schema:
+          $ref: "./components/base-types.yaml#/components/schemas/Pubkey"
+      - name: Configuration
+        required: false
+        description: Optional configuration object for sorting and pagination.
+        schema:
+          $ref: "./components/asset.yaml#/components/schemas/GetAssetsByCreatorConfig"
+    examples:
+      - name: getAssetsByCreator example
+        params:
+          - name: Creator address
+            value: "D3XrkNZz6wx6cofot7Zohsf2KSsu2ArngNk8VqU9cTY3"
+    result:
+      name: Assets by creator
+      description: Returns assets created by the specified address.
+      schema:
+        $ref: "./components/asset.yaml#/components/schemas/AssetList"
+
+  - name: searchAssets
+    description: Search for assets using a complex set of filter criteria.
+    params:
+      - name: Search filters
+        required: false
+        description: Object containing search criteria and filters.
+        schema:
+          $ref: "./components/asset.yaml#/components/schemas/SearchAssetsConfig"
+    examples:
+      - name: searchAssets example
+        params:
+          - name: Search filters
+            value:
+              interface: "V1_NFT"
+              ownerAddress: "N4f6zftYsuu4yT7icsjLwh4i6pB1zvvKbseHj2NmSQw"
+              limit: 50
+    result:
+      name: Search results
+      description: Returns assets matching the specified search criteria.
+      schema:
+        $ref: "./components/asset.yaml#/components/schemas/AssetList"
+
+  - name: getAssetSignatures
+    description: Returns signatures for transactions that have interacted with the given asset.
+    params:
+      - name: Asset ID
+        required: true
+        description: The ID of the asset to get signatures for.
+        schema:
+          $ref: "./components/asset.yaml#/components/schemas/AssetId"
+      - name: Configuration
+        required: false
+        description: Optional configuration object for pagination.
+        schema:
+          $ref: "./components/asset.yaml#/components/schemas/GetAssetSignaturesConfig"
+    examples:
+      - name: getAssetSignatures example
+        params:
+          - name: Asset ID
+            value: "Bu1DEKeawy7txbnCEJE4BU3BKLXaNAKCYcHR4XhndGss"
+    result:
+      name: Asset signatures
+      description: Returns signatures for transactions involving the specified asset.
+      schema:
+        $ref: "./components/asset.yaml#/components/schemas/AssetSignatureList"
+
+  - name: getNftEditions
+    description: Returns all editions of a given master NFT.
+    params:
+      - name: Master NFT ID
+        required: true
+        description: The ID of the master NFT to get editions for.
+        schema:
+          $ref: "./components/asset.yaml#/components/schemas/AssetId"
+      - name: Configuration
+        required: false
+        description: Optional configuration object for pagination.
+        schema:
+          $ref: "./components/asset.yaml#/components/schemas/GetNftEditionsConfig"
+    examples:
+      - name: getNftEditions example
+        params:
+          - name: Master NFT ID
+            value: "Bu1DEKeawy7txbnCEJE4BU3BKLXaNAKCYcHR4XhndGss"
+    result:
+      name: NFT editions
+      description: Returns all editions of the specified master NFT.
+      schema:
+        $ref: "./components/asset.yaml#/components/schemas/NftEditionList"
+
+  - name: getTokenAccounts
+    description: Returns token accounts based on the specified filters.
+    params:
+      - name: Configuration
+        required: false
+        description: Configuration object for filtering and pagination.
+        schema:
+          $ref: "./components/account.yaml#/components/schemas/GetTokenAccountsConfig"
+    examples:
+      - name: getTokenAccounts example
+        params:
+          - name: Configuration
+            value:
+              mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+              limit: 100
+    result:
+      name: Token accounts
+      description: Returns token accounts matching the specified criteria.
+      schema:
+        $ref: "./components/account.yaml#/components/schemas/TokenAccountsList"


### PR DESCRIPTION
## Description

Add the api specs for following missing solana methods:

    "getAsset",
    "getAssets",
    "getAssetProof",
    "getAssetProofs",
    "getStakeActivation",
    "getTokenAccountsByDelegate",
    "getTokenLargestAccounts",
    "getTransactionCount",
    "getAssetsByAuthority",
    "getAssetsByOwner",
    "getAssetsByGroup",
    "getAssetsByCreator",
    "searchAssets",
    "getAssetSignatures",
    "getNftEditions",
    "getTokenAccounts"

## Testing

<!-- Describe the tests that you ran to verify your changes -->

* \[x] I have tested these changes locally
* \[x] I have run the validation scripts (`pnpm run validate`)
* \[x] I have checked that the documentation builds correctly