### PR TITLE
fix: surface generated errors

### DIFF
--- a/scripts/generate-rpc.ts
+++ b/scripts/generate-rpc.ts
@@ -47,14 +47,34 @@ const main = async () => {
   });
 
   // Wait for all promises to complete
-  await Promise.allSettled([...chainPromises, ...alchemyPromises]);
+  const results = await Promise.allSettled([
+    ...chainPromises,
+    ...alchemyPromises,
+  ]);
+
+  // Check for unexpected rejections (errors that weren't handled by handleDerefErrors)
+  const unexpectedRejections = results.filter(
+    (result) => result.status === "rejected",
+  );
+  if (unexpectedRejections.length > 0) {
+    console.error(
+      `${unexpectedRejections.length} promise(s) rejected unexpectedly:`,
+    );
+    unexpectedRejections.forEach((rejection, idx) => {
+      if (rejection.status === "rejected") {
+        console.error(`  [${idx + 1}]`, rejection.reason);
+      }
+    });
+  }
 
   // Report all errors at once
   const errorMessages: string[] = [];
 
   if (genErrors.length > 0) {
     errorMessages.push(`Found ${genErrors.length} generation error(s):`);
-    errorMessages.push(...genErrors.map((error) => `  ${error}`));
+    errorMessages.push(
+      ...genErrors.map((error) => `  ${JSON.stringify(error, null, 2)}`),
+    );
   }
 
   if (missingTokens.length > 0) {

--- a/scripts/generate-rpc.ts
+++ b/scripts/generate-rpc.ts
@@ -52,19 +52,17 @@ const main = async () => {
     ...alchemyPromises,
   ]);
 
-  // Check for unexpected rejections (errors that weren't handled by handleDerefErrors)
   const unexpectedRejections = results.filter(
     (result) => result.status === "rejected",
   );
   if (unexpectedRejections.length > 0) {
-    console.error(
-      `${unexpectedRejections.length} promise(s) rejected unexpectedly:`,
-    );
-    unexpectedRejections.forEach((rejection, idx) => {
+    const errorMessages: string[] = [];
+    unexpectedRejections.forEach((rejection) => {
       if (rejection.status === "rejected") {
-        console.error(`  [${idx + 1}]`, rejection.reason);
+        errorMessages.push(rejection.reason.stack);
       }
     });
+    throw new Error(errorMessages.join("\n"));
   }
 
   // Report all errors at once

--- a/src/utils/generationHelpers.ts
+++ b/src/utils/generationHelpers.ts
@@ -83,13 +83,24 @@ export const handleDerefErrors = (
   genErrors: unknown[],
 ) => {
   const errorGroup = err as DerefErrorGroup;
-  errorGroup.errors.forEach((error) => {
-    if (error.code === "EMISSINGPOINTER") {
-      missingTokens.push(
-        `token: ${error.targetToken}\n    api: ${api}\n    source: ${error.source}`,
-      );
-    } else {
-      genErrors.push(error);
-    }
-  });
+
+  // Check if this is a DerefErrorGroup with an errors array
+  if (errorGroup.errors && Array.isArray(errorGroup.errors)) {
+    errorGroup.errors.forEach((error) => {
+      if (error.code === "EMISSINGPOINTER") {
+        missingTokens.push(
+          `token: ${error.targetToken}\n    api: ${api}\n    source: ${error.source}`,
+        );
+      } else {
+        genErrors.push(error);
+      }
+    });
+  } else {
+    // Handle other error types (e.g., validation errors)
+    genErrors.push({
+      name: (err as Error).name || "Unknown Error",
+      message: (err as Error).message || String(err),
+      api,
+    });
+  }
 };

--- a/src/utils/generationHelpers.ts
+++ b/src/utils/generationHelpers.ts
@@ -84,7 +84,6 @@ export const handleDerefErrors = (
 ) => {
   const errorGroup = err as DerefErrorGroup;
 
-  // Check if this is a DerefErrorGroup with an errors array
   if (errorGroup.errors && Array.isArray(errorGroup.errors)) {
     errorGroup.errors.forEach((error) => {
       if (error.code === "EMISSINGPOINTER") {
@@ -96,7 +95,6 @@ export const handleDerefErrors = (
       }
     });
   } else {
-    // Handle other error types (e.g., validation errors)
     genErrors.push({
       name: (err as Error).name || "Unknown Error",
       message: (err as Error).message || String(err),


### PR DESCRIPTION
## Description

Two updates to hopefully catch more generation errors:
- Updates `handleDerefErrors`  to check for other error types (like the `RangeError` in the screenshot below)
- Updates `Promise.allSettled` logic to check for rejected promises and throw, so we dont end up with silenced errors

Here's the two cases handled now in the console:

<img width="740" height="387" alt="image" src="https://github.com/user-attachments/assets/2371a372-cd34-4690-8420-e2b15be66918" />

## Testing

* \[x] I have tested these changes locally
* \[x] I have run the validation scripts (`pnpm run validate`)
* \[x] I have checked that the documentation builds correctly
