### PR TITLE
add quickstart and faq guides for plasma, moonbeam, bob, mode & citrea networks

### DIFF
--- a/fern/api-reference/bob/bob-api-faq.mdx
+++ b/fern/api-reference/bob/bob-api-faq.mdx
@@ -1,0 +1,34 @@
+---
+title: Bob API FAQ
+description: Frequently asked questions about the Bob API
+subtitle: Frequently asked questions about the Bob API
+url: https://docs.alchemy.com/reference/bob-api-faq
+slug: reference/bob-api-faq
+---
+
+## What is Bob?
+BOB (Build on Bitcoin) is a hybrid OP Stack Layer-2 that runs full-EVM apps while anchoring finality to Bitcoin and enabling trust-minimized BTC bridging for Bitcoin-native DeFi.
+
+## How do I get started with Bob?
+Check out our [Bob API Quickstart guide](./bob-api-quickstart) to get started building on Bob.
+
+## What is the Bob API?
+The Bob API allows developers to interface with the Bob mainnet. With this API, developers can execute transactions, query on-chain data, and interact with the Bob network, relying on a JSON-RPC standard.
+
+## Is Bob EVM compatible?
+Yes, Bob is EVM compatible.
+
+## What API does Bob use?
+Bob uses the JSON-RPC API standard. This API is crucial for any blockchain interaction on the Bob network, allowing users to read block/transaction data, query chain information, execute smart contracts, and store data on-chain.
+
+## What methods are supported on Bob?
+Bob supports standard Ethereum JSON-RPC methods. Some chain-specific methods may vary. Please check the Bob API endpoints documentation for a complete list.
+
+## What is a Bob API key?
+When accessing the Bob network via a node provider like Alchemy, Bob developers use an API key to send transactions and retrieve data from the network. For the best development experience, we recommend that you [sign up for a free API key](https://dashboard.alchemy.com/signup)!
+
+## Which libraries support Bob?
+Common Ethereum libraries like [ethers.js](https://docs.ethers.org/v5/) should be compatible with Bob, given its EVM nature.
+
+## My question isn’t here, where can I get help?
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.

--- a/fern/api-reference/bob/bob-api-quickstart.mdx
+++ b/fern/api-reference/bob/bob-api-quickstart.mdx
@@ -1,0 +1,118 @@
+---
+title: Bob API Quickstart
+description: How to get started building on Bob and using the JSON-RPC API
+subtitle: How to get started building on Bob and using the JSON-RPC API
+url: https://docs.alchemy.com/reference/bob-api-quickstart
+slug: reference/bob-api-quickstart
+---
+
+*To use the Bob API you'll need to [create a free Alchemy account](https://dashboard.alchemy.com/signup) first!*
+
+## Introduction
+
+BOB (Build on Bitcoin) is a hybrid OP Stack Layer-2 that runs full-EVM apps while anchoring finality to Bitcoin and enabling trust-minimized BTC bridging for Bitcoin-native DeFi.
+
+## What is the Bob API?
+
+The Bob API allows interaction with the Bob network through a set of JSON-RPC methods. Its design is familiar to developers who have worked with Ethereum's JSON-RPC APIs, making it intuitive and straightforward to use.
+
+## Getting Started Instructions
+
+### 1. Choose a Package Manager (npm or yarn)
+
+Select a package manager to manage your project's dependencies. Choose between `npm` and `yarn` based on your preference or project requirements.
+
+<CodeGroup>
+  ```shell npm
+  # Begin with npm by following the npm documentation
+  # https://docs.npmjs.com/downloading-and-installing-node-js-and-npm
+  ```
+
+  ```shell yarn
+  # For yarn, refer to yarn's installation guide
+  # https://classic.yarnpkg.com/lang/en/docs/install
+  ```
+</CodeGroup>
+
+### 2. Set Up Your Project
+
+Open your terminal and execute the following commands to create and initialize your project:
+
+<CodeGroup>
+  ```shell npm
+  mkdir bob-api-quickstart
+  cd bob-api-quickstart
+  npm init --yes
+  ```
+
+  ```shell yarn
+  mkdir bob-api-quickstart
+  cd bob-api-quickstart
+  yarn init --yes
+  ```
+</CodeGroup>
+
+This creates a new directory named `bob-api-quickstart` and initializes a Node.js project within it.
+
+### 3. Make Your First Request
+
+Install Axios, a popular HTTP client, to make API requests:
+
+<CodeGroup>
+  ```shell npm
+  npm install axios
+  ```
+
+  ```shell yarn
+  yarn add axios
+  ```
+</CodeGroup>
+
+Create an `index.js` file in your project directory and paste the following code:
+
+<CodeGroup>
+  ```javascript index.js
+  const axios = require('axios');
+
+  const url = 'https://bob-mainnet.g.alchemy.com/v2/${your-api-key}';
+
+  const payload = {
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'eth_blockNumber',
+    params: []
+  };
+
+  axios.post(url, payload)
+    .then(response => {
+      console.log('Latest Block:', response.data.result);
+    })
+    .catch(error => {
+      console.error(error);
+    });
+  ```
+</CodeGroup>
+
+Remember to replace `your-api-key` with your actual Alchemy API key that you can get from your [Alchemy dashboard](https://dashboard.alchemy.com/signup).
+
+### 4. Run Your Script
+
+Execute your script to make a request to the Bob network:
+
+<CodeGroup>
+  ```shell shell
+  node index.js
+  ```
+</CodeGroup>
+
+You should see the latest block information from Bob's network outputted to your console:
+
+<CodeGroup>
+  ```shell shell
+  Latest Block: 0x...
+  ```
+</CodeGroup>
+
+## Next Steps
+
+Congratulations! You've made your first request to the Bob network. You can now explore the various JSON-RPC methods available on Bob and start building your dApps on this innovative platform.

--- a/fern/api-reference/citrea/citrea-api-faq.mdx
+++ b/fern/api-reference/citrea/citrea-api-faq.mdx
@@ -1,0 +1,34 @@
+---
+title: Citrea API FAQ
+description: Frequently asked questions about the Citrea API
+subtitle: Frequently asked questions about the Citrea API
+url: https://docs.alchemy.com/reference/citrea-api-faq
+slug: reference/citrea-api-faq
+---
+
+## What is Citrea?
+Citrea is a Bitcoin L2 zk-rollup with a Type-2 zkEVM that keeps data availability and settlement on Bitcoin—via its BitVM-based “Clementine” two-way peg—bringing full EVM compatibility to BTC.
+
+## How do I get started with Citrea?
+Check out our [Citrea API Quickstart guide](./citrea-api-quickstart) to get started building on Citrea.
+
+## What is the Citrea API?
+The Citrea API allows developers to interface with the Citrea mainnet. With this API, developers can execute transactions, query on-chain data, and interact with the Citrea network, relying on a JSON-RPC standard.
+
+## Is Citrea EVM compatible?
+Yes, Citrea is EVM compatible.
+
+## What API does Citrea use?
+Citrea uses the JSON-RPC API standard. This API is crucial for any blockchain interaction on the Citrea network, allowing users to read block/transaction data, query chain information, execute smart contracts, and store data on-chain.
+
+## What methods are supported on Citrea?
+Citrea supports standard Ethereum JSON-RPC methods. Some chain-specific methods may vary. Please check the Citrea API endpoints documentation for a complete list.
+
+## What is a Citrea API key?
+When accessing the Citrea network via a node provider like Alchemy, Citrea developers use an API key to send transactions and retrieve data from the network. For the best development experience, we recommend that you [sign up for a free API key](https://dashboard.alchemy.com/signup)!
+
+## Which libraries support Citrea?
+Common Ethereum libraries like [ethers.js](https://docs.ethers.org/v5/) should be compatible with Citrea, given its EVM nature.
+
+## My question isn’t here, where can I get help?
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.

--- a/fern/api-reference/citrea/citrea-api-faq.mdx
+++ b/fern/api-reference/citrea/citrea-api-faq.mdx
@@ -13,7 +13,7 @@ Citrea is a Bitcoin L2 zk-rollup with a Type-2 zkEVM that keeps data availabilit
 Check out our [Citrea API Quickstart guide](./citrea-api-quickstart) to get started building on Citrea.
 
 ## What is the Citrea API?
-The Citrea API allows developers to interface with the Citrea mainnet. With this API, developers can execute transactions, query on-chain data, and interact with the Citrea network, relying on a JSON-RPC standard.
+The Citrea API allows developers to interface with the Citrea testnet (mainnet coming soon). With this API, developers can execute transactions, query on-chain data, and interact with the Citrea network, relying on a JSON-RPC standard.
 
 ## Is Citrea EVM compatible?
 Yes, Citrea is EVM compatible.

--- a/fern/api-reference/citrea/citrea-api-quickstart.mdx
+++ b/fern/api-reference/citrea/citrea-api-quickstart.mdx
@@ -1,0 +1,118 @@
+---
+title: Citrea API Quickstart
+description: How to get started building on Citrea and using the JSON-RPC API
+subtitle: How to get started building on Citrea and using the JSON-RPC API
+url: https://docs.alchemy.com/reference/citrea-api-quickstart
+slug: reference/citrea-api-quickstart
+---
+
+*To use the Citrea API you'll need to [create a free Alchemy account](https://dashboard.alchemy.com/signup) first!*
+
+## Introduction
+
+Citrea is a Bitcoin L2 zk-rollup with a Type-2 zkEVM that keeps data availability and settlement on Bitcoin—via its BitVM-based “Clementine” two-way peg—bringing full EVM compatibility to BTC.
+
+## What is the Citrea API?
+
+The Citrea API allows interaction with the Citrea network through a set of JSON-RPC methods. Its design is familiar to developers who have worked with Ethereum's JSON-RPC APIs, making it intuitive and straightforward to use.
+
+## Getting Started Instructions
+
+### 1. Choose a Package Manager (npm or yarn)
+
+Select a package manager to manage your project's dependencies. Choose between `npm` and `yarn` based on your preference or project requirements.
+
+<CodeGroup>
+  ```shell npm
+  # Begin with npm by following the npm documentation
+  # https://docs.npmjs.com/downloading-and-installing-node-js-and-npm
+  ```
+
+  ```shell yarn
+  # For yarn, refer to yarn's installation guide
+  # https://classic.yarnpkg.com/lang/en/docs/install
+  ```
+</CodeGroup>
+
+### 2. Set Up Your Project
+
+Open your terminal and execute the following commands to create and initialize your project:
+
+<CodeGroup>
+  ```shell npm
+  mkdir citrea-api-quickstart
+  cd citrea-api-quickstart
+  npm init --yes
+  ```
+
+  ```shell yarn
+  mkdir citrea-api-quickstart
+  cd citrea-api-quickstart
+  yarn init --yes
+  ```
+</CodeGroup>
+
+This creates a new directory named `citrea-api-quickstart` and initializes a Node.js project within it.
+
+### 3. Make Your First Request
+
+Install Axios, a popular HTTP client, to make API requests:
+
+<CodeGroup>
+  ```shell npm
+  npm install axios
+  ```
+
+  ```shell yarn
+  yarn add axios
+  ```
+</CodeGroup>
+
+Create an `index.js` file in your project directory and paste the following code:
+
+<CodeGroup>
+  ```javascript index.js
+  const axios = require('axios');
+
+  const url = 'https://citrea-testnet.g.alchemy.com/v2/${your-api-key}';
+
+  const payload = {
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'eth_blockNumber',
+    params: []
+  };
+
+  axios.post(url, payload)
+    .then(response => {
+      console.log('Latest Block:', response.data.result);
+    })
+    .catch(error => {
+      console.error(error);
+    });
+  ```
+</CodeGroup>
+
+Remember to replace `your-api-key` with your actual Alchemy API key that you can get from your [Alchemy dashboard](https://dashboard.alchemy.com/signup).
+
+### 4. Run Your Script
+
+Execute your script to make a request to the Citrea network:
+
+<CodeGroup>
+  ```shell shell
+  node index.js
+  ```
+</CodeGroup>
+
+You should see the latest block information from Citrea's network outputted to your console:
+
+<CodeGroup>
+  ```shell shell
+  Latest Block: 0x...
+  ```
+</CodeGroup>
+
+## Next Steps
+
+Congratulations! You've made your first request to the Citrea network. You can now explore the various JSON-RPC methods available on Citrea and start building your dApps on this innovative platform.

--- a/fern/api-reference/mode/mode-api-faq.mdx
+++ b/fern/api-reference/mode/mode-api-faq.mdx
@@ -1,0 +1,34 @@
+---
+title: Mode API FAQ
+description: Frequently asked questions about the Mode API
+subtitle: Frequently asked questions about the Mode API
+url: https://docs.alchemy.com/reference/mode-api-faq
+slug: reference/mode-api-faq
+---
+
+## What is Mode?
+Mode is an OP Stack–based, EVM-equivalent Ethereum Layer-2 that’s growth-focused—sharing sequencer fees with developers (SFS) and rewarding users to power DeFi/AiFi apps.
+
+## How do I get started with Mode?
+Check out our [Mode API Quickstart guide](./mode-api-quickstart) to get started building on Mode.
+
+## What is the Mode API?
+The Mode API allows developers to interface with the Mode mainnet. With this API, developers can execute transactions, query on-chain data, and interact with the Mode network, relying on a JSON-RPC standard.
+
+## Is Mode EVM compatible?
+Yes, Mode is EVM compatible.
+
+## What API does Mode use?
+Mode uses the JSON-RPC API standard. This API is crucial for any blockchain interaction on the Mode network, allowing users to read block/transaction data, query chain information, execute smart contracts, and store data on-chain.
+
+## What methods are supported on Mode?
+Mode supports standard Ethereum JSON-RPC methods. Some chain-specific methods may vary. Please check the Mode API endpoints documentation for a complete list.
+
+## What is a Mode API key?
+When accessing the Mode network via a node provider like Alchemy, Mode developers use an API key to send transactions and retrieve data from the network. For the best development experience, we recommend that you [sign up for a free API key](https://dashboard.alchemy.com/signup)!
+
+## Which libraries support Mode?
+Common Ethereum libraries like [ethers.js](https://docs.ethers.org/v5/) should be compatible with Mode, given its EVM nature.
+
+## My question isn’t here, where can I get help?
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.

--- a/fern/api-reference/mode/mode-api-quickstart.mdx
+++ b/fern/api-reference/mode/mode-api-quickstart.mdx
@@ -1,0 +1,118 @@
+---
+title: Mode API Quickstart
+description: How to get started building on Mode and using the JSON-RPC API
+subtitle: How to get started building on Mode and using the JSON-RPC API
+url: https://docs.alchemy.com/reference/mode-api-quickstart
+slug: reference/mode-api-quickstart
+---
+
+*To use the Mode API you'll need to [create a free Alchemy account](https://dashboard.alchemy.com/signup) first!*
+
+## Introduction
+
+Mode is an OP Stack–based, EVM-equivalent Ethereum Layer-2 that’s growth-focused—sharing sequencer fees with developers (SFS) and rewarding users to power DeFi/AiFi apps.
+
+## What is the Mode API?
+
+The Mode API allows interaction with the Mode network through a set of JSON-RPC methods. Its design is familiar to developers who have worked with Ethereum's JSON-RPC APIs, making it intuitive and straightforward to use.
+
+## Getting Started Instructions
+
+### 1. Choose a Package Manager (npm or yarn)
+
+Select a package manager to manage your project's dependencies. Choose between `npm` and `yarn` based on your preference or project requirements.
+
+<CodeGroup>
+  ```shell npm
+  # Begin with npm by following the npm documentation
+  # https://docs.npmjs.com/downloading-and-installing-node-js-and-npm
+  ```
+
+  ```shell yarn
+  # For yarn, refer to yarn's installation guide
+  # https://classic.yarnpkg.com/lang/en/docs/install
+  ```
+</CodeGroup>
+
+### 2. Set Up Your Project
+
+Open your terminal and execute the following commands to create and initialize your project:
+
+<CodeGroup>
+  ```shell npm
+  mkdir mode-api-quickstart
+  cd mode-api-quickstart
+  npm init --yes
+  ```
+
+  ```shell yarn
+  mkdir mode-api-quickstart
+  cd mode-api-quickstart
+  yarn init --yes
+  ```
+</CodeGroup>
+
+This creates a new directory named `mode-api-quickstart` and initializes a Node.js project within it.
+
+### 3. Make Your First Request
+
+Install Axios, a popular HTTP client, to make API requests:
+
+<CodeGroup>
+  ```shell npm
+  npm install axios
+  ```
+
+  ```shell yarn
+  yarn add axios
+  ```
+</CodeGroup>
+
+Create an `index.js` file in your project directory and paste the following code:
+
+<CodeGroup>
+  ```javascript index.js
+  const axios = require('axios');
+
+  const url = 'https://mode-mainnet.g.alchemy.com/v2/${your-api-key}';
+
+  const payload = {
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'eth_blockNumber',
+    params: []
+  };
+
+  axios.post(url, payload)
+    .then(response => {
+      console.log('Latest Block:', response.data.result);
+    })
+    .catch(error => {
+      console.error(error);
+    });
+  ```
+</CodeGroup>
+
+Remember to replace `your-api-key` with your actual Alchemy API key that you can get from your [Alchemy dashboard](https://dashboard.alchemy.com/signup).
+
+### 4. Run Your Script
+
+Execute your script to make a request to the Mode network:
+
+<CodeGroup>
+  ```shell shell
+  node index.js
+  ```
+</CodeGroup>
+
+You should see the latest block information from Mode's network outputted to your console:
+
+<CodeGroup>
+  ```shell shell
+  Latest Block: 0x...
+  ```
+</CodeGroup>
+
+## Next Steps
+
+Congratulations! You've made your first request to the Mode network. You can now explore the various JSON-RPC methods available on Mode and start building your dApps on this innovative platform.

--- a/fern/api-reference/moonbeam/moonbeam-api-faq.mdx
+++ b/fern/api-reference/moonbeam/moonbeam-api-faq.mdx
@@ -1,0 +1,34 @@
+---
+title: Moonbeam API FAQ
+description: Frequently asked questions about the Moonbeam API
+subtitle: Frequently asked questions about the Moonbeam API
+url: https://docs.alchemy.com/reference/moonbeam-api-faq
+slug: reference/moonbeam-api-faq
+---
+
+## What is Moonbeam?
+Moonbeam is an Ethereum-compatible smart-contract parachain on Polkadot that pairs full EVM tooling with native cross-chain interoperability (XCM/XC-20) for building connected dapps.
+
+## How do I get started with Moonbeam?
+Check out our [Moonbeam API Quickstart guide](./moonbeam-api-quickstart) to get started building on Moonbeam.
+
+## What is the Moonbeam API?
+The Moonbeam API allows developers to interface with the Moonbeam mainnet. With this API, developers can execute transactions, query on-chain data, and interact with the Moonbeam network, relying on a JSON-RPC standard.
+
+## Is Moonbeam EVM compatible?
+Yes, Moonbeam is EVM compatible.
+
+## What API does Moonbeam use?
+Moonbeam uses the JSON-RPC API standard. This API is crucial for any blockchain interaction on the Moonbeam network, allowing users to read block/transaction data, query chain information, execute smart contracts, and store data on-chain.
+
+## What methods are supported on Moonbeam?
+Moonbeam supports standard Ethereum JSON-RPC methods. Some chain-specific methods may vary. Please check the Moonbeam API endpoints documentation for a complete list.
+
+## What is a Moonbeam API key?
+When accessing the Moonbeam network via a node provider like Alchemy, Moonbeam developers use an API key to send transactions and retrieve data from the network. For the best development experience, we recommend that you [sign up for a free API key](https://dashboard.alchemy.com/signup)!
+
+## Which libraries support Moonbeam?
+Common Ethereum libraries like [ethers.js](https://docs.ethers.org/v5/) should be compatible with Moonbeam, given its EVM nature.
+
+## My question isn’t here, where can I get help?
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.

--- a/fern/api-reference/moonbeam/moonbeam-api-quickstart.mdx
+++ b/fern/api-reference/moonbeam/moonbeam-api-quickstart.mdx
@@ -1,0 +1,118 @@
+---
+title: Moonbeam API Quickstart
+description: How to get started building on Moonbeam and using the JSON-RPC API
+subtitle: How to get started building on Moonbeam and using the JSON-RPC API
+url: https://docs.alchemy.com/reference/moonbeam-api-quickstart
+slug: reference/moonbeam-api-quickstart
+---
+
+*To use the Moonbeam API you'll need to [create a free Alchemy account](https://dashboard.alchemy.com/signup) first!*
+
+## Introduction
+
+Moonbeam is an Ethereum-compatible smart-contract parachain on Polkadot that pairs full EVM tooling with native cross-chain interoperability (XCM/XC-20) for building connected dapps.
+
+## What is the Moonbeam API?
+
+The Moonbeam API allows interaction with the Moonbeam network through a set of JSON-RPC methods. Its design is familiar to developers who have worked with Ethereum's JSON-RPC APIs, making it intuitive and straightforward to use.
+
+## Getting Started Instructions
+
+### 1. Choose a Package Manager (npm or yarn)
+
+Select a package manager to manage your project's dependencies. Choose between `npm` and `yarn` based on your preference or project requirements.
+
+<CodeGroup>
+  ```shell npm
+  # Begin with npm by following the npm documentation
+  # https://docs.npmjs.com/downloading-and-installing-node-js-and-npm
+  ```
+
+  ```shell yarn
+  # For yarn, refer to yarn's installation guide
+  # https://classic.yarnpkg.com/lang/en/docs/install
+  ```
+</CodeGroup>
+
+### 2. Set Up Your Project
+
+Open your terminal and execute the following commands to create and initialize your project:
+
+<CodeGroup>
+  ```shell npm
+  mkdir moonbeam-api-quickstart
+  cd moonbeam-api-quickstart
+  npm init --yes
+  ```
+
+  ```shell yarn
+  mkdir moonbeam-api-quickstart
+  cd moonbeam-api-quickstart
+  yarn init --yes
+  ```
+</CodeGroup>
+
+This creates a new directory named `moonbeam-api-quickstart` and initializes a Node.js project within it.
+
+### 3. Make Your First Request
+
+Install Axios, a popular HTTP client, to make API requests:
+
+<CodeGroup>
+  ```shell npm
+  npm install axios
+  ```
+
+  ```shell yarn
+  yarn add axios
+  ```
+</CodeGroup>
+
+Create an `index.js` file in your project directory and paste the following code:
+
+<CodeGroup>
+  ```javascript index.js
+  const axios = require('axios');
+
+  const url = 'https://moonbeam-mainnet.g.alchemy.com/v2/${your-api-key}';
+
+  const payload = {
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'eth_blockNumber',
+    params: []
+  };
+
+  axios.post(url, payload)
+    .then(response => {
+      console.log('Latest Block:', response.data.result);
+    })
+    .catch(error => {
+      console.error(error);
+    });
+  ```
+</CodeGroup>
+
+Remember to replace `your-api-key` with your actual Alchemy API key that you can get from your [Alchemy dashboard](https://dashboard.alchemy.com/signup).
+
+### 4. Run Your Script
+
+Execute your script to make a request to the Moonbeam network:
+
+<CodeGroup>
+  ```shell shell
+  node index.js
+  ```
+</CodeGroup>
+
+You should see the latest block information from Moonbeam's network outputted to your console:
+
+<CodeGroup>
+  ```shell shell
+  Latest Block: 0x...
+  ```
+</CodeGroup>
+
+## Next Steps
+
+Congratulations! You've made your first request to the Moonbeam network. You can now explore the various JSON-RPC methods available on Moonbeam and start building your dApps on this innovative platform.

--- a/fern/api-reference/plasma/plasma-api-faq.mdx
+++ b/fern/api-reference/plasma/plasma-api-faq.mdx
@@ -1,0 +1,34 @@
+---
+title: Plasma API FAQ
+description: Frequently asked questions about the Plasma API
+subtitle: Frequently asked questions about the Plasma API
+url: https://docs.alchemy.com/reference/plasma-api-faq
+slug: reference/plasma-api-faq
+---
+
+## What is Plasma?
+Plasma is an EVM-compatible Layer-1 purpose-built for stablecoins, using PlasmaBFT (Fast HotStuff) and a native Bitcoin bridge to enable near-instant, zero-fee USD₮ transfers and confidential payments.
+
+## How do I get started with Plasma?
+Check out our [Plasma API Quickstart guide](./plasma-api-quickstart) to get started building on Plasma.
+
+## What is the Plasma API?
+The Plasma API allows developers to interface with the Plasma mainnet. With this API, developers can execute transactions, query on-chain data, and interact with the Plasma network, relying on a JSON-RPC standard.
+
+## Is Plasma EVM compatible?
+Yes, Plasma is EVM compatible.
+
+## What API does Plasma use?
+Plasma uses the JSON-RPC API standard. This API is crucial for any blockchain interaction on the Plasma network, allowing users to read block/transaction data, query chain information, execute smart contracts, and store data on-chain.
+
+## What methods are supported on Plasma?
+Plasma supports standard Ethereum JSON-RPC methods. Some chain-specific methods may vary. Please check the Plasma API endpoints documentation for a complete list.
+
+## What is a Plasma API key?
+When accessing the Plasma network via a node provider like Alchemy, Plasma developers use an API key to send transactions and retrieve data from the network. For the best development experience, we recommend that you [sign up for a free API key](https://dashboard.alchemy.com/signup)!
+
+## Which libraries support Plasma?
+Common Ethereum libraries like [ethers.js](https://docs.ethers.org/v5/) should be compatible with Plasma, given its EVM nature.
+
+## My question isn’t here, where can I get help?
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.

--- a/fern/api-reference/plasma/plasma-api-quickstart.mdx
+++ b/fern/api-reference/plasma/plasma-api-quickstart.mdx
@@ -1,0 +1,118 @@
+---
+title: Plasma API Quickstart
+description: How to get started building on Plasma and using the JSON-RPC API
+subtitle: How to get started building on Plasma and using the JSON-RPC API
+url: https://docs.alchemy.com/reference/plasma-api-quickstart
+slug: reference/plasma-api-quickstart
+---
+
+*To use the Plasma API you'll need to [create a free Alchemy account](https://dashboard.alchemy.com/signup) first!*
+
+## Introduction
+
+Plasma is an EVM-compatible Layer-1 purpose-built for stablecoins, using PlasmaBFT (Fast HotStuff) and a native Bitcoin bridge to enable near-instant, zero-fee USD₮ transfers and confidential payments.
+
+## What is the Plasma API?
+
+The Plasma API allows interaction with the Plasma network through a set of JSON-RPC methods. Its design is familiar to developers who have worked with Ethereum's JSON-RPC APIs, making it intuitive and straightforward to use.
+
+## Getting Started Instructions
+
+### 1. Choose a Package Manager (npm or yarn)
+
+Select a package manager to manage your project's dependencies. Choose between `npm` and `yarn` based on your preference or project requirements.
+
+<CodeGroup>
+  ```shell npm
+  # Begin with npm by following the npm documentation
+  # https://docs.npmjs.com/downloading-and-installing-node-js-and-npm
+  ```
+
+  ```shell yarn
+  # For yarn, refer to yarn's installation guide
+  # https://classic.yarnpkg.com/lang/en/docs/install
+  ```
+</CodeGroup>
+
+### 2. Set Up Your Project
+
+Open your terminal and execute the following commands to create and initialize your project:
+
+<CodeGroup>
+  ```shell npm
+  mkdir plasma-api-quickstart
+  cd plasma-api-quickstart
+  npm init --yes
+  ```
+
+  ```shell yarn
+  mkdir plasma-api-quickstart
+  cd plasma-api-quickstart
+  yarn init --yes
+  ```
+</CodeGroup>
+
+This creates a new directory named `plasma-api-quickstart` and initializes a Node.js project within it.
+
+### 3. Make Your First Request
+
+Install Axios, a popular HTTP client, to make API requests:
+
+<CodeGroup>
+  ```shell npm
+  npm install axios
+  ```
+
+  ```shell yarn
+  yarn add axios
+  ```
+</CodeGroup>
+
+Create an `index.js` file in your project directory and paste the following code:
+
+<CodeGroup>
+  ```javascript index.js
+  const axios = require('axios');
+
+  const url = 'https://plasma-mainnet.g.alchemy.com/v2/${your-api-key}';
+
+  const payload = {
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'eth_blockNumber',
+    params: []
+  };
+
+  axios.post(url, payload)
+    .then(response => {
+      console.log('Latest Block:', response.data.result);
+    })
+    .catch(error => {
+      console.error(error);
+    });
+  ```
+</CodeGroup>
+
+Remember to replace `your-api-key` with your actual Alchemy API key that you can get from your [Alchemy dashboard](https://dashboard.alchemy.com/signup).
+
+### 4. Run Your Script
+
+Execute your script to make a request to the Plasma network:
+
+<CodeGroup>
+  ```shell shell
+  node index.js
+  ```
+</CodeGroup>
+
+You should see the latest block information from Plasma's network outputted to your console:
+
+<CodeGroup>
+  ```shell shell
+  Latest Block: 0x...
+  ```
+</CodeGroup>
+
+## Next Steps
+
+Congratulations! You've made your first request to the Plasma network. You can now explore the various JSON-RPC methods available on Plasma and start building your dApps on this innovative platform.

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -1677,27 +1677,47 @@ navigation:
 
       - section: BOB
         contents:
+          - page: BOB API Quickstart
+            path: api-reference/bob/bob-api-quickstart.mdx
+          - page: BOB API FAQ
+            path: api-reference/bob/bob-api-faq.mdx
           - api: BOB API Endpoints
             api-name: bob
         slug: bob
       - section: Mode
         contents:
+          - page: Mode API Quickstart
+            path: api-reference/mode/mode-api-quickstart.mdx
+          - page: Mode API FAQ
+            path: api-reference/mode/mode-api-faq.mdx
           - api: Mode API Endpoints
             api-name: mode
         slug: mode
       - section: Moonbeam
         contents:
+          - page: Moonbeam API Quickstart
+            path: api-reference/moonbeam/moonbeam-api-quickstart.mdx
+          - page: Moonbeam API FAQ
+            path: api-reference/moonbeam/moonbeam-api-faq.mdx
           - api: Moonbeam API Endpoints
             api-name: moonbeam
         slug: moonbeam
       - section: Plasma
         contents:
+          - page: Plasma API Quickstart
+            path: api-reference/plasma/plasma-api-quickstart.mdx
+          - page: Plasma API FAQ
+            path: api-reference/plasma/plasma-api-faq.mdx
           - api: Plasma API Endpoints
             api-name: plasma
         slug: plasma
 
       - section: CITREA
         contents:
+          - page: CITREA API Quickstart
+            path: api-reference/citrea/citrea-api-quickstart.mdx
+          - page: CITREA API FAQ
+            path: api-reference/citrea/citrea-api-faq.mdx
           - api: CITREA API Endpoints
             api-name: citrea
         slug: citrea

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -1712,13 +1712,13 @@ navigation:
             api-name: plasma
         slug: plasma
 
-      - section: CITREA
+      - section: Citrea
         contents:
-          - page: CITREA API Quickstart
+          - page: Citrea API Quickstart
             path: api-reference/citrea/citrea-api-quickstart.mdx
-          - page: CITREA API FAQ
+          - page: Citrea API FAQ
             path: api-reference/citrea/citrea-api-faq.mdx
-          - api: CITREA API Endpoints
+          - api: Citrea API Endpoints
             api-name: citrea
         slug: citrea
 


### PR DESCRIPTION
* \[x] I have tested these changes locally
* \[x] I have run the validation scripts (`pnpm run validate`)
* \[x] I have checked that the documentation builds correctly