### PR TITLE
feat: eth_getLogs FREE tier new blockRange limits

### DIFF
--- a/src/openrpc/chains/_components/evm/methods.yaml
+++ b/src/openrpc/chains/_components/evm/methods.yaml
@@ -805,11 +805,11 @@ components:
 
         | Chain | Free | Pay As You Go | Enterprise |
         |-------|------|---------------|------------|
-        | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | 500 | unlimited | unlimited |
-        | Polygon | 500 | 2000 | unlimited |
-        | Monad | 500 | 1000 | 1000 |
-        | BSC | 500 | 10000 | 10000 |
-        | All Other Chains | 500 | 10000 | unlimited |
+        | Ethereum and Layer 2s (Ethereum, Base, Optimism, Arbitrum, Worldchain) | 10 | unlimited | unlimited |
+        | Polygon | 10 | 2000 | unlimited |
+        | Monad | 10 | 1000 | 1000 |
+        | BSC | 10 | 10000 | 10000 |
+        | All Other Chains | 10 | 10000 | unlimited |
       params:
         - name: Filter
           required: true


### PR DESCRIPTION
 - lower blockrange limit for FREE tier customers from 500 to 10 on eth_getLogs method

## Description

<!-- eth_getLogs FREE tier new blockRange limits -->

## Related Issues

https://app.asana.com/1/1129441638109975/project/1210902932268717/task/1211152828187894?focus=true

## Changes Made
Preview: https://alchemy-preview-170ecb52-8c25-4eab-bb87-3330c7cefa7b.docs.buildwithfern.com/docs/node/ethereum/ethereum-api-endpoints/eth-get-logs
<!-- Changed FREE tier limits for eth_getLogs -->

## Testing

<!-- Describe the tests that you ran to verify your changes -->

* \[ ] I have tested these changes locally
* \[x ] I have run the validation scripts (`pnpm run validate`)
* \[ ] I have checked that the documentation builds correctly
