### PR TITLE
chore: remove pay-as-you-go video

### DIFF
--- a/fern/api-reference/pricing-resources/pricing-plans.mdx
+++ b/fern/api-reference/pricing-resources/pricing-plans.mdx
@@ -71,4 +71,3 @@ Each application has reserved dedicated throughput, measured in Compute Units pe
 
 *Note: Even if your application limit is lower, the system may allow higher throughput based on available capacity. For a more robust experience, we recommend implementing retries when experiencing throughput errors.*
 
-## Pay as You Go Video Explainer

--- a/fern/api-reference/pricing-resources/pricing/pricing-plans.mdx
+++ b/fern/api-reference/pricing-resources/pricing/pricing-plans.mdx
@@ -71,6 +71,3 @@ Each application has reserved dedicated throughput, measured in Compute Units pe
 
 *Note: Even if your application limit is lower, the system may allow higher throughput based on available capacity. For a more robust experience, we recommend implementing retries when experiencing throughput errors.*
 
-## Pay as You Go Video Explainer
-
-<iframe width="560" height="315" src="https://www.youtube.com/embed/dyCON_NA_H8?si=OmrTZELm0FCviJWP" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>


### PR DESCRIPTION
## Summary
- remove outdated Pay-as-you-go video from pricing plans docs

## Testing
- `pnpm lint` *(fails: Binding element 'theme' implicitly has an 'any' type, Property 'button' does not exist on type...)*

------
https://chatgpt.com/codex/tasks/task_b_68963d99a1288329be384a637e6a1331