### PR TITLE
perf: move custom-app js to load only on homepage

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -74,8 +74,6 @@ css:
   - ./components/Footer.css
 
 js:
-  - path: ./dist/output.js
-    strategy: beforeInteractive
   - path: assets/heap.js
     strategy: afterInteractive
   - path: assets/dashboard-referral.js

--- a/fern/home/index.mdx
+++ b/fern/home/index.mdx
@@ -7,6 +7,7 @@ hide-feedback: true
 import { AlchemyFooter } from "../components/Footer.tsx";
 
 <div className="homepage-content">
+  <script src="/dist/output.js" async></script>
   <div className="products">
     <h2 id="build-anything-onchain" data-state="closed">Build anything onchain</h2>
     <div className="my-6 grid gap-4 first:mt-0 sm:gap-6 grid-cols-1 sm:grid-cols-2">


### PR DESCRIPTION
## Description

This is a test to see if we can download the custom-app JS on only the homepage.

## Related Issues

<!-- Link to any related issues or Asana tasks this PR addresses (e.g., "Fixes #123") -->

## Changes Made

<!-- List the specific changes made in this PR -->

## Testing

<!-- Describe the tests that you ran to verify your changes -->

* \[ ] I have tested these changes locally
* \[ ] I have run the validation scripts (`pnpm run validate`)
* \[ ] I have checked that the documentation builds correctly
