### PR TITLE
docs: correct eth_getLogs plan limits

### DIFF
--- a/src/openrpc/chains/_components/evm/methods.yaml
+++ b/src/openrpc/chains/_components/evm/methods.yaml
@@ -519,9 +519,9 @@ components:
 
         | Chain | Free | Pay As You Go | Enterprise |
         |-------|------|---------------|------------|
-        | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | unlimited | unlimited | unlimited |
+        | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | 500 | unlimited | unlimited |
         | Polygon | 500 | 2000 | unlimited |
-        | Monad | 500 | 1000 | unlimited |
+        | Monad | 500 | 1000 | 1000 |
         | BSC | 500 | 10000 | 10000 |
         | All Other Chains | 500 | 10000 | unlimited |
       params:

--- a/src/openrpc/chains/abstract/abstract.yaml
+++ b/src/openrpc/chains/abstract/abstract.yaml
@@ -388,9 +388,9 @@ methods:
 
       | Chain | Free | Pay As You Go | Enterprise |
       |-------|------|---------------|------------|
-      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | unlimited | unlimited | unlimited |
+      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | 500 | unlimited | unlimited |
       | Polygon | 500 | 2000 | unlimited |
-      | Monad | 500 | 1000 | unlimited |
+      | Monad | 500 | 1000 | 1000 |
       | BSC | 500 | 10000 | 10000 |
       | All Other Chains | 500 | 10000 | unlimited |
     params:

--- a/src/openrpc/chains/anime/anime.yaml
+++ b/src/openrpc/chains/anime/anime.yaml
@@ -1018,9 +1018,9 @@ methods:
 
       | Chain | Free | Pay As You Go | Enterprise |
       |-------|------|---------------|------------|
-      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | unlimited | unlimited | unlimited |
+      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | 500 | unlimited | unlimited |
       | Polygon | 500 | 2000 | unlimited |
-      | Monad | 500 | 1000 | unlimited |
+      | Monad | 500 | 1000 | 1000 |
       | BSC | 500 | 10000 | 10000 |
       | All Other Chains | 500 | 10000 | unlimited |
     params:

--- a/src/openrpc/chains/apechain/apechain.yaml
+++ b/src/openrpc/chains/apechain/apechain.yaml
@@ -393,9 +393,9 @@ methods:
 
       | Chain | Free | Pay As You Go | Enterprise |
       |-------|------|---------------|------------|
-      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | unlimited | unlimited | unlimited |
+      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | 500 | unlimited | unlimited |
       | Polygon | 500 | 2000 | unlimited |
-      | Monad | 500 | 1000 | unlimited |
+      | Monad | 500 | 1000 | 1000 |
       | BSC | 500 | 10000 | 10000 |
       | All Other Chains | 500 | 10000 | unlimited |
     params:

--- a/src/openrpc/chains/arbitrum-nova/arbitrum-nova.yaml
+++ b/src/openrpc/chains/arbitrum-nova/arbitrum-nova.yaml
@@ -391,9 +391,9 @@ methods:
 
       | Chain | Free | Pay As You Go | Enterprise |
       |-------|------|---------------|------------|
-      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | unlimited | unlimited | unlimited |
+      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | 500 | unlimited | unlimited |
       | Polygon | 500 | 2000 | unlimited |
-      | Monad | 500 | 1000 | unlimited |
+      | Monad | 500 | 1000 | 1000 |
       | BSC | 500 | 10000 | 10000 |
       | All Other Chains | 500 | 10000 | unlimited |
     params:

--- a/src/openrpc/chains/arbitrum/arbitrum.yaml
+++ b/src/openrpc/chains/arbitrum/arbitrum.yaml
@@ -1018,9 +1018,9 @@ methods:
 
       | Chain | Free | Pay As You Go | Enterprise |
       |-------|------|---------------|------------|
-      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | unlimited | unlimited | unlimited |
+      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | 500 | unlimited | unlimited |
       | Polygon | 500 | 2000 | unlimited |
-      | Monad | 500 | 1000 | unlimited |
+      | Monad | 500 | 1000 | 1000 |
       | BSC | 500 | 10000 | 10000 |
       | All Other Chains | 500 | 10000 | unlimited |
     params:

