### PR TITLE
Update Starknet FAQ version support

### DIFF
--- a/fern/api-reference/starknet/starknet-api-faq.mdx
+++ b/fern/api-reference/starknet/starknet-api-faq.mdx
@@ -20,26 +20,8 @@ Explained in the [Starknet API Quickstart Guide](/reference/starknet-api-quickst
 
 ## What versions of Starknet API are supported?
 
-We currently support `v0.4`, `v0.5`, `v0.6` and `v0_7`. We strongly recommend using `v0_7`.
+Alchemy currently supports `v0_6`, `v0_7`, and `v0_8`. We strongly recommend using `v0_8`.
 
-To access `v0.4` (soon deprecated) you can use the following URLs to make requests:
-
-* Mainnets
-
-  * [https://starknet-mainnet.g.alchemy.com/v2/\{apiKey}](https://starknet-mainnet.g.alchemy.com/v2/%7BapiKey%7D)
-  * [https://starknet-mainnet.g.alchemy.com/starknet/version/rpc/v0.4/\{apiKey}](https://starknet-mainnet.g.alchemy.com/starknet/version/rpc/v0.4/%7BapiKey%7D)
-
-* Testnets
-
-  * [\<https://starknet-sepolia.g.alchemy.com/v2/\{apiKey}>](https://starknet-sepolia.g.alchemy.com/v2/%7BapiKey%7D)
-  * [\<https://starknet-sepolia.g.alchemy.com/starknet/version/rpc/v0.4/\{apiKey}>](https://starknet-sepolia.g.alchemy.com/starknet/version/rpc/v0.4/%7BapiKey%7D)
-
-To access `v0.5` (soon deprecated) you can use the following URLs to make requests:
-
-* Mainnet
-  * [https://starknet-mainnet.g.alchemy.com/starknet/version/rpc/v0.5/\{apiKey}](https://starknet-mainnet.g.alchemy.com/starknet/version/rpc/v0.5/%7BapiKey%7D)
-* Testnet
-  * [\<https://starknet-sepolia.g.alchemy.com/starknet/version/rpc/v0.5/\{apiKey}>](https://starknet-sepolia.g.alchemy.com/starknet/version/rpc/v0.5/%7BapiKey%7D)
 
 To access `v0.6` you can use the following URLs to make requests:
 
@@ -54,6 +36,14 @@ To access `v0_7` (**notice the underscore**) you can use the following URLs to m
   * [https://starknet-mainnet.g.alchemy.com/starknet/version/rpc/v0\_7/\{apiKey}](https://starknet-mainnet.g.alchemy.com/starknet/version/rpc/v0_7/%7BapiKey%7D)
 * Testnet
   * [\<https://starknet-sepolia.g.alchemy.com/starknet/version/rpc/v0\_7/\{apiKey}>](https://starknet-sepolia.g.alchemy.com/starknet/version/rpc/v0_7/%7BapiKey%7D)
+
+To access `v0_8` (**notice the underscore**) you can use the following URLs to make requests:
+
+* Mainnet
+  * [https://starknet-mainnet.g.alchemy.com/starknet/version/rpc/v0_8/{apiKey}](https://starknet-mainnet.g.alchemy.com/starknet/version/rpc/v0_8/%7BapiKey%7D)
+* Testnet
+  * [<https://starknet-sepolia.g.alchemy.com/starknet/version/rpc/v0_8/{apiKey}>](https://starknet-sepolia.g.alchemy.com/starknet/version/rpc/v0_8/%7BapiKey%7D)
+
 
 You can also directly try these APIs from browser in our [API references for Starknet](/reference/starknet-api-endpoints)
 


### PR DESCRIPTION
## Summary
- update supported Starknet API versions to v0_6, v0_7, and v0_8
- recommend v0_8 as the default version
- remove references to deprecated versions
- add endpoint instructions for v0_8

## Testing
- `pnpm run lint` *(fails: network access needed)*

------
https://chatgpt.com/codex/tasks/task_b_688913ea3b8883299e08d96a5234e73e