### PR TITLE
docs: rename tools section

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -174,7 +174,7 @@ navigation:
                 path: api-reference/pricing-resources/resources/error-reference.mdx
             slug: resources
         slug: pricing-resources
-      - section: Tools & SDKs
+      - section: Tools
         contents:
           - section: Scaffold Alchemy
             contents:


### PR DESCRIPTION
## Summary
- rename "Tools & SDKs" navigation section to "Tools"

## Testing
- `pnpm lint` *(fails: custom-app TypeScript errors)*
- `pnpm lint:prettier`


------
https://chatgpt.com/codex/tasks/task_b_68a645612b108329a1ed887a824e81f6