--- a/src/openrpc/chains/astar/astar.yaml
+++ b/src/openrpc/chains/astar/astar.yaml
@@ -1016,9 +1016,9 @@ methods:
 
       | Chain | Free | Pay As You Go | Enterprise |
       |-------|------|---------------|------------|
-      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | unlimited | unlimited | unlimited |
+      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | 500 | unlimited | unlimited |
       | Polygon | 500 | 2000 | unlimited |
-      | Monad | 500 | 1000 | unlimited |
+      | Monad | 500 | 1000 | 1000 |
       | BSC | 500 | 10000 | 10000 |
       | All Other Chains | 500 | 10000 | unlimited |
     params:

--- a/src/openrpc/chains/avalanche/avalanche.yaml
+++ b/src/openrpc/chains/avalanche/avalanche.yaml
@@ -377,9 +377,9 @@ methods:
 
       | Chain | Free | Pay As You Go | Enterprise |
       |-------|------|---------------|------------|
-      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | unlimited | unlimited | unlimited |
+      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | 500 | unlimited | unlimited |
       | Polygon | 500 | 2000 | unlimited |
-      | Monad | 500 | 1000 | unlimited |
+      | Monad | 500 | 1000 | 1000 |
       | BSC | 500 | 10000 | 10000 |
       | All Other Chains | 500 | 10000 | unlimited |
     params:

--- a/src/openrpc/chains/base/base.yaml
+++ b/src/openrpc/chains/base/base.yaml
@@ -1018,9 +1018,9 @@ methods:
 
       | Chain | Free | Pay As You Go | Enterprise |
       |-------|------|---------------|------------|
-      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | unlimited | unlimited | unlimited |
+      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | 500 | unlimited | unlimited |
       | Polygon | 500 | 2000 | unlimited |
-      | Monad | 500 | 1000 | unlimited |
+      | Monad | 500 | 1000 | 1000 |
       | BSC | 500 | 10000 | 10000 |
       | All Other Chains | 500 | 10000 | unlimited |
     params:

--- a/src/openrpc/chains/berachain/berachain.yaml
+++ b/src/openrpc/chains/berachain/berachain.yaml
@@ -393,9 +393,9 @@ methods:
 
       | Chain | Free | Pay As You Go | Enterprise |
       |-------|------|---------------|------------|
-      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | unlimited | unlimited | unlimited |
+      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | 500 | unlimited | unlimited |
       | Polygon | 500 | 2000 | unlimited |
-      | Monad | 500 | 1000 | unlimited |
+      | Monad | 500 | 1000 | 1000 |
       | BSC | 500 | 10000 | 10000 |
       | All Other Chains | 500 | 10000 | unlimited |
     params:

--- a/src/openrpc/chains/blast/blast.yaml
+++ b/src/openrpc/chains/blast/blast.yaml
@@ -393,9 +393,9 @@ methods:
 
       | Chain | Free | Pay As You Go | Enterprise |
       |-------|------|---------------|------------|
-      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | unlimited | unlimited | unlimited |
+      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | 500 | unlimited | unlimited |
       | Polygon | 500 | 2000 | unlimited |
-      | Monad | 500 | 1000 | unlimited |
+      | Monad | 500 | 1000 | 1000 |
       | BSC | 500 | 10000 | 10000 |
       | All Other Chains | 500 | 10000 | unlimited |
     params:

--- a/src/openrpc/chains/botanix/botanix.yaml
+++ b/src/openrpc/chains/botanix/botanix.yaml
@@ -1119,9 +1119,9 @@ methods:
 
       | Chain | Free | Pay As You Go | Enterprise |
       |-------|------|---------------|------------|
-      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | unlimited | unlimited | unlimited |
+      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | 500 | unlimited | unlimited |
       | Polygon | 500 | 2000 | unlimited |
-      | Monad | 500 | 1000 | unlimited |
+      | Monad | 500 | 1000 | 1000 |
       | BSC | 500 | 10000 | 10000 |
       | All Other Chains | 500 | 10000 | unlimited |
     params:

