### PR TITLE
Redirect old SDK WebSockets page to docs home

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -6190,6 +6190,9 @@ redirects:
   - source: /reference/sdk-transact-methods
     destination: /docs
     permanent: true
+  - source: /reference/sdk-websockets-endpoints
+    destination: /docs
+    permanent: true
   - source: /reference/searchcontractmetadata-sdk-v3
     destination: /docs
     permanent: true


### PR DESCRIPTION
## Summary
- redirect obsolete SDK WebSockets endpoint page to docs homepage

## Testing
- `pnpm lint` *(fails: Property 'glob' does not exist on type 'ImportMeta', TS errors in custom-app)*

------
https://chatgpt.com/codex/tasks/task_b_68b1e93b6c208329b2409a7b978a4b7f