### PR TITLE
Clarify availability of block timestamp metadata

### DIFF
--- a/src/openrpc/alchemy/transfers/transfers.yaml
+++ b/src/openrpc/alchemy/transfers/transfers.yaml
@@ -142,7 +142,7 @@ methods:
                       properties:
                         blockTimestamp:
                           type: string
-                          description: "ISO-formatted timestamp of the block containing this transfer."
+                          description: "ISO-formatted timestamp of the block containing this transfer. (Available only on ETH, Base, Polygon, Arbitrum, Optimism)"
 
     examples:
       - name: alchemy_getAssetTransfers example


### PR DESCRIPTION
## Summary
- clarify that the metadata.blockTimestamp field is only available on specific chains in the alchemy_getAssetTransfers reference

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d5a45dbc6c8320afe252e622dc4d78