--- a/src/openrpc/chains/bsc/bsc.yaml
+++ b/src/openrpc/chains/bsc/bsc.yaml
@@ -558,9 +558,9 @@ methods:
 
       | Chain | Free | Pay As You Go | Enterprise |
       |-------|------|---------------|------------|
-      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | unlimited | unlimited | unlimited |
+      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | 500 | unlimited | unlimited |
       | Polygon | 500 | 2000 | unlimited |
-      | Monad | 500 | 1000 | unlimited |
+      | Monad | 500 | 1000 | 1000 |
       | BSC | 500 | 10000 | 10000 |
       | All Other Chains | 500 | 10000 | unlimited |
     params:

--- a/src/openrpc/chains/celo/celo.yaml
+++ b/src/openrpc/chains/celo/celo.yaml
@@ -1020,9 +1020,9 @@ methods:
 
       | Chain | Free | Pay As You Go | Enterprise |
       |-------|------|---------------|------------|
-      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | unlimited | unlimited | unlimited |
+      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | 500 | unlimited | unlimited |
       | Polygon | 500 | 2000 | unlimited |
-      | Monad | 500 | 1000 | unlimited |
+      | Monad | 500 | 1000 | 1000 |
       | BSC | 500 | 10000 | 10000 |
       | All Other Chains | 500 | 10000 | unlimited |
     params:

--- a/src/openrpc/chains/crossfi/crossfi.yaml
+++ b/src/openrpc/chains/crossfi/crossfi.yaml
@@ -393,9 +393,9 @@ methods:
 
       | Chain | Free | Pay As You Go | Enterprise |
       |-------|------|---------------|------------|
-      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | unlimited | unlimited | unlimited |
+      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | 500 | unlimited | unlimited |
       | Polygon | 500 | 2000 | unlimited |
-      | Monad | 500 | 1000 | unlimited |
+      | Monad | 500 | 1000 | 1000 |
       | BSC | 500 | 10000 | 10000 |
       | All Other Chains | 500 | 10000 | unlimited |
     params:

--- a/src/openrpc/chains/eth/eth.yaml
+++ b/src/openrpc/chains/eth/eth.yaml
@@ -1121,9 +1121,9 @@ methods:
 
       | Chain | Free | Pay As You Go | Enterprise |
       |-------|------|---------------|------------|
-      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | unlimited | unlimited | unlimited |
+      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | 500 | unlimited | unlimited |
       | Polygon | 500 | 2000 | unlimited |
-      | Monad | 500 | 1000 | unlimited |
+      | Monad | 500 | 1000 | 1000 |
       | BSC | 500 | 10000 | 10000 |
       | All Other Chains | 500 | 10000 | unlimited |
     params:

--- a/src/openrpc/chains/flow/flow.yaml
+++ b/src/openrpc/chains/flow/flow.yaml
@@ -393,9 +393,9 @@ methods:
 
       | Chain | Free | Pay As You Go | Enterprise |
       |-------|------|---------------|------------|
-      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | unlimited | unlimited | unlimited |
+      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | 500 | unlimited | unlimited |
       | Polygon | 500 | 2000 | unlimited |
-      | Monad | 500 | 1000 | unlimited |
+      | Monad | 500 | 1000 | 1000 |
       | BSC | 500 | 10000 | 10000 |
       | All Other Chains | 500 | 10000 | unlimited |
     params:

--- a/src/openrpc/chains/geist/geist.yaml
+++ b/src/openrpc/chains/geist/geist.yaml
@@ -393,9 +393,9 @@ methods:
 
       | Chain | Free | Pay As You Go | Enterprise |
       |-------|------|---------------|------------|
-      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | unlimited | unlimited | unlimited |
+      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | 500 | unlimited | unlimited |
       | Polygon | 500 | 2000 | unlimited |
-      | Monad | 500 | 1000 | unlimited |
+      | Monad | 500 | 1000 | 1000 |
       | BSC | 500 | 10000 | 10000 |
       | All Other Chains | 500 | 10000 | unlimited |
     params:

--- a/src/openrpc/chains/gnosis/gnosis.yaml
+++ b/src/openrpc/chains/gnosis/gnosis.yaml
@@ -393,9 +393,9 @@ methods:
 
       | Chain | Free | Pay As You Go | Enterprise |
       |-------|------|---------------|------------|
