### PR TITLE
docs: set the addresses field of the create-webhook method to required

### DIFF
--- a/src/openapi/notify/notify.yaml
+++ b/src/openapi/notify/notify.yaml
@@ -357,6 +357,7 @@ components:
         - network
         - webhook_type
         - webhook_url
+        - addresses
       properties:
         network:
           $ref: "#/components/schemas/network"


### PR DESCRIPTION
## Description

In the create-webhooks API, the documentation does not mark the addresses field as required. However, the actual call requires the addresses field to be filled for success.

## Related Issues

NA

## Changes Made

set the addresses field of the create-webhook method to required

## Testing

* \[ X ] I have tested these changes locally
* \[ X ] I have run the validation scripts (`pnpm run validate`)
* \[ X ] I have checked that the documentation builds correctly
