### PR TITLE
Remove Alchemy SDK references from subscription api guide

### DIFF
--- a/fern/api-reference/websockets/subscription-api.mdx
+++ b/fern/api-reference/websockets/subscription-api.mdx
@@ -8,14 +8,11 @@ slug: reference/subscription-api
 
 # Getting Started
 
-There are two primary ways to use the Subscription API or WebSockets:
-
-1. [Using the Alchemy SDK](/reference/alchemy-sdk-quickstart) (recommended)
-2. [Using standard JSON-RPC methods](#using-json-rpc-requests-to-access-websockets)
+The primary way to use the Subscription API or WebSockets is through standard JSON-RPC methods. See the [Using JSON-RPC Requests section](#using-json-rpc-requests-to-access-websockets) below to get started.
 
 # Subscription API Endpoints
 
-For a full list of Subscription API endpoints and supported chains see the [Subscription API Endpoints](/reference/subscription-api-endpoints) doc, or if you're using the [Alchemy SDK](/reference/alchemy-sdk-quickstart) see [SDK WebSockets Endpoints](/reference/sdk-websockets-endpoints). Below are the subscription endpoints available and the corresponding docs for each of them.
+For a full list of Subscription API endpoints and supported chains see the [Subscription API Endpoints](/reference/subscription-api-endpoints) doc. Below are the subscription endpoints available and the corresponding docs for each of them.
 
 <Info>
   Note: `alchemy_minedTransactions` and `alchemy_pendingTransactions` are only
@@ -48,7 +45,7 @@ Note that your app's URL for WebSockets is different from its URL for HTTP reque
 
 ![](2cbc56a-image.png)
 
-Next, install a command line tool for making WebSocket requests such as [wscat](https://github.com/websockets/wscat), or to make requests from your project files instead of the command line, check out the [Alchemy SDK](/reference/sdk-websockets-endpoints). Using `wscat`, you can send requests as follows:
+Next, install a command line tool for making WebSocket requests such as [wscat](https://github.com/websockets/wscat). Using `wscat`, you can send requests as follows:
 
 <CodeGroup>
   ```shell Shell
@@ -70,33 +67,6 @@ Next, install a command line tool for making WebSocket requests such as [wscat](
   > {"id": 1, "method": "eth_unsubscribe", "params": ["0xcd0c3e8af590364c09d0fa6a1210faf5"]}
 
   < {"jsonrpc":"2.0","id":1,"result":true}
-  ```
-
-  ```javascript Alchemy SDK
-  // Setup: npm install alchemy-sdk
-  import { Alchemy } from "alchemy-sdk";
-
-  // Optional config object, but defaults to demo api-key and eth-mainnet.
-  const settings = {
-    apiKey: "demo", // Replace with your Alchemy API Key.
-    network: Network.ETH_MAINNET, // Replace with your network.
-  };
-
-  const alchemy = new Alchemy(settings);
-
-  // Subscription for new blocks on Eth Mainnet.
-  alchemy.ws.on("block", (blockNumber) =>
-    console.log("The latest block number is", blockNumber),
-  );
-
-  // Subscription for Alchemy's pendingTransactions Enhanced API
-  alchemy.ws.on(
-    {
-      method: "alchemy_pendingTransactions",
-      toAddress: "vitalik.eth",
-    },
-    (tx) => console.log(tx),
-  );
   ```
 </CodeGroup>
 


### PR DESCRIPTION
Remove Alchemy SDK references from subscription api guide