-      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | unlimited | unlimited | unlimited |
+      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | 500 | unlimited | unlimited |
       | Polygon | 500 | 2000 | unlimited |
-      | Monad | 500 | 1000 | unlimited |
+      | Monad | 500 | 1000 | 1000 |
       | BSC | 500 | 10000 | 10000 |
       | All Other Chains | 500 | 10000 | unlimited |
     params:

--- a/src/openrpc/chains/ink/ink.yaml
+++ b/src/openrpc/chains/ink/ink.yaml
@@ -393,9 +393,9 @@ methods:
 
       | Chain | Free | Pay As You Go | Enterprise |
       |-------|------|---------------|------------|
-      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | unlimited | unlimited | unlimited |
+      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | 500 | unlimited | unlimited |
       | Polygon | 500 | 2000 | unlimited |
-      | Monad | 500 | 1000 | unlimited |
+      | Monad | 500 | 1000 | 1000 |
       | BSC | 500 | 10000 | 10000 |
       | All Other Chains | 500 | 10000 | unlimited |
     params:

--- a/src/openrpc/chains/lens/lens.yaml
+++ b/src/openrpc/chains/lens/lens.yaml
@@ -393,9 +393,9 @@ methods:
 
       | Chain | Free | Pay As You Go | Enterprise |
       |-------|------|---------------|------------|
-      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | unlimited | unlimited | unlimited |
+      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | 500 | unlimited | unlimited |
       | Polygon | 500 | 2000 | unlimited |
-      | Monad | 500 | 1000 | unlimited |
+      | Monad | 500 | 1000 | 1000 |
       | BSC | 500 | 10000 | 10000 |
       | All Other Chains | 500 | 10000 | unlimited |
     params:

--- a/src/openrpc/chains/linea/linea.yaml
+++ b/src/openrpc/chains/linea/linea.yaml
@@ -393,9 +393,9 @@ methods:
 
       | Chain | Free | Pay As You Go | Enterprise |
       |-------|------|---------------|------------|
-      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | unlimited | unlimited | unlimited |
+      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | 500 | unlimited | unlimited |
       | Polygon | 500 | 2000 | unlimited |
-      | Monad | 500 | 1000 | unlimited |
+      | Monad | 500 | 1000 | 1000 |
       | BSC | 500 | 10000 | 10000 |
       | All Other Chains | 500 | 10000 | unlimited |
     params:

--- a/src/openrpc/chains/lumia/lumia.yaml
+++ b/src/openrpc/chains/lumia/lumia.yaml
@@ -393,9 +393,9 @@ methods:
 
       | Chain | Free | Pay As You Go | Enterprise |
       |-------|------|---------------|------------|
-      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | unlimited | unlimited | unlimited |
+      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | 500 | unlimited | unlimited |
       | Polygon | 500 | 2000 | unlimited |
-      | Monad | 500 | 1000 | unlimited |
+      | Monad | 500 | 1000 | 1000 |
       | BSC | 500 | 10000 | 10000 |
       | All Other Chains | 500 | 10000 | unlimited |
     params:

--- a/src/openrpc/chains/mantle/mantle.yaml
+++ b/src/openrpc/chains/mantle/mantle.yaml
@@ -393,9 +393,9 @@ methods:
 
       | Chain | Free | Pay As You Go | Enterprise |
       |-------|------|---------------|------------|
-      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | unlimited | unlimited | unlimited |
+      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | 500 | unlimited | unlimited |
       | Polygon | 500 | 2000 | unlimited |
-      | Monad | 500 | 1000 | unlimited |
+      | Monad | 500 | 1000 | 1000 |
       | BSC | 500 | 10000 | 10000 |
       | All Other Chains | 500 | 10000 | unlimited |
     params:

--- a/src/openrpc/chains/metis/metis.yaml
+++ b/src/openrpc/chains/metis/metis.yaml
@@ -391,9 +391,9 @@ methods:
 
       | Chain | Free | Pay As You Go | Enterprise |
       |-------|------|---------------|------------|
