### PR TITLE
adds a linea eth_estimateGas with a callout to use linea_estimateGas

### DIFF
--- a/src/openrpc/chains/_components/linea/methods.yaml
+++ b/src/openrpc/chains/_components/linea/methods.yaml
@@ -102,3 +102,37 @@ components:
               gasLimit: "0xcf08"
               baseFeePerGas: "0x7"
               priorityFeePerGas: "0x43a82a4"
+
+    eth_estimateGas:
+      name: eth_estimateGas
+      description: |
+        Generates and returns an estimate of how much gas is necessary to allow the transaction to complete.
+
+        <Info> [linea_estimateGas](/docs/node/linea/linea-api-endpoints/linea-estimate-gas) uses the same inputs as the standard eth_estimateGas, but returns the recommended gas limit, the base fee per gas, and the priority fee per gas. We recommend using `linea_estimateGas` for more accurate results. </Info>
+      params:
+        - name: Transaction
+          required: true
+          description: The transaction object for which to estimate gas usage.
+          schema:
+            $ref: "../evm/transaction.yaml#/components/schemas/GenericTransaction"
+        - name: Block
+          required: false
+          description: The block number or tag at which to estimate gas usage. Defaults to `'latest'` if not provided.
+          schema:
+            $ref: "../evm/block.yaml#/components/schemas/BlockNumberOrTag"
+      result:
+        name: Gas used
+        description: The estimated amount of gas required for the transaction, as a hexadecimal string.
+        schema:
+          $ref: "../evm/base-types.yaml#/components/schemas/uint"
+      examples:
+        - name: eth_estimateGas example
+          params:
+            - name: Transaction
+              value:
+                from: "0xfe3b557e8fb62b89f4916b721be55ceb828dbd73"
+                to: "0x44aa93095d6749a706051658b970b941c72c1d53"
+                value: "0x1"
+          result:
+            name: Gas used
+            value: "0x5208"

--- a/src/openrpc/chains/linea/linea.yaml
+++ b/src/openrpc/chains/linea/linea.yaml
@@ -34,7 +34,7 @@ methods:
   - $ref: ../_components/evm/methods.yaml#/components/methods/eth_call
   - $ref: ../_components/evm/methods.yaml#/components/methods/eth_callMany
   - $ref: ../_components/evm/methods.yaml#/components/methods/eth_chainId
-  - $ref: ../_components/evm/methods.yaml#/components/methods/eth_estimateGas
+  - $ref: ../_components/linea/methods.yaml#/components/methods/eth_estimateGas
   - $ref: ../_components/evm/methods.yaml#/components/methods/eth_gasPrice
   - $ref: ../_components/evm/methods.yaml#/components/methods/eth_getAccount
   - $ref: ../_components/evm/methods.yaml#/components/methods/eth_getBalance
@@ -72,3 +72,5 @@ methods:
   - $ref: ../_components/evm/methods.yaml#/components/methods/web3_clientVersion
   - $ref: ../_components/evm/methods.yaml#/components/methods/web3_sha3
   - $ref: ../_components/linea/methods.yaml#/components/methods/linea_estimateGas
+x-bot-ignore:
+  - eth_estimateGas


### PR DESCRIPTION
## Description

adds a linea eth_estimateGas with a callout to use linea_estimateGas

* \[x] I have tested these changes locally
* \[x] I have run the validation scripts (`pnpm run validate`)
* \[x] I have checked that the documentation builds correctly
