### PR TITLE
Fix starknet APIs (in progress)

### DIFF
--- a/src/openrpc/chains/_components/starknet/methods.yaml
+++ b/src/openrpc/chains/_components/starknet/methods.yaml
@@ -729,21 +729,21 @@ components:
                               description: The max amount and max price per unit of L1 gas used in this tx
                               properties:
                                 max_amount:
-                                  type: string,
-                                  description: The max amount of the resource that can be used in the tx,
+                                  type: string
+                                  description: The max amount of the resource that can be used in the tx
                                 max_price_per_unit:
-                                  type: string,
-                                  description: The max price per unit of this resource for this tx,
+                                  type: string
+                                  description: The max price per unit of this resource for this tx
                             l2_gas:
                               type: object
                               description: The max amount and max price per unit of L2 gas used in this tx
                               properties:
                                 max_amount:
-                                  type: string,
-                                  description: The max amount of the resource that can be used in the tx,
+                                  type: string
+                                  description: The max amount of the resource that can be used in the tx
                                 max_price_per_unit:
-                                  type: string,
-                                  description: The max price per unit of this resource for this tx,
+                                  type: string
+                                  description: The max price per unit of this resource for this tx
                         tip:
                           type: string
                           description: The tip for the transaction

--- a/src/openrpc/chains/_components/starknet/transaction.yaml
+++ b/src/openrpc/chains/_components/starknet/transaction.yaml
@@ -451,9 +451,10 @@ components:
           $ref: "./base-types.yaml#/components/schemas/ADDRESS"
         calls:
           title: Nested calls
+          description: Array of nested contract calls. Each call has the same structure as its parent, allowing for recursive calls.
           type: array
           items:
-            $ref: "#/components/schemas/CALL_TRACE" # <-- recursion fixed
+            type: object
         class_hash:
           title: Class hash
           $ref: "./base-types.yaml#/components/schemas/FELT"


### PR DESCRIPTION
Couple issues blocking starknet API generation:
1. commas in yaml schema (fixed)
2. self-referential method definition (working on this)

## Testing

* \[ ] I have tested these changes locally
* \[ ] I have run the validation scripts (`pnpm run validate`)
* \[ ] I have checked that the documentation builds correctly