-      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | unlimited | unlimited | unlimited |
+      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | 500 | unlimited | unlimited |
       | Polygon | 500 | 2000 | unlimited |
-      | Monad | 500 | 1000 | unlimited |
+      | Monad | 500 | 1000 | 1000 |
       | BSC | 500 | 10000 | 10000 |
       | All Other Chains | 500 | 10000 | unlimited |
     params:

--- a/src/openrpc/chains/monad/monad.yaml
+++ b/src/openrpc/chains/monad/monad.yaml
@@ -1016,9 +1016,9 @@ methods:
 
       | Chain | Free | Pay As You Go | Enterprise |
       |-------|------|---------------|------------|
-      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | unlimited | unlimited | unlimited |
+      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | 500 | unlimited | unlimited |
       | Polygon | 500 | 2000 | unlimited |
-      | Monad | 500 | 1000 | unlimited |
+      | Monad | 500 | 1000 | 1000 |
       | BSC | 500 | 10000 | 10000 |
       | All Other Chains | 500 | 10000 | unlimited |
     params:

--- a/src/openrpc/chains/opBNB/opBNB.yaml
+++ b/src/openrpc/chains/opBNB/opBNB.yaml
@@ -393,9 +393,9 @@ methods:
 
       | Chain | Free | Pay As You Go | Enterprise |
       |-------|------|---------------|------------|
-      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | unlimited | unlimited | unlimited |
+      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | 500 | unlimited | unlimited |
       | Polygon | 500 | 2000 | unlimited |
-      | Monad | 500 | 1000 | unlimited |
+      | Monad | 500 | 1000 | 1000 |
       | BSC | 500 | 10000 | 10000 |
       | All Other Chains | 500 | 10000 | unlimited |
     params:

--- a/src/openrpc/chains/optimism/optimism.yaml
+++ b/src/openrpc/chains/optimism/optimism.yaml
@@ -1018,9 +1018,9 @@ methods:
 
       | Chain | Free | Pay As You Go | Enterprise |
       |-------|------|---------------|------------|
-      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | unlimited | unlimited | unlimited |
+      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | 500 | unlimited | unlimited |
       | Polygon | 500 | 2000 | unlimited |
-      | Monad | 500 | 1000 | unlimited |
+      | Monad | 500 | 1000 | 1000 |
       | BSC | 500 | 10000 | 10000 |
       | All Other Chains | 500 | 10000 | unlimited |
     params:

--- a/src/openrpc/chains/polygon-zkevm/polygon-zkevm.yaml
+++ b/src/openrpc/chains/polygon-zkevm/polygon-zkevm.yaml
@@ -1243,9 +1243,9 @@ methods:
 
       | Chain | Free | Pay As You Go | Enterprise |
       |-------|------|---------------|------------|
-      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | unlimited | unlimited | unlimited |
+      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | 500 | unlimited | unlimited |
       | Polygon | 500 | 2000 | unlimited |
-      | Monad | 500 | 1000 | unlimited |
+      | Monad | 500 | 1000 | 1000 |
       | BSC | 500 | 10000 | 10000 |
       | All Other Chains | 500 | 10000 | unlimited |
     params:

--- a/src/openrpc/chains/polygon/polygon.yaml
+++ b/src/openrpc/chains/polygon/polygon.yaml
@@ -1040,9 +1040,9 @@ methods:
 
       | Chain | Free | Pay As You Go | Enterprise |
       |-------|------|---------------|------------|
-      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | unlimited | unlimited | unlimited |
+      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | 500 | unlimited | unlimited |
       | Polygon | 500 | 2000 | unlimited |
-      | Monad | 500 | 1000 | unlimited |
+      | Monad | 500 | 1000 | 1000 |
       | BSC | 500 | 10000 | 10000 |
       | All Other Chains | 500 | 10000 | unlimited |
     params:

--- a/src/openrpc/chains/rootstock/rootstock.yaml
+++ b/src/openrpc/chains/rootstock/rootstock.yaml
@@ -393,9 +393,9 @@ methods:
 
       | Chain | Free | Pay As You Go | Enterprise |
       |-------|------|---------------|------------|
