### PR TITLE
update add-evm-chain script and add quickstart and faq for adi chain

### DIFF
--- a/fern/api-reference/adi/adi-api-faq.mdx
+++ b/fern/api-reference/adi/adi-api-faq.mdx
@@ -1,0 +1,37 @@
+---
+title: ADI API FAQ
+description: Frequently asked questions about the ADI API
+subtitle: Frequently asked questions about the ADI API
+url: https://docs.alchemy.com/reference/adi-api-faq
+slug: reference/adi-api-faq
+---
+
+## What is ADI?
+ADI Network is an EVM-compatible Layer 2 that leverages cryptographic Zero-Knowledge validity proofs (ZKPs) to ensure both security and efficiency in transaction processing. ADI is enabling seamless integration between traditional finance, crypto ecosystems, and regulated markets.
+
+## How do I get started with ADI?
+Check out our [ADI API Quickstart guide](./adi-api-quickstart) to get started building on ADI.
+
+## What is the ADI API?
+The ADI API allows developers to interface with the ADI mainnet. With this API, developers can execute transactions, query on-chain data, and interact with the ADI network, relying on a JSON-RPC standard.
+
+## Is ADI EVM compatible?
+Yes, ADI is EVM compatible.
+
+## What API does ADI use?
+ADI uses the JSON-RPC API standard. This API is crucial for any blockchain interaction on the ADI network, allowing users to read block/transaction data, query chain information, execute smart contracts, and store data on-chain.
+
+## What methods are supported on ADI?
+ADI supports standard Ethereum JSON-RPC methods. Some chain-specific methods may vary. Please check the ADI API endpoints documentation for a complete list.
+
+## What is a ADI API key?
+When accessing the ADI network via a node provider like Alchemy, ADI developers use an API key to send transactions and retrieve data from the network. For the best development experience, we recommend that you [sign up for a free API key](https://dashboard.alchemy.com/signup)!
+
+## Which libraries support ADI?
+Common Ethereum libraries like [ethers.js](https://docs.ethers.org/v5/) should be compatible with ADI, given its EVM nature.
+
+## What is the native currency of ADI?
+The native currency of ADI is ADI.
+
+## My question isn’t here, where can I get help?
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.

--- a/fern/api-reference/adi/adi-api-faq.mdx
+++ b/fern/api-reference/adi/adi-api-faq.mdx
@@ -24,7 +24,7 @@ ADI uses the JSON-RPC API standard. This API is crucial for any blockchain inter
 ## What methods are supported on ADI?
 ADI supports standard Ethereum JSON-RPC methods. Some chain-specific methods may vary. Please check the ADI API endpoints documentation for a complete list.
 
-## What is a ADI API key?
+## What is an ADI API key?
 When accessing the ADI network via a node provider like Alchemy, ADI developers use an API key to send transactions and retrieve data from the network. For the best development experience, we recommend that you [sign up for a free API key](https://dashboard.alchemy.com/signup)!
 
 ## Which libraries support ADI?

--- a/fern/api-reference/adi/adi-api-quickstart.mdx
+++ b/fern/api-reference/adi/adi-api-quickstart.mdx
@@ -1,0 +1,118 @@
+---
+title: ADI API Quickstart
+description: How to get started building on ADI and using the JSON-RPC API
+subtitle: How to get started building on ADI and using the JSON-RPC API
+url: https://docs.alchemy.com/reference/adi-api-quickstart
+slug: reference/adi-api-quickstart
+---
+
+*To use the ADI API you'll need to [create a free Alchemy account](https://dashboard.alchemy.com/signup) first!*
+
+## Introduction
+
+ADI Network is an EVM-compatible Layer 2 that leverages cryptographic Zero-Knowledge validity proofs (ZKPs) to ensure both security and efficiency in transaction processing. ADI is enabling seamless integration between traditional finance, crypto ecosystems, and regulated markets.
+
+## What is the ADI API?
+
+The ADI API allows interaction with the ADI network through a set of JSON-RPC methods. Its design is familiar to developers who have worked with Ethereum's JSON-RPC APIs, making it intuitive and straightforward to use.
+
+## Getting Started Instructions
+
+### 1. Choose a Package Manager (npm or yarn)
+
+Select a package manager to manage your project's dependencies. Choose between `npm` and `yarn` based on your preference or project requirements.
+
+<CodeGroup>
+  ```shell npm
+  # Begin with npm by following the npm documentation
+  # https://docs.npmjs.com/downloading-and-installing-node-js-and-npm
+  ```
+
+  ```shell yarn
+  # For yarn, refer to yarn's installation guide
+  # https://classic.yarnpkg.com/lang/en/docs/install
+  ```
+</CodeGroup>
+
+### 2. Set Up Your Project
+
+Open your terminal and execute the following commands to create and initialize your project:
+
+<CodeGroup>
+  ```shell npm
+  mkdir adi-api-quickstart
+  cd adi-api-quickstart
+  npm init --yes
+  ```
+
+  ```shell yarn
+  mkdir adi-api-quickstart
+  cd adi-api-quickstart
+  yarn init --yes
+  ```
+</CodeGroup>
+
+This creates a new directory named `adi-api-quickstart` and initializes a Node.js project within it.
+
+### 3. Make Your First Request
+
+Install Axios, a popular HTTP client, to make API requests:
+
+<CodeGroup>
+  ```shell npm
+  npm install axios
+  ```
+
+  ```shell yarn
+  yarn add axios
+  ```
+</CodeGroup>
+
+Create an `index.js` file in your project directory and paste the following code:
+
+<CodeGroup>
+  ```javascript index.js
+  const axios = require('axios');
+
+  const url = 'https://adi-testnet.g.alchemy.com/v2/${your-api-key}';
+
+  const payload = {
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'eth_blockNumber',
+    params: []
+  };
+
+  axios.post(url, payload)
+    .then(response => {
+      console.log('Latest Block:', response.data.result);
+    })
+    .catch(error => {
+      console.error(error);
+    });
+  ```
+</CodeGroup>
+
+Remember to replace `your-api-key` with your actual Alchemy API key that you can get from your [Alchemy dashboard](https://dashboard.alchemy.com/signup).
+
+### 4. Run Your Script
+
+Execute your script to make a request to the ADI network:
+
+<CodeGroup>
+  ```shell shell
+  node index.js
+  ```
+</CodeGroup>
+
+You should see the latest block information from ADI's network outputted to your console:
+
+<CodeGroup>
+  ```shell shell
+  Latest Block: 0x...
+  ```
+</CodeGroup>
+
+## Next Steps
+
+Congratulations! You've made your first request to the ADI network. You can now explore the various JSON-RPC methods available on ADI and start building your dApps on this innovative platform.

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -1663,6 +1663,10 @@ navigation:
 
       - section: ADI
         contents:
+          - page: ADI API Quickstart
+            path: api-reference/adi/adi-api-quickstart.mdx
+          - page: ADI API FAQ
+            path: api-reference/adi/adi-api-faq.mdx
           - api: ADI API Endpoints
             api-name: adi
         slug: adi

--- a/scripts/add-evm-chain.ts
+++ b/scripts/add-evm-chain.ts
@@ -8,7 +8,6 @@ import {
   createDirectoryStructure,
   formatChainName,
   normalizeUrl,
-  updateDocsYml,
   validateChainName,
   validateUrl,
   writeChainFiles,
@@ -158,30 +157,22 @@ function createChainConfig(
 }
 
 function logSuccess(chainName: string): void {
-  console.info("\n🎉 Successfully created new EVM chain!");
+  console.info("\n🎉 Successfully created quickstart and FAQ guides!");
   console.info("📍 Locations:");
-  console.info(
-    `   - OpenRPC: src/openrpc/chains/${chainName}/${chainName}.yaml`,
-  );
   console.info(`   - Quickstart: fern/api-reference/${chainName}/`);
-  console.info(`   - Generators: fern/apis/${chainName}/`);
-  console.info("   - Sidebar: Updated in fern/docs.yml");
   console.info("\n📋 Files created:");
   console.info(`   - ${chainName}-api-quickstart.mdx`);
   console.info(`   - ${chainName}-api-faq.mdx`);
-  console.info("   - generators.yaml");
   console.info("\n💡 Next steps:");
   console.info("1. Review the generated files");
-  console.info("2. Remove any methods that are not supported by this chain");
-  console.info("3. Add any chain-specific methods if needed");
-  console.info("4. Customize the FAQ content with chain-specific information");
-  console.info("5. Customize the emoji for chain section in docs.yml");
-  console.info("6. Run the generation script: pnpm run generate");
-  console.info("7. Run the docs locally to preview: pnpm run dev");
+  console.info("2. Customize the FAQ content with chain-specific information");
+  console.info(
+    "3. Manually add the guides to your documentation structure if needed",
+  );
 }
 
 async function main(): Promise<void> {
-  console.info("🚀 Adding new EVM chain to API references\n");
+  console.info("🚀 Creating quickstart and FAQ guides for new EVM chain\n");
 
   try {
     // Collect user input
@@ -206,13 +197,9 @@ async function main(): Promise<void> {
     console.info("\n📁 Creating directory structure...");
     const directories = createDirectoryStructure(chainName);
 
-    // Write all files
-    console.info("📝 Creating files...");
+    // Write only quickstart and FAQ files
+    console.info("📝 Creating quickstart and FAQ files...");
     writeChainFiles(config, directories);
-
-    // Update documentation
-    console.info("📝 Updating documentation...");
-    updateDocsYml(chainName, displayName);
 
     // Log success
     logSuccess(chainName);

--- a/src/utils/addEvmChainHelpers.ts
+++ b/src/utils/addEvmChainHelpers.ts
@@ -392,9 +392,8 @@ export function createDirectoryStructure(chainName: string): {
   );
   const generatorsDir = path.join(process.cwd(), "fern", "apis", chainName);
 
-  fs.mkdirSync(chainDir, { recursive: true });
+  // Only create the quickstart directory since we're only creating quickstart and FAQ files
   fs.mkdirSync(quickstartDir, { recursive: true });
-  fs.mkdirSync(generatorsDir, { recursive: true });
 
   return { chainDir, quickstartDir, generatorsDir };
 }
@@ -408,7 +407,7 @@ export function writeChainFiles(
   },
 ): void {
   const { chainName, displayName, introText, servers } = config;
-  const { chainDir: _chainDir, quickstartDir, generatorsDir } = directories;
+  const { quickstartDir } = directories;
 
   // Create quickstart guide
   const quickstartContent = generateQuickstartMarkdown(
@@ -427,11 +426,6 @@ export function writeChainFiles(
   const faqContent = generateFaqMarkdown(displayName, chainName, introText);
   const faqPath = path.join(quickstartDir, `${chainName}-api-faq.mdx`);
   fs.writeFileSync(faqPath, faqContent);
-
-  // Create generators.yaml
-  const generatorsContent = generateGeneratorsYaml(chainName);
-  const generatorsPath = path.join(generatorsDir, "generators.yaml");
-  fs.writeFileSync(generatorsPath, generatorsContent);
 }
 
 export function checkIfChainExists(chainName: string): boolean {

--- a/src/utils/addEvmChainHelpers.ts
+++ b/src/utils/addEvmChainHelpers.ts
@@ -373,37 +373,25 @@ ${tableRows.join("\n")}
 }
 
 export function createDirectoryStructure(chainName: string): {
-  chainDir: string;
   quickstartDir: string;
-  generatorsDir: string;
 } {
-  const chainDir = path.join(
-    process.cwd(),
-    "src",
-    "openrpc",
-    "chains",
-    chainName,
-  );
   const quickstartDir = path.join(
     process.cwd(),
     "fern",
     "api-reference",
     chainName,
   );
-  const generatorsDir = path.join(process.cwd(), "fern", "apis", chainName);
 
   // Only create the quickstart directory since we're only creating quickstart and FAQ files
   fs.mkdirSync(quickstartDir, { recursive: true });
 
-  return { chainDir, quickstartDir, generatorsDir };
+  return { quickstartDir };
 }
 
 export function writeChainFiles(
   config: ChainConfig,
   directories: {
-    chainDir: string;
     quickstartDir: string;
-    generatorsDir: string;
   },
 ): void {
   const { chainName, displayName, introText, servers } = config;


### PR DESCRIPTION
## Description

update add-evm-chain script to not add generators file and update docs.yml as that is part of daikon automation now + add quickstart and faq guides for ADI chain.

## Testing

* \[x] I have tested these changes locally
* \[x] I have run the validation scripts (`pnpm run validate`)
* \[x] I have checked that the documentation builds correctly
