### PR TITLE
revert: re-add missing chains to docs

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -3500,6 +3500,23 @@ redirects:
     destination: /docs/node/flow/flow-api-endpoints/eth-block-number
     permanent: true
 
+  # Fantom
+  - source: /docs/reference/fantom-opera-api-quickstart
+    destination: /docs/reference/fantom-deprecation-notice
+    permanent: true
+  - source: /docs/reference/fantom-api-quickstart
+    destination: /docs/reference/fantom-deprecation-notice
+    permanent: true
+  - source: /docs/reference/fantom-api-endpoints
+    destination: /docs/reference/fantom-deprecation-notice
+    permanent: true
+  - source: /docs/reference/fantom-api-endpoints/:method*
+    destination: /docs/reference/fantom-deprecation-notice
+    permanent: true
+  - source: /docs/reference/fantom-api-faq
+    destination: /docs/reference/fantom-deprecation-notice
+    permanent: true
+
   # Geist
   - source: /reference/geist-api-endpoints
     destination: /docs/node/geist/geist-deprecation-notice
@@ -5864,10 +5881,6 @@ redirects:
 
   - source: /docs/how-to-send-a-private-transaction-on-ethereum
     destination: /docs
-    permanent: true
-
-  - source: /docs/reference/fantom-opera-api-quickstart
-    destination: /docs/reference/sonic-api-quickstart
     permanent: true
 
   - source: /docs/reference/aa-sdk

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -1675,6 +1675,59 @@ navigation:
             api-name: adi
         slug: adi
 
+      - section: BOB
+        contents:
+          - page: BOB API Quickstart
+            path: api-reference/bob/bob-api-quickstart.mdx
+          - page: BOB API FAQ
+            path: api-reference/bob/bob-api-faq.mdx
+          - api: BOB API Endpoints
+            api-name: bob
+        slug: bob
+      - section: Mode
+        contents:
+          - page: Mode API Quickstart
+            path: api-reference/mode/mode-api-quickstart.mdx
+          - page: Mode API FAQ
+            path: api-reference/mode/mode-api-faq.mdx
+          - api: Mode API Endpoints
+            api-name: mode
+        slug: mode
+      - section: Moonbeam
+        contents:
+          - page: Moonbeam API Quickstart
+            path: api-reference/moonbeam/moonbeam-api-quickstart.mdx
+          - page: Moonbeam API FAQ
+            path: api-reference/moonbeam/moonbeam-api-faq.mdx
+          - api: Moonbeam API Endpoints
+            api-name: moonbeam
+        slug: moonbeam
+      - section: Plasma
+        contents:
+          - page: Plasma API Quickstart
+            path: api-reference/plasma/plasma-api-quickstart.mdx
+          - page: Plasma API FAQ
+            path: api-reference/plasma/plasma-api-faq.mdx
+          - api: Plasma API Endpoints
+            api-name: plasma
+        slug: plasma
+
+      - section: Citrea
+        contents:
+          - page: Citrea API Quickstart
+            path: api-reference/citrea/citrea-api-quickstart.mdx
+          - page: Citrea API FAQ
+            path: api-reference/citrea/citrea-api-faq.mdx
+          - api: Citrea API Endpoints
+            api-name: citrea
+        slug: citrea
+
+      - section: Fantom
+        contents:
+          - page: Fantom Deprecation Notice
+            path: api-reference/fantom/fantom-deprecation-notice.mdx
+        slug: fantom
+
   - tab: data
     layout:
       - section: Introduction


### PR DESCRIPTION
## Description

These chains were erroneously removed in https://github.com/alchemyplatform/docs/pull/715. Same with Fantom redirects. This adds them back.

## Related Issues

<!-- Link to any related issues or Asana tasks this PR addresses (e.g., "Fixes #123") -->

## Changes Made

<!-- List the specific changes made in this PR -->

## Testing

<!-- Describe the tests that you ran to verify your changes -->

* \[ ] I have tested these changes locally
* \[ ] I have run the validation scripts (`pnpm run validate`)
* \[ ] I have checked that the documentation builds correctly
