### PR TITLE
add citrea specific methods

### DIFF
--- a/src/openrpc/chains/_components/citrea/methods.yaml
+++ b/src/openrpc/chains/_components/citrea/methods.yaml
@@ -349,7 +349,7 @@ components:
                   hash: "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
                   prev_hash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
                   state_root: "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
-                  signature: "1111111111111111111111111111111111111111111111111111111111111111"
+                  signature: "11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"
                   l1_fee_rate: "0x9502f900"
                   timestamp: "0x67089f9e"
                   tx_merkle_root: "2222222222222222222222222222222222222222222222222222222222222222"


### PR DESCRIPTION
The method definitions for these Citrea specific methods are added as part of this PR: 

1. `citrea_syncStatus`
2. `ledger_getL2BlockByNumber`
3. `ledger_getL2BlockByHash`
4. `ledger_getL2BlockRange`
5. `ledger_getHeadL2Block`
6. `ledger_getHeadL2BlockHeight`
7. `ledger_getL2GenesisStateRoot`
8. `ledger_getSequencerCommitmentsOnSlotByNumber`
9. `ledger_getSequencerCommitmentsOnSlotByHash`
10. `ledger_getSequencerCommitmentByIndex`
11. `ledger_getVerifiedBatchProofsBySlotHeight`
12. `ledger_getLastVerifiedBatchProof`
13. `ledger_getLastScannedL1Height`
14. `citrea_getLastCommittedL2Height`
15. `citrea_getLastProvenL2Height`
16. `citrea_getL2StatusHeightsByL1Height`
17. `citrea_sendRawDepositTransaction`
18. `eth_estimateDiffSize`

<img width="4000" height="1942" alt="image" src="https://github.com/user-attachments/assets/a2563898-4945-4d90-8f7c-28131c25c1e1" />
