### PR TITLE
brighten active state in dark mode sidebar navigation

### DIFF
--- a/fern/assets/styles.css
+++ b/fern/assets/styles.css
@@ -324,7 +324,7 @@ header#fern-header a.fern-button.filled.normal.primary:hover {
 
 :is(.dark) .fern-sidebar-link[data-state="active"] {
   color: #ffffff !important;
-  background-color: #0f0f10 !important;
+  background-color: #1f2937 !important;
 }
 
 :is(.light) .fern-sidebar-link.nested[data-state="inactive"] {


### PR DESCRIPTION
See the difference in screenshots attached below:

<img width="4000" height="2026" alt="image" src="https://github.com/user-attachments/assets/5bcdcd89-33ae-431c-83d8-880531fc3d61" />


<img width="4000" height="2204" alt="image" src="https://github.com/user-attachments/assets/7e15e1a7-b5e5-487d-bdfe-1582c8b94bf4" />