-      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | unlimited | unlimited | unlimited |
+      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | 500 | unlimited | unlimited |
       | Polygon | 500 | 2000 | unlimited |
-      | Monad | 500 | 1000 | unlimited |
+      | Monad | 500 | 1000 | 1000 |
       | BSC | 500 | 10000 | 10000 |
       | All Other Chains | 500 | 10000 | unlimited |
     params:

--- a/src/openrpc/chains/scroll/scroll.yaml
+++ b/src/openrpc/chains/scroll/scroll.yaml
@@ -393,9 +393,9 @@ methods:
 
       | Chain | Free | Pay As You Go | Enterprise |
       |-------|------|---------------|------------|
-      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | unlimited | unlimited | unlimited |
+      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | 500 | unlimited | unlimited |
       | Polygon | 500 | 2000 | unlimited |
-      | Monad | 500 | 1000 | unlimited |
+      | Monad | 500 | 1000 | 1000 |
       | BSC | 500 | 10000 | 10000 |
       | All Other Chains | 500 | 10000 | unlimited |
     params:

--- a/src/openrpc/chains/sei/sei.yaml
+++ b/src/openrpc/chains/sei/sei.yaml
@@ -1018,9 +1018,9 @@ methods:
 
       | Chain | Free | Pay As You Go | Enterprise |
       |-------|------|---------------|------------|
-      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | unlimited | unlimited | unlimited |
+      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | 500 | unlimited | unlimited |
       | Polygon | 500 | 2000 | unlimited |
-      | Monad | 500 | 1000 | unlimited |
+      | Monad | 500 | 1000 | 1000 |
       | BSC | 500 | 10000 | 10000 |
       | All Other Chains | 500 | 10000 | unlimited |
     params:

--- a/src/openrpc/chains/shape/shape.yaml
+++ b/src/openrpc/chains/shape/shape.yaml
@@ -393,9 +393,9 @@ methods:
 
       | Chain | Free | Pay As You Go | Enterprise |
       |-------|------|---------------|------------|
-      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | unlimited | unlimited | unlimited |
+      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | 500 | unlimited | unlimited |
       | Polygon | 500 | 2000 | unlimited |
-      | Monad | 500 | 1000 | unlimited |
+      | Monad | 500 | 1000 | 1000 |
       | BSC | 500 | 10000 | 10000 |
       | All Other Chains | 500 | 10000 | unlimited |
     params:

--- a/src/openrpc/chains/soneium/soneium.yaml
+++ b/src/openrpc/chains/soneium/soneium.yaml
@@ -393,9 +393,9 @@ methods:
 
       | Chain | Free | Pay As You Go | Enterprise |
       |-------|------|---------------|------------|
-      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | unlimited | unlimited | unlimited |
+      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | 500 | unlimited | unlimited |
       | Polygon | 500 | 2000 | unlimited |
-      | Monad | 500 | 1000 | unlimited |
+      | Monad | 500 | 1000 | 1000 |
       | BSC | 500 | 10000 | 10000 |
       | All Other Chains | 500 | 10000 | unlimited |
     params:

--- a/src/openrpc/chains/sonic/sonic.yaml
+++ b/src/openrpc/chains/sonic/sonic.yaml
@@ -393,9 +393,9 @@ methods:
 
       | Chain | Free | Pay As You Go | Enterprise |
       |-------|------|---------------|------------|
-      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | unlimited | unlimited | unlimited |
+      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | 500 | unlimited | unlimited |
       | Polygon | 500 | 2000 | unlimited |
-      | Monad | 500 | 1000 | unlimited |
+      | Monad | 500 | 1000 | 1000 |
       | BSC | 500 | 10000 | 10000 |
       | All Other Chains | 500 | 10000 | unlimited |
     params:

--- a/src/openrpc/chains/story/story.yaml
+++ b/src/openrpc/chains/story/story.yaml
@@ -1117,9 +1117,9 @@ methods:
 
       | Chain | Free | Pay As You Go | Enterprise |
       |-------|------|---------------|------------|
-      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | unlimited | unlimited | unlimited |
+      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | 500 | unlimited | unlimited |
       | Polygon | 500 | 2000 | unlimited |
-      | Monad | 500 | 1000 | unlimited |
+      | Monad | 500 | 1000 | 1000 |
       | BSC | 500 | 10000 | 10000 |
       | All Other Chains | 500 | 10000 | unlimited |
     params:

--- a/src/openrpc/chains/superseed/superseed.yaml
+++ b/src/openrpc/chains/superseed/superseed.yaml
@@ -1059,9 +1059,9 @@ methods:
 
       | Chain | Free | Pay As You Go | Enterprise |
       |-------|------|---------------|------------|
-      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | unlimited | unlimited | unlimited |
+      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | 500 | unlimited | unlimited |
       | Polygon | 500 | 2000 | unlimited |
-      | Monad | 500 | 1000 | unlimited |
+      | Monad | 500 | 1000 | 1000 |
       | BSC | 500 | 10000 | 10000 |
       | All Other Chains | 500 | 10000 | unlimited |
     params:

--- a/src/openrpc/chains/unichain/unichain.yaml
+++ b/src/openrpc/chains/unichain/unichain.yaml
@@ -393,9 +393,9 @@ methods:
 
       | Chain | Free | Pay As You Go | Enterprise |
       |-------|------|---------------|------------|
-      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | unlimited | unlimited | unlimited |
+      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | 500 | unlimited | unlimited |
       | Polygon | 500 | 2000 | unlimited |
-      | Monad | 500 | 1000 | unlimited |
+      | Monad | 500 | 1000 | 1000 |
       | BSC | 500 | 10000 | 10000 |
       | All Other Chains | 500 | 10000 | unlimited |
     params:

--- a/src/openrpc/chains/worldchain/worldchain.yaml
+++ b/src/openrpc/chains/worldchain/worldchain.yaml
@@ -393,9 +393,9 @@ methods:
 
       | Chain | Free | Pay As You Go | Enterprise |
       |-------|------|---------------|------------|
-      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | unlimited | unlimited | unlimited |
+      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | 500 | unlimited | unlimited |
       | Polygon | 500 | 2000 | unlimited |
-      | Monad | 500 | 1000 | unlimited |
+      | Monad | 500 | 1000 | 1000 |
       | BSC | 500 | 10000 | 10000 |
       | All Other Chains | 500 | 10000 | unlimited |
     params:

--- a/src/openrpc/chains/zetachain/zetachain.yaml
+++ b/src/openrpc/chains/zetachain/zetachain.yaml
@@ -393,9 +393,9 @@ methods:
 
       | Chain | Free | Pay As You Go | Enterprise |
       |-------|------|---------------|------------|
-      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | unlimited | unlimited | unlimited |
+      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | 500 | unlimited | unlimited |
       | Polygon | 500 | 2000 | unlimited |
-      | Monad | 500 | 1000 | unlimited |
+      | Monad | 500 | 1000 | 1000 |
       | BSC | 500 | 10000 | 10000 |
       | All Other Chains | 500 | 10000 | unlimited |
     params:

--- a/src/openrpc/chains/zksync/zksync.yaml
+++ b/src/openrpc/chains/zksync/zksync.yaml
@@ -1018,9 +1018,9 @@ methods:
 
       | Chain | Free | Pay As You Go | Enterprise |
       |-------|------|---------------|------------|
-      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | unlimited | unlimited | unlimited |
+      | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | 500 | unlimited | unlimited |
       | Polygon | 500 | 2000 | unlimited |
-      | Monad | 500 | 1000 | unlimited |
+      | Monad | 500 | 1000 | 1000 |
       | BSC | 500 | 10000 | 10000 |
       | All Other Chains | 500 | 10000 | unlimited |
     params:


### PR DESCRIPTION
## Summary
- update eth_getLogs block range table: Free tier 500 on all chains
- set Monad Enterprise tier limit to 1000 logs per query

## Testing
- `pnpm lint` *(fails: Relative import paths need explicit file extensions, implicit any types in custom-app/src/Codeblock.tsx)*
- `pnpm run generate:rpc`

------
https://chatgpt.com/codex/tasks/task_b_6894b9529d3083308098dfbb71ead174