### PR TITLE
Rename Chains tab and update navigation

### DIFF
--- a/fern/api-reference/node-api/chain-apis-overview.mdx
+++ b/fern/api-reference/node-api/chain-apis-overview.mdx
@@ -20,30 +20,30 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_accounts`](/docs/node/ethereum/ethereum-api-endpoints/eth-accounts)                       | [`eth_blobBaseFee`](/docs/node/ethereum/ethereum-api-endpoints/eth-blob-base-fee)           |
-| [`eth_blockNumber`](/docs/node/ethereum/ethereum-api-endpoints/eth-block-number)                | [`eth_call`](/docs/node/ethereum/ethereum-api-endpoints/eth-call)                           |
-| [`eth_callBundle`](/docs/node/ethereum/ethereum-api-endpoints/eth-call-bundle)                  | [`eth_callMany`](/docs/node/ethereum/ethereum-api-endpoints/eth-call-many)                  |
-| [`eth_chainId`](/docs/node/ethereum/ethereum-api-endpoints/eth-chain-id)                        | [`eth_createAccessList`](/docs/node/ethereum/ethereum-api-endpoints/eth-create-access-list) |
-| [`eth_estimateGas`](/docs/node/ethereum/ethereum-api-endpoints/eth-estimate-gas)                | [`eth_feeHistory`](/docs/node/ethereum/ethereum-api-endpoints/eth-fee-history)              |
-| [`eth_gasPrice`](/docs/node/ethereum/ethereum-api-endpoints/eth-gas-price)                      | [`eth_getAccount`](/docs/node/ethereum/ethereum-api-endpoints/eth-get-account)              |
-| [`eth_getBalance`](/docs/node/ethereum/ethereum-api-endpoints/eth-get-balance)                  | [`eth_getBlockByHash`](/docs/node/ethereum/ethereum-api-endpoints/eth-get-block-by-hash)    |
-| [`eth_getBlockByNumber`](/docs/node/ethereum/ethereum-api-endpoints/eth-get-block-by-number)    | [`eth_getBlockReceipts`](/docs/node/ethereum/ethereum-api-endpoints/eth-get-block-receipts) |
-| [`eth_getBlockTransactionCountByHash`](/docs/node/ethereum/ethereum-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/node/ethereum/ethereum-api-endpoints/eth-get-block-transaction-count-by-number) |
-| [`eth_getCode`](/docs/node/ethereum/ethereum-api-endpoints/eth-get-code)                        | [`eth_getFilterChanges`](/docs/node/ethereum/ethereum-api-endpoints/eth-get-filter-changes) |
-| [`eth_getFilterLogs`](/docs/node/ethereum/ethereum-api-endpoints/eth-get-filter-logs)           | [`eth_getLogs`](/docs/node/ethereum/ethereum-api-endpoints/eth-get-logs)                    |
-| [`eth_getProof`](/docs/node/ethereum/ethereum-api-endpoints/eth-get-proof)                      | [`eth_getStorageAt`](/docs/node/ethereum/ethereum-api-endpoints/eth-get-storage-at)         |
-| [`eth_getTransactionByBlockHashAndIndex`](/docs/node/ethereum/ethereum-api-endpoints/eth-get-transaction-by-block-hash-and-index) | [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/ethereum/ethereum-api-endpoints/eth-get-transaction-by-block-number-and-index) |
-| [`eth_getTransactionByHash`](/docs/node/ethereum/ethereum-api-endpoints/eth-get-transaction-by-hash) | [`eth_getTransactionCount`](/docs/node/ethereum/ethereum-api-endpoints/eth-get-transaction-count) |
-| [`eth_getTransactionReceipt`](/docs/node/ethereum/ethereum-api-endpoints/eth-get-transaction-receipt) | [`eth_getUncleByBlockHashAndIndex`](/docs/node/ethereum/ethereum-api-endpoints/eth-get-uncle-by-block-hash-and-index) |
-| [`eth_getUncleByBlockNumberAndIndex`](/docs/node/ethereum/ethereum-api-endpoints/eth-get-uncle-by-block-number-and-index) | [`eth_getUncleCountByBlockHash`](/docs/node/ethereum/ethereum-api-endpoints/eth-get-uncle-count-by-block-hash) |
-| [`eth_getUncleCountByBlockNumber`](/docs/node/ethereum/ethereum-api-endpoints/eth-get-uncle-count-by-block-number) | [`eth_maxPriorityFeePerGas`](/docs/node/ethereum/ethereum-api-endpoints/eth-max-priority-fee-per-gas) |
-| [`eth_newBlockFilter`](/docs/node/ethereum/ethereum-api-endpoints/eth-new-block-filter)         | [`eth_newFilter`](/docs/node/ethereum/ethereum-api-endpoints/eth-new-filter)                |
-| [`eth_newPendingTransactionFilter`](/docs/node/ethereum/ethereum-api-endpoints/eth-new-pending-transaction-filter) | [`eth_protocolVersion`](/docs/node/ethereum/ethereum-api-endpoints/eth-protocol-version)    |
-| [`eth_sendRawTransaction`](/docs/node/ethereum/ethereum-api-endpoints/eth-send-raw-transaction) | [`eth_simulateV1`](/docs/node/ethereum/ethereum-api-endpoints/eth-simulate-v-1)             |
-| [`eth_submitWork`](/docs/node/ethereum/ethereum-api-endpoints/eth-submit-work)                  | [`eth_subscribe`](/docs/node/ethereum/ethereum-api-endpoints/eth-subscribe)                 |
-| [`eth_syncing`](/docs/node/ethereum/ethereum-api-endpoints/eth-syncing)                         | [`eth_uninstallFilter`](/docs/node/ethereum/ethereum-api-endpoints/eth-uninstall-filter)    |
-| [`eth_unsubscribe`](/docs/node/ethereum/ethereum-api-endpoints/eth-unsubscribe)                 | [`net_version`](/docs/node/ethereum/ethereum-api-endpoints/net-version)                     |
-| [`web3_clientVersion`](/docs/node/ethereum/ethereum-api-endpoints/web-3-client-version)         | [`web3_sha3`](/docs/node/ethereum/ethereum-api-endpoints/web-3-sha-3)                       |
+| [`eth_accounts`](/docs/chain-apis/ethereum/ethereum-api-endpoints/eth-accounts)                       | [`eth_blobBaseFee`](/docs/chain-apis/ethereum/ethereum-api-endpoints/eth-blob-base-fee)           |
+| [`eth_blockNumber`](/docs/chain-apis/ethereum/ethereum-api-endpoints/eth-block-number)                | [`eth_call`](/docs/chain-apis/ethereum/ethereum-api-endpoints/eth-call)                           |
+| [`eth_callBundle`](/docs/chain-apis/ethereum/ethereum-api-endpoints/eth-call-bundle)                  | [`eth_callMany`](/docs/chain-apis/ethereum/ethereum-api-endpoints/eth-call-many)                  |
+| [`eth_chainId`](/docs/chain-apis/ethereum/ethereum-api-endpoints/eth-chain-id)                        | [`eth_createAccessList`](/docs/chain-apis/ethereum/ethereum-api-endpoints/eth-create-access-list) |
+| [`eth_estimateGas`](/docs/chain-apis/ethereum/ethereum-api-endpoints/eth-estimate-gas)                | [`eth_feeHistory`](/docs/chain-apis/ethereum/ethereum-api-endpoints/eth-fee-history)              |
+| [`eth_gasPrice`](/docs/chain-apis/ethereum/ethereum-api-endpoints/eth-gas-price)                      | [`eth_getAccount`](/docs/chain-apis/ethereum/ethereum-api-endpoints/eth-get-account)              |
+| [`eth_getBalance`](/docs/chain-apis/ethereum/ethereum-api-endpoints/eth-get-balance)                  | [`eth_getBlockByHash`](/docs/chain-apis/ethereum/ethereum-api-endpoints/eth-get-block-by-hash)    |
+| [`eth_getBlockByNumber`](/docs/chain-apis/ethereum/ethereum-api-endpoints/eth-get-block-by-number)    | [`eth_getBlockReceipts`](/docs/chain-apis/ethereum/ethereum-api-endpoints/eth-get-block-receipts) |
+| [`eth_getBlockTransactionCountByHash`](/docs/chain-apis/ethereum/ethereum-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/chain-apis/ethereum/ethereum-api-endpoints/eth-get-block-transaction-count-by-number) |
+| [`eth_getCode`](/docs/chain-apis/ethereum/ethereum-api-endpoints/eth-get-code)                        | [`eth_getFilterChanges`](/docs/chain-apis/ethereum/ethereum-api-endpoints/eth-get-filter-changes) |
+| [`eth_getFilterLogs`](/docs/chain-apis/ethereum/ethereum-api-endpoints/eth-get-filter-logs)           | [`eth_getLogs`](/docs/chain-apis/ethereum/ethereum-api-endpoints/eth-get-logs)                    |
+| [`eth_getProof`](/docs/chain-apis/ethereum/ethereum-api-endpoints/eth-get-proof)                      | [`eth_getStorageAt`](/docs/chain-apis/ethereum/ethereum-api-endpoints/eth-get-storage-at)         |
+| [`eth_getTransactionByBlockHashAndIndex`](/docs/chain-apis/ethereum/ethereum-api-endpoints/eth-get-transaction-by-block-hash-and-index) | [`eth_getTransactionByBlockNumberAndIndex`](/docs/chain-apis/ethereum/ethereum-api-endpoints/eth-get-transaction-by-block-number-and-index) |
+| [`eth_getTransactionByHash`](/docs/chain-apis/ethereum/ethereum-api-endpoints/eth-get-transaction-by-hash) | [`eth_getTransactionCount`](/docs/chain-apis/ethereum/ethereum-api-endpoints/eth-get-transaction-count) |
+| [`eth_getTransactionReceipt`](/docs/chain-apis/ethereum/ethereum-api-endpoints/eth-get-transaction-receipt) | [`eth_getUncleByBlockHashAndIndex`](/docs/chain-apis/ethereum/ethereum-api-endpoints/eth-get-uncle-by-block-hash-and-index) |
+| [`eth_getUncleByBlockNumberAndIndex`](/docs/chain-apis/ethereum/ethereum-api-endpoints/eth-get-uncle-by-block-number-and-index) | [`eth_getUncleCountByBlockHash`](/docs/chain-apis/ethereum/ethereum-api-endpoints/eth-get-uncle-count-by-block-hash) |
+| [`eth_getUncleCountByBlockNumber`](/docs/chain-apis/ethereum/ethereum-api-endpoints/eth-get-uncle-count-by-block-number) | [`eth_maxPriorityFeePerGas`](/docs/chain-apis/ethereum/ethereum-api-endpoints/eth-max-priority-fee-per-gas) |
+| [`eth_newBlockFilter`](/docs/chain-apis/ethereum/ethereum-api-endpoints/eth-new-block-filter)         | [`eth_newFilter`](/docs/chain-apis/ethereum/ethereum-api-endpoints/eth-new-filter)                |
+| [`eth_newPendingTransactionFilter`](/docs/chain-apis/ethereum/ethereum-api-endpoints/eth-new-pending-transaction-filter) | [`eth_protocolVersion`](/docs/chain-apis/ethereum/ethereum-api-endpoints/eth-protocol-version)    |
+| [`eth_sendRawTransaction`](/docs/chain-apis/ethereum/ethereum-api-endpoints/eth-send-raw-transaction) | [`eth_simulateV1`](/docs/chain-apis/ethereum/ethereum-api-endpoints/eth-simulate-v-1)             |
+| [`eth_submitWork`](/docs/chain-apis/ethereum/ethereum-api-endpoints/eth-submit-work)                  | [`eth_subscribe`](/docs/chain-apis/ethereum/ethereum-api-endpoints/eth-subscribe)                 |
+| [`eth_syncing`](/docs/chain-apis/ethereum/ethereum-api-endpoints/eth-syncing)                         | [`eth_uninstallFilter`](/docs/chain-apis/ethereum/ethereum-api-endpoints/eth-uninstall-filter)    |
+| [`eth_unsubscribe`](/docs/chain-apis/ethereum/ethereum-api-endpoints/eth-unsubscribe)                 | [`net_version`](/docs/chain-apis/ethereum/ethereum-api-endpoints/net-version)                     |
+| [`web3_clientVersion`](/docs/chain-apis/ethereum/ethereum-api-endpoints/web-3-client-version)         | [`web3_sha3`](/docs/chain-apis/ethereum/ethereum-api-endpoints/web-3-sha-3)                       |
 
 ## Abstract APIs
 
@@ -51,22 +51,22 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_blockNumber`](/docs/node/abstract/abstract-api-endpoints/eth-block-number)                | [`eth_call`](/docs/node/abstract/abstract-api-endpoints/eth-call)                           |
-| [`eth_callMany`](/docs/node/abstract/abstract-api-endpoints/eth-call-many)                      | [`eth_chainId`](/docs/node/abstract/abstract-api-endpoints/eth-chain-id)                    |
-| [`eth_estimateGas`](/docs/node/abstract/abstract-api-endpoints/eth-estimate-gas)                | [`eth_gasPrice`](/docs/node/abstract/abstract-api-endpoints/eth-gas-price)                  |
-| [`eth_getAccount`](/docs/node/abstract/abstract-api-endpoints/eth-get-account)                  | [`eth_getBalance`](/docs/node/abstract/abstract-api-endpoints/eth-get-balance)              |
-| [`eth_getBlockByHash`](/docs/node/abstract/abstract-api-endpoints/eth-get-block-by-hash)        | [`eth_getBlockByNumber`](/docs/node/abstract/abstract-api-endpoints/eth-get-block-by-number) |
-| [`eth_getBlockTransactionCountByHash`](/docs/node/abstract/abstract-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/node/abstract/abstract-api-endpoints/eth-get-block-transaction-count-by-number) |
-| [`eth_getCode`](/docs/node/abstract/abstract-api-endpoints/eth-get-code)                        | [`eth_getFilterChanges`](/docs/node/abstract/abstract-api-endpoints/eth-get-filter-changes) |
-| [`eth_getFilterLogs`](/docs/node/abstract/abstract-api-endpoints/eth-get-filter-logs)           | [`eth_getLogs`](/docs/node/abstract/abstract-api-endpoints/eth-get-logs)                    |
-| [`eth_getStorageAt`](/docs/node/abstract/abstract-api-endpoints/eth-get-storage-at)             | [`eth_getTransactionByBlockHashAndIndex`](/docs/node/abstract/abstract-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
-| [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/abstract/abstract-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/node/abstract/abstract-api-endpoints/eth-get-transaction-by-hash) |
-| [`eth_getTransactionCount`](/docs/node/abstract/abstract-api-endpoints/eth-get-transaction-count) | [`eth_getTransactionReceipt`](/docs/node/abstract/abstract-api-endpoints/eth-get-transaction-receipt) |
-| [`eth_newBlockFilter`](/docs/node/abstract/abstract-api-endpoints/eth-new-block-filter)         | [`eth_newFilter`](/docs/node/abstract/abstract-api-endpoints/eth-new-filter)                |
-| [`eth_sendRawTransaction`](/docs/node/abstract/abstract-api-endpoints/eth-send-raw-transaction) | [`eth_submitWork`](/docs/node/abstract/abstract-api-endpoints/eth-submit-work)              |
-| [`eth_subscribe`](/docs/node/abstract/abstract-api-endpoints/eth-subscribe)                     | [`eth_uninstallFilter`](/docs/node/abstract/abstract-api-endpoints/eth-uninstall-filter)    |
-| [`eth_unsubscribe`](/docs/node/abstract/abstract-api-endpoints/eth-unsubscribe)                 | [`net_version`](/docs/node/abstract/abstract-api-endpoints/net-version)                     |
-| [`web3_clientVersion`](/docs/node/abstract/abstract-api-endpoints/web-3-client-version)         | [`web3_sha3`](/docs/node/abstract/abstract-api-endpoints/web-3-sha-3)                       |
+| [`eth_blockNumber`](/docs/chain-apis/abstract/abstract-api-endpoints/eth-block-number)                | [`eth_call`](/docs/chain-apis/abstract/abstract-api-endpoints/eth-call)                           |
+| [`eth_callMany`](/docs/chain-apis/abstract/abstract-api-endpoints/eth-call-many)                      | [`eth_chainId`](/docs/chain-apis/abstract/abstract-api-endpoints/eth-chain-id)                    |
+| [`eth_estimateGas`](/docs/chain-apis/abstract/abstract-api-endpoints/eth-estimate-gas)                | [`eth_gasPrice`](/docs/chain-apis/abstract/abstract-api-endpoints/eth-gas-price)                  |
+| [`eth_getAccount`](/docs/chain-apis/abstract/abstract-api-endpoints/eth-get-account)                  | [`eth_getBalance`](/docs/chain-apis/abstract/abstract-api-endpoints/eth-get-balance)              |
+| [`eth_getBlockByHash`](/docs/chain-apis/abstract/abstract-api-endpoints/eth-get-block-by-hash)        | [`eth_getBlockByNumber`](/docs/chain-apis/abstract/abstract-api-endpoints/eth-get-block-by-number) |
+| [`eth_getBlockTransactionCountByHash`](/docs/chain-apis/abstract/abstract-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/chain-apis/abstract/abstract-api-endpoints/eth-get-block-transaction-count-by-number) |
+| [`eth_getCode`](/docs/chain-apis/abstract/abstract-api-endpoints/eth-get-code)                        | [`eth_getFilterChanges`](/docs/chain-apis/abstract/abstract-api-endpoints/eth-get-filter-changes) |
+| [`eth_getFilterLogs`](/docs/chain-apis/abstract/abstract-api-endpoints/eth-get-filter-logs)           | [`eth_getLogs`](/docs/chain-apis/abstract/abstract-api-endpoints/eth-get-logs)                    |
+| [`eth_getStorageAt`](/docs/chain-apis/abstract/abstract-api-endpoints/eth-get-storage-at)             | [`eth_getTransactionByBlockHashAndIndex`](/docs/chain-apis/abstract/abstract-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
+| [`eth_getTransactionByBlockNumberAndIndex`](/docs/chain-apis/abstract/abstract-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/chain-apis/abstract/abstract-api-endpoints/eth-get-transaction-by-hash) |
+| [`eth_getTransactionCount`](/docs/chain-apis/abstract/abstract-api-endpoints/eth-get-transaction-count) | [`eth_getTransactionReceipt`](/docs/chain-apis/abstract/abstract-api-endpoints/eth-get-transaction-receipt) |
+| [`eth_newBlockFilter`](/docs/chain-apis/abstract/abstract-api-endpoints/eth-new-block-filter)         | [`eth_newFilter`](/docs/chain-apis/abstract/abstract-api-endpoints/eth-new-filter)                |
+| [`eth_sendRawTransaction`](/docs/chain-apis/abstract/abstract-api-endpoints/eth-send-raw-transaction) | [`eth_submitWork`](/docs/chain-apis/abstract/abstract-api-endpoints/eth-submit-work)              |
+| [`eth_subscribe`](/docs/chain-apis/abstract/abstract-api-endpoints/eth-subscribe)                     | [`eth_uninstallFilter`](/docs/chain-apis/abstract/abstract-api-endpoints/eth-uninstall-filter)    |
+| [`eth_unsubscribe`](/docs/chain-apis/abstract/abstract-api-endpoints/eth-unsubscribe)                 | [`net_version`](/docs/chain-apis/abstract/abstract-api-endpoints/net-version)                     |
+| [`web3_clientVersion`](/docs/chain-apis/abstract/abstract-api-endpoints/web-3-client-version)         | [`web3_sha3`](/docs/chain-apis/abstract/abstract-api-endpoints/web-3-sha-3)                       |
 
 ## ADI APIs
 
@@ -74,22 +74,22 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_blockNumber`](/docs/node/adi/adi-api-endpoints/eth-block-number)                          | [`eth_call`](/docs/node/adi/adi-api-endpoints/eth-call)                                     |
-| [`eth_callMany`](/docs/node/adi/adi-api-endpoints/eth-call-many)                                | [`eth_chainId`](/docs/node/adi/adi-api-endpoints/eth-chain-id)                              |
-| [`eth_estimateGas`](/docs/node/adi/adi-api-endpoints/eth-estimate-gas)                          | [`eth_gasPrice`](/docs/node/adi/adi-api-endpoints/eth-gas-price)                            |
-| [`eth_getAccount`](/docs/node/adi/adi-api-endpoints/eth-get-account)                            | [`eth_getBalance`](/docs/node/adi/adi-api-endpoints/eth-get-balance)                        |
-| [`eth_getBlockByHash`](/docs/node/adi/adi-api-endpoints/eth-get-block-by-hash)                  | [`eth_getBlockByNumber`](/docs/node/adi/adi-api-endpoints/eth-get-block-by-number)          |
-| [`eth_getBlockTransactionCountByHash`](/docs/node/adi/adi-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/node/adi/adi-api-endpoints/eth-get-block-transaction-count-by-number) |
-| [`eth_getCode`](/docs/node/adi/adi-api-endpoints/eth-get-code)                                  | [`eth_getFilterChanges`](/docs/node/adi/adi-api-endpoints/eth-get-filter-changes)           |
-| [`eth_getFilterLogs`](/docs/node/adi/adi-api-endpoints/eth-get-filter-logs)                     | [`eth_getLogs`](/docs/node/adi/adi-api-endpoints/eth-get-logs)                              |
-| [`eth_getStorageAt`](/docs/node/adi/adi-api-endpoints/eth-get-storage-at)                       | [`eth_getTransactionByBlockHashAndIndex`](/docs/node/adi/adi-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
-| [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/adi/adi-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/node/adi/adi-api-endpoints/eth-get-transaction-by-hash)  |
-| [`eth_getTransactionCount`](/docs/node/adi/adi-api-endpoints/eth-get-transaction-count)         | [`eth_getTransactionReceipt`](/docs/node/adi/adi-api-endpoints/eth-get-transaction-receipt) |
-| [`eth_newBlockFilter`](/docs/node/adi/adi-api-endpoints/eth-new-block-filter)                   | [`eth_newFilter`](/docs/node/adi/adi-api-endpoints/eth-new-filter)                          |
-| [`eth_sendRawTransaction`](/docs/node/adi/adi-api-endpoints/eth-send-raw-transaction)           | [`eth_submitWork`](/docs/node/adi/adi-api-endpoints/eth-submit-work)                        |
-| [`eth_subscribe`](/docs/node/adi/adi-api-endpoints/eth-subscribe)                               | [`eth_uninstallFilter`](/docs/node/adi/adi-api-endpoints/eth-uninstall-filter)              |
-| [`eth_unsubscribe`](/docs/node/adi/adi-api-endpoints/eth-unsubscribe)                           | [`net_version`](/docs/node/adi/adi-api-endpoints/net-version)                               |
-| [`web3_clientVersion`](/docs/node/adi/adi-api-endpoints/web-3-client-version)                   | [`web3_sha3`](/docs/node/adi/adi-api-endpoints/web-3-sha-3)                                 |
+| [`eth_blockNumber`](/docs/chain-apis/adi/adi-api-endpoints/eth-block-number)                          | [`eth_call`](/docs/chain-apis/adi/adi-api-endpoints/eth-call)                                     |
+| [`eth_callMany`](/docs/chain-apis/adi/adi-api-endpoints/eth-call-many)                                | [`eth_chainId`](/docs/chain-apis/adi/adi-api-endpoints/eth-chain-id)                              |
+| [`eth_estimateGas`](/docs/chain-apis/adi/adi-api-endpoints/eth-estimate-gas)                          | [`eth_gasPrice`](/docs/chain-apis/adi/adi-api-endpoints/eth-gas-price)                            |
+| [`eth_getAccount`](/docs/chain-apis/adi/adi-api-endpoints/eth-get-account)                            | [`eth_getBalance`](/docs/chain-apis/adi/adi-api-endpoints/eth-get-balance)                        |
+| [`eth_getBlockByHash`](/docs/chain-apis/adi/adi-api-endpoints/eth-get-block-by-hash)                  | [`eth_getBlockByNumber`](/docs/chain-apis/adi/adi-api-endpoints/eth-get-block-by-number)          |
+| [`eth_getBlockTransactionCountByHash`](/docs/chain-apis/adi/adi-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/chain-apis/adi/adi-api-endpoints/eth-get-block-transaction-count-by-number) |
+| [`eth_getCode`](/docs/chain-apis/adi/adi-api-endpoints/eth-get-code)                                  | [`eth_getFilterChanges`](/docs/chain-apis/adi/adi-api-endpoints/eth-get-filter-changes)           |
+| [`eth_getFilterLogs`](/docs/chain-apis/adi/adi-api-endpoints/eth-get-filter-logs)                     | [`eth_getLogs`](/docs/chain-apis/adi/adi-api-endpoints/eth-get-logs)                              |
+| [`eth_getStorageAt`](/docs/chain-apis/adi/adi-api-endpoints/eth-get-storage-at)                       | [`eth_getTransactionByBlockHashAndIndex`](/docs/chain-apis/adi/adi-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
+| [`eth_getTransactionByBlockNumberAndIndex`](/docs/chain-apis/adi/adi-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/chain-apis/adi/adi-api-endpoints/eth-get-transaction-by-hash)  |
+| [`eth_getTransactionCount`](/docs/chain-apis/adi/adi-api-endpoints/eth-get-transaction-count)         | [`eth_getTransactionReceipt`](/docs/chain-apis/adi/adi-api-endpoints/eth-get-transaction-receipt) |
+| [`eth_newBlockFilter`](/docs/chain-apis/adi/adi-api-endpoints/eth-new-block-filter)                   | [`eth_newFilter`](/docs/chain-apis/adi/adi-api-endpoints/eth-new-filter)                          |
+| [`eth_sendRawTransaction`](/docs/chain-apis/adi/adi-api-endpoints/eth-send-raw-transaction)           | [`eth_submitWork`](/docs/chain-apis/adi/adi-api-endpoints/eth-submit-work)                        |
+| [`eth_subscribe`](/docs/chain-apis/adi/adi-api-endpoints/eth-subscribe)                               | [`eth_uninstallFilter`](/docs/chain-apis/adi/adi-api-endpoints/eth-uninstall-filter)              |
+| [`eth_unsubscribe`](/docs/chain-apis/adi/adi-api-endpoints/eth-unsubscribe)                           | [`net_version`](/docs/chain-apis/adi/adi-api-endpoints/net-version)                               |
+| [`web3_clientVersion`](/docs/chain-apis/adi/adi-api-endpoints/web-3-client-version)                   | [`web3_sha3`](/docs/chain-apis/adi/adi-api-endpoints/web-3-sha-3)                                 |
 
 ## Anime APIs
 
@@ -97,22 +97,22 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_blockNumber`](/docs/node/anime/anime-api-endpoints/eth-block-number)                      | [`eth_call`](/docs/node/anime/anime-api-endpoints/eth-call)                                 |
-| [`eth_callMany`](/docs/node/anime/anime-api-endpoints/eth-call-many)                            | [`eth_chainId`](/docs/node/anime/anime-api-endpoints/eth-chain-id)                          |
-| [`eth_estimateGas`](/docs/node/anime/anime-api-endpoints/eth-estimate-gas)                      | [`eth_gasPrice`](/docs/node/anime/anime-api-endpoints/eth-gas-price)                        |
-| [`eth_getAccount`](/docs/node/anime/anime-api-endpoints/eth-get-account)                        | [`eth_getBalance`](/docs/node/anime/anime-api-endpoints/eth-get-balance)                    |
-| [`eth_getBlockByHash`](/docs/node/anime/anime-api-endpoints/eth-get-block-by-hash)              | [`eth_getBlockByNumber`](/docs/node/anime/anime-api-endpoints/eth-get-block-by-number)      |
-| [`eth_getBlockTransactionCountByHash`](/docs/node/anime/anime-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/node/anime/anime-api-endpoints/eth-get-block-transaction-count-by-number) |
-| [`eth_getCode`](/docs/node/anime/anime-api-endpoints/eth-get-code)                              | [`eth_getFilterChanges`](/docs/node/anime/anime-api-endpoints/eth-get-filter-changes)       |
-| [`eth_getFilterLogs`](/docs/node/anime/anime-api-endpoints/eth-get-filter-logs)                 | [`eth_getLogs`](/docs/node/anime/anime-api-endpoints/eth-get-logs)                          |
-| [`eth_getStorageAt`](/docs/node/anime/anime-api-endpoints/eth-get-storage-at)                   | [`eth_getTransactionByBlockHashAndIndex`](/docs/node/anime/anime-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
-| [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/anime/anime-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/node/anime/anime-api-endpoints/eth-get-transaction-by-hash) |
-| [`eth_getTransactionCount`](/docs/node/anime/anime-api-endpoints/eth-get-transaction-count)     | [`eth_getTransactionReceipt`](/docs/node/anime/anime-api-endpoints/eth-get-transaction-receipt) |
-| [`eth_newBlockFilter`](/docs/node/anime/anime-api-endpoints/eth-new-block-filter)               | [`eth_newFilter`](/docs/node/anime/anime-api-endpoints/eth-new-filter)                      |
-| [`eth_sendRawTransaction`](/docs/node/anime/anime-api-endpoints/eth-send-raw-transaction)       | [`eth_submitWork`](/docs/node/anime/anime-api-endpoints/eth-submit-work)                    |
-| [`eth_subscribe`](/docs/node/anime/anime-api-endpoints/eth-subscribe)                           | [`eth_uninstallFilter`](/docs/node/anime/anime-api-endpoints/eth-uninstall-filter)          |
-| [`eth_unsubscribe`](/docs/node/anime/anime-api-endpoints/eth-unsubscribe)                       | [`net_version`](/docs/node/anime/anime-api-endpoints/net-version)                           |
-| [`web3_clientVersion`](/docs/node/anime/anime-api-endpoints/web-3-client-version)               | [`web3_sha3`](/docs/node/anime/anime-api-endpoints/web-3-sha-3)                             |
+| [`eth_blockNumber`](/docs/chain-apis/anime/anime-api-endpoints/eth-block-number)                      | [`eth_call`](/docs/chain-apis/anime/anime-api-endpoints/eth-call)                                 |
+| [`eth_callMany`](/docs/chain-apis/anime/anime-api-endpoints/eth-call-many)                            | [`eth_chainId`](/docs/chain-apis/anime/anime-api-endpoints/eth-chain-id)                          |
+| [`eth_estimateGas`](/docs/chain-apis/anime/anime-api-endpoints/eth-estimate-gas)                      | [`eth_gasPrice`](/docs/chain-apis/anime/anime-api-endpoints/eth-gas-price)                        |
+| [`eth_getAccount`](/docs/chain-apis/anime/anime-api-endpoints/eth-get-account)                        | [`eth_getBalance`](/docs/chain-apis/anime/anime-api-endpoints/eth-get-balance)                    |
+| [`eth_getBlockByHash`](/docs/chain-apis/anime/anime-api-endpoints/eth-get-block-by-hash)              | [`eth_getBlockByNumber`](/docs/chain-apis/anime/anime-api-endpoints/eth-get-block-by-number)      |
+| [`eth_getBlockTransactionCountByHash`](/docs/chain-apis/anime/anime-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/chain-apis/anime/anime-api-endpoints/eth-get-block-transaction-count-by-number) |
+| [`eth_getCode`](/docs/chain-apis/anime/anime-api-endpoints/eth-get-code)                              | [`eth_getFilterChanges`](/docs/chain-apis/anime/anime-api-endpoints/eth-get-filter-changes)       |
+| [`eth_getFilterLogs`](/docs/chain-apis/anime/anime-api-endpoints/eth-get-filter-logs)                 | [`eth_getLogs`](/docs/chain-apis/anime/anime-api-endpoints/eth-get-logs)                          |
+| [`eth_getStorageAt`](/docs/chain-apis/anime/anime-api-endpoints/eth-get-storage-at)                   | [`eth_getTransactionByBlockHashAndIndex`](/docs/chain-apis/anime/anime-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
+| [`eth_getTransactionByBlockNumberAndIndex`](/docs/chain-apis/anime/anime-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/chain-apis/anime/anime-api-endpoints/eth-get-transaction-by-hash) |
+| [`eth_getTransactionCount`](/docs/chain-apis/anime/anime-api-endpoints/eth-get-transaction-count)     | [`eth_getTransactionReceipt`](/docs/chain-apis/anime/anime-api-endpoints/eth-get-transaction-receipt) |
+| [`eth_newBlockFilter`](/docs/chain-apis/anime/anime-api-endpoints/eth-new-block-filter)               | [`eth_newFilter`](/docs/chain-apis/anime/anime-api-endpoints/eth-new-filter)                      |
+| [`eth_sendRawTransaction`](/docs/chain-apis/anime/anime-api-endpoints/eth-send-raw-transaction)       | [`eth_submitWork`](/docs/chain-apis/anime/anime-api-endpoints/eth-submit-work)                    |
+| [`eth_subscribe`](/docs/chain-apis/anime/anime-api-endpoints/eth-subscribe)                           | [`eth_uninstallFilter`](/docs/chain-apis/anime/anime-api-endpoints/eth-uninstall-filter)          |
+| [`eth_unsubscribe`](/docs/chain-apis/anime/anime-api-endpoints/eth-unsubscribe)                       | [`net_version`](/docs/chain-apis/anime/anime-api-endpoints/net-version)                           |
+| [`web3_clientVersion`](/docs/chain-apis/anime/anime-api-endpoints/web-3-client-version)               | [`web3_sha3`](/docs/chain-apis/anime/anime-api-endpoints/web-3-sha-3)                             |
 
 ## ApeChain APIs
 
@@ -120,22 +120,22 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_blockNumber`](/docs/node/apechain/ape-chain-api-endpoints/eth-block-number)               | [`eth_call`](/docs/node/apechain/ape-chain-api-endpoints/eth-call)                          |
-| [`eth_callMany`](/docs/node/apechain/ape-chain-api-endpoints/eth-call-many)                     | [`eth_chainId`](/docs/node/apechain/ape-chain-api-endpoints/eth-chain-id)                   |
-| [`eth_estimateGas`](/docs/node/apechain/ape-chain-api-endpoints/eth-estimate-gas)               | [`eth_gasPrice`](/docs/node/apechain/ape-chain-api-endpoints/eth-gas-price)                 |
-| [`eth_getAccount`](/docs/node/apechain/ape-chain-api-endpoints/eth-get-account)                 | [`eth_getBalance`](/docs/node/apechain/ape-chain-api-endpoints/eth-get-balance)             |
-| [`eth_getBlockByHash`](/docs/node/apechain/ape-chain-api-endpoints/eth-get-block-by-hash)       | [`eth_getBlockByNumber`](/docs/node/apechain/ape-chain-api-endpoints/eth-get-block-by-number) |
-| [`eth_getBlockTransactionCountByHash`](/docs/node/apechain/ape-chain-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/node/apechain/ape-chain-api-endpoints/eth-get-block-transaction-count-by-number) |
-| [`eth_getCode`](/docs/node/apechain/ape-chain-api-endpoints/eth-get-code)                       | [`eth_getFilterChanges`](/docs/node/apechain/ape-chain-api-endpoints/eth-get-filter-changes) |
-| [`eth_getFilterLogs`](/docs/node/apechain/ape-chain-api-endpoints/eth-get-filter-logs)          | [`eth_getLogs`](/docs/node/apechain/ape-chain-api-endpoints/eth-get-logs)                   |
-| [`eth_getStorageAt`](/docs/node/apechain/ape-chain-api-endpoints/eth-get-storage-at)            | [`eth_getTransactionByBlockHashAndIndex`](/docs/node/apechain/ape-chain-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
-| [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/apechain/ape-chain-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/node/apechain/ape-chain-api-endpoints/eth-get-transaction-by-hash) |
-| [`eth_getTransactionCount`](/docs/node/apechain/ape-chain-api-endpoints/eth-get-transaction-count) | [`eth_getTransactionReceipt`](/docs/node/apechain/ape-chain-api-endpoints/eth-get-transaction-receipt) |
-| [`eth_newBlockFilter`](/docs/node/apechain/ape-chain-api-endpoints/eth-new-block-filter)        | [`eth_newFilter`](/docs/node/apechain/ape-chain-api-endpoints/eth-new-filter)               |
-| [`eth_sendRawTransaction`](/docs/node/apechain/ape-chain-api-endpoints/eth-send-raw-transaction) | [`eth_submitWork`](/docs/node/apechain/ape-chain-api-endpoints/eth-submit-work)             |
-| [`eth_subscribe`](/docs/node/apechain/ape-chain-api-endpoints/eth-subscribe)                    | [`eth_uninstallFilter`](/docs/node/apechain/ape-chain-api-endpoints/eth-uninstall-filter)   |
-| [`eth_unsubscribe`](/docs/node/apechain/ape-chain-api-endpoints/eth-unsubscribe)                | [`net_version`](/docs/node/apechain/ape-chain-api-endpoints/net-version)                    |
-| [`web3_clientVersion`](/docs/node/apechain/ape-chain-api-endpoints/web-3-client-version)        | [`web3_sha3`](/docs/node/apechain/ape-chain-api-endpoints/web-3-sha-3)                      |
+| [`eth_blockNumber`](/docs/chain-apis/apechain/ape-chain-api-endpoints/eth-block-number)               | [`eth_call`](/docs/chain-apis/apechain/ape-chain-api-endpoints/eth-call)                          |
+| [`eth_callMany`](/docs/chain-apis/apechain/ape-chain-api-endpoints/eth-call-many)                     | [`eth_chainId`](/docs/chain-apis/apechain/ape-chain-api-endpoints/eth-chain-id)                   |
+| [`eth_estimateGas`](/docs/chain-apis/apechain/ape-chain-api-endpoints/eth-estimate-gas)               | [`eth_gasPrice`](/docs/chain-apis/apechain/ape-chain-api-endpoints/eth-gas-price)                 |
+| [`eth_getAccount`](/docs/chain-apis/apechain/ape-chain-api-endpoints/eth-get-account)                 | [`eth_getBalance`](/docs/chain-apis/apechain/ape-chain-api-endpoints/eth-get-balance)             |
+| [`eth_getBlockByHash`](/docs/chain-apis/apechain/ape-chain-api-endpoints/eth-get-block-by-hash)       | [`eth_getBlockByNumber`](/docs/chain-apis/apechain/ape-chain-api-endpoints/eth-get-block-by-number) |
+| [`eth_getBlockTransactionCountByHash`](/docs/chain-apis/apechain/ape-chain-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/chain-apis/apechain/ape-chain-api-endpoints/eth-get-block-transaction-count-by-number) |
+| [`eth_getCode`](/docs/chain-apis/apechain/ape-chain-api-endpoints/eth-get-code)                       | [`eth_getFilterChanges`](/docs/chain-apis/apechain/ape-chain-api-endpoints/eth-get-filter-changes) |
+| [`eth_getFilterLogs`](/docs/chain-apis/apechain/ape-chain-api-endpoints/eth-get-filter-logs)          | [`eth_getLogs`](/docs/chain-apis/apechain/ape-chain-api-endpoints/eth-get-logs)                   |
+| [`eth_getStorageAt`](/docs/chain-apis/apechain/ape-chain-api-endpoints/eth-get-storage-at)            | [`eth_getTransactionByBlockHashAndIndex`](/docs/chain-apis/apechain/ape-chain-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
+| [`eth_getTransactionByBlockNumberAndIndex`](/docs/chain-apis/apechain/ape-chain-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/chain-apis/apechain/ape-chain-api-endpoints/eth-get-transaction-by-hash) |
+| [`eth_getTransactionCount`](/docs/chain-apis/apechain/ape-chain-api-endpoints/eth-get-transaction-count) | [`eth_getTransactionReceipt`](/docs/chain-apis/apechain/ape-chain-api-endpoints/eth-get-transaction-receipt) |
+| [`eth_newBlockFilter`](/docs/chain-apis/apechain/ape-chain-api-endpoints/eth-new-block-filter)        | [`eth_newFilter`](/docs/chain-apis/apechain/ape-chain-api-endpoints/eth-new-filter)               |
+| [`eth_sendRawTransaction`](/docs/chain-apis/apechain/ape-chain-api-endpoints/eth-send-raw-transaction) | [`eth_submitWork`](/docs/chain-apis/apechain/ape-chain-api-endpoints/eth-submit-work)             |
+| [`eth_subscribe`](/docs/chain-apis/apechain/ape-chain-api-endpoints/eth-subscribe)                    | [`eth_uninstallFilter`](/docs/chain-apis/apechain/ape-chain-api-endpoints/eth-uninstall-filter)   |
+| [`eth_unsubscribe`](/docs/chain-apis/apechain/ape-chain-api-endpoints/eth-unsubscribe)                | [`net_version`](/docs/chain-apis/apechain/ape-chain-api-endpoints/net-version)                    |
+| [`web3_clientVersion`](/docs/chain-apis/apechain/ape-chain-api-endpoints/web-3-client-version)        | [`web3_sha3`](/docs/chain-apis/apechain/ape-chain-api-endpoints/web-3-sha-3)                      |
 
 ## Arbitrum APIs
 
@@ -143,29 +143,29 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_accounts`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-accounts)                       | [`eth_blockNumber`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-block-number)            |
-| [`eth_call`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-call)                               | [`eth_callMany`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-call-many)                  |
-| [`eth_chainId`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-chain-id)                        | [`eth_createAccessList`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-create-access-list) |
-| [`eth_estimateGas`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-estimate-gas)                | [`eth_feeHistory`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-fee-history)              |
-| [`eth_gasPrice`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-gas-price)                      | [`eth_getAccount`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-get-account)              |
-| [`eth_getBalance`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-get-balance)                  | [`eth_getBlockByHash`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-get-block-by-hash)    |
-| [`eth_getBlockByNumber`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-get-block-by-number)    | [`eth_getBlockReceipts`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-get-block-receipts) |
-| [`eth_getBlockTransactionCountByHash`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-get-block-transaction-count-by-number) |
-| [`eth_getCode`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-get-code)                        | [`eth_getFilterChanges`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-get-filter-changes) |
-| [`eth_getFilterLogs`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-get-filter-logs)           | [`eth_getLogs`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-get-logs)                    |
-| [`eth_getProof`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-get-proof)                      | [`eth_getStorageAt`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-get-storage-at)         |
-| [`eth_getTransactionByBlockHashAndIndex`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-get-transaction-by-block-hash-and-index) | [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-get-transaction-by-block-number-and-index) |
-| [`eth_getTransactionByHash`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-get-transaction-by-hash) | [`eth_getTransactionCount`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-get-transaction-count) |
-| [`eth_getTransactionReceipt`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-get-transaction-receipt) | [`eth_getUncleByBlockHashAndIndex`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-get-uncle-by-block-hash-and-index) |
-| [`eth_getUncleByBlockNumberAndIndex`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-get-uncle-by-block-number-and-index) | [`eth_getUncleCountByBlockHash`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-get-uncle-count-by-block-hash) |
-| [`eth_getUncleCountByBlockNumber`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-get-uncle-count-by-block-number) | [`eth_maxPriorityFeePerGas`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-max-priority-fee-per-gas) |
-| [`eth_newBlockFilter`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-new-block-filter)         | [`eth_newFilter`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-new-filter)                |
-| [`eth_newPendingTransactionFilter`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-new-pending-transaction-filter) | [`eth_sendRawTransaction`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-send-raw-transaction) |
-| [`eth_sendRawTransactionSync`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-send-raw-transaction-sync) | [`eth_simulateV1`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-simulate-v-1)             |
-| [`eth_submitWork`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-submit-work)                  | [`eth_subscribe`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-subscribe)                 |
-| [`eth_syncing`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-syncing)                         | [`eth_uninstallFilter`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-uninstall-filter)    |
-| [`eth_unsubscribe`](/docs/node/arbitrum/arbitrum-api-endpoints/eth-unsubscribe)                 | [`net_version`](/docs/node/arbitrum/arbitrum-api-endpoints/net-version)                     |
-| [`web3_clientVersion`](/docs/node/arbitrum/arbitrum-api-endpoints/web-3-client-version)         | [`web3_sha3`](/docs/node/arbitrum/arbitrum-api-endpoints/web-3-sha-3)                       |
+| [`eth_accounts`](/docs/chain-apis/arbitrum/arbitrum-api-endpoints/eth-accounts)                       | [`eth_blockNumber`](/docs/chain-apis/arbitrum/arbitrum-api-endpoints/eth-block-number)            |
+| [`eth_call`](/docs/chain-apis/arbitrum/arbitrum-api-endpoints/eth-call)                               | [`eth_callMany`](/docs/chain-apis/arbitrum/arbitrum-api-endpoints/eth-call-many)                  |
+| [`eth_chainId`](/docs/chain-apis/arbitrum/arbitrum-api-endpoints/eth-chain-id)                        | [`eth_createAccessList`](/docs/chain-apis/arbitrum/arbitrum-api-endpoints/eth-create-access-list) |
+| [`eth_estimateGas`](/docs/chain-apis/arbitrum/arbitrum-api-endpoints/eth-estimate-gas)                | [`eth_feeHistory`](/docs/chain-apis/arbitrum/arbitrum-api-endpoints/eth-fee-history)              |
+| [`eth_gasPrice`](/docs/chain-apis/arbitrum/arbitrum-api-endpoints/eth-gas-price)                      | [`eth_getAccount`](/docs/chain-apis/arbitrum/arbitrum-api-endpoints/eth-get-account)              |
+| [`eth_getBalance`](/docs/chain-apis/arbitrum/arbitrum-api-endpoints/eth-get-balance)                  | [`eth_getBlockByHash`](/docs/chain-apis/arbitrum/arbitrum-api-endpoints/eth-get-block-by-hash)    |
+| [`eth_getBlockByNumber`](/docs/chain-apis/arbitrum/arbitrum-api-endpoints/eth-get-block-by-number)    | [`eth_getBlockReceipts`](/docs/chain-apis/arbitrum/arbitrum-api-endpoints/eth-get-block-receipts) |
+| [`eth_getBlockTransactionCountByHash`](/docs/chain-apis/arbitrum/arbitrum-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/chain-apis/arbitrum/arbitrum-api-endpoints/eth-get-block-transaction-count-by-number) |
+| [`eth_getCode`](/docs/chain-apis/arbitrum/arbitrum-api-endpoints/eth-get-code)                        | [`eth_getFilterChanges`](/docs/chain-apis/arbitrum/arbitrum-api-endpoints/eth-get-filter-changes) |
+| [`eth_getFilterLogs`](/docs/chain-apis/arbitrum/arbitrum-api-endpoints/eth-get-filter-logs)           | [`eth_getLogs`](/docs/chain-apis/arbitrum/arbitrum-api-endpoints/eth-get-logs)                    |
+| [`eth_getProof`](/docs/chain-apis/arbitrum/arbitrum-api-endpoints/eth-get-proof)                      | [`eth_getStorageAt`](/docs/chain-apis/arbitrum/arbitrum-api-endpoints/eth-get-storage-at)         |
+| [`eth_getTransactionByBlockHashAndIndex`](/docs/chain-apis/arbitrum/arbitrum-api-endpoints/eth-get-transaction-by-block-hash-and-index) | [`eth_getTransactionByBlockNumberAndIndex`](/docs/chain-apis/arbitrum/arbitrum-api-endpoints/eth-get-transaction-by-block-number-and-index) |
+| [`eth_getTransactionByHash`](/docs/chain-apis/arbitrum/arbitrum-api-endpoints/eth-get-transaction-by-hash) | [`eth_getTransactionCount`](/docs/chain-apis/arbitrum/arbitrum-api-endpoints/eth-get-transaction-count) |
+| [`eth_getTransactionReceipt`](/docs/chain-apis/arbitrum/arbitrum-api-endpoints/eth-get-transaction-receipt) | [`eth_getUncleByBlockHashAndIndex`](/docs/chain-apis/arbitrum/arbitrum-api-endpoints/eth-get-uncle-by-block-hash-and-index) |
+| [`eth_getUncleByBlockNumberAndIndex`](/docs/chain-apis/arbitrum/arbitrum-api-endpoints/eth-get-uncle-by-block-number-and-index) | [`eth_getUncleCountByBlockHash`](/docs/chain-apis/arbitrum/arbitrum-api-endpoints/eth-get-uncle-count-by-block-hash) |
+| [`eth_getUncleCountByBlockNumber`](/docs/chain-apis/arbitrum/arbitrum-api-endpoints/eth-get-uncle-count-by-block-number) | [`eth_maxPriorityFeePerGas`](/docs/chain-apis/arbitrum/arbitrum-api-endpoints/eth-max-priority-fee-per-gas) |
+| [`eth_newBlockFilter`](/docs/chain-apis/arbitrum/arbitrum-api-endpoints/eth-new-block-filter)         | [`eth_newFilter`](/docs/chain-apis/arbitrum/arbitrum-api-endpoints/eth-new-filter)                |
+| [`eth_newPendingTransactionFilter`](/docs/chain-apis/arbitrum/arbitrum-api-endpoints/eth-new-pending-transaction-filter) | [`eth_sendRawTransaction`](/docs/chain-apis/arbitrum/arbitrum-api-endpoints/eth-send-raw-transaction) |
+| [`eth_sendRawTransactionSync`](/docs/chain-apis/arbitrum/arbitrum-api-endpoints/eth-send-raw-transaction-sync) | [`eth_simulateV1`](/docs/chain-apis/arbitrum/arbitrum-api-endpoints/eth-simulate-v-1)             |
+| [`eth_submitWork`](/docs/chain-apis/arbitrum/arbitrum-api-endpoints/eth-submit-work)                  | [`eth_subscribe`](/docs/chain-apis/arbitrum/arbitrum-api-endpoints/eth-subscribe)                 |
+| [`eth_syncing`](/docs/chain-apis/arbitrum/arbitrum-api-endpoints/eth-syncing)                         | [`eth_uninstallFilter`](/docs/chain-apis/arbitrum/arbitrum-api-endpoints/eth-uninstall-filter)    |
+| [`eth_unsubscribe`](/docs/chain-apis/arbitrum/arbitrum-api-endpoints/eth-unsubscribe)                 | [`net_version`](/docs/chain-apis/arbitrum/arbitrum-api-endpoints/net-version)                     |
+| [`web3_clientVersion`](/docs/chain-apis/arbitrum/arbitrum-api-endpoints/web-3-client-version)         | [`web3_sha3`](/docs/chain-apis/arbitrum/arbitrum-api-endpoints/web-3-sha-3)                       |
 
 ## Arbitrum Nova APIs
 
@@ -173,24 +173,24 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_blockNumber`](/docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/eth-block-number)      | [`eth_call`](/docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/eth-call)                 |
-| [`eth_callMany`](/docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/eth-call-many)            | [`eth_chainId`](/docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/eth-chain-id)          |
-| [`eth_createAccessList`](/docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/eth-create-access-list) | [`eth_estimateGas`](/docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/eth-estimate-gas)  |
-| [`eth_feeHistory`](/docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/eth-fee-history)        | [`eth_gasPrice`](/docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/eth-gas-price)        |
-| [`eth_getAccount`](/docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/eth-get-account)        | [`eth_getBalance`](/docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/eth-get-balance)    |
-| [`eth_getBlockByHash`](/docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/eth-get-block-by-hash) | [`eth_getBlockByNumber`](/docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/eth-get-block-by-number) |
-| [`eth_getBlockTransactionCountByHash`](/docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/eth-get-block-transaction-count-by-number) |
-| [`eth_getCode`](/docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/eth-get-code)              | [`eth_getFilterChanges`](/docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/eth-get-filter-changes) |
-| [`eth_getFilterLogs`](/docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/eth-get-filter-logs) | [`eth_getLogs`](/docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/eth-get-logs)          |
-| [`eth_getProof`](/docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/eth-get-proof)            | [`eth_getStorageAt`](/docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/eth-get-storage-at) |
-| [`eth_getTransactionByBlockHashAndIndex`](/docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/eth-get-transaction-by-block-hash-and-index) | [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/eth-get-transaction-by-block-number-and-index) |
-| [`eth_getTransactionByHash`](/docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/eth-get-transaction-by-hash) | [`eth_getTransactionCount`](/docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/eth-get-transaction-count) |
-| [`eth_getTransactionReceipt`](/docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/eth-get-transaction-receipt) | [`eth_maxPriorityFeePerGas`](/docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/eth-max-priority-fee-per-gas) |
-| [`eth_newBlockFilter`](/docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/eth-new-block-filter) | [`eth_newFilter`](/docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/eth-new-filter)      |
-| [`eth_sendRawTransaction`](/docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/eth-send-raw-transaction) | [`eth_submitWork`](/docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/eth-submit-work)    |
-| [`eth_subscribe`](/docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/eth-subscribe)           | [`eth_uninstallFilter`](/docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/eth-uninstall-filter) |
-| [`eth_unsubscribe`](/docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/eth-unsubscribe)       | [`net_version`](/docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/net-version)           |
-| [`web3_clientVersion`](/docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/web-3-client-version) | [`web3_sha3`](/docs/node/arbitrum-nova/arbitrum-nova-api-endpoints/web-3-sha-3)             |
+| [`eth_blockNumber`](/docs/chain-apis/arbitrum-nova/arbitrum-nova-api-endpoints/eth-block-number)      | [`eth_call`](/docs/chain-apis/arbitrum-nova/arbitrum-nova-api-endpoints/eth-call)                 |
+| [`eth_callMany`](/docs/chain-apis/arbitrum-nova/arbitrum-nova-api-endpoints/eth-call-many)            | [`eth_chainId`](/docs/chain-apis/arbitrum-nova/arbitrum-nova-api-endpoints/eth-chain-id)          |
+| [`eth_createAccessList`](/docs/chain-apis/arbitrum-nova/arbitrum-nova-api-endpoints/eth-create-access-list) | [`eth_estimateGas`](/docs/chain-apis/arbitrum-nova/arbitrum-nova-api-endpoints/eth-estimate-gas)  |
+| [`eth_feeHistory`](/docs/chain-apis/arbitrum-nova/arbitrum-nova-api-endpoints/eth-fee-history)        | [`eth_gasPrice`](/docs/chain-apis/arbitrum-nova/arbitrum-nova-api-endpoints/eth-gas-price)        |
+| [`eth_getAccount`](/docs/chain-apis/arbitrum-nova/arbitrum-nova-api-endpoints/eth-get-account)        | [`eth_getBalance`](/docs/chain-apis/arbitrum-nova/arbitrum-nova-api-endpoints/eth-get-balance)    |
+| [`eth_getBlockByHash`](/docs/chain-apis/arbitrum-nova/arbitrum-nova-api-endpoints/eth-get-block-by-hash) | [`eth_getBlockByNumber`](/docs/chain-apis/arbitrum-nova/arbitrum-nova-api-endpoints/eth-get-block-by-number) |
+| [`eth_getBlockTransactionCountByHash`](/docs/chain-apis/arbitrum-nova/arbitrum-nova-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/chain-apis/arbitrum-nova/arbitrum-nova-api-endpoints/eth-get-block-transaction-count-by-number) |
+| [`eth_getCode`](/docs/chain-apis/arbitrum-nova/arbitrum-nova-api-endpoints/eth-get-code)              | [`eth_getFilterChanges`](/docs/chain-apis/arbitrum-nova/arbitrum-nova-api-endpoints/eth-get-filter-changes) |
+| [`eth_getFilterLogs`](/docs/chain-apis/arbitrum-nova/arbitrum-nova-api-endpoints/eth-get-filter-logs) | [`eth_getLogs`](/docs/chain-apis/arbitrum-nova/arbitrum-nova-api-endpoints/eth-get-logs)          |
+| [`eth_getProof`](/docs/chain-apis/arbitrum-nova/arbitrum-nova-api-endpoints/eth-get-proof)            | [`eth_getStorageAt`](/docs/chain-apis/arbitrum-nova/arbitrum-nova-api-endpoints/eth-get-storage-at) |
+| [`eth_getTransactionByBlockHashAndIndex`](/docs/chain-apis/arbitrum-nova/arbitrum-nova-api-endpoints/eth-get-transaction-by-block-hash-and-index) | [`eth_getTransactionByBlockNumberAndIndex`](/docs/chain-apis/arbitrum-nova/arbitrum-nova-api-endpoints/eth-get-transaction-by-block-number-and-index) |
+| [`eth_getTransactionByHash`](/docs/chain-apis/arbitrum-nova/arbitrum-nova-api-endpoints/eth-get-transaction-by-hash) | [`eth_getTransactionCount`](/docs/chain-apis/arbitrum-nova/arbitrum-nova-api-endpoints/eth-get-transaction-count) |
+| [`eth_getTransactionReceipt`](/docs/chain-apis/arbitrum-nova/arbitrum-nova-api-endpoints/eth-get-transaction-receipt) | [`eth_maxPriorityFeePerGas`](/docs/chain-apis/arbitrum-nova/arbitrum-nova-api-endpoints/eth-max-priority-fee-per-gas) |
+| [`eth_newBlockFilter`](/docs/chain-apis/arbitrum-nova/arbitrum-nova-api-endpoints/eth-new-block-filter) | [`eth_newFilter`](/docs/chain-apis/arbitrum-nova/arbitrum-nova-api-endpoints/eth-new-filter)      |
+| [`eth_sendRawTransaction`](/docs/chain-apis/arbitrum-nova/arbitrum-nova-api-endpoints/eth-send-raw-transaction) | [`eth_submitWork`](/docs/chain-apis/arbitrum-nova/arbitrum-nova-api-endpoints/eth-submit-work)    |
+| [`eth_subscribe`](/docs/chain-apis/arbitrum-nova/arbitrum-nova-api-endpoints/eth-subscribe)           | [`eth_uninstallFilter`](/docs/chain-apis/arbitrum-nova/arbitrum-nova-api-endpoints/eth-uninstall-filter) |
+| [`eth_unsubscribe`](/docs/chain-apis/arbitrum-nova/arbitrum-nova-api-endpoints/eth-unsubscribe)       | [`net_version`](/docs/chain-apis/arbitrum-nova/arbitrum-nova-api-endpoints/net-version)           |
+| [`web3_clientVersion`](/docs/chain-apis/arbitrum-nova/arbitrum-nova-api-endpoints/web-3-client-version) | [`web3_sha3`](/docs/chain-apis/arbitrum-nova/arbitrum-nova-api-endpoints/web-3-sha-3)             |
 
 ## Astar APIs
 
@@ -198,24 +198,24 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_accounts`](/docs/node/astar/astar-api-endpoints/eth-accounts)                             | [`eth_blockNumber`](/docs/node/astar/astar-api-endpoints/eth-block-number)                  |
-| [`eth_call`](/docs/node/astar/astar-api-endpoints/eth-call)                                     | [`eth_callMany`](/docs/node/astar/astar-api-endpoints/eth-call-many)                        |
-| [`eth_chainId`](/docs/node/astar/astar-api-endpoints/eth-chain-id)                              | [`eth_estimateGas`](/docs/node/astar/astar-api-endpoints/eth-estimate-gas)                  |
-| [`eth_feeHistory`](/docs/node/astar/astar-api-endpoints/eth-fee-history)                        | [`eth_gasPrice`](/docs/node/astar/astar-api-endpoints/eth-gas-price)                        |
-| [`eth_getAccount`](/docs/node/astar/astar-api-endpoints/eth-get-account)                        | [`eth_getBalance`](/docs/node/astar/astar-api-endpoints/eth-get-balance)                    |
-| [`eth_getBlockByHash`](/docs/node/astar/astar-api-endpoints/eth-get-block-by-hash)              | [`eth_getBlockByNumber`](/docs/node/astar/astar-api-endpoints/eth-get-block-by-number)      |
-| [`eth_getBlockReceipts`](/docs/node/astar/astar-api-endpoints/eth-get-block-receipts)           | [`eth_getBlockTransactionCountByHash`](/docs/node/astar/astar-api-endpoints/eth-get-block-transaction-count-by-hash) |
-| [`eth_getBlockTransactionCountByNumber`](/docs/node/astar/astar-api-endpoints/eth-get-block-transaction-count-by-number) | [`eth_getCode`](/docs/node/astar/astar-api-endpoints/eth-get-code)                          |
-| [`eth_getFilterChanges`](/docs/node/astar/astar-api-endpoints/eth-get-filter-changes)           | [`eth_getFilterLogs`](/docs/node/astar/astar-api-endpoints/eth-get-filter-logs)             |
-| [`eth_getLogs`](/docs/node/astar/astar-api-endpoints/eth-get-logs)                              | [`eth_getStorageAt`](/docs/node/astar/astar-api-endpoints/eth-get-storage-at)               |
-| [`eth_getTransactionByBlockHashAndIndex`](/docs/node/astar/astar-api-endpoints/eth-get-transaction-by-block-hash-and-index) | [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/astar/astar-api-endpoints/eth-get-transaction-by-block-number-and-index) |
-| [`eth_getTransactionByHash`](/docs/node/astar/astar-api-endpoints/eth-get-transaction-by-hash)  | [`eth_getTransactionCount`](/docs/node/astar/astar-api-endpoints/eth-get-transaction-count) |
-| [`eth_getTransactionReceipt`](/docs/node/astar/astar-api-endpoints/eth-get-transaction-receipt) | [`eth_newBlockFilter`](/docs/node/astar/astar-api-endpoints/eth-new-block-filter)           |
-| [`eth_newFilter`](/docs/node/astar/astar-api-endpoints/eth-new-filter)                          | [`eth_sendRawTransaction`](/docs/node/astar/astar-api-endpoints/eth-send-raw-transaction)   |
-| [`eth_submitWork`](/docs/node/astar/astar-api-endpoints/eth-submit-work)                        | [`eth_subscribe`](/docs/node/astar/astar-api-endpoints/eth-subscribe)                       |
-| [`eth_uninstallFilter`](/docs/node/astar/astar-api-endpoints/eth-uninstall-filter)              | [`eth_unsubscribe`](/docs/node/astar/astar-api-endpoints/eth-unsubscribe)                   |
-| [`net_version`](/docs/node/astar/astar-api-endpoints/net-version)                               | [`web3_clientVersion`](/docs/node/astar/astar-api-endpoints/web-3-client-version)           |
-| [`web3_sha3`](/docs/node/astar/astar-api-endpoints/web-3-sha-3)                                 |                                                                                             |
+| [`eth_accounts`](/docs/chain-apis/astar/astar-api-endpoints/eth-accounts)                             | [`eth_blockNumber`](/docs/chain-apis/astar/astar-api-endpoints/eth-block-number)                  |
+| [`eth_call`](/docs/chain-apis/astar/astar-api-endpoints/eth-call)                                     | [`eth_callMany`](/docs/chain-apis/astar/astar-api-endpoints/eth-call-many)                        |
+| [`eth_chainId`](/docs/chain-apis/astar/astar-api-endpoints/eth-chain-id)                              | [`eth_estimateGas`](/docs/chain-apis/astar/astar-api-endpoints/eth-estimate-gas)                  |
+| [`eth_feeHistory`](/docs/chain-apis/astar/astar-api-endpoints/eth-fee-history)                        | [`eth_gasPrice`](/docs/chain-apis/astar/astar-api-endpoints/eth-gas-price)                        |
+| [`eth_getAccount`](/docs/chain-apis/astar/astar-api-endpoints/eth-get-account)                        | [`eth_getBalance`](/docs/chain-apis/astar/astar-api-endpoints/eth-get-balance)                    |
+| [`eth_getBlockByHash`](/docs/chain-apis/astar/astar-api-endpoints/eth-get-block-by-hash)              | [`eth_getBlockByNumber`](/docs/chain-apis/astar/astar-api-endpoints/eth-get-block-by-number)      |
+| [`eth_getBlockReceipts`](/docs/chain-apis/astar/astar-api-endpoints/eth-get-block-receipts)           | [`eth_getBlockTransactionCountByHash`](/docs/chain-apis/astar/astar-api-endpoints/eth-get-block-transaction-count-by-hash) |
+| [`eth_getBlockTransactionCountByNumber`](/docs/chain-apis/astar/astar-api-endpoints/eth-get-block-transaction-count-by-number) | [`eth_getCode`](/docs/chain-apis/astar/astar-api-endpoints/eth-get-code)                          |
+| [`eth_getFilterChanges`](/docs/chain-apis/astar/astar-api-endpoints/eth-get-filter-changes)           | [`eth_getFilterLogs`](/docs/chain-apis/astar/astar-api-endpoints/eth-get-filter-logs)             |
+| [`eth_getLogs`](/docs/chain-apis/astar/astar-api-endpoints/eth-get-logs)                              | [`eth_getStorageAt`](/docs/chain-apis/astar/astar-api-endpoints/eth-get-storage-at)               |
+| [`eth_getTransactionByBlockHashAndIndex`](/docs/chain-apis/astar/astar-api-endpoints/eth-get-transaction-by-block-hash-and-index) | [`eth_getTransactionByBlockNumberAndIndex`](/docs/chain-apis/astar/astar-api-endpoints/eth-get-transaction-by-block-number-and-index) |
+| [`eth_getTransactionByHash`](/docs/chain-apis/astar/astar-api-endpoints/eth-get-transaction-by-hash)  | [`eth_getTransactionCount`](/docs/chain-apis/astar/astar-api-endpoints/eth-get-transaction-count) |
+| [`eth_getTransactionReceipt`](/docs/chain-apis/astar/astar-api-endpoints/eth-get-transaction-receipt) | [`eth_newBlockFilter`](/docs/chain-apis/astar/astar-api-endpoints/eth-new-block-filter)           |
+| [`eth_newFilter`](/docs/chain-apis/astar/astar-api-endpoints/eth-new-filter)                          | [`eth_sendRawTransaction`](/docs/chain-apis/astar/astar-api-endpoints/eth-send-raw-transaction)   |
+| [`eth_submitWork`](/docs/chain-apis/astar/astar-api-endpoints/eth-submit-work)                        | [`eth_subscribe`](/docs/chain-apis/astar/astar-api-endpoints/eth-subscribe)                       |
+| [`eth_uninstallFilter`](/docs/chain-apis/astar/astar-api-endpoints/eth-uninstall-filter)              | [`eth_unsubscribe`](/docs/chain-apis/astar/astar-api-endpoints/eth-unsubscribe)                   |
+| [`net_version`](/docs/chain-apis/astar/astar-api-endpoints/net-version)                               | [`web3_clientVersion`](/docs/chain-apis/astar/astar-api-endpoints/web-3-client-version)           |
+| [`web3_sha3`](/docs/chain-apis/astar/astar-api-endpoints/web-3-sha-3)                                 |                                                                                             |
 
 ## Avalanche APIs
 
@@ -223,29 +223,29 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_baseFee`](/docs/node/avalanche/avalanche-api-endpoints/eth-base-fee)                      | [`eth_blockNumber`](/docs/node/avalanche/avalanche-api-endpoints/eth-block-number)          |
-| [`eth_call`](/docs/node/avalanche/avalanche-api-endpoints/eth-call)                             | [`eth_callMany`](/docs/node/avalanche/avalanche-api-endpoints/eth-call-many)                |
-| [`eth_chainId`](/docs/node/avalanche/avalanche-api-endpoints/eth-chain-id)                      | [`eth_createAccessList`](/docs/node/avalanche/avalanche-api-endpoints/eth-create-access-list) |
-| [`eth_estimateGas`](/docs/node/avalanche/avalanche-api-endpoints/eth-estimate-gas)              | [`eth_feeHistory`](/docs/node/avalanche/avalanche-api-endpoints/eth-fee-history)            |
-| [`eth_gasPrice`](/docs/node/avalanche/avalanche-api-endpoints/eth-gas-price)                    | [`eth_getAccount`](/docs/node/avalanche/avalanche-api-endpoints/eth-get-account)            |
-| [`eth_getAssetBalance`](/docs/node/avalanche/avalanche-api-endpoints/eth-get-asset-balance)     | [`eth_getBalance`](/docs/node/avalanche/avalanche-api-endpoints/eth-get-balance)            |
-| [`eth_getBlockByHash`](/docs/node/avalanche/avalanche-api-endpoints/eth-get-block-by-hash)      | [`eth_getBlockByNumber`](/docs/node/avalanche/avalanche-api-endpoints/eth-get-block-by-number) |
-| [`eth_getBlockReceipts`](/docs/node/avalanche/avalanche-api-endpoints/eth-get-block-receipts)   | [`eth_getBlockTransactionCountByHash`](/docs/node/avalanche/avalanche-api-endpoints/eth-get-block-transaction-count-by-hash) |
-| [`eth_getBlockTransactionCountByNumber`](/docs/node/avalanche/avalanche-api-endpoints/eth-get-block-transaction-count-by-number) | [`eth_getChainConfig`](/docs/node/avalanche/avalanche-api-endpoints/eth-get-chain-config)   |
-| [`eth_getCode`](/docs/node/avalanche/avalanche-api-endpoints/eth-get-code)                      | [`eth_getFilterChanges`](/docs/node/avalanche/avalanche-api-endpoints/eth-get-filter-changes) |
-| [`eth_getFilterLogs`](/docs/node/avalanche/avalanche-api-endpoints/eth-get-filter-logs)         | [`eth_getLogs`](/docs/node/avalanche/avalanche-api-endpoints/eth-get-logs)                  |
-| [`eth_getProof`](/docs/node/avalanche/avalanche-api-endpoints/eth-get-proof)                    | [`eth_getStorageAt`](/docs/node/avalanche/avalanche-api-endpoints/eth-get-storage-at)       |
-| [`eth_getTransactionByBlockHashAndIndex`](/docs/node/avalanche/avalanche-api-endpoints/eth-get-transaction-by-block-hash-and-index) | [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/avalanche/avalanche-api-endpoints/eth-get-transaction-by-block-number-and-index) |
-| [`eth_getTransactionByHash`](/docs/node/avalanche/avalanche-api-endpoints/eth-get-transaction-by-hash) | [`eth_getTransactionCount`](/docs/node/avalanche/avalanche-api-endpoints/eth-get-transaction-count) |
-| [`eth_getTransactionReceipt`](/docs/node/avalanche/avalanche-api-endpoints/eth-get-transaction-receipt) | [`eth_getUncleByBlockHashAndIndex`](/docs/node/avalanche/avalanche-api-endpoints/eth-get-uncle-by-block-hash-and-index) |
-| [`eth_getUncleByBlockNumberAndIndex`](/docs/node/avalanche/avalanche-api-endpoints/eth-get-uncle-by-block-number-and-index) | [`eth_getUncleCountByBlockHash`](/docs/node/avalanche/avalanche-api-endpoints/eth-get-uncle-count-by-block-hash) |
-| [`eth_getUncleCountByBlockNumber`](/docs/node/avalanche/avalanche-api-endpoints/eth-get-uncle-count-by-block-number) | [`eth_maxPriorityFeePerGas`](/docs/node/avalanche/avalanche-api-endpoints/eth-max-priority-fee-per-gas) |
-| [`eth_newBlockFilter`](/docs/node/avalanche/avalanche-api-endpoints/eth-new-block-filter)       | [`eth_newFilter`](/docs/node/avalanche/avalanche-api-endpoints/eth-new-filter)              |
-| [`eth_sendRawTransaction`](/docs/node/avalanche/avalanche-api-endpoints/eth-send-raw-transaction) | [`eth_sendRawTransactionSync`](/docs/node/avalanche/avalanche-api-endpoints/eth-send-raw-transaction-sync) |
-| [`eth_submitWork`](/docs/node/avalanche/avalanche-api-endpoints/eth-submit-work)                | [`eth_subscribe`](/docs/node/avalanche/avalanche-api-endpoints/eth-subscribe)               |
-| [`eth_syncing`](/docs/node/avalanche/avalanche-api-endpoints/eth-syncing)                       | [`eth_uninstallFilter`](/docs/node/avalanche/avalanche-api-endpoints/eth-uninstall-filter)  |
-| [`eth_unsubscribe`](/docs/node/avalanche/avalanche-api-endpoints/eth-unsubscribe)               | [`net_version`](/docs/node/avalanche/avalanche-api-endpoints/net-version)                   |
-| [`web3_clientVersion`](/docs/node/avalanche/avalanche-api-endpoints/web-3-client-version)       | [`web3_sha3`](/docs/node/avalanche/avalanche-api-endpoints/web-3-sha-3)                     |
+| [`eth_baseFee`](/docs/chain-apis/avalanche/avalanche-api-endpoints/eth-base-fee)                      | [`eth_blockNumber`](/docs/chain-apis/avalanche/avalanche-api-endpoints/eth-block-number)          |
+| [`eth_call`](/docs/chain-apis/avalanche/avalanche-api-endpoints/eth-call)                             | [`eth_callMany`](/docs/chain-apis/avalanche/avalanche-api-endpoints/eth-call-many)                |
+| [`eth_chainId`](/docs/chain-apis/avalanche/avalanche-api-endpoints/eth-chain-id)                      | [`eth_createAccessList`](/docs/chain-apis/avalanche/avalanche-api-endpoints/eth-create-access-list) |
+| [`eth_estimateGas`](/docs/chain-apis/avalanche/avalanche-api-endpoints/eth-estimate-gas)              | [`eth_feeHistory`](/docs/chain-apis/avalanche/avalanche-api-endpoints/eth-fee-history)            |
+| [`eth_gasPrice`](/docs/chain-apis/avalanche/avalanche-api-endpoints/eth-gas-price)                    | [`eth_getAccount`](/docs/chain-apis/avalanche/avalanche-api-endpoints/eth-get-account)            |
+| [`eth_getAssetBalance`](/docs/chain-apis/avalanche/avalanche-api-endpoints/eth-get-asset-balance)     | [`eth_getBalance`](/docs/chain-apis/avalanche/avalanche-api-endpoints/eth-get-balance)            |
+| [`eth_getBlockByHash`](/docs/chain-apis/avalanche/avalanche-api-endpoints/eth-get-block-by-hash)      | [`eth_getBlockByNumber`](/docs/chain-apis/avalanche/avalanche-api-endpoints/eth-get-block-by-number) |
+| [`eth_getBlockReceipts`](/docs/chain-apis/avalanche/avalanche-api-endpoints/eth-get-block-receipts)   | [`eth_getBlockTransactionCountByHash`](/docs/chain-apis/avalanche/avalanche-api-endpoints/eth-get-block-transaction-count-by-hash) |
+| [`eth_getBlockTransactionCountByNumber`](/docs/chain-apis/avalanche/avalanche-api-endpoints/eth-get-block-transaction-count-by-number) | [`eth_getChainConfig`](/docs/chain-apis/avalanche/avalanche-api-endpoints/eth-get-chain-config)   |
+| [`eth_getCode`](/docs/chain-apis/avalanche/avalanche-api-endpoints/eth-get-code)                      | [`eth_getFilterChanges`](/docs/chain-apis/avalanche/avalanche-api-endpoints/eth-get-filter-changes) |
+| [`eth_getFilterLogs`](/docs/chain-apis/avalanche/avalanche-api-endpoints/eth-get-filter-logs)         | [`eth_getLogs`](/docs/chain-apis/avalanche/avalanche-api-endpoints/eth-get-logs)                  |
+| [`eth_getProof`](/docs/chain-apis/avalanche/avalanche-api-endpoints/eth-get-proof)                    | [`eth_getStorageAt`](/docs/chain-apis/avalanche/avalanche-api-endpoints/eth-get-storage-at)       |
+| [`eth_getTransactionByBlockHashAndIndex`](/docs/chain-apis/avalanche/avalanche-api-endpoints/eth-get-transaction-by-block-hash-and-index) | [`eth_getTransactionByBlockNumberAndIndex`](/docs/chain-apis/avalanche/avalanche-api-endpoints/eth-get-transaction-by-block-number-and-index) |
+| [`eth_getTransactionByHash`](/docs/chain-apis/avalanche/avalanche-api-endpoints/eth-get-transaction-by-hash) | [`eth_getTransactionCount`](/docs/chain-apis/avalanche/avalanche-api-endpoints/eth-get-transaction-count) |
+| [`eth_getTransactionReceipt`](/docs/chain-apis/avalanche/avalanche-api-endpoints/eth-get-transaction-receipt) | [`eth_getUncleByBlockHashAndIndex`](/docs/chain-apis/avalanche/avalanche-api-endpoints/eth-get-uncle-by-block-hash-and-index) |
+| [`eth_getUncleByBlockNumberAndIndex`](/docs/chain-apis/avalanche/avalanche-api-endpoints/eth-get-uncle-by-block-number-and-index) | [`eth_getUncleCountByBlockHash`](/docs/chain-apis/avalanche/avalanche-api-endpoints/eth-get-uncle-count-by-block-hash) |
+| [`eth_getUncleCountByBlockNumber`](/docs/chain-apis/avalanche/avalanche-api-endpoints/eth-get-uncle-count-by-block-number) | [`eth_maxPriorityFeePerGas`](/docs/chain-apis/avalanche/avalanche-api-endpoints/eth-max-priority-fee-per-gas) |
+| [`eth_newBlockFilter`](/docs/chain-apis/avalanche/avalanche-api-endpoints/eth-new-block-filter)       | [`eth_newFilter`](/docs/chain-apis/avalanche/avalanche-api-endpoints/eth-new-filter)              |
+| [`eth_sendRawTransaction`](/docs/chain-apis/avalanche/avalanche-api-endpoints/eth-send-raw-transaction) | [`eth_sendRawTransactionSync`](/docs/chain-apis/avalanche/avalanche-api-endpoints/eth-send-raw-transaction-sync) |
+| [`eth_submitWork`](/docs/chain-apis/avalanche/avalanche-api-endpoints/eth-submit-work)                | [`eth_subscribe`](/docs/chain-apis/avalanche/avalanche-api-endpoints/eth-subscribe)               |
+| [`eth_syncing`](/docs/chain-apis/avalanche/avalanche-api-endpoints/eth-syncing)                       | [`eth_uninstallFilter`](/docs/chain-apis/avalanche/avalanche-api-endpoints/eth-uninstall-filter)  |
+| [`eth_unsubscribe`](/docs/chain-apis/avalanche/avalanche-api-endpoints/eth-unsubscribe)               | [`net_version`](/docs/chain-apis/avalanche/avalanche-api-endpoints/net-version)                   |
+| [`web3_clientVersion`](/docs/chain-apis/avalanche/avalanche-api-endpoints/web-3-client-version)       | [`web3_sha3`](/docs/chain-apis/avalanche/avalanche-api-endpoints/web-3-sha-3)                     |
 
 ## Base APIs
 
@@ -253,30 +253,30 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_accounts`](/docs/node/base/base-api-endpoints/eth-accounts)                               | [`eth_blobBaseFee`](/docs/node/base/base-api-endpoints/eth-blob-base-fee)                   |
-| [`eth_blockNumber`](/docs/node/base/base-api-endpoints/eth-block-number)                        | [`eth_call`](/docs/node/base/base-api-endpoints/eth-call)                                   |
-| [`eth_callBundle`](/docs/node/base/base-api-endpoints/eth-call-bundle)                          | [`eth_callMany`](/docs/node/base/base-api-endpoints/eth-call-many)                          |
-| [`eth_chainId`](/docs/node/base/base-api-endpoints/eth-chain-id)                                | [`eth_createAccessList`](/docs/node/base/base-api-endpoints/eth-create-access-list)         |
-| [`eth_estimateGas`](/docs/node/base/base-api-endpoints/eth-estimate-gas)                        | [`eth_feeHistory`](/docs/node/base/base-api-endpoints/eth-fee-history)                      |
-| [`eth_gasPrice`](/docs/node/base/base-api-endpoints/eth-gas-price)                              | [`eth_getAccount`](/docs/node/base/base-api-endpoints/eth-get-account)                      |
-| [`eth_getBalance`](/docs/node/base/base-api-endpoints/eth-get-balance)                          | [`eth_getBlockByHash`](/docs/node/base/base-api-endpoints/eth-get-block-by-hash)            |
-| [`eth_getBlockByNumber`](/docs/node/base/base-api-endpoints/eth-get-block-by-number)            | [`eth_getBlockReceipts`](/docs/node/base/base-api-endpoints/eth-get-block-receipts)         |
-| [`eth_getBlockTransactionCountByHash`](/docs/node/base/base-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/node/base/base-api-endpoints/eth-get-block-transaction-count-by-number) |
-| [`eth_getCode`](/docs/node/base/base-api-endpoints/eth-get-code)                                | [`eth_getFilterChanges`](/docs/node/base/base-api-endpoints/eth-get-filter-changes)         |
-| [`eth_getFilterLogs`](/docs/node/base/base-api-endpoints/eth-get-filter-logs)                   | [`eth_getLogs`](/docs/node/base/base-api-endpoints/eth-get-logs)                            |
-| [`eth_getProof`](/docs/node/base/base-api-endpoints/eth-get-proof)                              | [`eth_getStorageAt`](/docs/node/base/base-api-endpoints/eth-get-storage-at)                 |
-| [`eth_getTransactionByBlockHashAndIndex`](/docs/node/base/base-api-endpoints/eth-get-transaction-by-block-hash-and-index) | [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/base/base-api-endpoints/eth-get-transaction-by-block-number-and-index) |
-| [`eth_getTransactionByHash`](/docs/node/base/base-api-endpoints/eth-get-transaction-by-hash)    | [`eth_getTransactionCount`](/docs/node/base/base-api-endpoints/eth-get-transaction-count)   |
-| [`eth_getTransactionReceipt`](/docs/node/base/base-api-endpoints/eth-get-transaction-receipt)   | [`eth_getUncleByBlockHashAndIndex`](/docs/node/base/base-api-endpoints/eth-get-uncle-by-block-hash-and-index) |
-| [`eth_getUncleByBlockNumberAndIndex`](/docs/node/base/base-api-endpoints/eth-get-uncle-by-block-number-and-index) | [`eth_getUncleCountByBlockHash`](/docs/node/base/base-api-endpoints/eth-get-uncle-count-by-block-hash) |
-| [`eth_getUncleCountByBlockNumber`](/docs/node/base/base-api-endpoints/eth-get-uncle-count-by-block-number) | [`eth_maxPriorityFeePerGas`](/docs/node/base/base-api-endpoints/eth-max-priority-fee-per-gas) |
-| [`eth_newBlockFilter`](/docs/node/base/base-api-endpoints/eth-new-block-filter)                 | [`eth_newFilter`](/docs/node/base/base-api-endpoints/eth-new-filter)                        |
-| [`eth_newPendingTransactionFilter`](/docs/node/base/base-api-endpoints/eth-new-pending-transaction-filter) | [`eth_sendRawTransaction`](/docs/node/base/base-api-endpoints/eth-send-raw-transaction)     |
-| [`eth_sendRawTransactionSync`](/docs/node/base/base-api-endpoints/eth-send-raw-transaction-sync) | [`eth_simulateV1`](/docs/node/base/base-api-endpoints/eth-simulate-v-1)                     |
-| [`eth_submitWork`](/docs/node/base/base-api-endpoints/eth-submit-work)                          | [`eth_subscribe`](/docs/node/base/base-api-endpoints/eth-subscribe)                         |
-| [`eth_syncing`](/docs/node/base/base-api-endpoints/eth-syncing)                                 | [`eth_uninstallFilter`](/docs/node/base/base-api-endpoints/eth-uninstall-filter)            |
-| [`eth_unsubscribe`](/docs/node/base/base-api-endpoints/eth-unsubscribe)                         | [`net_version`](/docs/node/base/base-api-endpoints/net-version)                             |
-| [`web3_clientVersion`](/docs/node/base/base-api-endpoints/web-3-client-version)                 | [`web3_sha3`](/docs/node/base/base-api-endpoints/web-3-sha-3)                               |
+| [`eth_accounts`](/docs/chain-apis/base/base-api-endpoints/eth-accounts)                               | [`eth_blobBaseFee`](/docs/chain-apis/base/base-api-endpoints/eth-blob-base-fee)                   |
+| [`eth_blockNumber`](/docs/chain-apis/base/base-api-endpoints/eth-block-number)                        | [`eth_call`](/docs/chain-apis/base/base-api-endpoints/eth-call)                                   |
+| [`eth_callBundle`](/docs/chain-apis/base/base-api-endpoints/eth-call-bundle)                          | [`eth_callMany`](/docs/chain-apis/base/base-api-endpoints/eth-call-many)                          |
+| [`eth_chainId`](/docs/chain-apis/base/base-api-endpoints/eth-chain-id)                                | [`eth_createAccessList`](/docs/chain-apis/base/base-api-endpoints/eth-create-access-list)         |
+| [`eth_estimateGas`](/docs/chain-apis/base/base-api-endpoints/eth-estimate-gas)                        | [`eth_feeHistory`](/docs/chain-apis/base/base-api-endpoints/eth-fee-history)                      |
+| [`eth_gasPrice`](/docs/chain-apis/base/base-api-endpoints/eth-gas-price)                              | [`eth_getAccount`](/docs/chain-apis/base/base-api-endpoints/eth-get-account)                      |
+| [`eth_getBalance`](/docs/chain-apis/base/base-api-endpoints/eth-get-balance)                          | [`eth_getBlockByHash`](/docs/chain-apis/base/base-api-endpoints/eth-get-block-by-hash)            |
+| [`eth_getBlockByNumber`](/docs/chain-apis/base/base-api-endpoints/eth-get-block-by-number)            | [`eth_getBlockReceipts`](/docs/chain-apis/base/base-api-endpoints/eth-get-block-receipts)         |
+| [`eth_getBlockTransactionCountByHash`](/docs/chain-apis/base/base-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/chain-apis/base/base-api-endpoints/eth-get-block-transaction-count-by-number) |
+| [`eth_getCode`](/docs/chain-apis/base/base-api-endpoints/eth-get-code)                                | [`eth_getFilterChanges`](/docs/chain-apis/base/base-api-endpoints/eth-get-filter-changes)         |
+| [`eth_getFilterLogs`](/docs/chain-apis/base/base-api-endpoints/eth-get-filter-logs)                   | [`eth_getLogs`](/docs/chain-apis/base/base-api-endpoints/eth-get-logs)                            |
+| [`eth_getProof`](/docs/chain-apis/base/base-api-endpoints/eth-get-proof)                              | [`eth_getStorageAt`](/docs/chain-apis/base/base-api-endpoints/eth-get-storage-at)                 |
+| [`eth_getTransactionByBlockHashAndIndex`](/docs/chain-apis/base/base-api-endpoints/eth-get-transaction-by-block-hash-and-index) | [`eth_getTransactionByBlockNumberAndIndex`](/docs/chain-apis/base/base-api-endpoints/eth-get-transaction-by-block-number-and-index) |
+| [`eth_getTransactionByHash`](/docs/chain-apis/base/base-api-endpoints/eth-get-transaction-by-hash)    | [`eth_getTransactionCount`](/docs/chain-apis/base/base-api-endpoints/eth-get-transaction-count)   |
+| [`eth_getTransactionReceipt`](/docs/chain-apis/base/base-api-endpoints/eth-get-transaction-receipt)   | [`eth_getUncleByBlockHashAndIndex`](/docs/chain-apis/base/base-api-endpoints/eth-get-uncle-by-block-hash-and-index) |
+| [`eth_getUncleByBlockNumberAndIndex`](/docs/chain-apis/base/base-api-endpoints/eth-get-uncle-by-block-number-and-index) | [`eth_getUncleCountByBlockHash`](/docs/chain-apis/base/base-api-endpoints/eth-get-uncle-count-by-block-hash) |
+| [`eth_getUncleCountByBlockNumber`](/docs/chain-apis/base/base-api-endpoints/eth-get-uncle-count-by-block-number) | [`eth_maxPriorityFeePerGas`](/docs/chain-apis/base/base-api-endpoints/eth-max-priority-fee-per-gas) |
+| [`eth_newBlockFilter`](/docs/chain-apis/base/base-api-endpoints/eth-new-block-filter)                 | [`eth_newFilter`](/docs/chain-apis/base/base-api-endpoints/eth-new-filter)                        |
+| [`eth_newPendingTransactionFilter`](/docs/chain-apis/base/base-api-endpoints/eth-new-pending-transaction-filter) | [`eth_sendRawTransaction`](/docs/chain-apis/base/base-api-endpoints/eth-send-raw-transaction)     |
+| [`eth_sendRawTransactionSync`](/docs/chain-apis/base/base-api-endpoints/eth-send-raw-transaction-sync) | [`eth_simulateV1`](/docs/chain-apis/base/base-api-endpoints/eth-simulate-v-1)                     |
+| [`eth_submitWork`](/docs/chain-apis/base/base-api-endpoints/eth-submit-work)                          | [`eth_subscribe`](/docs/chain-apis/base/base-api-endpoints/eth-subscribe)                         |
+| [`eth_syncing`](/docs/chain-apis/base/base-api-endpoints/eth-syncing)                                 | [`eth_uninstallFilter`](/docs/chain-apis/base/base-api-endpoints/eth-uninstall-filter)            |
+| [`eth_unsubscribe`](/docs/chain-apis/base/base-api-endpoints/eth-unsubscribe)                         | [`net_version`](/docs/chain-apis/base/base-api-endpoints/net-version)                             |
+| [`web3_clientVersion`](/docs/chain-apis/base/base-api-endpoints/web-3-client-version)                 | [`web3_sha3`](/docs/chain-apis/base/base-api-endpoints/web-3-sha-3)                               |
 
 ## Berachain APIs
 
@@ -284,23 +284,23 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_blockNumber`](/docs/node/berachain/berachain-api-endpoints/eth-block-number)              | [`eth_call`](/docs/node/berachain/berachain-api-endpoints/eth-call)                         |
-| [`eth_callMany`](/docs/node/berachain/berachain-api-endpoints/eth-call-many)                    | [`eth_chainId`](/docs/node/berachain/berachain-api-endpoints/eth-chain-id)                  |
-| [`eth_estimateGas`](/docs/node/berachain/berachain-api-endpoints/eth-estimate-gas)              | [`eth_gasPrice`](/docs/node/berachain/berachain-api-endpoints/eth-gas-price)                |
-| [`eth_getAccount`](/docs/node/berachain/berachain-api-endpoints/eth-get-account)                | [`eth_getBalance`](/docs/node/berachain/berachain-api-endpoints/eth-get-balance)            |
-| [`eth_getBlockByHash`](/docs/node/berachain/berachain-api-endpoints/eth-get-block-by-hash)      | [`eth_getBlockByNumber`](/docs/node/berachain/berachain-api-endpoints/eth-get-block-by-number) |
-| [`eth_getBlockTransactionCountByHash`](/docs/node/berachain/berachain-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/node/berachain/berachain-api-endpoints/eth-get-block-transaction-count-by-number) |
-| [`eth_getCode`](/docs/node/berachain/berachain-api-endpoints/eth-get-code)                      | [`eth_getFilterChanges`](/docs/node/berachain/berachain-api-endpoints/eth-get-filter-changes) |
-| [`eth_getFilterLogs`](/docs/node/berachain/berachain-api-endpoints/eth-get-filter-logs)         | [`eth_getLogs`](/docs/node/berachain/berachain-api-endpoints/eth-get-logs)                  |
-| [`eth_getStorageAt`](/docs/node/berachain/berachain-api-endpoints/eth-get-storage-at)           | [`eth_getTransactionByBlockHashAndIndex`](/docs/node/berachain/berachain-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
-| [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/berachain/berachain-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/node/berachain/berachain-api-endpoints/eth-get-transaction-by-hash) |
-| [`eth_getTransactionCount`](/docs/node/berachain/berachain-api-endpoints/eth-get-transaction-count) | [`eth_getTransactionReceipt`](/docs/node/berachain/berachain-api-endpoints/eth-get-transaction-receipt) |
-| [`eth_newBlockFilter`](/docs/node/berachain/berachain-api-endpoints/eth-new-block-filter)       | [`eth_newFilter`](/docs/node/berachain/berachain-api-endpoints/eth-new-filter)              |
-| [`eth_sendRawTransaction`](/docs/node/berachain/berachain-api-endpoints/eth-send-raw-transaction) | [`eth_simulateV1`](/docs/node/berachain/berachain-api-endpoints/eth-simulate-v-1)           |
-| [`eth_submitWork`](/docs/node/berachain/berachain-api-endpoints/eth-submit-work)                | [`eth_subscribe`](/docs/node/berachain/berachain-api-endpoints/eth-subscribe)               |
-| [`eth_uninstallFilter`](/docs/node/berachain/berachain-api-endpoints/eth-uninstall-filter)      | [`eth_unsubscribe`](/docs/node/berachain/berachain-api-endpoints/eth-unsubscribe)           |
-| [`net_version`](/docs/node/berachain/berachain-api-endpoints/net-version)                       | [`web3_clientVersion`](/docs/node/berachain/berachain-api-endpoints/web-3-client-version)   |
-| [`web3_sha3`](/docs/node/berachain/berachain-api-endpoints/web-3-sha-3)                         |                                                                                             |
+| [`eth_blockNumber`](/docs/chain-apis/berachain/berachain-api-endpoints/eth-block-number)              | [`eth_call`](/docs/chain-apis/berachain/berachain-api-endpoints/eth-call)                         |
+| [`eth_callMany`](/docs/chain-apis/berachain/berachain-api-endpoints/eth-call-many)                    | [`eth_chainId`](/docs/chain-apis/berachain/berachain-api-endpoints/eth-chain-id)                  |
+| [`eth_estimateGas`](/docs/chain-apis/berachain/berachain-api-endpoints/eth-estimate-gas)              | [`eth_gasPrice`](/docs/chain-apis/berachain/berachain-api-endpoints/eth-gas-price)                |
+| [`eth_getAccount`](/docs/chain-apis/berachain/berachain-api-endpoints/eth-get-account)                | [`eth_getBalance`](/docs/chain-apis/berachain/berachain-api-endpoints/eth-get-balance)            |
+| [`eth_getBlockByHash`](/docs/chain-apis/berachain/berachain-api-endpoints/eth-get-block-by-hash)      | [`eth_getBlockByNumber`](/docs/chain-apis/berachain/berachain-api-endpoints/eth-get-block-by-number) |
+| [`eth_getBlockTransactionCountByHash`](/docs/chain-apis/berachain/berachain-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/chain-apis/berachain/berachain-api-endpoints/eth-get-block-transaction-count-by-number) |
+| [`eth_getCode`](/docs/chain-apis/berachain/berachain-api-endpoints/eth-get-code)                      | [`eth_getFilterChanges`](/docs/chain-apis/berachain/berachain-api-endpoints/eth-get-filter-changes) |
+| [`eth_getFilterLogs`](/docs/chain-apis/berachain/berachain-api-endpoints/eth-get-filter-logs)         | [`eth_getLogs`](/docs/chain-apis/berachain/berachain-api-endpoints/eth-get-logs)                  |
+| [`eth_getStorageAt`](/docs/chain-apis/berachain/berachain-api-endpoints/eth-get-storage-at)           | [`eth_getTransactionByBlockHashAndIndex`](/docs/chain-apis/berachain/berachain-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
+| [`eth_getTransactionByBlockNumberAndIndex`](/docs/chain-apis/berachain/berachain-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/chain-apis/berachain/berachain-api-endpoints/eth-get-transaction-by-hash) |
+| [`eth_getTransactionCount`](/docs/chain-apis/berachain/berachain-api-endpoints/eth-get-transaction-count) | [`eth_getTransactionReceipt`](/docs/chain-apis/berachain/berachain-api-endpoints/eth-get-transaction-receipt) |
+| [`eth_newBlockFilter`](/docs/chain-apis/berachain/berachain-api-endpoints/eth-new-block-filter)       | [`eth_newFilter`](/docs/chain-apis/berachain/berachain-api-endpoints/eth-new-filter)              |
+| [`eth_sendRawTransaction`](/docs/chain-apis/berachain/berachain-api-endpoints/eth-send-raw-transaction) | [`eth_simulateV1`](/docs/chain-apis/berachain/berachain-api-endpoints/eth-simulate-v-1)           |
+| [`eth_submitWork`](/docs/chain-apis/berachain/berachain-api-endpoints/eth-submit-work)                | [`eth_subscribe`](/docs/chain-apis/berachain/berachain-api-endpoints/eth-subscribe)               |
+| [`eth_uninstallFilter`](/docs/chain-apis/berachain/berachain-api-endpoints/eth-uninstall-filter)      | [`eth_unsubscribe`](/docs/chain-apis/berachain/berachain-api-endpoints/eth-unsubscribe)           |
+| [`net_version`](/docs/chain-apis/berachain/berachain-api-endpoints/net-version)                       | [`web3_clientVersion`](/docs/chain-apis/berachain/berachain-api-endpoints/web-3-client-version)   |
+| [`web3_sha3`](/docs/chain-apis/berachain/berachain-api-endpoints/web-3-sha-3)                         |                                                                                             |
 
 ## Bitcoin APIs
 
@@ -308,21 +308,21 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`decoderawtransaction`](/docs/node/bitcoin/bitcoin-api-endpoints/decoderawtransaction)         | [`decodescript`](/docs/node/bitcoin/bitcoin-api-endpoints/decodescript)                     |
-| [`estimatesmartfee`](/docs/node/bitcoin/bitcoin-api-endpoints/estimatesmartfee)                 | [`getbestblockhash`](/docs/node/bitcoin/bitcoin-api-endpoints/getbestblockhash)             |
-| [`getblock`](/docs/node/bitcoin/bitcoin-api-endpoints/getblock)                                 | [`getblockchaininfo`](/docs/node/bitcoin/bitcoin-api-endpoints/getblockchaininfo)           |
-| [`getblockcount`](/docs/node/bitcoin/bitcoin-api-endpoints/getblockcount)                       | [`getblockhash`](/docs/node/bitcoin/bitcoin-api-endpoints/getblockhash)                     |
-| [`getblockheader`](/docs/node/bitcoin/bitcoin-api-endpoints/getblockheader)                     | [`getblockstats`](/docs/node/bitcoin/bitcoin-api-endpoints/getblockstats)                   |
-| [`getchaintips`](/docs/node/bitcoin/bitcoin-api-endpoints/getchaintips)                         | [`getchaintxstats`](/docs/node/bitcoin/bitcoin-api-endpoints/getchaintxstats)               |
-| [`getconnectioncount`](/docs/node/bitcoin/bitcoin-api-endpoints/getconnectioncount)             | [`getdifficulty`](/docs/node/bitcoin/bitcoin-api-endpoints/getdifficulty)                   |
-| [`getindexinfo`](/docs/node/bitcoin/bitcoin-api-endpoints/getindexinfo)                         | [`getmemoryinfo`](/docs/node/bitcoin/bitcoin-api-endpoints/getmemoryinfo)                   |
-| [`getmempoolancestors`](/docs/node/bitcoin/bitcoin-api-endpoints/getmempoolancestors)           | [`getmempooldescendants`](/docs/node/bitcoin/bitcoin-api-endpoints/getmempooldescendants)   |
-| [`getmempoolinfo`](/docs/node/bitcoin/bitcoin-api-endpoints/getmempoolinfo)                     | [`getrawmempool`](/docs/node/bitcoin/bitcoin-api-endpoints/getrawmempool)                   |
-| [`getrawtransaction`](/docs/node/bitcoin/bitcoin-api-endpoints/getrawtransaction)               | [`gettxout`](/docs/node/bitcoin/bitcoin-api-endpoints/gettxout)                             |
-| [`gettxoutproof`](/docs/node/bitcoin/bitcoin-api-endpoints/gettxoutproof)                       | [`gettxoutsetinfo`](/docs/node/bitcoin/bitcoin-api-endpoints/gettxoutsetinfo)               |
-| [`sendrawtransaction`](/docs/node/bitcoin/bitcoin-api-endpoints/sendrawtransaction)             | [`submitpackage`](/docs/node/bitcoin/bitcoin-api-endpoints/submitpackage)                   |
-| [`testmempoolaccept`](/docs/node/bitcoin/bitcoin-api-endpoints/testmempoolaccept)               | [`validateaddress`](/docs/node/bitcoin/bitcoin-api-endpoints/validateaddress)               |
-| [`verifymessage`](/docs/node/bitcoin/bitcoin-api-endpoints/verifymessage)                       |                                                                                             |
+| [`decoderawtransaction`](/docs/chain-apis/bitcoin/bitcoin-api-endpoints/decoderawtransaction)         | [`decodescript`](/docs/chain-apis/bitcoin/bitcoin-api-endpoints/decodescript)                     |
+| [`estimatesmartfee`](/docs/chain-apis/bitcoin/bitcoin-api-endpoints/estimatesmartfee)                 | [`getbestblockhash`](/docs/chain-apis/bitcoin/bitcoin-api-endpoints/getbestblockhash)             |
+| [`getblock`](/docs/chain-apis/bitcoin/bitcoin-api-endpoints/getblock)                                 | [`getblockchaininfo`](/docs/chain-apis/bitcoin/bitcoin-api-endpoints/getblockchaininfo)           |
+| [`getblockcount`](/docs/chain-apis/bitcoin/bitcoin-api-endpoints/getblockcount)                       | [`getblockhash`](/docs/chain-apis/bitcoin/bitcoin-api-endpoints/getblockhash)                     |
+| [`getblockheader`](/docs/chain-apis/bitcoin/bitcoin-api-endpoints/getblockheader)                     | [`getblockstats`](/docs/chain-apis/bitcoin/bitcoin-api-endpoints/getblockstats)                   |
+| [`getchaintips`](/docs/chain-apis/bitcoin/bitcoin-api-endpoints/getchaintips)                         | [`getchaintxstats`](/docs/chain-apis/bitcoin/bitcoin-api-endpoints/getchaintxstats)               |
+| [`getconnectioncount`](/docs/chain-apis/bitcoin/bitcoin-api-endpoints/getconnectioncount)             | [`getdifficulty`](/docs/chain-apis/bitcoin/bitcoin-api-endpoints/getdifficulty)                   |
+| [`getindexinfo`](/docs/chain-apis/bitcoin/bitcoin-api-endpoints/getindexinfo)                         | [`getmemoryinfo`](/docs/chain-apis/bitcoin/bitcoin-api-endpoints/getmemoryinfo)                   |
+| [`getmempoolancestors`](/docs/chain-apis/bitcoin/bitcoin-api-endpoints/getmempoolancestors)           | [`getmempooldescendants`](/docs/chain-apis/bitcoin/bitcoin-api-endpoints/getmempooldescendants)   |
+| [`getmempoolinfo`](/docs/chain-apis/bitcoin/bitcoin-api-endpoints/getmempoolinfo)                     | [`getrawmempool`](/docs/chain-apis/bitcoin/bitcoin-api-endpoints/getrawmempool)                   |
+| [`getrawtransaction`](/docs/chain-apis/bitcoin/bitcoin-api-endpoints/getrawtransaction)               | [`gettxout`](/docs/chain-apis/bitcoin/bitcoin-api-endpoints/gettxout)                             |
+| [`gettxoutproof`](/docs/chain-apis/bitcoin/bitcoin-api-endpoints/gettxoutproof)                       | [`gettxoutsetinfo`](/docs/chain-apis/bitcoin/bitcoin-api-endpoints/gettxoutsetinfo)               |
+| [`sendrawtransaction`](/docs/chain-apis/bitcoin/bitcoin-api-endpoints/sendrawtransaction)             | [`submitpackage`](/docs/chain-apis/bitcoin/bitcoin-api-endpoints/submitpackage)                   |
+| [`testmempoolaccept`](/docs/chain-apis/bitcoin/bitcoin-api-endpoints/testmempoolaccept)               | [`validateaddress`](/docs/chain-apis/bitcoin/bitcoin-api-endpoints/validateaddress)               |
+| [`verifymessage`](/docs/chain-apis/bitcoin/bitcoin-api-endpoints/verifymessage)                       |                                                                                             |
 
 ## Blast APIs
 
@@ -330,28 +330,28 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_blockNumber`](/docs/node/blast/blast-api-endpoints/eth-block-number)                      | [`eth_call`](/docs/node/blast/blast-api-endpoints/eth-call)                                 |
-| [`eth_callMany`](/docs/node/blast/blast-api-endpoints/eth-call-many)                            | [`eth_chainId`](/docs/node/blast/blast-api-endpoints/eth-chain-id)                          |
-| [`eth_createAccessList`](/docs/node/blast/blast-api-endpoints/eth-create-access-list)           | [`eth_estimateGas`](/docs/node/blast/blast-api-endpoints/eth-estimate-gas)                  |
-| [`eth_feeHistory`](/docs/node/blast/blast-api-endpoints/eth-fee-history)                        | [`eth_gasPrice`](/docs/node/blast/blast-api-endpoints/eth-gas-price)                        |
-| [`eth_getAccount`](/docs/node/blast/blast-api-endpoints/eth-get-account)                        | [`eth_getBalance`](/docs/node/blast/blast-api-endpoints/eth-get-balance)                    |
-| [`eth_getBlockByHash`](/docs/node/blast/blast-api-endpoints/eth-get-block-by-hash)              | [`eth_getBlockByNumber`](/docs/node/blast/blast-api-endpoints/eth-get-block-by-number)      |
-| [`eth_getBlockReceipts`](/docs/node/blast/blast-api-endpoints/eth-get-block-receipts)           | [`eth_getBlockTransactionCountByHash`](/docs/node/blast/blast-api-endpoints/eth-get-block-transaction-count-by-hash) |
-| [`eth_getBlockTransactionCountByNumber`](/docs/node/blast/blast-api-endpoints/eth-get-block-transaction-count-by-number) | [`eth_getCode`](/docs/node/blast/blast-api-endpoints/eth-get-code)                          |
-| [`eth_getFilterChanges`](/docs/node/blast/blast-api-endpoints/eth-get-filter-changes)           | [`eth_getFilterLogs`](/docs/node/blast/blast-api-endpoints/eth-get-filter-logs)             |
-| [`eth_getLogs`](/docs/node/blast/blast-api-endpoints/eth-get-logs)                              | [`eth_getProof`](/docs/node/blast/blast-api-endpoints/eth-get-proof)                        |
-| [`eth_getStorageAt`](/docs/node/blast/blast-api-endpoints/eth-get-storage-at)                   | [`eth_getTransactionByBlockHashAndIndex`](/docs/node/blast/blast-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
-| [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/blast/blast-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/node/blast/blast-api-endpoints/eth-get-transaction-by-hash) |
-| [`eth_getTransactionCount`](/docs/node/blast/blast-api-endpoints/eth-get-transaction-count)     | [`eth_getTransactionReceipt`](/docs/node/blast/blast-api-endpoints/eth-get-transaction-receipt) |
-| [`eth_getUncleByBlockHashAndIndex`](/docs/node/blast/blast-api-endpoints/eth-get-uncle-by-block-hash-and-index) | [`eth_getUncleByBlockNumberAndIndex`](/docs/node/blast/blast-api-endpoints/eth-get-uncle-by-block-number-and-index) |
-| [`eth_getUncleCountByBlockHash`](/docs/node/blast/blast-api-endpoints/eth-get-uncle-count-by-block-hash) | [`eth_getUncleCountByBlockNumber`](/docs/node/blast/blast-api-endpoints/eth-get-uncle-count-by-block-number) |
-| [`eth_maxPriorityFeePerGas`](/docs/node/blast/blast-api-endpoints/eth-max-priority-fee-per-gas) | [`eth_newBlockFilter`](/docs/node/blast/blast-api-endpoints/eth-new-block-filter)           |
-| [`eth_newFilter`](/docs/node/blast/blast-api-endpoints/eth-new-filter)                          | [`eth_sendRawTransaction`](/docs/node/blast/blast-api-endpoints/eth-send-raw-transaction)   |
-| [`eth_sendRawTransactionSync`](/docs/node/blast/blast-api-endpoints/eth-send-raw-transaction-sync) | [`eth_submitWork`](/docs/node/blast/blast-api-endpoints/eth-submit-work)                    |
-| [`eth_subscribe`](/docs/node/blast/blast-api-endpoints/eth-subscribe)                           | [`eth_syncing`](/docs/node/blast/blast-api-endpoints/eth-syncing)                           |
-| [`eth_uninstallFilter`](/docs/node/blast/blast-api-endpoints/eth-uninstall-filter)              | [`eth_unsubscribe`](/docs/node/blast/blast-api-endpoints/eth-unsubscribe)                   |
-| [`net_version`](/docs/node/blast/blast-api-endpoints/net-version)                               | [`web3_clientVersion`](/docs/node/blast/blast-api-endpoints/web-3-client-version)           |
-| [`web3_sha3`](/docs/node/blast/blast-api-endpoints/web-3-sha-3)                                 |                                                                                             |
+| [`eth_blockNumber`](/docs/chain-apis/blast/blast-api-endpoints/eth-block-number)                      | [`eth_call`](/docs/chain-apis/blast/blast-api-endpoints/eth-call)                                 |
+| [`eth_callMany`](/docs/chain-apis/blast/blast-api-endpoints/eth-call-many)                            | [`eth_chainId`](/docs/chain-apis/blast/blast-api-endpoints/eth-chain-id)                          |
+| [`eth_createAccessList`](/docs/chain-apis/blast/blast-api-endpoints/eth-create-access-list)           | [`eth_estimateGas`](/docs/chain-apis/blast/blast-api-endpoints/eth-estimate-gas)                  |
+| [`eth_feeHistory`](/docs/chain-apis/blast/blast-api-endpoints/eth-fee-history)                        | [`eth_gasPrice`](/docs/chain-apis/blast/blast-api-endpoints/eth-gas-price)                        |
+| [`eth_getAccount`](/docs/chain-apis/blast/blast-api-endpoints/eth-get-account)                        | [`eth_getBalance`](/docs/chain-apis/blast/blast-api-endpoints/eth-get-balance)                    |
+| [`eth_getBlockByHash`](/docs/chain-apis/blast/blast-api-endpoints/eth-get-block-by-hash)              | [`eth_getBlockByNumber`](/docs/chain-apis/blast/blast-api-endpoints/eth-get-block-by-number)      |
+| [`eth_getBlockReceipts`](/docs/chain-apis/blast/blast-api-endpoints/eth-get-block-receipts)           | [`eth_getBlockTransactionCountByHash`](/docs/chain-apis/blast/blast-api-endpoints/eth-get-block-transaction-count-by-hash) |
+| [`eth_getBlockTransactionCountByNumber`](/docs/chain-apis/blast/blast-api-endpoints/eth-get-block-transaction-count-by-number) | [`eth_getCode`](/docs/chain-apis/blast/blast-api-endpoints/eth-get-code)                          |
+| [`eth_getFilterChanges`](/docs/chain-apis/blast/blast-api-endpoints/eth-get-filter-changes)           | [`eth_getFilterLogs`](/docs/chain-apis/blast/blast-api-endpoints/eth-get-filter-logs)             |
+| [`eth_getLogs`](/docs/chain-apis/blast/blast-api-endpoints/eth-get-logs)                              | [`eth_getProof`](/docs/chain-apis/blast/blast-api-endpoints/eth-get-proof)                        |
+| [`eth_getStorageAt`](/docs/chain-apis/blast/blast-api-endpoints/eth-get-storage-at)                   | [`eth_getTransactionByBlockHashAndIndex`](/docs/chain-apis/blast/blast-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
+| [`eth_getTransactionByBlockNumberAndIndex`](/docs/chain-apis/blast/blast-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/chain-apis/blast/blast-api-endpoints/eth-get-transaction-by-hash) |
+| [`eth_getTransactionCount`](/docs/chain-apis/blast/blast-api-endpoints/eth-get-transaction-count)     | [`eth_getTransactionReceipt`](/docs/chain-apis/blast/blast-api-endpoints/eth-get-transaction-receipt) |
+| [`eth_getUncleByBlockHashAndIndex`](/docs/chain-apis/blast/blast-api-endpoints/eth-get-uncle-by-block-hash-and-index) | [`eth_getUncleByBlockNumberAndIndex`](/docs/chain-apis/blast/blast-api-endpoints/eth-get-uncle-by-block-number-and-index) |
+| [`eth_getUncleCountByBlockHash`](/docs/chain-apis/blast/blast-api-endpoints/eth-get-uncle-count-by-block-hash) | [`eth_getUncleCountByBlockNumber`](/docs/chain-apis/blast/blast-api-endpoints/eth-get-uncle-count-by-block-number) |
+| [`eth_maxPriorityFeePerGas`](/docs/chain-apis/blast/blast-api-endpoints/eth-max-priority-fee-per-gas) | [`eth_newBlockFilter`](/docs/chain-apis/blast/blast-api-endpoints/eth-new-block-filter)           |
+| [`eth_newFilter`](/docs/chain-apis/blast/blast-api-endpoints/eth-new-filter)                          | [`eth_sendRawTransaction`](/docs/chain-apis/blast/blast-api-endpoints/eth-send-raw-transaction)   |
+| [`eth_sendRawTransactionSync`](/docs/chain-apis/blast/blast-api-endpoints/eth-send-raw-transaction-sync) | [`eth_submitWork`](/docs/chain-apis/blast/blast-api-endpoints/eth-submit-work)                    |
+| [`eth_subscribe`](/docs/chain-apis/blast/blast-api-endpoints/eth-subscribe)                           | [`eth_syncing`](/docs/chain-apis/blast/blast-api-endpoints/eth-syncing)                           |
+| [`eth_uninstallFilter`](/docs/chain-apis/blast/blast-api-endpoints/eth-uninstall-filter)              | [`eth_unsubscribe`](/docs/chain-apis/blast/blast-api-endpoints/eth-unsubscribe)                   |
+| [`net_version`](/docs/chain-apis/blast/blast-api-endpoints/net-version)                               | [`web3_clientVersion`](/docs/chain-apis/blast/blast-api-endpoints/web-3-client-version)           |
+| [`web3_sha3`](/docs/chain-apis/blast/blast-api-endpoints/web-3-sha-3)                                 |                                                                                             |
 
 ## BNB Smart Chain APIs
 
@@ -359,30 +359,30 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_blockNumber`](/docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-block-number)  | [`eth_call`](/docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-call)             |
-| [`eth_callMany`](/docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-call-many)        | [`eth_chainId`](/docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-chain-id)      |
-| [`eth_createAccessList`](/docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-create-access-list) | [`eth_estimateGas`](/docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-estimate-gas) |
-| [`eth_feeHistory`](/docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-fee-history)    | [`eth_gasPrice`](/docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-gas-price)    |
-| [`eth_getAccount`](/docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-account)    | [`eth_getBalance`](/docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-balance) |
-| [`eth_getBlobSidecars`](/docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-blob-sidecars) | [`eth_getBlockByHash`](/docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-block-by-hash) |
-| [`eth_getBlockByNumber`](/docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-block-by-number) | [`eth_getBlockReceipts`](/docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-block-receipts) |
-| [`eth_getBlockTransactionCountByHash`](/docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-block-transaction-count-by-number) |
-| [`eth_getCode`](/docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-code)          | [`eth_getFilterChanges`](/docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-filter-changes) |
-| [`eth_getFilterLogs`](/docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-filter-logs) | [`eth_getFinalizedHeader`](/docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-finalized-header) |
-| [`eth_getLogs`](/docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-logs)          | [`eth_getProof`](/docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-proof)    |
-| [`eth_getStorageAt`](/docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-storage-at) | [`eth_getTransactionByBlockHashAndIndex`](/docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
-| [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-transaction-by-hash) |
-| [`eth_getTransactionCount`](/docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-transaction-count) | [`eth_getTransactionReceipt`](/docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-transaction-receipt) |
-| [`eth_getUncleByBlockHashAndIndex`](/docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-uncle-by-block-hash-and-index) | [`eth_getUncleByBlockNumberAndIndex`](/docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-uncle-by-block-number-and-index) |
-| [`eth_getUncleCountByBlockHash`](/docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-uncle-count-by-block-hash) | [`eth_getUncleCountByBlockNumber`](/docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-uncle-count-by-block-number) |
-| [`eth_maxPriorityFeePerGas`](/docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-max-priority-fee-per-gas) | [`eth_newBlockFilter`](/docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-new-block-filter) |
-| [`eth_newFilter`](/docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-new-filter)      | [`eth_protocolVersion`](/docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-protocol-version) |
-| [`eth_sendRawTransaction`](/docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-send-raw-transaction) | [`eth_sendRawTransactionSync`](/docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-send-raw-transaction-sync) |
-| [`eth_simulateV1`](/docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-simulate-v-1)   | [`eth_submitWork`](/docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-submit-work) |
-| [`eth_subscribe`](/docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-subscribe)       | [`eth_syncing`](/docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-syncing)       |
-| [`eth_uninstallFilter`](/docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-uninstall-filter) | [`eth_unsubscribe`](/docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-unsubscribe) |
-| [`net_version`](/docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/net-version)           | [`web3_clientVersion`](/docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/web-3-client-version) |
-| [`web3_sha3`](/docs/node/bnb-smart-chain/bnb-smart-chain-api-endpoints/web-3-sha-3)             |                                                                                             |
+| [`eth_blockNumber`](/docs/chain-apis/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-block-number)  | [`eth_call`](/docs/chain-apis/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-call)             |
+| [`eth_callMany`](/docs/chain-apis/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-call-many)        | [`eth_chainId`](/docs/chain-apis/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-chain-id)      |
+| [`eth_createAccessList`](/docs/chain-apis/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-create-access-list) | [`eth_estimateGas`](/docs/chain-apis/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-estimate-gas) |
+| [`eth_feeHistory`](/docs/chain-apis/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-fee-history)    | [`eth_gasPrice`](/docs/chain-apis/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-gas-price)    |
+| [`eth_getAccount`](/docs/chain-apis/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-account)    | [`eth_getBalance`](/docs/chain-apis/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-balance) |
+| [`eth_getBlobSidecars`](/docs/chain-apis/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-blob-sidecars) | [`eth_getBlockByHash`](/docs/chain-apis/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-block-by-hash) |
+| [`eth_getBlockByNumber`](/docs/chain-apis/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-block-by-number) | [`eth_getBlockReceipts`](/docs/chain-apis/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-block-receipts) |
+| [`eth_getBlockTransactionCountByHash`](/docs/chain-apis/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/chain-apis/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-block-transaction-count-by-number) |
+| [`eth_getCode`](/docs/chain-apis/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-code)          | [`eth_getFilterChanges`](/docs/chain-apis/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-filter-changes) |
+| [`eth_getFilterLogs`](/docs/chain-apis/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-filter-logs) | [`eth_getFinalizedHeader`](/docs/chain-apis/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-finalized-header) |
+| [`eth_getLogs`](/docs/chain-apis/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-logs)          | [`eth_getProof`](/docs/chain-apis/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-proof)    |
+| [`eth_getStorageAt`](/docs/chain-apis/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-storage-at) | [`eth_getTransactionByBlockHashAndIndex`](/docs/chain-apis/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
+| [`eth_getTransactionByBlockNumberAndIndex`](/docs/chain-apis/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/chain-apis/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-transaction-by-hash) |
+| [`eth_getTransactionCount`](/docs/chain-apis/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-transaction-count) | [`eth_getTransactionReceipt`](/docs/chain-apis/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-transaction-receipt) |
+| [`eth_getUncleByBlockHashAndIndex`](/docs/chain-apis/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-uncle-by-block-hash-and-index) | [`eth_getUncleByBlockNumberAndIndex`](/docs/chain-apis/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-uncle-by-block-number-and-index) |
+| [`eth_getUncleCountByBlockHash`](/docs/chain-apis/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-uncle-count-by-block-hash) | [`eth_getUncleCountByBlockNumber`](/docs/chain-apis/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-get-uncle-count-by-block-number) |
+| [`eth_maxPriorityFeePerGas`](/docs/chain-apis/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-max-priority-fee-per-gas) | [`eth_newBlockFilter`](/docs/chain-apis/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-new-block-filter) |
+| [`eth_newFilter`](/docs/chain-apis/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-new-filter)      | [`eth_protocolVersion`](/docs/chain-apis/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-protocol-version) |
+| [`eth_sendRawTransaction`](/docs/chain-apis/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-send-raw-transaction) | [`eth_sendRawTransactionSync`](/docs/chain-apis/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-send-raw-transaction-sync) |
+| [`eth_simulateV1`](/docs/chain-apis/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-simulate-v-1)   | [`eth_submitWork`](/docs/chain-apis/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-submit-work) |
+| [`eth_subscribe`](/docs/chain-apis/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-subscribe)       | [`eth_syncing`](/docs/chain-apis/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-syncing)       |
+| [`eth_uninstallFilter`](/docs/chain-apis/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-uninstall-filter) | [`eth_unsubscribe`](/docs/chain-apis/bnb-smart-chain/bnb-smart-chain-api-endpoints/eth-unsubscribe) |
+| [`net_version`](/docs/chain-apis/bnb-smart-chain/bnb-smart-chain-api-endpoints/net-version)           | [`web3_clientVersion`](/docs/chain-apis/bnb-smart-chain/bnb-smart-chain-api-endpoints/web-3-client-version) |
+| [`web3_sha3`](/docs/chain-apis/bnb-smart-chain/bnb-smart-chain-api-endpoints/web-3-sha-3)             |                                                                                             |
 
 ## BOB APIs
 
@@ -390,23 +390,23 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_blockNumber`](/docs/node/bob/bob-api-endpoints/eth-block-number)                          | [`eth_call`](/docs/node/bob/bob-api-endpoints/eth-call)                                     |
-| [`eth_callMany`](/docs/node/bob/bob-api-endpoints/eth-call-many)                                | [`eth_chainId`](/docs/node/bob/bob-api-endpoints/eth-chain-id)                              |
-| [`eth_estimateGas`](/docs/node/bob/bob-api-endpoints/eth-estimate-gas)                          | [`eth_gasPrice`](/docs/node/bob/bob-api-endpoints/eth-gas-price)                            |
-| [`eth_getAccount`](/docs/node/bob/bob-api-endpoints/eth-get-account)                            | [`eth_getBalance`](/docs/node/bob/bob-api-endpoints/eth-get-balance)                        |
-| [`eth_getBlockByHash`](/docs/node/bob/bob-api-endpoints/eth-get-block-by-hash)                  | [`eth_getBlockByNumber`](/docs/node/bob/bob-api-endpoints/eth-get-block-by-number)          |
-| [`eth_getBlockTransactionCountByHash`](/docs/node/bob/bob-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/node/bob/bob-api-endpoints/eth-get-block-transaction-count-by-number) |
-| [`eth_getCode`](/docs/node/bob/bob-api-endpoints/eth-get-code)                                  | [`eth_getFilterChanges`](/docs/node/bob/bob-api-endpoints/eth-get-filter-changes)           |
-| [`eth_getFilterLogs`](/docs/node/bob/bob-api-endpoints/eth-get-filter-logs)                     | [`eth_getLogs`](/docs/node/bob/bob-api-endpoints/eth-get-logs)                              |
-| [`eth_getStorageAt`](/docs/node/bob/bob-api-endpoints/eth-get-storage-at)                       | [`eth_getTransactionByBlockHashAndIndex`](/docs/node/bob/bob-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
-| [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/bob/bob-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/node/bob/bob-api-endpoints/eth-get-transaction-by-hash)  |
-| [`eth_getTransactionCount`](/docs/node/bob/bob-api-endpoints/eth-get-transaction-count)         | [`eth_getTransactionReceipt`](/docs/node/bob/bob-api-endpoints/eth-get-transaction-receipt) |
-| [`eth_newBlockFilter`](/docs/node/bob/bob-api-endpoints/eth-new-block-filter)                   | [`eth_newFilter`](/docs/node/bob/bob-api-endpoints/eth-new-filter)                          |
-| [`eth_sendRawTransaction`](/docs/node/bob/bob-api-endpoints/eth-send-raw-transaction)           | [`eth_simulateV1`](/docs/node/bob/bob-api-endpoints/eth-simulate-v-1)                       |
-| [`eth_submitWork`](/docs/node/bob/bob-api-endpoints/eth-submit-work)                            | [`eth_subscribe`](/docs/node/bob/bob-api-endpoints/eth-subscribe)                           |
-| [`eth_uninstallFilter`](/docs/node/bob/bob-api-endpoints/eth-uninstall-filter)                  | [`eth_unsubscribe`](/docs/node/bob/bob-api-endpoints/eth-unsubscribe)                       |
-| [`net_version`](/docs/node/bob/bob-api-endpoints/net-version)                                   | [`web3_clientVersion`](/docs/node/bob/bob-api-endpoints/web-3-client-version)               |
-| [`web3_sha3`](/docs/node/bob/bob-api-endpoints/web-3-sha-3)                                     |                                                                                             |
+| [`eth_blockNumber`](/docs/chain-apis/bob/bob-api-endpoints/eth-block-number)                          | [`eth_call`](/docs/chain-apis/bob/bob-api-endpoints/eth-call)                                     |
+| [`eth_callMany`](/docs/chain-apis/bob/bob-api-endpoints/eth-call-many)                                | [`eth_chainId`](/docs/chain-apis/bob/bob-api-endpoints/eth-chain-id)                              |
+| [`eth_estimateGas`](/docs/chain-apis/bob/bob-api-endpoints/eth-estimate-gas)                          | [`eth_gasPrice`](/docs/chain-apis/bob/bob-api-endpoints/eth-gas-price)                            |
+| [`eth_getAccount`](/docs/chain-apis/bob/bob-api-endpoints/eth-get-account)                            | [`eth_getBalance`](/docs/chain-apis/bob/bob-api-endpoints/eth-get-balance)                        |
+| [`eth_getBlockByHash`](/docs/chain-apis/bob/bob-api-endpoints/eth-get-block-by-hash)                  | [`eth_getBlockByNumber`](/docs/chain-apis/bob/bob-api-endpoints/eth-get-block-by-number)          |
+| [`eth_getBlockTransactionCountByHash`](/docs/chain-apis/bob/bob-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/chain-apis/bob/bob-api-endpoints/eth-get-block-transaction-count-by-number) |
+| [`eth_getCode`](/docs/chain-apis/bob/bob-api-endpoints/eth-get-code)                                  | [`eth_getFilterChanges`](/docs/chain-apis/bob/bob-api-endpoints/eth-get-filter-changes)           |
+| [`eth_getFilterLogs`](/docs/chain-apis/bob/bob-api-endpoints/eth-get-filter-logs)                     | [`eth_getLogs`](/docs/chain-apis/bob/bob-api-endpoints/eth-get-logs)                              |
+| [`eth_getStorageAt`](/docs/chain-apis/bob/bob-api-endpoints/eth-get-storage-at)                       | [`eth_getTransactionByBlockHashAndIndex`](/docs/chain-apis/bob/bob-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
+| [`eth_getTransactionByBlockNumberAndIndex`](/docs/chain-apis/bob/bob-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/chain-apis/bob/bob-api-endpoints/eth-get-transaction-by-hash)  |
+| [`eth_getTransactionCount`](/docs/chain-apis/bob/bob-api-endpoints/eth-get-transaction-count)         | [`eth_getTransactionReceipt`](/docs/chain-apis/bob/bob-api-endpoints/eth-get-transaction-receipt) |
+| [`eth_newBlockFilter`](/docs/chain-apis/bob/bob-api-endpoints/eth-new-block-filter)                   | [`eth_newFilter`](/docs/chain-apis/bob/bob-api-endpoints/eth-new-filter)                          |
+| [`eth_sendRawTransaction`](/docs/chain-apis/bob/bob-api-endpoints/eth-send-raw-transaction)           | [`eth_simulateV1`](/docs/chain-apis/bob/bob-api-endpoints/eth-simulate-v-1)                       |
+| [`eth_submitWork`](/docs/chain-apis/bob/bob-api-endpoints/eth-submit-work)                            | [`eth_subscribe`](/docs/chain-apis/bob/bob-api-endpoints/eth-subscribe)                           |
+| [`eth_uninstallFilter`](/docs/chain-apis/bob/bob-api-endpoints/eth-uninstall-filter)                  | [`eth_unsubscribe`](/docs/chain-apis/bob/bob-api-endpoints/eth-unsubscribe)                       |
+| [`net_version`](/docs/chain-apis/bob/bob-api-endpoints/net-version)                                   | [`web3_clientVersion`](/docs/chain-apis/bob/bob-api-endpoints/web-3-client-version)               |
+| [`web3_sha3`](/docs/chain-apis/bob/bob-api-endpoints/web-3-sha-3)                                     |                                                                                             |
 
 ## Botanix APIs
 
@@ -414,22 +414,22 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_blockNumber`](/docs/node/botanix/botanix-api-endpoints/eth-block-number)                  | [`eth_call`](/docs/node/botanix/botanix-api-endpoints/eth-call)                             |
-| [`eth_callMany`](/docs/node/botanix/botanix-api-endpoints/eth-call-many)                        | [`eth_chainId`](/docs/node/botanix/botanix-api-endpoints/eth-chain-id)                      |
-| [`eth_estimateGas`](/docs/node/botanix/botanix-api-endpoints/eth-estimate-gas)                  | [`eth_gasPrice`](/docs/node/botanix/botanix-api-endpoints/eth-gas-price)                    |
-| [`eth_getAccount`](/docs/node/botanix/botanix-api-endpoints/eth-get-account)                    | [`eth_getBalance`](/docs/node/botanix/botanix-api-endpoints/eth-get-balance)                |
-| [`eth_getBlockByHash`](/docs/node/botanix/botanix-api-endpoints/eth-get-block-by-hash)          | [`eth_getBlockByNumber`](/docs/node/botanix/botanix-api-endpoints/eth-get-block-by-number)  |
-| [`eth_getBlockTransactionCountByHash`](/docs/node/botanix/botanix-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/node/botanix/botanix-api-endpoints/eth-get-block-transaction-count-by-number) |
-| [`eth_getCode`](/docs/node/botanix/botanix-api-endpoints/eth-get-code)                          | [`eth_getFilterChanges`](/docs/node/botanix/botanix-api-endpoints/eth-get-filter-changes)   |
-| [`eth_getFilterLogs`](/docs/node/botanix/botanix-api-endpoints/eth-get-filter-logs)             | [`eth_getLogs`](/docs/node/botanix/botanix-api-endpoints/eth-get-logs)                      |
-| [`eth_getStorageAt`](/docs/node/botanix/botanix-api-endpoints/eth-get-storage-at)               | [`eth_getTransactionByBlockHashAndIndex`](/docs/node/botanix/botanix-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
-| [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/botanix/botanix-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/node/botanix/botanix-api-endpoints/eth-get-transaction-by-hash) |
-| [`eth_getTransactionCount`](/docs/node/botanix/botanix-api-endpoints/eth-get-transaction-count) | [`eth_getTransactionReceipt`](/docs/node/botanix/botanix-api-endpoints/eth-get-transaction-receipt) |
-| [`eth_newBlockFilter`](/docs/node/botanix/botanix-api-endpoints/eth-new-block-filter)           | [`eth_newFilter`](/docs/node/botanix/botanix-api-endpoints/eth-new-filter)                  |
-| [`eth_sendRawTransaction`](/docs/node/botanix/botanix-api-endpoints/eth-send-raw-transaction)   | [`eth_submitWork`](/docs/node/botanix/botanix-api-endpoints/eth-submit-work)                |
-| [`eth_subscribe`](/docs/node/botanix/botanix-api-endpoints/eth-subscribe)                       | [`eth_uninstallFilter`](/docs/node/botanix/botanix-api-endpoints/eth-uninstall-filter)      |
-| [`eth_unsubscribe`](/docs/node/botanix/botanix-api-endpoints/eth-unsubscribe)                   | [`net_version`](/docs/node/botanix/botanix-api-endpoints/net-version)                       |
-| [`web3_clientVersion`](/docs/node/botanix/botanix-api-endpoints/web-3-client-version)           | [`web3_sha3`](/docs/node/botanix/botanix-api-endpoints/web-3-sha-3)                         |
+| [`eth_blockNumber`](/docs/chain-apis/botanix/botanix-api-endpoints/eth-block-number)                  | [`eth_call`](/docs/chain-apis/botanix/botanix-api-endpoints/eth-call)                             |
+| [`eth_callMany`](/docs/chain-apis/botanix/botanix-api-endpoints/eth-call-many)                        | [`eth_chainId`](/docs/chain-apis/botanix/botanix-api-endpoints/eth-chain-id)                      |
+| [`eth_estimateGas`](/docs/chain-apis/botanix/botanix-api-endpoints/eth-estimate-gas)                  | [`eth_gasPrice`](/docs/chain-apis/botanix/botanix-api-endpoints/eth-gas-price)                    |
+| [`eth_getAccount`](/docs/chain-apis/botanix/botanix-api-endpoints/eth-get-account)                    | [`eth_getBalance`](/docs/chain-apis/botanix/botanix-api-endpoints/eth-get-balance)                |
+| [`eth_getBlockByHash`](/docs/chain-apis/botanix/botanix-api-endpoints/eth-get-block-by-hash)          | [`eth_getBlockByNumber`](/docs/chain-apis/botanix/botanix-api-endpoints/eth-get-block-by-number)  |
+| [`eth_getBlockTransactionCountByHash`](/docs/chain-apis/botanix/botanix-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/chain-apis/botanix/botanix-api-endpoints/eth-get-block-transaction-count-by-number) |
+| [`eth_getCode`](/docs/chain-apis/botanix/botanix-api-endpoints/eth-get-code)                          | [`eth_getFilterChanges`](/docs/chain-apis/botanix/botanix-api-endpoints/eth-get-filter-changes)   |
+| [`eth_getFilterLogs`](/docs/chain-apis/botanix/botanix-api-endpoints/eth-get-filter-logs)             | [`eth_getLogs`](/docs/chain-apis/botanix/botanix-api-endpoints/eth-get-logs)                      |
+| [`eth_getStorageAt`](/docs/chain-apis/botanix/botanix-api-endpoints/eth-get-storage-at)               | [`eth_getTransactionByBlockHashAndIndex`](/docs/chain-apis/botanix/botanix-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
+| [`eth_getTransactionByBlockNumberAndIndex`](/docs/chain-apis/botanix/botanix-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/chain-apis/botanix/botanix-api-endpoints/eth-get-transaction-by-hash) |
+| [`eth_getTransactionCount`](/docs/chain-apis/botanix/botanix-api-endpoints/eth-get-transaction-count) | [`eth_getTransactionReceipt`](/docs/chain-apis/botanix/botanix-api-endpoints/eth-get-transaction-receipt) |
+| [`eth_newBlockFilter`](/docs/chain-apis/botanix/botanix-api-endpoints/eth-new-block-filter)           | [`eth_newFilter`](/docs/chain-apis/botanix/botanix-api-endpoints/eth-new-filter)                  |
+| [`eth_sendRawTransaction`](/docs/chain-apis/botanix/botanix-api-endpoints/eth-send-raw-transaction)   | [`eth_submitWork`](/docs/chain-apis/botanix/botanix-api-endpoints/eth-submit-work)                |
+| [`eth_subscribe`](/docs/chain-apis/botanix/botanix-api-endpoints/eth-subscribe)                       | [`eth_uninstallFilter`](/docs/chain-apis/botanix/botanix-api-endpoints/eth-uninstall-filter)      |
+| [`eth_unsubscribe`](/docs/chain-apis/botanix/botanix-api-endpoints/eth-unsubscribe)                   | [`net_version`](/docs/chain-apis/botanix/botanix-api-endpoints/net-version)                       |
+| [`web3_clientVersion`](/docs/chain-apis/botanix/botanix-api-endpoints/web-3-client-version)           | [`web3_sha3`](/docs/chain-apis/botanix/botanix-api-endpoints/web-3-sha-3)                         |
 
 ## Celo APIs
 
@@ -437,24 +437,24 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_blockNumber`](/docs/node/celo/celo-api-endpoints/eth-block-number)                        | [`eth_call`](/docs/node/celo/celo-api-endpoints/eth-call)                                   |
-| [`eth_callMany`](/docs/node/celo/celo-api-endpoints/eth-call-many)                              | [`eth_chainId`](/docs/node/celo/celo-api-endpoints/eth-chain-id)                            |
-| [`eth_estimateGas`](/docs/node/celo/celo-api-endpoints/eth-estimate-gas)                        | [`eth_feeHistory`](/docs/node/celo/celo-api-endpoints/eth-fee-history)                      |
-| [`eth_gasPrice`](/docs/node/celo/celo-api-endpoints/eth-gas-price)                              | [`eth_getAccount`](/docs/node/celo/celo-api-endpoints/eth-get-account)                      |
-| [`eth_getBalance`](/docs/node/celo/celo-api-endpoints/eth-get-balance)                          | [`eth_getBlockByHash`](/docs/node/celo/celo-api-endpoints/eth-get-block-by-hash)            |
-| [`eth_getBlockByNumber`](/docs/node/celo/celo-api-endpoints/eth-get-block-by-number)            | [`eth_getBlockReceipts`](/docs/node/celo/celo-api-endpoints/eth-get-block-receipts)         |
-| [`eth_getBlockTransactionCountByHash`](/docs/node/celo/celo-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/node/celo/celo-api-endpoints/eth-get-block-transaction-count-by-number) |
-| [`eth_getCode`](/docs/node/celo/celo-api-endpoints/eth-get-code)                                | [`eth_getFilterChanges`](/docs/node/celo/celo-api-endpoints/eth-get-filter-changes)         |
-| [`eth_getFilterLogs`](/docs/node/celo/celo-api-endpoints/eth-get-filter-logs)                   | [`eth_getLogs`](/docs/node/celo/celo-api-endpoints/eth-get-logs)                            |
-| [`eth_getStorageAt`](/docs/node/celo/celo-api-endpoints/eth-get-storage-at)                     | [`eth_getTransactionByBlockHashAndIndex`](/docs/node/celo/celo-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
-| [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/celo/celo-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/node/celo/celo-api-endpoints/eth-get-transaction-by-hash) |
-| [`eth_getTransactionCount`](/docs/node/celo/celo-api-endpoints/eth-get-transaction-count)       | [`eth_getTransactionReceipt`](/docs/node/celo/celo-api-endpoints/eth-get-transaction-receipt) |
-| [`eth_newBlockFilter`](/docs/node/celo/celo-api-endpoints/eth-new-block-filter)                 | [`eth_newFilter`](/docs/node/celo/celo-api-endpoints/eth-new-filter)                        |
-| [`eth_sendRawTransaction`](/docs/node/celo/celo-api-endpoints/eth-send-raw-transaction)         | [`eth_sendRawTransactionSync`](/docs/node/celo/celo-api-endpoints/eth-send-raw-transaction-sync) |
-| [`eth_simulateV1`](/docs/node/celo/celo-api-endpoints/eth-simulate-v-1)                         | [`eth_submitWork`](/docs/node/celo/celo-api-endpoints/eth-submit-work)                      |
-| [`eth_subscribe`](/docs/node/celo/celo-api-endpoints/eth-subscribe)                             | [`eth_uninstallFilter`](/docs/node/celo/celo-api-endpoints/eth-uninstall-filter)            |
-| [`eth_unsubscribe`](/docs/node/celo/celo-api-endpoints/eth-unsubscribe)                         | [`net_version`](/docs/node/celo/celo-api-endpoints/net-version)                             |
-| [`web3_clientVersion`](/docs/node/celo/celo-api-endpoints/web-3-client-version)                 | [`web3_sha3`](/docs/node/celo/celo-api-endpoints/web-3-sha-3)                               |
+| [`eth_blockNumber`](/docs/chain-apis/celo/celo-api-endpoints/eth-block-number)                        | [`eth_call`](/docs/chain-apis/celo/celo-api-endpoints/eth-call)                                   |
+| [`eth_callMany`](/docs/chain-apis/celo/celo-api-endpoints/eth-call-many)                              | [`eth_chainId`](/docs/chain-apis/celo/celo-api-endpoints/eth-chain-id)                            |
+| [`eth_estimateGas`](/docs/chain-apis/celo/celo-api-endpoints/eth-estimate-gas)                        | [`eth_feeHistory`](/docs/chain-apis/celo/celo-api-endpoints/eth-fee-history)                      |
+| [`eth_gasPrice`](/docs/chain-apis/celo/celo-api-endpoints/eth-gas-price)                              | [`eth_getAccount`](/docs/chain-apis/celo/celo-api-endpoints/eth-get-account)                      |
+| [`eth_getBalance`](/docs/chain-apis/celo/celo-api-endpoints/eth-get-balance)                          | [`eth_getBlockByHash`](/docs/chain-apis/celo/celo-api-endpoints/eth-get-block-by-hash)            |
+| [`eth_getBlockByNumber`](/docs/chain-apis/celo/celo-api-endpoints/eth-get-block-by-number)            | [`eth_getBlockReceipts`](/docs/chain-apis/celo/celo-api-endpoints/eth-get-block-receipts)         |
+| [`eth_getBlockTransactionCountByHash`](/docs/chain-apis/celo/celo-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/chain-apis/celo/celo-api-endpoints/eth-get-block-transaction-count-by-number) |
+| [`eth_getCode`](/docs/chain-apis/celo/celo-api-endpoints/eth-get-code)                                | [`eth_getFilterChanges`](/docs/chain-apis/celo/celo-api-endpoints/eth-get-filter-changes)         |
+| [`eth_getFilterLogs`](/docs/chain-apis/celo/celo-api-endpoints/eth-get-filter-logs)                   | [`eth_getLogs`](/docs/chain-apis/celo/celo-api-endpoints/eth-get-logs)                            |
+| [`eth_getStorageAt`](/docs/chain-apis/celo/celo-api-endpoints/eth-get-storage-at)                     | [`eth_getTransactionByBlockHashAndIndex`](/docs/chain-apis/celo/celo-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
+| [`eth_getTransactionByBlockNumberAndIndex`](/docs/chain-apis/celo/celo-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/chain-apis/celo/celo-api-endpoints/eth-get-transaction-by-hash) |
+| [`eth_getTransactionCount`](/docs/chain-apis/celo/celo-api-endpoints/eth-get-transaction-count)       | [`eth_getTransactionReceipt`](/docs/chain-apis/celo/celo-api-endpoints/eth-get-transaction-receipt) |
+| [`eth_newBlockFilter`](/docs/chain-apis/celo/celo-api-endpoints/eth-new-block-filter)                 | [`eth_newFilter`](/docs/chain-apis/celo/celo-api-endpoints/eth-new-filter)                        |
+| [`eth_sendRawTransaction`](/docs/chain-apis/celo/celo-api-endpoints/eth-send-raw-transaction)         | [`eth_sendRawTransactionSync`](/docs/chain-apis/celo/celo-api-endpoints/eth-send-raw-transaction-sync) |
+| [`eth_simulateV1`](/docs/chain-apis/celo/celo-api-endpoints/eth-simulate-v-1)                         | [`eth_submitWork`](/docs/chain-apis/celo/celo-api-endpoints/eth-submit-work)                      |
+| [`eth_subscribe`](/docs/chain-apis/celo/celo-api-endpoints/eth-subscribe)                             | [`eth_uninstallFilter`](/docs/chain-apis/celo/celo-api-endpoints/eth-uninstall-filter)            |
+| [`eth_unsubscribe`](/docs/chain-apis/celo/celo-api-endpoints/eth-unsubscribe)                         | [`net_version`](/docs/chain-apis/celo/celo-api-endpoints/net-version)                             |
+| [`web3_clientVersion`](/docs/chain-apis/celo/celo-api-endpoints/web-3-client-version)                 | [`web3_sha3`](/docs/chain-apis/celo/celo-api-endpoints/web-3-sha-3)                               |
 
 ## Citrea APIs
 
@@ -462,31 +462,31 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`citrea_getL2StatusHeightsByL1Height`](/docs/node/citrea/citrea-api-endpoints/citrea-get-l-2-status-heights-by-l-1-height) | [`citrea_getLastCommittedL2Height`](/docs/node/citrea/citrea-api-endpoints/citrea-get-last-committed-l-2-height) |
-| [`citrea_getLastProvenL2Height`](/docs/node/citrea/citrea-api-endpoints/citrea-get-last-proven-l-2-height) | [`citrea_sendRawDepositTransaction`](/docs/node/citrea/citrea-api-endpoints/citrea-send-raw-deposit-transaction) |
-| [`citrea_syncStatus`](/docs/node/citrea/citrea-api-endpoints/citrea-sync-status)                | [`eth_blockNumber`](/docs/node/citrea/citrea-api-endpoints/eth-block-number)                |
-| [`eth_call`](/docs/node/citrea/citrea-api-endpoints/eth-call)                                   | [`eth_callMany`](/docs/node/citrea/citrea-api-endpoints/eth-call-many)                      |
-| [`eth_chainId`](/docs/node/citrea/citrea-api-endpoints/eth-chain-id)                            | [`eth_estimateDiffSize`](/docs/node/citrea/citrea-api-endpoints/eth-estimate-diff-size)     |
-| [`eth_estimateGas`](/docs/node/citrea/citrea-api-endpoints/eth-estimate-gas)                    | [`eth_gasPrice`](/docs/node/citrea/citrea-api-endpoints/eth-gas-price)                      |
-| [`eth_getAccount`](/docs/node/citrea/citrea-api-endpoints/eth-get-account)                      | [`eth_getBalance`](/docs/node/citrea/citrea-api-endpoints/eth-get-balance)                  |
-| [`eth_getBlockByHash`](/docs/node/citrea/citrea-api-endpoints/eth-get-block-by-hash)            | [`eth_getBlockByNumber`](/docs/node/citrea/citrea-api-endpoints/eth-get-block-by-number)    |
-| [`eth_getBlockTransactionCountByHash`](/docs/node/citrea/citrea-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/node/citrea/citrea-api-endpoints/eth-get-block-transaction-count-by-number) |
-| [`eth_getCode`](/docs/node/citrea/citrea-api-endpoints/eth-get-code)                            | [`eth_getFilterChanges`](/docs/node/citrea/citrea-api-endpoints/eth-get-filter-changes)     |
-| [`eth_getFilterLogs`](/docs/node/citrea/citrea-api-endpoints/eth-get-filter-logs)               | [`eth_getLogs`](/docs/node/citrea/citrea-api-endpoints/eth-get-logs)                        |
-| [`eth_getStorageAt`](/docs/node/citrea/citrea-api-endpoints/eth-get-storage-at)                 | [`eth_getTransactionByBlockHashAndIndex`](/docs/node/citrea/citrea-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
-| [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/citrea/citrea-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/node/citrea/citrea-api-endpoints/eth-get-transaction-by-hash) |
-| [`eth_getTransactionCount`](/docs/node/citrea/citrea-api-endpoints/eth-get-transaction-count)   | [`eth_getTransactionReceipt`](/docs/node/citrea/citrea-api-endpoints/eth-get-transaction-receipt) |
-| [`eth_newBlockFilter`](/docs/node/citrea/citrea-api-endpoints/eth-new-block-filter)             | [`eth_newFilter`](/docs/node/citrea/citrea-api-endpoints/eth-new-filter)                    |
-| [`eth_sendRawTransaction`](/docs/node/citrea/citrea-api-endpoints/eth-send-raw-transaction)     | [`eth_submitWork`](/docs/node/citrea/citrea-api-endpoints/eth-submit-work)                  |
-| [`eth_subscribe`](/docs/node/citrea/citrea-api-endpoints/eth-subscribe)                         | [`eth_uninstallFilter`](/docs/node/citrea/citrea-api-endpoints/eth-uninstall-filter)        |
-| [`eth_unsubscribe`](/docs/node/citrea/citrea-api-endpoints/eth-unsubscribe)                     | [`ledger_getHeadL2Block`](/docs/node/citrea/citrea-api-endpoints/ledger-get-head-l-2-block) |
-| [`ledger_getHeadL2BlockHeight`](/docs/node/citrea/citrea-api-endpoints/ledger-get-head-l-2-block-height) | [`ledger_getL2BlockByHash`](/docs/node/citrea/citrea-api-endpoints/ledger-get-l-2-block-by-hash) |
-| [`ledger_getL2BlockByNumber`](/docs/node/citrea/citrea-api-endpoints/ledger-get-l-2-block-by-number) | [`ledger_getL2BlockRange`](/docs/node/citrea/citrea-api-endpoints/ledger-get-l-2-block-range) |
-| [`ledger_getL2GenesisStateRoot`](/docs/node/citrea/citrea-api-endpoints/ledger-get-l-2-genesis-state-root) | [`ledger_getLastScannedL1Height`](/docs/node/citrea/citrea-api-endpoints/ledger-get-last-scanned-l-1-height) |
-| [`ledger_getLastVerifiedBatchProof`](/docs/node/citrea/citrea-api-endpoints/ledger-get-last-verified-batch-proof) | [`ledger_getSequencerCommitmentByIndex`](/docs/node/citrea/citrea-api-endpoints/ledger-get-sequencer-commitment-by-index) |
-| [`ledger_getSequencerCommitmentsOnSlotByHash`](/docs/node/citrea/citrea-api-endpoints/ledger-get-sequencer-commitments-on-slot-by-hash) | [`ledger_getSequencerCommitmentsOnSlotByNumber`](/docs/node/citrea/citrea-api-endpoints/ledger-get-sequencer-commitments-on-slot-by-number) |
-| [`ledger_getVerifiedBatchProofsBySlotHeight`](/docs/node/citrea/citrea-api-endpoints/ledger-get-verified-batch-proofs-by-slot-height) | [`net_version`](/docs/node/citrea/citrea-api-endpoints/net-version)                         |
-| [`web3_clientVersion`](/docs/node/citrea/citrea-api-endpoints/web-3-client-version)             | [`web3_sha3`](/docs/node/citrea/citrea-api-endpoints/web-3-sha-3)                           |
+| [`citrea_getL2StatusHeightsByL1Height`](/docs/chain-apis/citrea/citrea-api-endpoints/citrea-get-l-2-status-heights-by-l-1-height) | [`citrea_getLastCommittedL2Height`](/docs/chain-apis/citrea/citrea-api-endpoints/citrea-get-last-committed-l-2-height) |
+| [`citrea_getLastProvenL2Height`](/docs/chain-apis/citrea/citrea-api-endpoints/citrea-get-last-proven-l-2-height) | [`citrea_sendRawDepositTransaction`](/docs/chain-apis/citrea/citrea-api-endpoints/citrea-send-raw-deposit-transaction) |
+| [`citrea_syncStatus`](/docs/chain-apis/citrea/citrea-api-endpoints/citrea-sync-status)                | [`eth_blockNumber`](/docs/chain-apis/citrea/citrea-api-endpoints/eth-block-number)                |
+| [`eth_call`](/docs/chain-apis/citrea/citrea-api-endpoints/eth-call)                                   | [`eth_callMany`](/docs/chain-apis/citrea/citrea-api-endpoints/eth-call-many)                      |
+| [`eth_chainId`](/docs/chain-apis/citrea/citrea-api-endpoints/eth-chain-id)                            | [`eth_estimateDiffSize`](/docs/chain-apis/citrea/citrea-api-endpoints/eth-estimate-diff-size)     |
+| [`eth_estimateGas`](/docs/chain-apis/citrea/citrea-api-endpoints/eth-estimate-gas)                    | [`eth_gasPrice`](/docs/chain-apis/citrea/citrea-api-endpoints/eth-gas-price)                      |
+| [`eth_getAccount`](/docs/chain-apis/citrea/citrea-api-endpoints/eth-get-account)                      | [`eth_getBalance`](/docs/chain-apis/citrea/citrea-api-endpoints/eth-get-balance)                  |
+| [`eth_getBlockByHash`](/docs/chain-apis/citrea/citrea-api-endpoints/eth-get-block-by-hash)            | [`eth_getBlockByNumber`](/docs/chain-apis/citrea/citrea-api-endpoints/eth-get-block-by-number)    |
+| [`eth_getBlockTransactionCountByHash`](/docs/chain-apis/citrea/citrea-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/chain-apis/citrea/citrea-api-endpoints/eth-get-block-transaction-count-by-number) |
+| [`eth_getCode`](/docs/chain-apis/citrea/citrea-api-endpoints/eth-get-code)                            | [`eth_getFilterChanges`](/docs/chain-apis/citrea/citrea-api-endpoints/eth-get-filter-changes)     |
+| [`eth_getFilterLogs`](/docs/chain-apis/citrea/citrea-api-endpoints/eth-get-filter-logs)               | [`eth_getLogs`](/docs/chain-apis/citrea/citrea-api-endpoints/eth-get-logs)                        |
+| [`eth_getStorageAt`](/docs/chain-apis/citrea/citrea-api-endpoints/eth-get-storage-at)                 | [`eth_getTransactionByBlockHashAndIndex`](/docs/chain-apis/citrea/citrea-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
+| [`eth_getTransactionByBlockNumberAndIndex`](/docs/chain-apis/citrea/citrea-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/chain-apis/citrea/citrea-api-endpoints/eth-get-transaction-by-hash) |
+| [`eth_getTransactionCount`](/docs/chain-apis/citrea/citrea-api-endpoints/eth-get-transaction-count)   | [`eth_getTransactionReceipt`](/docs/chain-apis/citrea/citrea-api-endpoints/eth-get-transaction-receipt) |
+| [`eth_newBlockFilter`](/docs/chain-apis/citrea/citrea-api-endpoints/eth-new-block-filter)             | [`eth_newFilter`](/docs/chain-apis/citrea/citrea-api-endpoints/eth-new-filter)                    |
+| [`eth_sendRawTransaction`](/docs/chain-apis/citrea/citrea-api-endpoints/eth-send-raw-transaction)     | [`eth_submitWork`](/docs/chain-apis/citrea/citrea-api-endpoints/eth-submit-work)                  |
+| [`eth_subscribe`](/docs/chain-apis/citrea/citrea-api-endpoints/eth-subscribe)                         | [`eth_uninstallFilter`](/docs/chain-apis/citrea/citrea-api-endpoints/eth-uninstall-filter)        |
+| [`eth_unsubscribe`](/docs/chain-apis/citrea/citrea-api-endpoints/eth-unsubscribe)                     | [`ledger_getHeadL2Block`](/docs/chain-apis/citrea/citrea-api-endpoints/ledger-get-head-l-2-block) |
+| [`ledger_getHeadL2BlockHeight`](/docs/chain-apis/citrea/citrea-api-endpoints/ledger-get-head-l-2-block-height) | [`ledger_getL2BlockByHash`](/docs/chain-apis/citrea/citrea-api-endpoints/ledger-get-l-2-block-by-hash) |
+| [`ledger_getL2BlockByNumber`](/docs/chain-apis/citrea/citrea-api-endpoints/ledger-get-l-2-block-by-number) | [`ledger_getL2BlockRange`](/docs/chain-apis/citrea/citrea-api-endpoints/ledger-get-l-2-block-range) |
+| [`ledger_getL2GenesisStateRoot`](/docs/chain-apis/citrea/citrea-api-endpoints/ledger-get-l-2-genesis-state-root) | [`ledger_getLastScannedL1Height`](/docs/chain-apis/citrea/citrea-api-endpoints/ledger-get-last-scanned-l-1-height) |
+| [`ledger_getLastVerifiedBatchProof`](/docs/chain-apis/citrea/citrea-api-endpoints/ledger-get-last-verified-batch-proof) | [`ledger_getSequencerCommitmentByIndex`](/docs/chain-apis/citrea/citrea-api-endpoints/ledger-get-sequencer-commitment-by-index) |
+| [`ledger_getSequencerCommitmentsOnSlotByHash`](/docs/chain-apis/citrea/citrea-api-endpoints/ledger-get-sequencer-commitments-on-slot-by-hash) | [`ledger_getSequencerCommitmentsOnSlotByNumber`](/docs/chain-apis/citrea/citrea-api-endpoints/ledger-get-sequencer-commitments-on-slot-by-number) |
+| [`ledger_getVerifiedBatchProofsBySlotHeight`](/docs/chain-apis/citrea/citrea-api-endpoints/ledger-get-verified-batch-proofs-by-slot-height) | [`net_version`](/docs/chain-apis/citrea/citrea-api-endpoints/net-version)                         |
+| [`web3_clientVersion`](/docs/chain-apis/citrea/citrea-api-endpoints/web-3-client-version)             | [`web3_sha3`](/docs/chain-apis/citrea/citrea-api-endpoints/web-3-sha-3)                           |
 
 ## Clankermon APIs
 
@@ -494,22 +494,22 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_blockNumber`](/docs/node/clankermon/clankermon-api-endpoints/eth-block-number)            | [`eth_call`](/docs/node/clankermon/clankermon-api-endpoints/eth-call)                       |
-| [`eth_callMany`](/docs/node/clankermon/clankermon-api-endpoints/eth-call-many)                  | [`eth_chainId`](/docs/node/clankermon/clankermon-api-endpoints/eth-chain-id)                |
-| [`eth_estimateGas`](/docs/node/clankermon/clankermon-api-endpoints/eth-estimate-gas)            | [`eth_gasPrice`](/docs/node/clankermon/clankermon-api-endpoints/eth-gas-price)              |
-| [`eth_getAccount`](/docs/node/clankermon/clankermon-api-endpoints/eth-get-account)              | [`eth_getBalance`](/docs/node/clankermon/clankermon-api-endpoints/eth-get-balance)          |
-| [`eth_getBlockByHash`](/docs/node/clankermon/clankermon-api-endpoints/eth-get-block-by-hash)    | [`eth_getBlockByNumber`](/docs/node/clankermon/clankermon-api-endpoints/eth-get-block-by-number) |
-| [`eth_getBlockTransactionCountByHash`](/docs/node/clankermon/clankermon-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/node/clankermon/clankermon-api-endpoints/eth-get-block-transaction-count-by-number) |
-| [`eth_getCode`](/docs/node/clankermon/clankermon-api-endpoints/eth-get-code)                    | [`eth_getFilterChanges`](/docs/node/clankermon/clankermon-api-endpoints/eth-get-filter-changes) |
-| [`eth_getFilterLogs`](/docs/node/clankermon/clankermon-api-endpoints/eth-get-filter-logs)       | [`eth_getLogs`](/docs/node/clankermon/clankermon-api-endpoints/eth-get-logs)                |
-| [`eth_getStorageAt`](/docs/node/clankermon/clankermon-api-endpoints/eth-get-storage-at)         | [`eth_getTransactionByBlockHashAndIndex`](/docs/node/clankermon/clankermon-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
-| [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/clankermon/clankermon-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/node/clankermon/clankermon-api-endpoints/eth-get-transaction-by-hash) |
-| [`eth_getTransactionCount`](/docs/node/clankermon/clankermon-api-endpoints/eth-get-transaction-count) | [`eth_getTransactionReceipt`](/docs/node/clankermon/clankermon-api-endpoints/eth-get-transaction-receipt) |
-| [`eth_newBlockFilter`](/docs/node/clankermon/clankermon-api-endpoints/eth-new-block-filter)     | [`eth_newFilter`](/docs/node/clankermon/clankermon-api-endpoints/eth-new-filter)            |
-| [`eth_sendRawTransaction`](/docs/node/clankermon/clankermon-api-endpoints/eth-send-raw-transaction) | [`eth_submitWork`](/docs/node/clankermon/clankermon-api-endpoints/eth-submit-work)          |
-| [`eth_subscribe`](/docs/node/clankermon/clankermon-api-endpoints/eth-subscribe)                 | [`eth_uninstallFilter`](/docs/node/clankermon/clankermon-api-endpoints/eth-uninstall-filter) |
-| [`eth_unsubscribe`](/docs/node/clankermon/clankermon-api-endpoints/eth-unsubscribe)             | [`net_version`](/docs/node/clankermon/clankermon-api-endpoints/net-version)                 |
-| [`web3_clientVersion`](/docs/node/clankermon/clankermon-api-endpoints/web-3-client-version)     | [`web3_sha3`](/docs/node/clankermon/clankermon-api-endpoints/web-3-sha-3)                   |
+| [`eth_blockNumber`](/docs/chain-apis/clankermon/clankermon-api-endpoints/eth-block-number)            | [`eth_call`](/docs/chain-apis/clankermon/clankermon-api-endpoints/eth-call)                       |
+| [`eth_callMany`](/docs/chain-apis/clankermon/clankermon-api-endpoints/eth-call-many)                  | [`eth_chainId`](/docs/chain-apis/clankermon/clankermon-api-endpoints/eth-chain-id)                |
+| [`eth_estimateGas`](/docs/chain-apis/clankermon/clankermon-api-endpoints/eth-estimate-gas)            | [`eth_gasPrice`](/docs/chain-apis/clankermon/clankermon-api-endpoints/eth-gas-price)              |
+| [`eth_getAccount`](/docs/chain-apis/clankermon/clankermon-api-endpoints/eth-get-account)              | [`eth_getBalance`](/docs/chain-apis/clankermon/clankermon-api-endpoints/eth-get-balance)          |
+| [`eth_getBlockByHash`](/docs/chain-apis/clankermon/clankermon-api-endpoints/eth-get-block-by-hash)    | [`eth_getBlockByNumber`](/docs/chain-apis/clankermon/clankermon-api-endpoints/eth-get-block-by-number) |
+| [`eth_getBlockTransactionCountByHash`](/docs/chain-apis/clankermon/clankermon-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/chain-apis/clankermon/clankermon-api-endpoints/eth-get-block-transaction-count-by-number) |
+| [`eth_getCode`](/docs/chain-apis/clankermon/clankermon-api-endpoints/eth-get-code)                    | [`eth_getFilterChanges`](/docs/chain-apis/clankermon/clankermon-api-endpoints/eth-get-filter-changes) |
+| [`eth_getFilterLogs`](/docs/chain-apis/clankermon/clankermon-api-endpoints/eth-get-filter-logs)       | [`eth_getLogs`](/docs/chain-apis/clankermon/clankermon-api-endpoints/eth-get-logs)                |
+| [`eth_getStorageAt`](/docs/chain-apis/clankermon/clankermon-api-endpoints/eth-get-storage-at)         | [`eth_getTransactionByBlockHashAndIndex`](/docs/chain-apis/clankermon/clankermon-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
+| [`eth_getTransactionByBlockNumberAndIndex`](/docs/chain-apis/clankermon/clankermon-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/chain-apis/clankermon/clankermon-api-endpoints/eth-get-transaction-by-hash) |
+| [`eth_getTransactionCount`](/docs/chain-apis/clankermon/clankermon-api-endpoints/eth-get-transaction-count) | [`eth_getTransactionReceipt`](/docs/chain-apis/clankermon/clankermon-api-endpoints/eth-get-transaction-receipt) |
+| [`eth_newBlockFilter`](/docs/chain-apis/clankermon/clankermon-api-endpoints/eth-new-block-filter)     | [`eth_newFilter`](/docs/chain-apis/clankermon/clankermon-api-endpoints/eth-new-filter)            |
+| [`eth_sendRawTransaction`](/docs/chain-apis/clankermon/clankermon-api-endpoints/eth-send-raw-transaction) | [`eth_submitWork`](/docs/chain-apis/clankermon/clankermon-api-endpoints/eth-submit-work)          |
+| [`eth_subscribe`](/docs/chain-apis/clankermon/clankermon-api-endpoints/eth-subscribe)                 | [`eth_uninstallFilter`](/docs/chain-apis/clankermon/clankermon-api-endpoints/eth-uninstall-filter) |
+| [`eth_unsubscribe`](/docs/chain-apis/clankermon/clankermon-api-endpoints/eth-unsubscribe)             | [`net_version`](/docs/chain-apis/clankermon/clankermon-api-endpoints/net-version)                 |
+| [`web3_clientVersion`](/docs/chain-apis/clankermon/clankermon-api-endpoints/web-3-client-version)     | [`web3_sha3`](/docs/chain-apis/clankermon/clankermon-api-endpoints/web-3-sha-3)                   |
 
 ## CrossFi APIs
 
@@ -517,22 +517,22 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_blockNumber`](/docs/node/crossfi/cross-fi-api-endpoints/eth-block-number)                 | [`eth_call`](/docs/node/crossfi/cross-fi-api-endpoints/eth-call)                            |
-| [`eth_callMany`](/docs/node/crossfi/cross-fi-api-endpoints/eth-call-many)                       | [`eth_chainId`](/docs/node/crossfi/cross-fi-api-endpoints/eth-chain-id)                     |
-| [`eth_estimateGas`](/docs/node/crossfi/cross-fi-api-endpoints/eth-estimate-gas)                 | [`eth_gasPrice`](/docs/node/crossfi/cross-fi-api-endpoints/eth-gas-price)                   |
-| [`eth_getAccount`](/docs/node/crossfi/cross-fi-api-endpoints/eth-get-account)                   | [`eth_getBalance`](/docs/node/crossfi/cross-fi-api-endpoints/eth-get-balance)               |
-| [`eth_getBlockByHash`](/docs/node/crossfi/cross-fi-api-endpoints/eth-get-block-by-hash)         | [`eth_getBlockByNumber`](/docs/node/crossfi/cross-fi-api-endpoints/eth-get-block-by-number) |
-| [`eth_getBlockTransactionCountByHash`](/docs/node/crossfi/cross-fi-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/node/crossfi/cross-fi-api-endpoints/eth-get-block-transaction-count-by-number) |
-| [`eth_getCode`](/docs/node/crossfi/cross-fi-api-endpoints/eth-get-code)                         | [`eth_getFilterChanges`](/docs/node/crossfi/cross-fi-api-endpoints/eth-get-filter-changes)  |
-| [`eth_getFilterLogs`](/docs/node/crossfi/cross-fi-api-endpoints/eth-get-filter-logs)            | [`eth_getLogs`](/docs/node/crossfi/cross-fi-api-endpoints/eth-get-logs)                     |
-| [`eth_getStorageAt`](/docs/node/crossfi/cross-fi-api-endpoints/eth-get-storage-at)              | [`eth_getTransactionByBlockHashAndIndex`](/docs/node/crossfi/cross-fi-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
-| [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/crossfi/cross-fi-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/node/crossfi/cross-fi-api-endpoints/eth-get-transaction-by-hash) |
-| [`eth_getTransactionCount`](/docs/node/crossfi/cross-fi-api-endpoints/eth-get-transaction-count) | [`eth_getTransactionReceipt`](/docs/node/crossfi/cross-fi-api-endpoints/eth-get-transaction-receipt) |
-| [`eth_newBlockFilter`](/docs/node/crossfi/cross-fi-api-endpoints/eth-new-block-filter)          | [`eth_newFilter`](/docs/node/crossfi/cross-fi-api-endpoints/eth-new-filter)                 |
-| [`eth_sendRawTransaction`](/docs/node/crossfi/cross-fi-api-endpoints/eth-send-raw-transaction)  | [`eth_submitWork`](/docs/node/crossfi/cross-fi-api-endpoints/eth-submit-work)               |
-| [`eth_subscribe`](/docs/node/crossfi/cross-fi-api-endpoints/eth-subscribe)                      | [`eth_uninstallFilter`](/docs/node/crossfi/cross-fi-api-endpoints/eth-uninstall-filter)     |
-| [`eth_unsubscribe`](/docs/node/crossfi/cross-fi-api-endpoints/eth-unsubscribe)                  | [`net_version`](/docs/node/crossfi/cross-fi-api-endpoints/net-version)                      |
-| [`web3_clientVersion`](/docs/node/crossfi/cross-fi-api-endpoints/web-3-client-version)          | [`web3_sha3`](/docs/node/crossfi/cross-fi-api-endpoints/web-3-sha-3)                        |
+| [`eth_blockNumber`](/docs/chain-apis/crossfi/cross-fi-api-endpoints/eth-block-number)                 | [`eth_call`](/docs/chain-apis/crossfi/cross-fi-api-endpoints/eth-call)                            |
+| [`eth_callMany`](/docs/chain-apis/crossfi/cross-fi-api-endpoints/eth-call-many)                       | [`eth_chainId`](/docs/chain-apis/crossfi/cross-fi-api-endpoints/eth-chain-id)                     |
+| [`eth_estimateGas`](/docs/chain-apis/crossfi/cross-fi-api-endpoints/eth-estimate-gas)                 | [`eth_gasPrice`](/docs/chain-apis/crossfi/cross-fi-api-endpoints/eth-gas-price)                   |
+| [`eth_getAccount`](/docs/chain-apis/crossfi/cross-fi-api-endpoints/eth-get-account)                   | [`eth_getBalance`](/docs/chain-apis/crossfi/cross-fi-api-endpoints/eth-get-balance)               |
+| [`eth_getBlockByHash`](/docs/chain-apis/crossfi/cross-fi-api-endpoints/eth-get-block-by-hash)         | [`eth_getBlockByNumber`](/docs/chain-apis/crossfi/cross-fi-api-endpoints/eth-get-block-by-number) |
+| [`eth_getBlockTransactionCountByHash`](/docs/chain-apis/crossfi/cross-fi-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/chain-apis/crossfi/cross-fi-api-endpoints/eth-get-block-transaction-count-by-number) |
+| [`eth_getCode`](/docs/chain-apis/crossfi/cross-fi-api-endpoints/eth-get-code)                         | [`eth_getFilterChanges`](/docs/chain-apis/crossfi/cross-fi-api-endpoints/eth-get-filter-changes)  |
+| [`eth_getFilterLogs`](/docs/chain-apis/crossfi/cross-fi-api-endpoints/eth-get-filter-logs)            | [`eth_getLogs`](/docs/chain-apis/crossfi/cross-fi-api-endpoints/eth-get-logs)                     |
+| [`eth_getStorageAt`](/docs/chain-apis/crossfi/cross-fi-api-endpoints/eth-get-storage-at)              | [`eth_getTransactionByBlockHashAndIndex`](/docs/chain-apis/crossfi/cross-fi-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
+| [`eth_getTransactionByBlockNumberAndIndex`](/docs/chain-apis/crossfi/cross-fi-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/chain-apis/crossfi/cross-fi-api-endpoints/eth-get-transaction-by-hash) |
+| [`eth_getTransactionCount`](/docs/chain-apis/crossfi/cross-fi-api-endpoints/eth-get-transaction-count) | [`eth_getTransactionReceipt`](/docs/chain-apis/crossfi/cross-fi-api-endpoints/eth-get-transaction-receipt) |
+| [`eth_newBlockFilter`](/docs/chain-apis/crossfi/cross-fi-api-endpoints/eth-new-block-filter)          | [`eth_newFilter`](/docs/chain-apis/crossfi/cross-fi-api-endpoints/eth-new-filter)                 |
+| [`eth_sendRawTransaction`](/docs/chain-apis/crossfi/cross-fi-api-endpoints/eth-send-raw-transaction)  | [`eth_submitWork`](/docs/chain-apis/crossfi/cross-fi-api-endpoints/eth-submit-work)               |
+| [`eth_subscribe`](/docs/chain-apis/crossfi/cross-fi-api-endpoints/eth-subscribe)                      | [`eth_uninstallFilter`](/docs/chain-apis/crossfi/cross-fi-api-endpoints/eth-uninstall-filter)     |
+| [`eth_unsubscribe`](/docs/chain-apis/crossfi/cross-fi-api-endpoints/eth-unsubscribe)                  | [`net_version`](/docs/chain-apis/crossfi/cross-fi-api-endpoints/net-version)                      |
+| [`web3_clientVersion`](/docs/chain-apis/crossfi/cross-fi-api-endpoints/web-3-client-version)          | [`web3_sha3`](/docs/chain-apis/crossfi/cross-fi-api-endpoints/web-3-sha-3)                        |
 
 ## Degen APIs
 
@@ -540,22 +540,22 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_blockNumber`](/docs/node/degen/degen-api-endpoints/eth-block-number)                      | [`eth_call`](/docs/node/degen/degen-api-endpoints/eth-call)                                 |
-| [`eth_callMany`](/docs/node/degen/degen-api-endpoints/eth-call-many)                            | [`eth_chainId`](/docs/node/degen/degen-api-endpoints/eth-chain-id)                          |
-| [`eth_estimateGas`](/docs/node/degen/degen-api-endpoints/eth-estimate-gas)                      | [`eth_gasPrice`](/docs/node/degen/degen-api-endpoints/eth-gas-price)                        |
-| [`eth_getAccount`](/docs/node/degen/degen-api-endpoints/eth-get-account)                        | [`eth_getBalance`](/docs/node/degen/degen-api-endpoints/eth-get-balance)                    |
-| [`eth_getBlockByHash`](/docs/node/degen/degen-api-endpoints/eth-get-block-by-hash)              | [`eth_getBlockByNumber`](/docs/node/degen/degen-api-endpoints/eth-get-block-by-number)      |
-| [`eth_getBlockTransactionCountByHash`](/docs/node/degen/degen-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/node/degen/degen-api-endpoints/eth-get-block-transaction-count-by-number) |
-| [`eth_getCode`](/docs/node/degen/degen-api-endpoints/eth-get-code)                              | [`eth_getFilterChanges`](/docs/node/degen/degen-api-endpoints/eth-get-filter-changes)       |
-| [`eth_getFilterLogs`](/docs/node/degen/degen-api-endpoints/eth-get-filter-logs)                 | [`eth_getLogs`](/docs/node/degen/degen-api-endpoints/eth-get-logs)                          |
-| [`eth_getStorageAt`](/docs/node/degen/degen-api-endpoints/eth-get-storage-at)                   | [`eth_getTransactionByBlockHashAndIndex`](/docs/node/degen/degen-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
-| [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/degen/degen-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/node/degen/degen-api-endpoints/eth-get-transaction-by-hash) |
-| [`eth_getTransactionCount`](/docs/node/degen/degen-api-endpoints/eth-get-transaction-count)     | [`eth_getTransactionReceipt`](/docs/node/degen/degen-api-endpoints/eth-get-transaction-receipt) |
-| [`eth_newBlockFilter`](/docs/node/degen/degen-api-endpoints/eth-new-block-filter)               | [`eth_newFilter`](/docs/node/degen/degen-api-endpoints/eth-new-filter)                      |
-| [`eth_sendRawTransaction`](/docs/node/degen/degen-api-endpoints/eth-send-raw-transaction)       | [`eth_submitWork`](/docs/node/degen/degen-api-endpoints/eth-submit-work)                    |
-| [`eth_subscribe`](/docs/node/degen/degen-api-endpoints/eth-subscribe)                           | [`eth_uninstallFilter`](/docs/node/degen/degen-api-endpoints/eth-uninstall-filter)          |
-| [`eth_unsubscribe`](/docs/node/degen/degen-api-endpoints/eth-unsubscribe)                       | [`net_version`](/docs/node/degen/degen-api-endpoints/net-version)                           |
-| [`web3_clientVersion`](/docs/node/degen/degen-api-endpoints/web-3-client-version)               | [`web3_sha3`](/docs/node/degen/degen-api-endpoints/web-3-sha-3)                             |
+| [`eth_blockNumber`](/docs/chain-apis/degen/degen-api-endpoints/eth-block-number)                      | [`eth_call`](/docs/chain-apis/degen/degen-api-endpoints/eth-call)                                 |
+| [`eth_callMany`](/docs/chain-apis/degen/degen-api-endpoints/eth-call-many)                            | [`eth_chainId`](/docs/chain-apis/degen/degen-api-endpoints/eth-chain-id)                          |
+| [`eth_estimateGas`](/docs/chain-apis/degen/degen-api-endpoints/eth-estimate-gas)                      | [`eth_gasPrice`](/docs/chain-apis/degen/degen-api-endpoints/eth-gas-price)                        |
+| [`eth_getAccount`](/docs/chain-apis/degen/degen-api-endpoints/eth-get-account)                        | [`eth_getBalance`](/docs/chain-apis/degen/degen-api-endpoints/eth-get-balance)                    |
+| [`eth_getBlockByHash`](/docs/chain-apis/degen/degen-api-endpoints/eth-get-block-by-hash)              | [`eth_getBlockByNumber`](/docs/chain-apis/degen/degen-api-endpoints/eth-get-block-by-number)      |
+| [`eth_getBlockTransactionCountByHash`](/docs/chain-apis/degen/degen-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/chain-apis/degen/degen-api-endpoints/eth-get-block-transaction-count-by-number) |
+| [`eth_getCode`](/docs/chain-apis/degen/degen-api-endpoints/eth-get-code)                              | [`eth_getFilterChanges`](/docs/chain-apis/degen/degen-api-endpoints/eth-get-filter-changes)       |
+| [`eth_getFilterLogs`](/docs/chain-apis/degen/degen-api-endpoints/eth-get-filter-logs)                 | [`eth_getLogs`](/docs/chain-apis/degen/degen-api-endpoints/eth-get-logs)                          |
+| [`eth_getStorageAt`](/docs/chain-apis/degen/degen-api-endpoints/eth-get-storage-at)                   | [`eth_getTransactionByBlockHashAndIndex`](/docs/chain-apis/degen/degen-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
+| [`eth_getTransactionByBlockNumberAndIndex`](/docs/chain-apis/degen/degen-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/chain-apis/degen/degen-api-endpoints/eth-get-transaction-by-hash) |
+| [`eth_getTransactionCount`](/docs/chain-apis/degen/degen-api-endpoints/eth-get-transaction-count)     | [`eth_getTransactionReceipt`](/docs/chain-apis/degen/degen-api-endpoints/eth-get-transaction-receipt) |
+| [`eth_newBlockFilter`](/docs/chain-apis/degen/degen-api-endpoints/eth-new-block-filter)               | [`eth_newFilter`](/docs/chain-apis/degen/degen-api-endpoints/eth-new-filter)                      |
+| [`eth_sendRawTransaction`](/docs/chain-apis/degen/degen-api-endpoints/eth-send-raw-transaction)       | [`eth_submitWork`](/docs/chain-apis/degen/degen-api-endpoints/eth-submit-work)                    |
+| [`eth_subscribe`](/docs/chain-apis/degen/degen-api-endpoints/eth-subscribe)                           | [`eth_uninstallFilter`](/docs/chain-apis/degen/degen-api-endpoints/eth-uninstall-filter)          |
+| [`eth_unsubscribe`](/docs/chain-apis/degen/degen-api-endpoints/eth-unsubscribe)                       | [`net_version`](/docs/chain-apis/degen/degen-api-endpoints/net-version)                           |
+| [`web3_clientVersion`](/docs/chain-apis/degen/degen-api-endpoints/web-3-client-version)               | [`web3_sha3`](/docs/chain-apis/degen/degen-api-endpoints/web-3-sha-3)                             |
 
 ## Flow EVM APIs
 
@@ -563,22 +563,22 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_blockNumber`](/docs/node/flow-evm/flow-evm-api-endpoints/eth-block-number)                | [`eth_call`](/docs/node/flow-evm/flow-evm-api-endpoints/eth-call)                           |
-| [`eth_callMany`](/docs/node/flow-evm/flow-evm-api-endpoints/eth-call-many)                      | [`eth_chainId`](/docs/node/flow-evm/flow-evm-api-endpoints/eth-chain-id)                    |
-| [`eth_estimateGas`](/docs/node/flow-evm/flow-evm-api-endpoints/eth-estimate-gas)                | [`eth_gasPrice`](/docs/node/flow-evm/flow-evm-api-endpoints/eth-gas-price)                  |
-| [`eth_getAccount`](/docs/node/flow-evm/flow-evm-api-endpoints/eth-get-account)                  | [`eth_getBalance`](/docs/node/flow-evm/flow-evm-api-endpoints/eth-get-balance)              |
-| [`eth_getBlockByHash`](/docs/node/flow-evm/flow-evm-api-endpoints/eth-get-block-by-hash)        | [`eth_getBlockByNumber`](/docs/node/flow-evm/flow-evm-api-endpoints/eth-get-block-by-number) |
-| [`eth_getBlockTransactionCountByHash`](/docs/node/flow-evm/flow-evm-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/node/flow-evm/flow-evm-api-endpoints/eth-get-block-transaction-count-by-number) |
-| [`eth_getCode`](/docs/node/flow-evm/flow-evm-api-endpoints/eth-get-code)                        | [`eth_getFilterChanges`](/docs/node/flow-evm/flow-evm-api-endpoints/eth-get-filter-changes) |
-| [`eth_getFilterLogs`](/docs/node/flow-evm/flow-evm-api-endpoints/eth-get-filter-logs)           | [`eth_getLogs`](/docs/node/flow-evm/flow-evm-api-endpoints/eth-get-logs)                    |
-| [`eth_getStorageAt`](/docs/node/flow-evm/flow-evm-api-endpoints/eth-get-storage-at)             | [`eth_getTransactionByBlockHashAndIndex`](/docs/node/flow-evm/flow-evm-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
-| [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/flow-evm/flow-evm-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/node/flow-evm/flow-evm-api-endpoints/eth-get-transaction-by-hash) |
-| [`eth_getTransactionCount`](/docs/node/flow-evm/flow-evm-api-endpoints/eth-get-transaction-count) | [`eth_getTransactionReceipt`](/docs/node/flow-evm/flow-evm-api-endpoints/eth-get-transaction-receipt) |
-| [`eth_newBlockFilter`](/docs/node/flow-evm/flow-evm-api-endpoints/eth-new-block-filter)         | [`eth_newFilter`](/docs/node/flow-evm/flow-evm-api-endpoints/eth-new-filter)                |
-| [`eth_sendRawTransaction`](/docs/node/flow-evm/flow-evm-api-endpoints/eth-send-raw-transaction) | [`eth_submitWork`](/docs/node/flow-evm/flow-evm-api-endpoints/eth-submit-work)              |
-| [`eth_subscribe`](/docs/node/flow-evm/flow-evm-api-endpoints/eth-subscribe)                     | [`eth_uninstallFilter`](/docs/node/flow-evm/flow-evm-api-endpoints/eth-uninstall-filter)    |
-| [`eth_unsubscribe`](/docs/node/flow-evm/flow-evm-api-endpoints/eth-unsubscribe)                 | [`net_version`](/docs/node/flow-evm/flow-evm-api-endpoints/net-version)                     |
-| [`web3_clientVersion`](/docs/node/flow-evm/flow-evm-api-endpoints/web-3-client-version)         | [`web3_sha3`](/docs/node/flow-evm/flow-evm-api-endpoints/web-3-sha-3)                       |
+| [`eth_blockNumber`](/docs/chain-apis/flow-evm/flow-evm-api-endpoints/eth-block-number)                | [`eth_call`](/docs/chain-apis/flow-evm/flow-evm-api-endpoints/eth-call)                           |
+| [`eth_callMany`](/docs/chain-apis/flow-evm/flow-evm-api-endpoints/eth-call-many)                      | [`eth_chainId`](/docs/chain-apis/flow-evm/flow-evm-api-endpoints/eth-chain-id)                    |
+| [`eth_estimateGas`](/docs/chain-apis/flow-evm/flow-evm-api-endpoints/eth-estimate-gas)                | [`eth_gasPrice`](/docs/chain-apis/flow-evm/flow-evm-api-endpoints/eth-gas-price)                  |
+| [`eth_getAccount`](/docs/chain-apis/flow-evm/flow-evm-api-endpoints/eth-get-account)                  | [`eth_getBalance`](/docs/chain-apis/flow-evm/flow-evm-api-endpoints/eth-get-balance)              |
+| [`eth_getBlockByHash`](/docs/chain-apis/flow-evm/flow-evm-api-endpoints/eth-get-block-by-hash)        | [`eth_getBlockByNumber`](/docs/chain-apis/flow-evm/flow-evm-api-endpoints/eth-get-block-by-number) |
+| [`eth_getBlockTransactionCountByHash`](/docs/chain-apis/flow-evm/flow-evm-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/chain-apis/flow-evm/flow-evm-api-endpoints/eth-get-block-transaction-count-by-number) |
+| [`eth_getCode`](/docs/chain-apis/flow-evm/flow-evm-api-endpoints/eth-get-code)                        | [`eth_getFilterChanges`](/docs/chain-apis/flow-evm/flow-evm-api-endpoints/eth-get-filter-changes) |
+| [`eth_getFilterLogs`](/docs/chain-apis/flow-evm/flow-evm-api-endpoints/eth-get-filter-logs)           | [`eth_getLogs`](/docs/chain-apis/flow-evm/flow-evm-api-endpoints/eth-get-logs)                    |
+| [`eth_getStorageAt`](/docs/chain-apis/flow-evm/flow-evm-api-endpoints/eth-get-storage-at)             | [`eth_getTransactionByBlockHashAndIndex`](/docs/chain-apis/flow-evm/flow-evm-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
+| [`eth_getTransactionByBlockNumberAndIndex`](/docs/chain-apis/flow-evm/flow-evm-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/chain-apis/flow-evm/flow-evm-api-endpoints/eth-get-transaction-by-hash) |
+| [`eth_getTransactionCount`](/docs/chain-apis/flow-evm/flow-evm-api-endpoints/eth-get-transaction-count) | [`eth_getTransactionReceipt`](/docs/chain-apis/flow-evm/flow-evm-api-endpoints/eth-get-transaction-receipt) |
+| [`eth_newBlockFilter`](/docs/chain-apis/flow-evm/flow-evm-api-endpoints/eth-new-block-filter)         | [`eth_newFilter`](/docs/chain-apis/flow-evm/flow-evm-api-endpoints/eth-new-filter)                |
+| [`eth_sendRawTransaction`](/docs/chain-apis/flow-evm/flow-evm-api-endpoints/eth-send-raw-transaction) | [`eth_submitWork`](/docs/chain-apis/flow-evm/flow-evm-api-endpoints/eth-submit-work)              |
+| [`eth_subscribe`](/docs/chain-apis/flow-evm/flow-evm-api-endpoints/eth-subscribe)                     | [`eth_uninstallFilter`](/docs/chain-apis/flow-evm/flow-evm-api-endpoints/eth-uninstall-filter)    |
+| [`eth_unsubscribe`](/docs/chain-apis/flow-evm/flow-evm-api-endpoints/eth-unsubscribe)                 | [`net_version`](/docs/chain-apis/flow-evm/flow-evm-api-endpoints/net-version)                     |
+| [`web3_clientVersion`](/docs/chain-apis/flow-evm/flow-evm-api-endpoints/web-3-client-version)         | [`web3_sha3`](/docs/chain-apis/flow-evm/flow-evm-api-endpoints/web-3-sha-3)                       |
 
 ## Frax APIs
 
@@ -586,22 +586,22 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_blockNumber`](/docs/node/frax/frax-api-endpoints/eth-block-number)                        | [`eth_call`](/docs/node/frax/frax-api-endpoints/eth-call)                                   |
-| [`eth_callMany`](/docs/node/frax/frax-api-endpoints/eth-call-many)                              | [`eth_chainId`](/docs/node/frax/frax-api-endpoints/eth-chain-id)                            |
-| [`eth_estimateGas`](/docs/node/frax/frax-api-endpoints/eth-estimate-gas)                        | [`eth_gasPrice`](/docs/node/frax/frax-api-endpoints/eth-gas-price)                          |
-| [`eth_getAccount`](/docs/node/frax/frax-api-endpoints/eth-get-account)                          | [`eth_getBalance`](/docs/node/frax/frax-api-endpoints/eth-get-balance)                      |
-| [`eth_getBlockByHash`](/docs/node/frax/frax-api-endpoints/eth-get-block-by-hash)                | [`eth_getBlockByNumber`](/docs/node/frax/frax-api-endpoints/eth-get-block-by-number)        |
-| [`eth_getBlockTransactionCountByHash`](/docs/node/frax/frax-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/node/frax/frax-api-endpoints/eth-get-block-transaction-count-by-number) |
-| [`eth_getCode`](/docs/node/frax/frax-api-endpoints/eth-get-code)                                | [`eth_getFilterChanges`](/docs/node/frax/frax-api-endpoints/eth-get-filter-changes)         |
-| [`eth_getFilterLogs`](/docs/node/frax/frax-api-endpoints/eth-get-filter-logs)                   | [`eth_getLogs`](/docs/node/frax/frax-api-endpoints/eth-get-logs)                            |
-| [`eth_getStorageAt`](/docs/node/frax/frax-api-endpoints/eth-get-storage-at)                     | [`eth_getTransactionByBlockHashAndIndex`](/docs/node/frax/frax-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
-| [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/frax/frax-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/node/frax/frax-api-endpoints/eth-get-transaction-by-hash) |
-| [`eth_getTransactionCount`](/docs/node/frax/frax-api-endpoints/eth-get-transaction-count)       | [`eth_getTransactionReceipt`](/docs/node/frax/frax-api-endpoints/eth-get-transaction-receipt) |
-| [`eth_newBlockFilter`](/docs/node/frax/frax-api-endpoints/eth-new-block-filter)                 | [`eth_newFilter`](/docs/node/frax/frax-api-endpoints/eth-new-filter)                        |
-| [`eth_sendRawTransaction`](/docs/node/frax/frax-api-endpoints/eth-send-raw-transaction)         | [`eth_submitWork`](/docs/node/frax/frax-api-endpoints/eth-submit-work)                      |
-| [`eth_subscribe`](/docs/node/frax/frax-api-endpoints/eth-subscribe)                             | [`eth_uninstallFilter`](/docs/node/frax/frax-api-endpoints/eth-uninstall-filter)            |
-| [`eth_unsubscribe`](/docs/node/frax/frax-api-endpoints/eth-unsubscribe)                         | [`net_version`](/docs/node/frax/frax-api-endpoints/net-version)                             |
-| [`web3_clientVersion`](/docs/node/frax/frax-api-endpoints/web-3-client-version)                 | [`web3_sha3`](/docs/node/frax/frax-api-endpoints/web-3-sha-3)                               |
+| [`eth_blockNumber`](/docs/chain-apis/frax/frax-api-endpoints/eth-block-number)                        | [`eth_call`](/docs/chain-apis/frax/frax-api-endpoints/eth-call)                                   |
+| [`eth_callMany`](/docs/chain-apis/frax/frax-api-endpoints/eth-call-many)                              | [`eth_chainId`](/docs/chain-apis/frax/frax-api-endpoints/eth-chain-id)                            |
+| [`eth_estimateGas`](/docs/chain-apis/frax/frax-api-endpoints/eth-estimate-gas)                        | [`eth_gasPrice`](/docs/chain-apis/frax/frax-api-endpoints/eth-gas-price)                          |
+| [`eth_getAccount`](/docs/chain-apis/frax/frax-api-endpoints/eth-get-account)                          | [`eth_getBalance`](/docs/chain-apis/frax/frax-api-endpoints/eth-get-balance)                      |
+| [`eth_getBlockByHash`](/docs/chain-apis/frax/frax-api-endpoints/eth-get-block-by-hash)                | [`eth_getBlockByNumber`](/docs/chain-apis/frax/frax-api-endpoints/eth-get-block-by-number)        |
+| [`eth_getBlockTransactionCountByHash`](/docs/chain-apis/frax/frax-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/chain-apis/frax/frax-api-endpoints/eth-get-block-transaction-count-by-number) |
+| [`eth_getCode`](/docs/chain-apis/frax/frax-api-endpoints/eth-get-code)                                | [`eth_getFilterChanges`](/docs/chain-apis/frax/frax-api-endpoints/eth-get-filter-changes)         |
+| [`eth_getFilterLogs`](/docs/chain-apis/frax/frax-api-endpoints/eth-get-filter-logs)                   | [`eth_getLogs`](/docs/chain-apis/frax/frax-api-endpoints/eth-get-logs)                            |
+| [`eth_getStorageAt`](/docs/chain-apis/frax/frax-api-endpoints/eth-get-storage-at)                     | [`eth_getTransactionByBlockHashAndIndex`](/docs/chain-apis/frax/frax-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
+| [`eth_getTransactionByBlockNumberAndIndex`](/docs/chain-apis/frax/frax-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/chain-apis/frax/frax-api-endpoints/eth-get-transaction-by-hash) |
+| [`eth_getTransactionCount`](/docs/chain-apis/frax/frax-api-endpoints/eth-get-transaction-count)       | [`eth_getTransactionReceipt`](/docs/chain-apis/frax/frax-api-endpoints/eth-get-transaction-receipt) |
+| [`eth_newBlockFilter`](/docs/chain-apis/frax/frax-api-endpoints/eth-new-block-filter)                 | [`eth_newFilter`](/docs/chain-apis/frax/frax-api-endpoints/eth-new-filter)                        |
+| [`eth_sendRawTransaction`](/docs/chain-apis/frax/frax-api-endpoints/eth-send-raw-transaction)         | [`eth_submitWork`](/docs/chain-apis/frax/frax-api-endpoints/eth-submit-work)                      |
+| [`eth_subscribe`](/docs/chain-apis/frax/frax-api-endpoints/eth-subscribe)                             | [`eth_uninstallFilter`](/docs/chain-apis/frax/frax-api-endpoints/eth-uninstall-filter)            |
+| [`eth_unsubscribe`](/docs/chain-apis/frax/frax-api-endpoints/eth-unsubscribe)                         | [`net_version`](/docs/chain-apis/frax/frax-api-endpoints/net-version)                             |
+| [`web3_clientVersion`](/docs/chain-apis/frax/frax-api-endpoints/web-3-client-version)                 | [`web3_sha3`](/docs/chain-apis/frax/frax-api-endpoints/web-3-sha-3)                               |
 
 ## Gensyn APIs
 
@@ -609,22 +609,22 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_blockNumber`](/docs/node/gensyn/gensyn-api-endpoints/eth-block-number)                    | [`eth_call`](/docs/node/gensyn/gensyn-api-endpoints/eth-call)                               |
-| [`eth_callMany`](/docs/node/gensyn/gensyn-api-endpoints/eth-call-many)                          | [`eth_chainId`](/docs/node/gensyn/gensyn-api-endpoints/eth-chain-id)                        |
-| [`eth_estimateGas`](/docs/node/gensyn/gensyn-api-endpoints/eth-estimate-gas)                    | [`eth_gasPrice`](/docs/node/gensyn/gensyn-api-endpoints/eth-gas-price)                      |
-| [`eth_getAccount`](/docs/node/gensyn/gensyn-api-endpoints/eth-get-account)                      | [`eth_getBalance`](/docs/node/gensyn/gensyn-api-endpoints/eth-get-balance)                  |
-| [`eth_getBlockByHash`](/docs/node/gensyn/gensyn-api-endpoints/eth-get-block-by-hash)            | [`eth_getBlockByNumber`](/docs/node/gensyn/gensyn-api-endpoints/eth-get-block-by-number)    |
-| [`eth_getBlockTransactionCountByHash`](/docs/node/gensyn/gensyn-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/node/gensyn/gensyn-api-endpoints/eth-get-block-transaction-count-by-number) |
-| [`eth_getCode`](/docs/node/gensyn/gensyn-api-endpoints/eth-get-code)                            | [`eth_getFilterChanges`](/docs/node/gensyn/gensyn-api-endpoints/eth-get-filter-changes)     |
-| [`eth_getFilterLogs`](/docs/node/gensyn/gensyn-api-endpoints/eth-get-filter-logs)               | [`eth_getLogs`](/docs/node/gensyn/gensyn-api-endpoints/eth-get-logs)                        |
-| [`eth_getStorageAt`](/docs/node/gensyn/gensyn-api-endpoints/eth-get-storage-at)                 | [`eth_getTransactionByBlockHashAndIndex`](/docs/node/gensyn/gensyn-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
-| [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/gensyn/gensyn-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/node/gensyn/gensyn-api-endpoints/eth-get-transaction-by-hash) |
-| [`eth_getTransactionCount`](/docs/node/gensyn/gensyn-api-endpoints/eth-get-transaction-count)   | [`eth_getTransactionReceipt`](/docs/node/gensyn/gensyn-api-endpoints/eth-get-transaction-receipt) |
-| [`eth_newBlockFilter`](/docs/node/gensyn/gensyn-api-endpoints/eth-new-block-filter)             | [`eth_newFilter`](/docs/node/gensyn/gensyn-api-endpoints/eth-new-filter)                    |
-| [`eth_sendRawTransaction`](/docs/node/gensyn/gensyn-api-endpoints/eth-send-raw-transaction)     | [`eth_submitWork`](/docs/node/gensyn/gensyn-api-endpoints/eth-submit-work)                  |
-| [`eth_subscribe`](/docs/node/gensyn/gensyn-api-endpoints/eth-subscribe)                         | [`eth_uninstallFilter`](/docs/node/gensyn/gensyn-api-endpoints/eth-uninstall-filter)        |
-| [`eth_unsubscribe`](/docs/node/gensyn/gensyn-api-endpoints/eth-unsubscribe)                     | [`net_version`](/docs/node/gensyn/gensyn-api-endpoints/net-version)                         |
-| [`web3_clientVersion`](/docs/node/gensyn/gensyn-api-endpoints/web-3-client-version)             | [`web3_sha3`](/docs/node/gensyn/gensyn-api-endpoints/web-3-sha-3)                           |
+| [`eth_blockNumber`](/docs/chain-apis/gensyn/gensyn-api-endpoints/eth-block-number)                    | [`eth_call`](/docs/chain-apis/gensyn/gensyn-api-endpoints/eth-call)                               |
+| [`eth_callMany`](/docs/chain-apis/gensyn/gensyn-api-endpoints/eth-call-many)                          | [`eth_chainId`](/docs/chain-apis/gensyn/gensyn-api-endpoints/eth-chain-id)                        |
+| [`eth_estimateGas`](/docs/chain-apis/gensyn/gensyn-api-endpoints/eth-estimate-gas)                    | [`eth_gasPrice`](/docs/chain-apis/gensyn/gensyn-api-endpoints/eth-gas-price)                      |
+| [`eth_getAccount`](/docs/chain-apis/gensyn/gensyn-api-endpoints/eth-get-account)                      | [`eth_getBalance`](/docs/chain-apis/gensyn/gensyn-api-endpoints/eth-get-balance)                  |
+| [`eth_getBlockByHash`](/docs/chain-apis/gensyn/gensyn-api-endpoints/eth-get-block-by-hash)            | [`eth_getBlockByNumber`](/docs/chain-apis/gensyn/gensyn-api-endpoints/eth-get-block-by-number)    |
+| [`eth_getBlockTransactionCountByHash`](/docs/chain-apis/gensyn/gensyn-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/chain-apis/gensyn/gensyn-api-endpoints/eth-get-block-transaction-count-by-number) |
+| [`eth_getCode`](/docs/chain-apis/gensyn/gensyn-api-endpoints/eth-get-code)                            | [`eth_getFilterChanges`](/docs/chain-apis/gensyn/gensyn-api-endpoints/eth-get-filter-changes)     |
+| [`eth_getFilterLogs`](/docs/chain-apis/gensyn/gensyn-api-endpoints/eth-get-filter-logs)               | [`eth_getLogs`](/docs/chain-apis/gensyn/gensyn-api-endpoints/eth-get-logs)                        |
+| [`eth_getStorageAt`](/docs/chain-apis/gensyn/gensyn-api-endpoints/eth-get-storage-at)                 | [`eth_getTransactionByBlockHashAndIndex`](/docs/chain-apis/gensyn/gensyn-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
+| [`eth_getTransactionByBlockNumberAndIndex`](/docs/chain-apis/gensyn/gensyn-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/chain-apis/gensyn/gensyn-api-endpoints/eth-get-transaction-by-hash) |
+| [`eth_getTransactionCount`](/docs/chain-apis/gensyn/gensyn-api-endpoints/eth-get-transaction-count)   | [`eth_getTransactionReceipt`](/docs/chain-apis/gensyn/gensyn-api-endpoints/eth-get-transaction-receipt) |
+| [`eth_newBlockFilter`](/docs/chain-apis/gensyn/gensyn-api-endpoints/eth-new-block-filter)             | [`eth_newFilter`](/docs/chain-apis/gensyn/gensyn-api-endpoints/eth-new-filter)                    |
+| [`eth_sendRawTransaction`](/docs/chain-apis/gensyn/gensyn-api-endpoints/eth-send-raw-transaction)     | [`eth_submitWork`](/docs/chain-apis/gensyn/gensyn-api-endpoints/eth-submit-work)                  |
+| [`eth_subscribe`](/docs/chain-apis/gensyn/gensyn-api-endpoints/eth-subscribe)                         | [`eth_uninstallFilter`](/docs/chain-apis/gensyn/gensyn-api-endpoints/eth-uninstall-filter)        |
+| [`eth_unsubscribe`](/docs/chain-apis/gensyn/gensyn-api-endpoints/eth-unsubscribe)                     | [`net_version`](/docs/chain-apis/gensyn/gensyn-api-endpoints/net-version)                         |
+| [`web3_clientVersion`](/docs/chain-apis/gensyn/gensyn-api-endpoints/web-3-client-version)             | [`web3_sha3`](/docs/chain-apis/gensyn/gensyn-api-endpoints/web-3-sha-3)                           |
 
 ## Gnosis APIs
 
@@ -632,27 +632,27 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_accounts`](/docs/node/gnosis/gnosis-api-endpoints/eth-accounts)                           | [`eth_blockNumber`](/docs/node/gnosis/gnosis-api-endpoints/eth-block-number)                |
-| [`eth_call`](/docs/node/gnosis/gnosis-api-endpoints/eth-call)                                   | [`eth_callMany`](/docs/node/gnosis/gnosis-api-endpoints/eth-call-many)                      |
-| [`eth_chainId`](/docs/node/gnosis/gnosis-api-endpoints/eth-chain-id)                            | [`eth_createAccessList`](/docs/node/gnosis/gnosis-api-endpoints/eth-create-access-list)     |
-| [`eth_estimateGas`](/docs/node/gnosis/gnosis-api-endpoints/eth-estimate-gas)                    | [`eth_feeHistory`](/docs/node/gnosis/gnosis-api-endpoints/eth-fee-history)                  |
-| [`eth_gasPrice`](/docs/node/gnosis/gnosis-api-endpoints/eth-gas-price)                          | [`eth_getAccount`](/docs/node/gnosis/gnosis-api-endpoints/eth-get-account)                  |
-| [`eth_getBalance`](/docs/node/gnosis/gnosis-api-endpoints/eth-get-balance)                      | [`eth_getBlockByHash`](/docs/node/gnosis/gnosis-api-endpoints/eth-get-block-by-hash)        |
-| [`eth_getBlockByNumber`](/docs/node/gnosis/gnosis-api-endpoints/eth-get-block-by-number)        | [`eth_getBlockReceipts`](/docs/node/gnosis/gnosis-api-endpoints/eth-get-block-receipts)     |
-| [`eth_getBlockTransactionCountByHash`](/docs/node/gnosis/gnosis-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/node/gnosis/gnosis-api-endpoints/eth-get-block-transaction-count-by-number) |
-| [`eth_getCode`](/docs/node/gnosis/gnosis-api-endpoints/eth-get-code)                            | [`eth_getFilterChanges`](/docs/node/gnosis/gnosis-api-endpoints/eth-get-filter-changes)     |
-| [`eth_getFilterLogs`](/docs/node/gnosis/gnosis-api-endpoints/eth-get-filter-logs)               | [`eth_getLogs`](/docs/node/gnosis/gnosis-api-endpoints/eth-get-logs)                        |
-| [`eth_getProof`](/docs/node/gnosis/gnosis-api-endpoints/eth-get-proof)                          | [`eth_getStorageAt`](/docs/node/gnosis/gnosis-api-endpoints/eth-get-storage-at)             |
-| [`eth_getTransactionByBlockHashAndIndex`](/docs/node/gnosis/gnosis-api-endpoints/eth-get-transaction-by-block-hash-and-index) | [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/gnosis/gnosis-api-endpoints/eth-get-transaction-by-block-number-and-index) |
-| [`eth_getTransactionByHash`](/docs/node/gnosis/gnosis-api-endpoints/eth-get-transaction-by-hash) | [`eth_getTransactionCount`](/docs/node/gnosis/gnosis-api-endpoints/eth-get-transaction-count) |
-| [`eth_getTransactionReceipt`](/docs/node/gnosis/gnosis-api-endpoints/eth-get-transaction-receipt) | [`eth_getUncleByBlockHashAndIndex`](/docs/node/gnosis/gnosis-api-endpoints/eth-get-uncle-by-block-hash-and-index) |
-| [`eth_getUncleCountByBlockNumber`](/docs/node/gnosis/gnosis-api-endpoints/eth-get-uncle-count-by-block-number) | [`eth_maxPriorityFeePerGas`](/docs/node/gnosis/gnosis-api-endpoints/eth-max-priority-fee-per-gas) |
-| [`eth_newBlockFilter`](/docs/node/gnosis/gnosis-api-endpoints/eth-new-block-filter)             | [`eth_newFilter`](/docs/node/gnosis/gnosis-api-endpoints/eth-new-filter)                    |
-| [`eth_protocolVersion`](/docs/node/gnosis/gnosis-api-endpoints/eth-protocol-version)            | [`eth_sendRawTransaction`](/docs/node/gnosis/gnosis-api-endpoints/eth-send-raw-transaction) |
-| [`eth_submitWork`](/docs/node/gnosis/gnosis-api-endpoints/eth-submit-work)                      | [`eth_subscribe`](/docs/node/gnosis/gnosis-api-endpoints/eth-subscribe)                     |
-| [`eth_syncing`](/docs/node/gnosis/gnosis-api-endpoints/eth-syncing)                             | [`eth_uninstallFilter`](/docs/node/gnosis/gnosis-api-endpoints/eth-uninstall-filter)        |
-| [`eth_unsubscribe`](/docs/node/gnosis/gnosis-api-endpoints/eth-unsubscribe)                     | [`net_version`](/docs/node/gnosis/gnosis-api-endpoints/net-version)                         |
-| [`web3_clientVersion`](/docs/node/gnosis/gnosis-api-endpoints/web-3-client-version)             | [`web3_sha3`](/docs/node/gnosis/gnosis-api-endpoints/web-3-sha-3)                           |
+| [`eth_accounts`](/docs/chain-apis/gnosis/gnosis-api-endpoints/eth-accounts)                           | [`eth_blockNumber`](/docs/chain-apis/gnosis/gnosis-api-endpoints/eth-block-number)                |
+| [`eth_call`](/docs/chain-apis/gnosis/gnosis-api-endpoints/eth-call)                                   | [`eth_callMany`](/docs/chain-apis/gnosis/gnosis-api-endpoints/eth-call-many)                      |
+| [`eth_chainId`](/docs/chain-apis/gnosis/gnosis-api-endpoints/eth-chain-id)                            | [`eth_createAccessList`](/docs/chain-apis/gnosis/gnosis-api-endpoints/eth-create-access-list)     |
+| [`eth_estimateGas`](/docs/chain-apis/gnosis/gnosis-api-endpoints/eth-estimate-gas)                    | [`eth_feeHistory`](/docs/chain-apis/gnosis/gnosis-api-endpoints/eth-fee-history)                  |
+| [`eth_gasPrice`](/docs/chain-apis/gnosis/gnosis-api-endpoints/eth-gas-price)                          | [`eth_getAccount`](/docs/chain-apis/gnosis/gnosis-api-endpoints/eth-get-account)                  |
+| [`eth_getBalance`](/docs/chain-apis/gnosis/gnosis-api-endpoints/eth-get-balance)                      | [`eth_getBlockByHash`](/docs/chain-apis/gnosis/gnosis-api-endpoints/eth-get-block-by-hash)        |
+| [`eth_getBlockByNumber`](/docs/chain-apis/gnosis/gnosis-api-endpoints/eth-get-block-by-number)        | [`eth_getBlockReceipts`](/docs/chain-apis/gnosis/gnosis-api-endpoints/eth-get-block-receipts)     |
+| [`eth_getBlockTransactionCountByHash`](/docs/chain-apis/gnosis/gnosis-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/chain-apis/gnosis/gnosis-api-endpoints/eth-get-block-transaction-count-by-number) |
+| [`eth_getCode`](/docs/chain-apis/gnosis/gnosis-api-endpoints/eth-get-code)                            | [`eth_getFilterChanges`](/docs/chain-apis/gnosis/gnosis-api-endpoints/eth-get-filter-changes)     |
+| [`eth_getFilterLogs`](/docs/chain-apis/gnosis/gnosis-api-endpoints/eth-get-filter-logs)               | [`eth_getLogs`](/docs/chain-apis/gnosis/gnosis-api-endpoints/eth-get-logs)                        |
+| [`eth_getProof`](/docs/chain-apis/gnosis/gnosis-api-endpoints/eth-get-proof)                          | [`eth_getStorageAt`](/docs/chain-apis/gnosis/gnosis-api-endpoints/eth-get-storage-at)             |
+| [`eth_getTransactionByBlockHashAndIndex`](/docs/chain-apis/gnosis/gnosis-api-endpoints/eth-get-transaction-by-block-hash-and-index) | [`eth_getTransactionByBlockNumberAndIndex`](/docs/chain-apis/gnosis/gnosis-api-endpoints/eth-get-transaction-by-block-number-and-index) |
+| [`eth_getTransactionByHash`](/docs/chain-apis/gnosis/gnosis-api-endpoints/eth-get-transaction-by-hash) | [`eth_getTransactionCount`](/docs/chain-apis/gnosis/gnosis-api-endpoints/eth-get-transaction-count) |
+| [`eth_getTransactionReceipt`](/docs/chain-apis/gnosis/gnosis-api-endpoints/eth-get-transaction-receipt) | [`eth_getUncleByBlockHashAndIndex`](/docs/chain-apis/gnosis/gnosis-api-endpoints/eth-get-uncle-by-block-hash-and-index) |
+| [`eth_getUncleCountByBlockNumber`](/docs/chain-apis/gnosis/gnosis-api-endpoints/eth-get-uncle-count-by-block-number) | [`eth_maxPriorityFeePerGas`](/docs/chain-apis/gnosis/gnosis-api-endpoints/eth-max-priority-fee-per-gas) |
+| [`eth_newBlockFilter`](/docs/chain-apis/gnosis/gnosis-api-endpoints/eth-new-block-filter)             | [`eth_newFilter`](/docs/chain-apis/gnosis/gnosis-api-endpoints/eth-new-filter)                    |
+| [`eth_protocolVersion`](/docs/chain-apis/gnosis/gnosis-api-endpoints/eth-protocol-version)            | [`eth_sendRawTransaction`](/docs/chain-apis/gnosis/gnosis-api-endpoints/eth-send-raw-transaction) |
+| [`eth_submitWork`](/docs/chain-apis/gnosis/gnosis-api-endpoints/eth-submit-work)                      | [`eth_subscribe`](/docs/chain-apis/gnosis/gnosis-api-endpoints/eth-subscribe)                     |
+| [`eth_syncing`](/docs/chain-apis/gnosis/gnosis-api-endpoints/eth-syncing)                             | [`eth_uninstallFilter`](/docs/chain-apis/gnosis/gnosis-api-endpoints/eth-uninstall-filter)        |
+| [`eth_unsubscribe`](/docs/chain-apis/gnosis/gnosis-api-endpoints/eth-unsubscribe)                     | [`net_version`](/docs/chain-apis/gnosis/gnosis-api-endpoints/net-version)                         |
+| [`web3_clientVersion`](/docs/chain-apis/gnosis/gnosis-api-endpoints/web-3-client-version)             | [`web3_sha3`](/docs/chain-apis/gnosis/gnosis-api-endpoints/web-3-sha-3)                           |
 
 ## Humanity APIs
 
@@ -660,22 +660,22 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_blockNumber`](/docs/node/humanity/humanity-api-endpoints/eth-block-number)                | [`eth_call`](/docs/node/humanity/humanity-api-endpoints/eth-call)                           |
-| [`eth_callMany`](/docs/node/humanity/humanity-api-endpoints/eth-call-many)                      | [`eth_chainId`](/docs/node/humanity/humanity-api-endpoints/eth-chain-id)                    |
-| [`eth_estimateGas`](/docs/node/humanity/humanity-api-endpoints/eth-estimate-gas)                | [`eth_gasPrice`](/docs/node/humanity/humanity-api-endpoints/eth-gas-price)                  |
-| [`eth_getAccount`](/docs/node/humanity/humanity-api-endpoints/eth-get-account)                  | [`eth_getBalance`](/docs/node/humanity/humanity-api-endpoints/eth-get-balance)              |
-| [`eth_getBlockByHash`](/docs/node/humanity/humanity-api-endpoints/eth-get-block-by-hash)        | [`eth_getBlockByNumber`](/docs/node/humanity/humanity-api-endpoints/eth-get-block-by-number) |
-| [`eth_getBlockTransactionCountByHash`](/docs/node/humanity/humanity-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/node/humanity/humanity-api-endpoints/eth-get-block-transaction-count-by-number) |
-| [`eth_getCode`](/docs/node/humanity/humanity-api-endpoints/eth-get-code)                        | [`eth_getFilterChanges`](/docs/node/humanity/humanity-api-endpoints/eth-get-filter-changes) |
-| [`eth_getFilterLogs`](/docs/node/humanity/humanity-api-endpoints/eth-get-filter-logs)           | [`eth_getLogs`](/docs/node/humanity/humanity-api-endpoints/eth-get-logs)                    |
-| [`eth_getStorageAt`](/docs/node/humanity/humanity-api-endpoints/eth-get-storage-at)             | [`eth_getTransactionByBlockHashAndIndex`](/docs/node/humanity/humanity-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
-| [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/humanity/humanity-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/node/humanity/humanity-api-endpoints/eth-get-transaction-by-hash) |
-| [`eth_getTransactionCount`](/docs/node/humanity/humanity-api-endpoints/eth-get-transaction-count) | [`eth_getTransactionReceipt`](/docs/node/humanity/humanity-api-endpoints/eth-get-transaction-receipt) |
-| [`eth_newBlockFilter`](/docs/node/humanity/humanity-api-endpoints/eth-new-block-filter)         | [`eth_newFilter`](/docs/node/humanity/humanity-api-endpoints/eth-new-filter)                |
-| [`eth_sendRawTransaction`](/docs/node/humanity/humanity-api-endpoints/eth-send-raw-transaction) | [`eth_submitWork`](/docs/node/humanity/humanity-api-endpoints/eth-submit-work)              |
-| [`eth_subscribe`](/docs/node/humanity/humanity-api-endpoints/eth-subscribe)                     | [`eth_uninstallFilter`](/docs/node/humanity/humanity-api-endpoints/eth-uninstall-filter)    |
-| [`eth_unsubscribe`](/docs/node/humanity/humanity-api-endpoints/eth-unsubscribe)                 | [`net_version`](/docs/node/humanity/humanity-api-endpoints/net-version)                     |
-| [`web3_clientVersion`](/docs/node/humanity/humanity-api-endpoints/web-3-client-version)         | [`web3_sha3`](/docs/node/humanity/humanity-api-endpoints/web-3-sha-3)                       |
+| [`eth_blockNumber`](/docs/chain-apis/humanity/humanity-api-endpoints/eth-block-number)                | [`eth_call`](/docs/chain-apis/humanity/humanity-api-endpoints/eth-call)                           |
+| [`eth_callMany`](/docs/chain-apis/humanity/humanity-api-endpoints/eth-call-many)                      | [`eth_chainId`](/docs/chain-apis/humanity/humanity-api-endpoints/eth-chain-id)                    |
+| [`eth_estimateGas`](/docs/chain-apis/humanity/humanity-api-endpoints/eth-estimate-gas)                | [`eth_gasPrice`](/docs/chain-apis/humanity/humanity-api-endpoints/eth-gas-price)                  |
+| [`eth_getAccount`](/docs/chain-apis/humanity/humanity-api-endpoints/eth-get-account)                  | [`eth_getBalance`](/docs/chain-apis/humanity/humanity-api-endpoints/eth-get-balance)              |
+| [`eth_getBlockByHash`](/docs/chain-apis/humanity/humanity-api-endpoints/eth-get-block-by-hash)        | [`eth_getBlockByNumber`](/docs/chain-apis/humanity/humanity-api-endpoints/eth-get-block-by-number) |
+| [`eth_getBlockTransactionCountByHash`](/docs/chain-apis/humanity/humanity-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/chain-apis/humanity/humanity-api-endpoints/eth-get-block-transaction-count-by-number) |
+| [`eth_getCode`](/docs/chain-apis/humanity/humanity-api-endpoints/eth-get-code)                        | [`eth_getFilterChanges`](/docs/chain-apis/humanity/humanity-api-endpoints/eth-get-filter-changes) |
+| [`eth_getFilterLogs`](/docs/chain-apis/humanity/humanity-api-endpoints/eth-get-filter-logs)           | [`eth_getLogs`](/docs/chain-apis/humanity/humanity-api-endpoints/eth-get-logs)                    |
+| [`eth_getStorageAt`](/docs/chain-apis/humanity/humanity-api-endpoints/eth-get-storage-at)             | [`eth_getTransactionByBlockHashAndIndex`](/docs/chain-apis/humanity/humanity-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
+| [`eth_getTransactionByBlockNumberAndIndex`](/docs/chain-apis/humanity/humanity-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/chain-apis/humanity/humanity-api-endpoints/eth-get-transaction-by-hash) |
+| [`eth_getTransactionCount`](/docs/chain-apis/humanity/humanity-api-endpoints/eth-get-transaction-count) | [`eth_getTransactionReceipt`](/docs/chain-apis/humanity/humanity-api-endpoints/eth-get-transaction-receipt) |
+| [`eth_newBlockFilter`](/docs/chain-apis/humanity/humanity-api-endpoints/eth-new-block-filter)         | [`eth_newFilter`](/docs/chain-apis/humanity/humanity-api-endpoints/eth-new-filter)                |
+| [`eth_sendRawTransaction`](/docs/chain-apis/humanity/humanity-api-endpoints/eth-send-raw-transaction) | [`eth_submitWork`](/docs/chain-apis/humanity/humanity-api-endpoints/eth-submit-work)              |
+| [`eth_subscribe`](/docs/chain-apis/humanity/humanity-api-endpoints/eth-subscribe)                     | [`eth_uninstallFilter`](/docs/chain-apis/humanity/humanity-api-endpoints/eth-uninstall-filter)    |
+| [`eth_unsubscribe`](/docs/chain-apis/humanity/humanity-api-endpoints/eth-unsubscribe)                 | [`net_version`](/docs/chain-apis/humanity/humanity-api-endpoints/net-version)                     |
+| [`web3_clientVersion`](/docs/chain-apis/humanity/humanity-api-endpoints/web-3-client-version)         | [`web3_sha3`](/docs/chain-apis/humanity/humanity-api-endpoints/web-3-sha-3)                       |
 
 ## HyperEVM APIs
 
@@ -683,25 +683,25 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_accounts`](/docs/node/hyperevm/hyper-evm-api-endpoints/eth-accounts)                      | [`eth_blockNumber`](/docs/node/hyperevm/hyper-evm-api-endpoints/eth-block-number)           |
-| [`eth_call`](/docs/node/hyperevm/hyper-evm-api-endpoints/eth-call)                              | [`eth_callMany`](/docs/node/hyperevm/hyper-evm-api-endpoints/eth-call-many)                 |
-| [`eth_chainId`](/docs/node/hyperevm/hyper-evm-api-endpoints/eth-chain-id)                       | [`eth_estimateGas`](/docs/node/hyperevm/hyper-evm-api-endpoints/eth-estimate-gas)           |
-| [`eth_feeHistory`](/docs/node/hyperevm/hyper-evm-api-endpoints/eth-fee-history)                 | [`eth_gasPrice`](/docs/node/hyperevm/hyper-evm-api-endpoints/eth-gas-price)                 |
-| [`eth_getAccount`](/docs/node/hyperevm/hyper-evm-api-endpoints/eth-get-account)                 | [`eth_getBalance`](/docs/node/hyperevm/hyper-evm-api-endpoints/eth-get-balance)             |
-| [`eth_getBlockByHash`](/docs/node/hyperevm/hyper-evm-api-endpoints/eth-get-block-by-hash)       | [`eth_getBlockByNumber`](/docs/node/hyperevm/hyper-evm-api-endpoints/eth-get-block-by-number) |
-| [`eth_getBlockReceipts`](/docs/node/hyperevm/hyper-evm-api-endpoints/eth-get-block-receipts)    | [`eth_getBlockTransactionCountByHash`](/docs/node/hyperevm/hyper-evm-api-endpoints/eth-get-block-transaction-count-by-hash) |
-| [`eth_getBlockTransactionCountByNumber`](/docs/node/hyperevm/hyper-evm-api-endpoints/eth-get-block-transaction-count-by-number) | [`eth_getCode`](/docs/node/hyperevm/hyper-evm-api-endpoints/eth-get-code)                   |
-| [`eth_getFilterChanges`](/docs/node/hyperevm/hyper-evm-api-endpoints/eth-get-filter-changes)    | [`eth_getFilterLogs`](/docs/node/hyperevm/hyper-evm-api-endpoints/eth-get-filter-logs)      |
-| [`eth_getLogs`](/docs/node/hyperevm/hyper-evm-api-endpoints/eth-get-logs)                       | [`eth_getStorageAt`](/docs/node/hyperevm/hyper-evm-api-endpoints/eth-get-storage-at)        |
-| [`eth_getTransactionByBlockHashAndIndex`](/docs/node/hyperevm/hyper-evm-api-endpoints/eth-get-transaction-by-block-hash-and-index) | [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/hyperevm/hyper-evm-api-endpoints/eth-get-transaction-by-block-number-and-index) |
-| [`eth_getTransactionByHash`](/docs/node/hyperevm/hyper-evm-api-endpoints/eth-get-transaction-by-hash) | [`eth_getTransactionCount`](/docs/node/hyperevm/hyper-evm-api-endpoints/eth-get-transaction-count) |
-| [`eth_getTransactionReceipt`](/docs/node/hyperevm/hyper-evm-api-endpoints/eth-get-transaction-receipt) | [`eth_maxPriorityFeePerGas`](/docs/node/hyperevm/hyper-evm-api-endpoints/eth-max-priority-fee-per-gas) |
-| [`eth_newBlockFilter`](/docs/node/hyperevm/hyper-evm-api-endpoints/eth-new-block-filter)        | [`eth_newFilter`](/docs/node/hyperevm/hyper-evm-api-endpoints/eth-new-filter)               |
-| [`eth_sendRawTransaction`](/docs/node/hyperevm/hyper-evm-api-endpoints/eth-send-raw-transaction) | [`eth_simulateV1`](/docs/node/hyperevm/hyper-evm-api-endpoints/eth-simulate-v-1)            |
-| [`eth_submitWork`](/docs/node/hyperevm/hyper-evm-api-endpoints/eth-submit-work)                 | [`eth_subscribe`](/docs/node/hyperevm/hyper-evm-api-endpoints/eth-subscribe)                |
-| [`eth_uninstallFilter`](/docs/node/hyperevm/hyper-evm-api-endpoints/eth-uninstall-filter)       | [`eth_unsubscribe`](/docs/node/hyperevm/hyper-evm-api-endpoints/eth-unsubscribe)            |
-| [`net_version`](/docs/node/hyperevm/hyper-evm-api-endpoints/net-version)                        | [`web3_clientVersion`](/docs/node/hyperevm/hyper-evm-api-endpoints/web-3-client-version)    |
-| [`web3_sha3`](/docs/node/hyperevm/hyper-evm-api-endpoints/web-3-sha-3)                          |                                                                                             |
+| [`eth_accounts`](/docs/chain-apis/hyperevm/hyper-evm-api-endpoints/eth-accounts)                      | [`eth_blockNumber`](/docs/chain-apis/hyperevm/hyper-evm-api-endpoints/eth-block-number)           |
+| [`eth_call`](/docs/chain-apis/hyperevm/hyper-evm-api-endpoints/eth-call)                              | [`eth_callMany`](/docs/chain-apis/hyperevm/hyper-evm-api-endpoints/eth-call-many)                 |
+| [`eth_chainId`](/docs/chain-apis/hyperevm/hyper-evm-api-endpoints/eth-chain-id)                       | [`eth_estimateGas`](/docs/chain-apis/hyperevm/hyper-evm-api-endpoints/eth-estimate-gas)           |
+| [`eth_feeHistory`](/docs/chain-apis/hyperevm/hyper-evm-api-endpoints/eth-fee-history)                 | [`eth_gasPrice`](/docs/chain-apis/hyperevm/hyper-evm-api-endpoints/eth-gas-price)                 |
+| [`eth_getAccount`](/docs/chain-apis/hyperevm/hyper-evm-api-endpoints/eth-get-account)                 | [`eth_getBalance`](/docs/chain-apis/hyperevm/hyper-evm-api-endpoints/eth-get-balance)             |
+| [`eth_getBlockByHash`](/docs/chain-apis/hyperevm/hyper-evm-api-endpoints/eth-get-block-by-hash)       | [`eth_getBlockByNumber`](/docs/chain-apis/hyperevm/hyper-evm-api-endpoints/eth-get-block-by-number) |
+| [`eth_getBlockReceipts`](/docs/chain-apis/hyperevm/hyper-evm-api-endpoints/eth-get-block-receipts)    | [`eth_getBlockTransactionCountByHash`](/docs/chain-apis/hyperevm/hyper-evm-api-endpoints/eth-get-block-transaction-count-by-hash) |
+| [`eth_getBlockTransactionCountByNumber`](/docs/chain-apis/hyperevm/hyper-evm-api-endpoints/eth-get-block-transaction-count-by-number) | [`eth_getCode`](/docs/chain-apis/hyperevm/hyper-evm-api-endpoints/eth-get-code)                   |
+| [`eth_getFilterChanges`](/docs/chain-apis/hyperevm/hyper-evm-api-endpoints/eth-get-filter-changes)    | [`eth_getFilterLogs`](/docs/chain-apis/hyperevm/hyper-evm-api-endpoints/eth-get-filter-logs)      |
+| [`eth_getLogs`](/docs/chain-apis/hyperevm/hyper-evm-api-endpoints/eth-get-logs)                       | [`eth_getStorageAt`](/docs/chain-apis/hyperevm/hyper-evm-api-endpoints/eth-get-storage-at)        |
+| [`eth_getTransactionByBlockHashAndIndex`](/docs/chain-apis/hyperevm/hyper-evm-api-endpoints/eth-get-transaction-by-block-hash-and-index) | [`eth_getTransactionByBlockNumberAndIndex`](/docs/chain-apis/hyperevm/hyper-evm-api-endpoints/eth-get-transaction-by-block-number-and-index) |
+| [`eth_getTransactionByHash`](/docs/chain-apis/hyperevm/hyper-evm-api-endpoints/eth-get-transaction-by-hash) | [`eth_getTransactionCount`](/docs/chain-apis/hyperevm/hyper-evm-api-endpoints/eth-get-transaction-count) |
+| [`eth_getTransactionReceipt`](/docs/chain-apis/hyperevm/hyper-evm-api-endpoints/eth-get-transaction-receipt) | [`eth_maxPriorityFeePerGas`](/docs/chain-apis/hyperevm/hyper-evm-api-endpoints/eth-max-priority-fee-per-gas) |
+| [`eth_newBlockFilter`](/docs/chain-apis/hyperevm/hyper-evm-api-endpoints/eth-new-block-filter)        | [`eth_newFilter`](/docs/chain-apis/hyperevm/hyper-evm-api-endpoints/eth-new-filter)               |
+| [`eth_sendRawTransaction`](/docs/chain-apis/hyperevm/hyper-evm-api-endpoints/eth-send-raw-transaction) | [`eth_simulateV1`](/docs/chain-apis/hyperevm/hyper-evm-api-endpoints/eth-simulate-v-1)            |
+| [`eth_submitWork`](/docs/chain-apis/hyperevm/hyper-evm-api-endpoints/eth-submit-work)                 | [`eth_subscribe`](/docs/chain-apis/hyperevm/hyper-evm-api-endpoints/eth-subscribe)                |
+| [`eth_uninstallFilter`](/docs/chain-apis/hyperevm/hyper-evm-api-endpoints/eth-uninstall-filter)       | [`eth_unsubscribe`](/docs/chain-apis/hyperevm/hyper-evm-api-endpoints/eth-unsubscribe)            |
+| [`net_version`](/docs/chain-apis/hyperevm/hyper-evm-api-endpoints/net-version)                        | [`web3_clientVersion`](/docs/chain-apis/hyperevm/hyper-evm-api-endpoints/web-3-client-version)    |
+| [`web3_sha3`](/docs/chain-apis/hyperevm/hyper-evm-api-endpoints/web-3-sha-3)                          |                                                                                             |
 
 ## Ink APIs
 
@@ -709,23 +709,23 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_blockNumber`](/docs/node/ink/ink-api-endpoints/eth-block-number)                          | [`eth_call`](/docs/node/ink/ink-api-endpoints/eth-call)                                     |
-| [`eth_callMany`](/docs/node/ink/ink-api-endpoints/eth-call-many)                                | [`eth_chainId`](/docs/node/ink/ink-api-endpoints/eth-chain-id)                              |
-| [`eth_estimateGas`](/docs/node/ink/ink-api-endpoints/eth-estimate-gas)                          | [`eth_gasPrice`](/docs/node/ink/ink-api-endpoints/eth-gas-price)                            |
-| [`eth_getAccount`](/docs/node/ink/ink-api-endpoints/eth-get-account)                            | [`eth_getBalance`](/docs/node/ink/ink-api-endpoints/eth-get-balance)                        |
-| [`eth_getBlockByHash`](/docs/node/ink/ink-api-endpoints/eth-get-block-by-hash)                  | [`eth_getBlockByNumber`](/docs/node/ink/ink-api-endpoints/eth-get-block-by-number)          |
-| [`eth_getBlockTransactionCountByHash`](/docs/node/ink/ink-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/node/ink/ink-api-endpoints/eth-get-block-transaction-count-by-number) |
-| [`eth_getCode`](/docs/node/ink/ink-api-endpoints/eth-get-code)                                  | [`eth_getFilterChanges`](/docs/node/ink/ink-api-endpoints/eth-get-filter-changes)           |
-| [`eth_getFilterLogs`](/docs/node/ink/ink-api-endpoints/eth-get-filter-logs)                     | [`eth_getLogs`](/docs/node/ink/ink-api-endpoints/eth-get-logs)                              |
-| [`eth_getStorageAt`](/docs/node/ink/ink-api-endpoints/eth-get-storage-at)                       | [`eth_getTransactionByBlockHashAndIndex`](/docs/node/ink/ink-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
-| [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/ink/ink-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/node/ink/ink-api-endpoints/eth-get-transaction-by-hash)  |
-| [`eth_getTransactionCount`](/docs/node/ink/ink-api-endpoints/eth-get-transaction-count)         | [`eth_getTransactionReceipt`](/docs/node/ink/ink-api-endpoints/eth-get-transaction-receipt) |
-| [`eth_newBlockFilter`](/docs/node/ink/ink-api-endpoints/eth-new-block-filter)                   | [`eth_newFilter`](/docs/node/ink/ink-api-endpoints/eth-new-filter)                          |
-| [`eth_sendRawTransaction`](/docs/node/ink/ink-api-endpoints/eth-send-raw-transaction)           | [`eth_simulateV1`](/docs/node/ink/ink-api-endpoints/eth-simulate-v-1)                       |
-| [`eth_submitWork`](/docs/node/ink/ink-api-endpoints/eth-submit-work)                            | [`eth_subscribe`](/docs/node/ink/ink-api-endpoints/eth-subscribe)                           |
-| [`eth_uninstallFilter`](/docs/node/ink/ink-api-endpoints/eth-uninstall-filter)                  | [`eth_unsubscribe`](/docs/node/ink/ink-api-endpoints/eth-unsubscribe)                       |
-| [`net_version`](/docs/node/ink/ink-api-endpoints/net-version)                                   | [`web3_clientVersion`](/docs/node/ink/ink-api-endpoints/web-3-client-version)               |
-| [`web3_sha3`](/docs/node/ink/ink-api-endpoints/web-3-sha-3)                                     |                                                                                             |
+| [`eth_blockNumber`](/docs/chain-apis/ink/ink-api-endpoints/eth-block-number)                          | [`eth_call`](/docs/chain-apis/ink/ink-api-endpoints/eth-call)                                     |
+| [`eth_callMany`](/docs/chain-apis/ink/ink-api-endpoints/eth-call-many)                                | [`eth_chainId`](/docs/chain-apis/ink/ink-api-endpoints/eth-chain-id)                              |
+| [`eth_estimateGas`](/docs/chain-apis/ink/ink-api-endpoints/eth-estimate-gas)                          | [`eth_gasPrice`](/docs/chain-apis/ink/ink-api-endpoints/eth-gas-price)                            |
+| [`eth_getAccount`](/docs/chain-apis/ink/ink-api-endpoints/eth-get-account)                            | [`eth_getBalance`](/docs/chain-apis/ink/ink-api-endpoints/eth-get-balance)                        |
+| [`eth_getBlockByHash`](/docs/chain-apis/ink/ink-api-endpoints/eth-get-block-by-hash)                  | [`eth_getBlockByNumber`](/docs/chain-apis/ink/ink-api-endpoints/eth-get-block-by-number)          |
+| [`eth_getBlockTransactionCountByHash`](/docs/chain-apis/ink/ink-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/chain-apis/ink/ink-api-endpoints/eth-get-block-transaction-count-by-number) |
+| [`eth_getCode`](/docs/chain-apis/ink/ink-api-endpoints/eth-get-code)                                  | [`eth_getFilterChanges`](/docs/chain-apis/ink/ink-api-endpoints/eth-get-filter-changes)           |
+| [`eth_getFilterLogs`](/docs/chain-apis/ink/ink-api-endpoints/eth-get-filter-logs)                     | [`eth_getLogs`](/docs/chain-apis/ink/ink-api-endpoints/eth-get-logs)                              |
+| [`eth_getStorageAt`](/docs/chain-apis/ink/ink-api-endpoints/eth-get-storage-at)                       | [`eth_getTransactionByBlockHashAndIndex`](/docs/chain-apis/ink/ink-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
+| [`eth_getTransactionByBlockNumberAndIndex`](/docs/chain-apis/ink/ink-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/chain-apis/ink/ink-api-endpoints/eth-get-transaction-by-hash)  |
+| [`eth_getTransactionCount`](/docs/chain-apis/ink/ink-api-endpoints/eth-get-transaction-count)         | [`eth_getTransactionReceipt`](/docs/chain-apis/ink/ink-api-endpoints/eth-get-transaction-receipt) |
+| [`eth_newBlockFilter`](/docs/chain-apis/ink/ink-api-endpoints/eth-new-block-filter)                   | [`eth_newFilter`](/docs/chain-apis/ink/ink-api-endpoints/eth-new-filter)                          |
+| [`eth_sendRawTransaction`](/docs/chain-apis/ink/ink-api-endpoints/eth-send-raw-transaction)           | [`eth_simulateV1`](/docs/chain-apis/ink/ink-api-endpoints/eth-simulate-v-1)                       |
+| [`eth_submitWork`](/docs/chain-apis/ink/ink-api-endpoints/eth-submit-work)                            | [`eth_subscribe`](/docs/chain-apis/ink/ink-api-endpoints/eth-subscribe)                           |
+| [`eth_uninstallFilter`](/docs/chain-apis/ink/ink-api-endpoints/eth-uninstall-filter)                  | [`eth_unsubscribe`](/docs/chain-apis/ink/ink-api-endpoints/eth-unsubscribe)                       |
+| [`net_version`](/docs/chain-apis/ink/ink-api-endpoints/net-version)                                   | [`web3_clientVersion`](/docs/chain-apis/ink/ink-api-endpoints/web-3-client-version)               |
+| [`web3_sha3`](/docs/chain-apis/ink/ink-api-endpoints/web-3-sha-3)                                     |                                                                                             |
 
 ## Lens APIs
 
@@ -733,22 +733,22 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_blockNumber`](/docs/node/lens/lens-api-endpoints/eth-block-number)                        | [`eth_call`](/docs/node/lens/lens-api-endpoints/eth-call)                                   |
-| [`eth_callMany`](/docs/node/lens/lens-api-endpoints/eth-call-many)                              | [`eth_chainId`](/docs/node/lens/lens-api-endpoints/eth-chain-id)                            |
-| [`eth_estimateGas`](/docs/node/lens/lens-api-endpoints/eth-estimate-gas)                        | [`eth_gasPrice`](/docs/node/lens/lens-api-endpoints/eth-gas-price)                          |
-| [`eth_getAccount`](/docs/node/lens/lens-api-endpoints/eth-get-account)                          | [`eth_getBalance`](/docs/node/lens/lens-api-endpoints/eth-get-balance)                      |
-| [`eth_getBlockByHash`](/docs/node/lens/lens-api-endpoints/eth-get-block-by-hash)                | [`eth_getBlockByNumber`](/docs/node/lens/lens-api-endpoints/eth-get-block-by-number)        |
-| [`eth_getBlockTransactionCountByHash`](/docs/node/lens/lens-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/node/lens/lens-api-endpoints/eth-get-block-transaction-count-by-number) |
-| [`eth_getCode`](/docs/node/lens/lens-api-endpoints/eth-get-code)                                | [`eth_getFilterChanges`](/docs/node/lens/lens-api-endpoints/eth-get-filter-changes)         |
-| [`eth_getFilterLogs`](/docs/node/lens/lens-api-endpoints/eth-get-filter-logs)                   | [`eth_getLogs`](/docs/node/lens/lens-api-endpoints/eth-get-logs)                            |
-| [`eth_getStorageAt`](/docs/node/lens/lens-api-endpoints/eth-get-storage-at)                     | [`eth_getTransactionByBlockHashAndIndex`](/docs/node/lens/lens-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
-| [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/lens/lens-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/node/lens/lens-api-endpoints/eth-get-transaction-by-hash) |
-| [`eth_getTransactionCount`](/docs/node/lens/lens-api-endpoints/eth-get-transaction-count)       | [`eth_getTransactionReceipt`](/docs/node/lens/lens-api-endpoints/eth-get-transaction-receipt) |
-| [`eth_newBlockFilter`](/docs/node/lens/lens-api-endpoints/eth-new-block-filter)                 | [`eth_newFilter`](/docs/node/lens/lens-api-endpoints/eth-new-filter)                        |
-| [`eth_sendRawTransaction`](/docs/node/lens/lens-api-endpoints/eth-send-raw-transaction)         | [`eth_submitWork`](/docs/node/lens/lens-api-endpoints/eth-submit-work)                      |
-| [`eth_subscribe`](/docs/node/lens/lens-api-endpoints/eth-subscribe)                             | [`eth_uninstallFilter`](/docs/node/lens/lens-api-endpoints/eth-uninstall-filter)            |
-| [`eth_unsubscribe`](/docs/node/lens/lens-api-endpoints/eth-unsubscribe)                         | [`net_version`](/docs/node/lens/lens-api-endpoints/net-version)                             |
-| [`web3_clientVersion`](/docs/node/lens/lens-api-endpoints/web-3-client-version)                 | [`web3_sha3`](/docs/node/lens/lens-api-endpoints/web-3-sha-3)                               |
+| [`eth_blockNumber`](/docs/chain-apis/lens/lens-api-endpoints/eth-block-number)                        | [`eth_call`](/docs/chain-apis/lens/lens-api-endpoints/eth-call)                                   |
+| [`eth_callMany`](/docs/chain-apis/lens/lens-api-endpoints/eth-call-many)                              | [`eth_chainId`](/docs/chain-apis/lens/lens-api-endpoints/eth-chain-id)                            |
+| [`eth_estimateGas`](/docs/chain-apis/lens/lens-api-endpoints/eth-estimate-gas)                        | [`eth_gasPrice`](/docs/chain-apis/lens/lens-api-endpoints/eth-gas-price)                          |
+| [`eth_getAccount`](/docs/chain-apis/lens/lens-api-endpoints/eth-get-account)                          | [`eth_getBalance`](/docs/chain-apis/lens/lens-api-endpoints/eth-get-balance)                      |
+| [`eth_getBlockByHash`](/docs/chain-apis/lens/lens-api-endpoints/eth-get-block-by-hash)                | [`eth_getBlockByNumber`](/docs/chain-apis/lens/lens-api-endpoints/eth-get-block-by-number)        |
+| [`eth_getBlockTransactionCountByHash`](/docs/chain-apis/lens/lens-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/chain-apis/lens/lens-api-endpoints/eth-get-block-transaction-count-by-number) |
+| [`eth_getCode`](/docs/chain-apis/lens/lens-api-endpoints/eth-get-code)                                | [`eth_getFilterChanges`](/docs/chain-apis/lens/lens-api-endpoints/eth-get-filter-changes)         |
+| [`eth_getFilterLogs`](/docs/chain-apis/lens/lens-api-endpoints/eth-get-filter-logs)                   | [`eth_getLogs`](/docs/chain-apis/lens/lens-api-endpoints/eth-get-logs)                            |
+| [`eth_getStorageAt`](/docs/chain-apis/lens/lens-api-endpoints/eth-get-storage-at)                     | [`eth_getTransactionByBlockHashAndIndex`](/docs/chain-apis/lens/lens-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
+| [`eth_getTransactionByBlockNumberAndIndex`](/docs/chain-apis/lens/lens-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/chain-apis/lens/lens-api-endpoints/eth-get-transaction-by-hash) |
+| [`eth_getTransactionCount`](/docs/chain-apis/lens/lens-api-endpoints/eth-get-transaction-count)       | [`eth_getTransactionReceipt`](/docs/chain-apis/lens/lens-api-endpoints/eth-get-transaction-receipt) |
+| [`eth_newBlockFilter`](/docs/chain-apis/lens/lens-api-endpoints/eth-new-block-filter)                 | [`eth_newFilter`](/docs/chain-apis/lens/lens-api-endpoints/eth-new-filter)                        |
+| [`eth_sendRawTransaction`](/docs/chain-apis/lens/lens-api-endpoints/eth-send-raw-transaction)         | [`eth_submitWork`](/docs/chain-apis/lens/lens-api-endpoints/eth-submit-work)                      |
+| [`eth_subscribe`](/docs/chain-apis/lens/lens-api-endpoints/eth-subscribe)                             | [`eth_uninstallFilter`](/docs/chain-apis/lens/lens-api-endpoints/eth-uninstall-filter)            |
+| [`eth_unsubscribe`](/docs/chain-apis/lens/lens-api-endpoints/eth-unsubscribe)                         | [`net_version`](/docs/chain-apis/lens/lens-api-endpoints/net-version)                             |
+| [`web3_clientVersion`](/docs/chain-apis/lens/lens-api-endpoints/web-3-client-version)                 | [`web3_sha3`](/docs/chain-apis/lens/lens-api-endpoints/web-3-sha-3)                               |
 
 ## Linea APIs
 
@@ -756,28 +756,28 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_blockNumber`](/docs/node/linea/linea-api-endpoints/eth-block-number)                      | [`eth_call`](/docs/node/linea/linea-api-endpoints/eth-call)                                 |
-| [`eth_callMany`](/docs/node/linea/linea-api-endpoints/eth-call-many)                            | [`eth_chainId`](/docs/node/linea/linea-api-endpoints/eth-chain-id)                          |
-| [`eth_createAccessList`](/docs/node/linea/linea-api-endpoints/eth-create-access-list)           | [`eth_estimateGas`](/docs/node/linea/linea-api-endpoints/eth-estimate-gas)                  |
-| [`eth_feeHistory`](/docs/node/linea/linea-api-endpoints/eth-fee-history)                        | [`eth_gasPrice`](/docs/node/linea/linea-api-endpoints/eth-gas-price)                        |
-| [`eth_getAccount`](/docs/node/linea/linea-api-endpoints/eth-get-account)                        | [`eth_getBalance`](/docs/node/linea/linea-api-endpoints/eth-get-balance)                    |
-| [`eth_getBlockByHash`](/docs/node/linea/linea-api-endpoints/eth-get-block-by-hash)              | [`eth_getBlockByNumber`](/docs/node/linea/linea-api-endpoints/eth-get-block-by-number)      |
-| [`eth_getBlockReceipts`](/docs/node/linea/linea-api-endpoints/eth-get-block-receipts)           | [`eth_getBlockTransactionCountByHash`](/docs/node/linea/linea-api-endpoints/eth-get-block-transaction-count-by-hash) |
-| [`eth_getBlockTransactionCountByNumber`](/docs/node/linea/linea-api-endpoints/eth-get-block-transaction-count-by-number) | [`eth_getCode`](/docs/node/linea/linea-api-endpoints/eth-get-code)                          |
-| [`eth_getFilterChanges`](/docs/node/linea/linea-api-endpoints/eth-get-filter-changes)           | [`eth_getFilterLogs`](/docs/node/linea/linea-api-endpoints/eth-get-filter-logs)             |
-| [`eth_getLogs`](/docs/node/linea/linea-api-endpoints/eth-get-logs)                              | [`eth_getProof`](/docs/node/linea/linea-api-endpoints/eth-get-proof)                        |
-| [`eth_getStorageAt`](/docs/node/linea/linea-api-endpoints/eth-get-storage-at)                   | [`eth_getTransactionByBlockHashAndIndex`](/docs/node/linea/linea-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
-| [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/linea/linea-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/node/linea/linea-api-endpoints/eth-get-transaction-by-hash) |
-| [`eth_getTransactionCount`](/docs/node/linea/linea-api-endpoints/eth-get-transaction-count)     | [`eth_getTransactionReceipt`](/docs/node/linea/linea-api-endpoints/eth-get-transaction-receipt) |
-| [`eth_getUncleByBlockHashAndIndex`](/docs/node/linea/linea-api-endpoints/eth-get-uncle-by-block-hash-and-index) | [`eth_getUncleByBlockNumberAndIndex`](/docs/node/linea/linea-api-endpoints/eth-get-uncle-by-block-number-and-index) |
-| [`eth_getUncleCountByBlockHash`](/docs/node/linea/linea-api-endpoints/eth-get-uncle-count-by-block-hash) | [`eth_getUncleCountByBlockNumber`](/docs/node/linea/linea-api-endpoints/eth-get-uncle-count-by-block-number) |
-| [`eth_maxPriorityFeePerGas`](/docs/node/linea/linea-api-endpoints/eth-max-priority-fee-per-gas) | [`eth_newBlockFilter`](/docs/node/linea/linea-api-endpoints/eth-new-block-filter)           |
-| [`eth_newFilter`](/docs/node/linea/linea-api-endpoints/eth-new-filter)                          | [`eth_protocolVersion`](/docs/node/linea/linea-api-endpoints/eth-protocol-version)          |
-| [`eth_sendRawTransaction`](/docs/node/linea/linea-api-endpoints/eth-send-raw-transaction)       | [`eth_submitWork`](/docs/node/linea/linea-api-endpoints/eth-submit-work)                    |
-| [`eth_subscribe`](/docs/node/linea/linea-api-endpoints/eth-subscribe)                           | [`eth_syncing`](/docs/node/linea/linea-api-endpoints/eth-syncing)                           |
-| [`eth_uninstallFilter`](/docs/node/linea/linea-api-endpoints/eth-uninstall-filter)              | [`eth_unsubscribe`](/docs/node/linea/linea-api-endpoints/eth-unsubscribe)                   |
-| [`linea_estimateGas`](/docs/node/linea/linea-api-endpoints/linea-estimate-gas)                  | [`net_version`](/docs/node/linea/linea-api-endpoints/net-version)                           |
-| [`web3_clientVersion`](/docs/node/linea/linea-api-endpoints/web-3-client-version)               | [`web3_sha3`](/docs/node/linea/linea-api-endpoints/web-3-sha-3)                             |
+| [`eth_blockNumber`](/docs/chain-apis/linea/linea-api-endpoints/eth-block-number)                      | [`eth_call`](/docs/chain-apis/linea/linea-api-endpoints/eth-call)                                 |
+| [`eth_callMany`](/docs/chain-apis/linea/linea-api-endpoints/eth-call-many)                            | [`eth_chainId`](/docs/chain-apis/linea/linea-api-endpoints/eth-chain-id)                          |
+| [`eth_createAccessList`](/docs/chain-apis/linea/linea-api-endpoints/eth-create-access-list)           | [`eth_estimateGas`](/docs/chain-apis/linea/linea-api-endpoints/eth-estimate-gas)                  |
+| [`eth_feeHistory`](/docs/chain-apis/linea/linea-api-endpoints/eth-fee-history)                        | [`eth_gasPrice`](/docs/chain-apis/linea/linea-api-endpoints/eth-gas-price)                        |
+| [`eth_getAccount`](/docs/chain-apis/linea/linea-api-endpoints/eth-get-account)                        | [`eth_getBalance`](/docs/chain-apis/linea/linea-api-endpoints/eth-get-balance)                    |
+| [`eth_getBlockByHash`](/docs/chain-apis/linea/linea-api-endpoints/eth-get-block-by-hash)              | [`eth_getBlockByNumber`](/docs/chain-apis/linea/linea-api-endpoints/eth-get-block-by-number)      |
+| [`eth_getBlockReceipts`](/docs/chain-apis/linea/linea-api-endpoints/eth-get-block-receipts)           | [`eth_getBlockTransactionCountByHash`](/docs/chain-apis/linea/linea-api-endpoints/eth-get-block-transaction-count-by-hash) |
+| [`eth_getBlockTransactionCountByNumber`](/docs/chain-apis/linea/linea-api-endpoints/eth-get-block-transaction-count-by-number) | [`eth_getCode`](/docs/chain-apis/linea/linea-api-endpoints/eth-get-code)                          |
+| [`eth_getFilterChanges`](/docs/chain-apis/linea/linea-api-endpoints/eth-get-filter-changes)           | [`eth_getFilterLogs`](/docs/chain-apis/linea/linea-api-endpoints/eth-get-filter-logs)             |
+| [`eth_getLogs`](/docs/chain-apis/linea/linea-api-endpoints/eth-get-logs)                              | [`eth_getProof`](/docs/chain-apis/linea/linea-api-endpoints/eth-get-proof)                        |
+| [`eth_getStorageAt`](/docs/chain-apis/linea/linea-api-endpoints/eth-get-storage-at)                   | [`eth_getTransactionByBlockHashAndIndex`](/docs/chain-apis/linea/linea-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
+| [`eth_getTransactionByBlockNumberAndIndex`](/docs/chain-apis/linea/linea-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/chain-apis/linea/linea-api-endpoints/eth-get-transaction-by-hash) |
+| [`eth_getTransactionCount`](/docs/chain-apis/linea/linea-api-endpoints/eth-get-transaction-count)     | [`eth_getTransactionReceipt`](/docs/chain-apis/linea/linea-api-endpoints/eth-get-transaction-receipt) |
+| [`eth_getUncleByBlockHashAndIndex`](/docs/chain-apis/linea/linea-api-endpoints/eth-get-uncle-by-block-hash-and-index) | [`eth_getUncleByBlockNumberAndIndex`](/docs/chain-apis/linea/linea-api-endpoints/eth-get-uncle-by-block-number-and-index) |
+| [`eth_getUncleCountByBlockHash`](/docs/chain-apis/linea/linea-api-endpoints/eth-get-uncle-count-by-block-hash) | [`eth_getUncleCountByBlockNumber`](/docs/chain-apis/linea/linea-api-endpoints/eth-get-uncle-count-by-block-number) |
+| [`eth_maxPriorityFeePerGas`](/docs/chain-apis/linea/linea-api-endpoints/eth-max-priority-fee-per-gas) | [`eth_newBlockFilter`](/docs/chain-apis/linea/linea-api-endpoints/eth-new-block-filter)           |
+| [`eth_newFilter`](/docs/chain-apis/linea/linea-api-endpoints/eth-new-filter)                          | [`eth_protocolVersion`](/docs/chain-apis/linea/linea-api-endpoints/eth-protocol-version)          |
+| [`eth_sendRawTransaction`](/docs/chain-apis/linea/linea-api-endpoints/eth-send-raw-transaction)       | [`eth_submitWork`](/docs/chain-apis/linea/linea-api-endpoints/eth-submit-work)                    |
+| [`eth_subscribe`](/docs/chain-apis/linea/linea-api-endpoints/eth-subscribe)                           | [`eth_syncing`](/docs/chain-apis/linea/linea-api-endpoints/eth-syncing)                           |
+| [`eth_uninstallFilter`](/docs/chain-apis/linea/linea-api-endpoints/eth-uninstall-filter)              | [`eth_unsubscribe`](/docs/chain-apis/linea/linea-api-endpoints/eth-unsubscribe)                   |
+| [`linea_estimateGas`](/docs/chain-apis/linea/linea-api-endpoints/linea-estimate-gas)                  | [`net_version`](/docs/chain-apis/linea/linea-api-endpoints/net-version)                           |
+| [`web3_clientVersion`](/docs/chain-apis/linea/linea-api-endpoints/web-3-client-version)               | [`web3_sha3`](/docs/chain-apis/linea/linea-api-endpoints/web-3-sha-3)                             |
 
 ## Lumia APIs
 
@@ -785,22 +785,22 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_blockNumber`](/docs/node/lumia/lumia-api-endpoints/eth-block-number)                      | [`eth_call`](/docs/node/lumia/lumia-api-endpoints/eth-call)                                 |
-| [`eth_callMany`](/docs/node/lumia/lumia-api-endpoints/eth-call-many)                            | [`eth_chainId`](/docs/node/lumia/lumia-api-endpoints/eth-chain-id)                          |
-| [`eth_estimateGas`](/docs/node/lumia/lumia-api-endpoints/eth-estimate-gas)                      | [`eth_gasPrice`](/docs/node/lumia/lumia-api-endpoints/eth-gas-price)                        |
-| [`eth_getAccount`](/docs/node/lumia/lumia-api-endpoints/eth-get-account)                        | [`eth_getBalance`](/docs/node/lumia/lumia-api-endpoints/eth-get-balance)                    |
-| [`eth_getBlockByHash`](/docs/node/lumia/lumia-api-endpoints/eth-get-block-by-hash)              | [`eth_getBlockByNumber`](/docs/node/lumia/lumia-api-endpoints/eth-get-block-by-number)      |
-| [`eth_getBlockTransactionCountByHash`](/docs/node/lumia/lumia-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/node/lumia/lumia-api-endpoints/eth-get-block-transaction-count-by-number) |
-| [`eth_getCode`](/docs/node/lumia/lumia-api-endpoints/eth-get-code)                              | [`eth_getFilterChanges`](/docs/node/lumia/lumia-api-endpoints/eth-get-filter-changes)       |
-| [`eth_getFilterLogs`](/docs/node/lumia/lumia-api-endpoints/eth-get-filter-logs)                 | [`eth_getLogs`](/docs/node/lumia/lumia-api-endpoints/eth-get-logs)                          |
-| [`eth_getStorageAt`](/docs/node/lumia/lumia-api-endpoints/eth-get-storage-at)                   | [`eth_getTransactionByBlockHashAndIndex`](/docs/node/lumia/lumia-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
-| [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/lumia/lumia-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/node/lumia/lumia-api-endpoints/eth-get-transaction-by-hash) |
-| [`eth_getTransactionCount`](/docs/node/lumia/lumia-api-endpoints/eth-get-transaction-count)     | [`eth_getTransactionReceipt`](/docs/node/lumia/lumia-api-endpoints/eth-get-transaction-receipt) |
-| [`eth_newBlockFilter`](/docs/node/lumia/lumia-api-endpoints/eth-new-block-filter)               | [`eth_newFilter`](/docs/node/lumia/lumia-api-endpoints/eth-new-filter)                      |
-| [`eth_sendRawTransaction`](/docs/node/lumia/lumia-api-endpoints/eth-send-raw-transaction)       | [`eth_submitWork`](/docs/node/lumia/lumia-api-endpoints/eth-submit-work)                    |
-| [`eth_subscribe`](/docs/node/lumia/lumia-api-endpoints/eth-subscribe)                           | [`eth_uninstallFilter`](/docs/node/lumia/lumia-api-endpoints/eth-uninstall-filter)          |
-| [`eth_unsubscribe`](/docs/node/lumia/lumia-api-endpoints/eth-unsubscribe)                       | [`net_version`](/docs/node/lumia/lumia-api-endpoints/net-version)                           |
-| [`web3_clientVersion`](/docs/node/lumia/lumia-api-endpoints/web-3-client-version)               | [`web3_sha3`](/docs/node/lumia/lumia-api-endpoints/web-3-sha-3)                             |
+| [`eth_blockNumber`](/docs/chain-apis/lumia/lumia-api-endpoints/eth-block-number)                      | [`eth_call`](/docs/chain-apis/lumia/lumia-api-endpoints/eth-call)                                 |
+| [`eth_callMany`](/docs/chain-apis/lumia/lumia-api-endpoints/eth-call-many)                            | [`eth_chainId`](/docs/chain-apis/lumia/lumia-api-endpoints/eth-chain-id)                          |
+| [`eth_estimateGas`](/docs/chain-apis/lumia/lumia-api-endpoints/eth-estimate-gas)                      | [`eth_gasPrice`](/docs/chain-apis/lumia/lumia-api-endpoints/eth-gas-price)                        |
+| [`eth_getAccount`](/docs/chain-apis/lumia/lumia-api-endpoints/eth-get-account)                        | [`eth_getBalance`](/docs/chain-apis/lumia/lumia-api-endpoints/eth-get-balance)                    |
+| [`eth_getBlockByHash`](/docs/chain-apis/lumia/lumia-api-endpoints/eth-get-block-by-hash)              | [`eth_getBlockByNumber`](/docs/chain-apis/lumia/lumia-api-endpoints/eth-get-block-by-number)      |
+| [`eth_getBlockTransactionCountByHash`](/docs/chain-apis/lumia/lumia-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/chain-apis/lumia/lumia-api-endpoints/eth-get-block-transaction-count-by-number) |
+| [`eth_getCode`](/docs/chain-apis/lumia/lumia-api-endpoints/eth-get-code)                              | [`eth_getFilterChanges`](/docs/chain-apis/lumia/lumia-api-endpoints/eth-get-filter-changes)       |
+| [`eth_getFilterLogs`](/docs/chain-apis/lumia/lumia-api-endpoints/eth-get-filter-logs)                 | [`eth_getLogs`](/docs/chain-apis/lumia/lumia-api-endpoints/eth-get-logs)                          |
+| [`eth_getStorageAt`](/docs/chain-apis/lumia/lumia-api-endpoints/eth-get-storage-at)                   | [`eth_getTransactionByBlockHashAndIndex`](/docs/chain-apis/lumia/lumia-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
+| [`eth_getTransactionByBlockNumberAndIndex`](/docs/chain-apis/lumia/lumia-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/chain-apis/lumia/lumia-api-endpoints/eth-get-transaction-by-hash) |
+| [`eth_getTransactionCount`](/docs/chain-apis/lumia/lumia-api-endpoints/eth-get-transaction-count)     | [`eth_getTransactionReceipt`](/docs/chain-apis/lumia/lumia-api-endpoints/eth-get-transaction-receipt) |
+| [`eth_newBlockFilter`](/docs/chain-apis/lumia/lumia-api-endpoints/eth-new-block-filter)               | [`eth_newFilter`](/docs/chain-apis/lumia/lumia-api-endpoints/eth-new-filter)                      |
+| [`eth_sendRawTransaction`](/docs/chain-apis/lumia/lumia-api-endpoints/eth-send-raw-transaction)       | [`eth_submitWork`](/docs/chain-apis/lumia/lumia-api-endpoints/eth-submit-work)                    |
+| [`eth_subscribe`](/docs/chain-apis/lumia/lumia-api-endpoints/eth-subscribe)                           | [`eth_uninstallFilter`](/docs/chain-apis/lumia/lumia-api-endpoints/eth-uninstall-filter)          |
+| [`eth_unsubscribe`](/docs/chain-apis/lumia/lumia-api-endpoints/eth-unsubscribe)                       | [`net_version`](/docs/chain-apis/lumia/lumia-api-endpoints/net-version)                           |
+| [`web3_clientVersion`](/docs/chain-apis/lumia/lumia-api-endpoints/web-3-client-version)               | [`web3_sha3`](/docs/chain-apis/lumia/lumia-api-endpoints/web-3-sha-3)                             |
 
 ## Mantle APIs
 
@@ -808,26 +808,26 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_blockNumber`](/docs/node/mantle/mantle-api-endpoints/eth-block-number)                    | [`eth_call`](/docs/node/mantle/mantle-api-endpoints/eth-call)                               |
-| [`eth_callMany`](/docs/node/mantle/mantle-api-endpoints/eth-call-many)                          | [`eth_chainId`](/docs/node/mantle/mantle-api-endpoints/eth-chain-id)                        |
-| [`eth_estimateGas`](/docs/node/mantle/mantle-api-endpoints/eth-estimate-gas)                    | [`eth_feeHistory`](/docs/node/mantle/mantle-api-endpoints/eth-fee-history)                  |
-| [`eth_gasPrice`](/docs/node/mantle/mantle-api-endpoints/eth-gas-price)                          | [`eth_getAccount`](/docs/node/mantle/mantle-api-endpoints/eth-get-account)                  |
-| [`eth_getBalance`](/docs/node/mantle/mantle-api-endpoints/eth-get-balance)                      | [`eth_getBlockByHash`](/docs/node/mantle/mantle-api-endpoints/eth-get-block-by-hash)        |
-| [`eth_getBlockByNumber`](/docs/node/mantle/mantle-api-endpoints/eth-get-block-by-number)        | [`eth_getBlockTransactionCountByHash`](/docs/node/mantle/mantle-api-endpoints/eth-get-block-transaction-count-by-hash) |
-| [`eth_getBlockTransactionCountByNumber`](/docs/node/mantle/mantle-api-endpoints/eth-get-block-transaction-count-by-number) | [`eth_getCode`](/docs/node/mantle/mantle-api-endpoints/eth-get-code)                        |
-| [`eth_getFilterChanges`](/docs/node/mantle/mantle-api-endpoints/eth-get-filter-changes)         | [`eth_getFilterLogs`](/docs/node/mantle/mantle-api-endpoints/eth-get-filter-logs)           |
-| [`eth_getLogs`](/docs/node/mantle/mantle-api-endpoints/eth-get-logs)                            | [`eth_getProof`](/docs/node/mantle/mantle-api-endpoints/eth-get-proof)                      |
-| [`eth_getStorageAt`](/docs/node/mantle/mantle-api-endpoints/eth-get-storage-at)                 | [`eth_getTransactionByBlockHashAndIndex`](/docs/node/mantle/mantle-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
-| [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/mantle/mantle-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/node/mantle/mantle-api-endpoints/eth-get-transaction-by-hash) |
-| [`eth_getTransactionCount`](/docs/node/mantle/mantle-api-endpoints/eth-get-transaction-count)   | [`eth_getTransactionReceipt`](/docs/node/mantle/mantle-api-endpoints/eth-get-transaction-receipt) |
-| [`eth_getUncleByBlockHashAndIndex`](/docs/node/mantle/mantle-api-endpoints/eth-get-uncle-by-block-hash-and-index) | [`eth_getUncleByBlockNumberAndIndex`](/docs/node/mantle/mantle-api-endpoints/eth-get-uncle-by-block-number-and-index) |
-| [`eth_getUncleCountByBlockHash`](/docs/node/mantle/mantle-api-endpoints/eth-get-uncle-count-by-block-hash) | [`eth_getUncleCountByBlockNumber`](/docs/node/mantle/mantle-api-endpoints/eth-get-uncle-count-by-block-number) |
-| [`eth_maxPriorityFeePerGas`](/docs/node/mantle/mantle-api-endpoints/eth-max-priority-fee-per-gas) | [`eth_newBlockFilter`](/docs/node/mantle/mantle-api-endpoints/eth-new-block-filter)         |
-| [`eth_newFilter`](/docs/node/mantle/mantle-api-endpoints/eth-new-filter)                        | [`eth_sendRawTransaction`](/docs/node/mantle/mantle-api-endpoints/eth-send-raw-transaction) |
-| [`eth_submitWork`](/docs/node/mantle/mantle-api-endpoints/eth-submit-work)                      | [`eth_subscribe`](/docs/node/mantle/mantle-api-endpoints/eth-subscribe)                     |
-| [`eth_syncing`](/docs/node/mantle/mantle-api-endpoints/eth-syncing)                             | [`eth_uninstallFilter`](/docs/node/mantle/mantle-api-endpoints/eth-uninstall-filter)        |
-| [`eth_unsubscribe`](/docs/node/mantle/mantle-api-endpoints/eth-unsubscribe)                     | [`net_version`](/docs/node/mantle/mantle-api-endpoints/net-version)                         |
-| [`web3_clientVersion`](/docs/node/mantle/mantle-api-endpoints/web-3-client-version)             | [`web3_sha3`](/docs/node/mantle/mantle-api-endpoints/web-3-sha-3)                           |
+| [`eth_blockNumber`](/docs/chain-apis/mantle/mantle-api-endpoints/eth-block-number)                    | [`eth_call`](/docs/chain-apis/mantle/mantle-api-endpoints/eth-call)                               |
+| [`eth_callMany`](/docs/chain-apis/mantle/mantle-api-endpoints/eth-call-many)                          | [`eth_chainId`](/docs/chain-apis/mantle/mantle-api-endpoints/eth-chain-id)                        |
+| [`eth_estimateGas`](/docs/chain-apis/mantle/mantle-api-endpoints/eth-estimate-gas)                    | [`eth_feeHistory`](/docs/chain-apis/mantle/mantle-api-endpoints/eth-fee-history)                  |
+| [`eth_gasPrice`](/docs/chain-apis/mantle/mantle-api-endpoints/eth-gas-price)                          | [`eth_getAccount`](/docs/chain-apis/mantle/mantle-api-endpoints/eth-get-account)                  |
+| [`eth_getBalance`](/docs/chain-apis/mantle/mantle-api-endpoints/eth-get-balance)                      | [`eth_getBlockByHash`](/docs/chain-apis/mantle/mantle-api-endpoints/eth-get-block-by-hash)        |
+| [`eth_getBlockByNumber`](/docs/chain-apis/mantle/mantle-api-endpoints/eth-get-block-by-number)        | [`eth_getBlockTransactionCountByHash`](/docs/chain-apis/mantle/mantle-api-endpoints/eth-get-block-transaction-count-by-hash) |
+| [`eth_getBlockTransactionCountByNumber`](/docs/chain-apis/mantle/mantle-api-endpoints/eth-get-block-transaction-count-by-number) | [`eth_getCode`](/docs/chain-apis/mantle/mantle-api-endpoints/eth-get-code)                        |
+| [`eth_getFilterChanges`](/docs/chain-apis/mantle/mantle-api-endpoints/eth-get-filter-changes)         | [`eth_getFilterLogs`](/docs/chain-apis/mantle/mantle-api-endpoints/eth-get-filter-logs)           |
+| [`eth_getLogs`](/docs/chain-apis/mantle/mantle-api-endpoints/eth-get-logs)                            | [`eth_getProof`](/docs/chain-apis/mantle/mantle-api-endpoints/eth-get-proof)                      |
+| [`eth_getStorageAt`](/docs/chain-apis/mantle/mantle-api-endpoints/eth-get-storage-at)                 | [`eth_getTransactionByBlockHashAndIndex`](/docs/chain-apis/mantle/mantle-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
+| [`eth_getTransactionByBlockNumberAndIndex`](/docs/chain-apis/mantle/mantle-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/chain-apis/mantle/mantle-api-endpoints/eth-get-transaction-by-hash) |
+| [`eth_getTransactionCount`](/docs/chain-apis/mantle/mantle-api-endpoints/eth-get-transaction-count)   | [`eth_getTransactionReceipt`](/docs/chain-apis/mantle/mantle-api-endpoints/eth-get-transaction-receipt) |
+| [`eth_getUncleByBlockHashAndIndex`](/docs/chain-apis/mantle/mantle-api-endpoints/eth-get-uncle-by-block-hash-and-index) | [`eth_getUncleByBlockNumberAndIndex`](/docs/chain-apis/mantle/mantle-api-endpoints/eth-get-uncle-by-block-number-and-index) |
+| [`eth_getUncleCountByBlockHash`](/docs/chain-apis/mantle/mantle-api-endpoints/eth-get-uncle-count-by-block-hash) | [`eth_getUncleCountByBlockNumber`](/docs/chain-apis/mantle/mantle-api-endpoints/eth-get-uncle-count-by-block-number) |
+| [`eth_maxPriorityFeePerGas`](/docs/chain-apis/mantle/mantle-api-endpoints/eth-max-priority-fee-per-gas) | [`eth_newBlockFilter`](/docs/chain-apis/mantle/mantle-api-endpoints/eth-new-block-filter)         |
+| [`eth_newFilter`](/docs/chain-apis/mantle/mantle-api-endpoints/eth-new-filter)                        | [`eth_sendRawTransaction`](/docs/chain-apis/mantle/mantle-api-endpoints/eth-send-raw-transaction) |
+| [`eth_submitWork`](/docs/chain-apis/mantle/mantle-api-endpoints/eth-submit-work)                      | [`eth_subscribe`](/docs/chain-apis/mantle/mantle-api-endpoints/eth-subscribe)                     |
+| [`eth_syncing`](/docs/chain-apis/mantle/mantle-api-endpoints/eth-syncing)                             | [`eth_uninstallFilter`](/docs/chain-apis/mantle/mantle-api-endpoints/eth-uninstall-filter)        |
+| [`eth_unsubscribe`](/docs/chain-apis/mantle/mantle-api-endpoints/eth-unsubscribe)                     | [`net_version`](/docs/chain-apis/mantle/mantle-api-endpoints/net-version)                         |
+| [`web3_clientVersion`](/docs/chain-apis/mantle/mantle-api-endpoints/web-3-client-version)             | [`web3_sha3`](/docs/chain-apis/mantle/mantle-api-endpoints/web-3-sha-3)                           |
 
 ## Metis APIs
 
@@ -835,27 +835,27 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_blockNumber`](/docs/node/metis/metis-api-endpoints/eth-block-number)                      | [`eth_call`](/docs/node/metis/metis-api-endpoints/eth-call)                                 |
-| [`eth_callMany`](/docs/node/metis/metis-api-endpoints/eth-call-many)                            | [`eth_chainId`](/docs/node/metis/metis-api-endpoints/eth-chain-id)                          |
-| [`eth_estimateGas`](/docs/node/metis/metis-api-endpoints/eth-estimate-gas)                      | [`eth_feeHistory`](/docs/node/metis/metis-api-endpoints/eth-fee-history)                    |
-| [`eth_gasPrice`](/docs/node/metis/metis-api-endpoints/eth-gas-price)                            | [`eth_getAccount`](/docs/node/metis/metis-api-endpoints/eth-get-account)                    |
-| [`eth_getBalance`](/docs/node/metis/metis-api-endpoints/eth-get-balance)                        | [`eth_getBlockByHash`](/docs/node/metis/metis-api-endpoints/eth-get-block-by-hash)          |
-| [`eth_getBlockByNumber`](/docs/node/metis/metis-api-endpoints/eth-get-block-by-number)          | [`eth_getBlockReceipts`](/docs/node/metis/metis-api-endpoints/eth-get-block-receipts)       |
-| [`eth_getBlockTransactionCountByHash`](/docs/node/metis/metis-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/node/metis/metis-api-endpoints/eth-get-block-transaction-count-by-number) |
-| [`eth_getCode`](/docs/node/metis/metis-api-endpoints/eth-get-code)                              | [`eth_getFilterChanges`](/docs/node/metis/metis-api-endpoints/eth-get-filter-changes)       |
-| [`eth_getFilterLogs`](/docs/node/metis/metis-api-endpoints/eth-get-filter-logs)                 | [`eth_getLogs`](/docs/node/metis/metis-api-endpoints/eth-get-logs)                          |
-| [`eth_getProof`](/docs/node/metis/metis-api-endpoints/eth-get-proof)                            | [`eth_getStorageAt`](/docs/node/metis/metis-api-endpoints/eth-get-storage-at)               |
-| [`eth_getTransactionByBlockHashAndIndex`](/docs/node/metis/metis-api-endpoints/eth-get-transaction-by-block-hash-and-index) | [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/metis/metis-api-endpoints/eth-get-transaction-by-block-number-and-index) |
-| [`eth_getTransactionByHash`](/docs/node/metis/metis-api-endpoints/eth-get-transaction-by-hash)  | [`eth_getTransactionCount`](/docs/node/metis/metis-api-endpoints/eth-get-transaction-count) |
-| [`eth_getTransactionReceipt`](/docs/node/metis/metis-api-endpoints/eth-get-transaction-receipt) | [`eth_getUncleByBlockHashAndIndex`](/docs/node/metis/metis-api-endpoints/eth-get-uncle-by-block-hash-and-index) |
-| [`eth_getUncleByBlockNumberAndIndex`](/docs/node/metis/metis-api-endpoints/eth-get-uncle-by-block-number-and-index) | [`eth_getUncleCountByBlockHash`](/docs/node/metis/metis-api-endpoints/eth-get-uncle-count-by-block-hash) |
-| [`eth_getUncleCountByBlockNumber`](/docs/node/metis/metis-api-endpoints/eth-get-uncle-count-by-block-number) | [`eth_newBlockFilter`](/docs/node/metis/metis-api-endpoints/eth-new-block-filter)           |
-| [`eth_newFilter`](/docs/node/metis/metis-api-endpoints/eth-new-filter)                          | [`eth_protocolVersion`](/docs/node/metis/metis-api-endpoints/eth-protocol-version)          |
-| [`eth_sendRawTransaction`](/docs/node/metis/metis-api-endpoints/eth-send-raw-transaction)       | [`eth_submitWork`](/docs/node/metis/metis-api-endpoints/eth-submit-work)                    |
-| [`eth_subscribe`](/docs/node/metis/metis-api-endpoints/eth-subscribe)                           | [`eth_syncing`](/docs/node/metis/metis-api-endpoints/eth-syncing)                           |
-| [`eth_uninstallFilter`](/docs/node/metis/metis-api-endpoints/eth-uninstall-filter)              | [`eth_unsubscribe`](/docs/node/metis/metis-api-endpoints/eth-unsubscribe)                   |
-| [`net_version`](/docs/node/metis/metis-api-endpoints/net-version)                               | [`web3_clientVersion`](/docs/node/metis/metis-api-endpoints/web-3-client-version)           |
-| [`web3_sha3`](/docs/node/metis/metis-api-endpoints/web-3-sha-3)                                 |                                                                                             |
+| [`eth_blockNumber`](/docs/chain-apis/metis/metis-api-endpoints/eth-block-number)                      | [`eth_call`](/docs/chain-apis/metis/metis-api-endpoints/eth-call)                                 |
+| [`eth_callMany`](/docs/chain-apis/metis/metis-api-endpoints/eth-call-many)                            | [`eth_chainId`](/docs/chain-apis/metis/metis-api-endpoints/eth-chain-id)                          |
+| [`eth_estimateGas`](/docs/chain-apis/metis/metis-api-endpoints/eth-estimate-gas)                      | [`eth_feeHistory`](/docs/chain-apis/metis/metis-api-endpoints/eth-fee-history)                    |
+| [`eth_gasPrice`](/docs/chain-apis/metis/metis-api-endpoints/eth-gas-price)                            | [`eth_getAccount`](/docs/chain-apis/metis/metis-api-endpoints/eth-get-account)                    |
+| [`eth_getBalance`](/docs/chain-apis/metis/metis-api-endpoints/eth-get-balance)                        | [`eth_getBlockByHash`](/docs/chain-apis/metis/metis-api-endpoints/eth-get-block-by-hash)          |
+| [`eth_getBlockByNumber`](/docs/chain-apis/metis/metis-api-endpoints/eth-get-block-by-number)          | [`eth_getBlockReceipts`](/docs/chain-apis/metis/metis-api-endpoints/eth-get-block-receipts)       |
+| [`eth_getBlockTransactionCountByHash`](/docs/chain-apis/metis/metis-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/chain-apis/metis/metis-api-endpoints/eth-get-block-transaction-count-by-number) |
+| [`eth_getCode`](/docs/chain-apis/metis/metis-api-endpoints/eth-get-code)                              | [`eth_getFilterChanges`](/docs/chain-apis/metis/metis-api-endpoints/eth-get-filter-changes)       |
+| [`eth_getFilterLogs`](/docs/chain-apis/metis/metis-api-endpoints/eth-get-filter-logs)                 | [`eth_getLogs`](/docs/chain-apis/metis/metis-api-endpoints/eth-get-logs)                          |
+| [`eth_getProof`](/docs/chain-apis/metis/metis-api-endpoints/eth-get-proof)                            | [`eth_getStorageAt`](/docs/chain-apis/metis/metis-api-endpoints/eth-get-storage-at)               |
+| [`eth_getTransactionByBlockHashAndIndex`](/docs/chain-apis/metis/metis-api-endpoints/eth-get-transaction-by-block-hash-and-index) | [`eth_getTransactionByBlockNumberAndIndex`](/docs/chain-apis/metis/metis-api-endpoints/eth-get-transaction-by-block-number-and-index) |
+| [`eth_getTransactionByHash`](/docs/chain-apis/metis/metis-api-endpoints/eth-get-transaction-by-hash)  | [`eth_getTransactionCount`](/docs/chain-apis/metis/metis-api-endpoints/eth-get-transaction-count) |
+| [`eth_getTransactionReceipt`](/docs/chain-apis/metis/metis-api-endpoints/eth-get-transaction-receipt) | [`eth_getUncleByBlockHashAndIndex`](/docs/chain-apis/metis/metis-api-endpoints/eth-get-uncle-by-block-hash-and-index) |
+| [`eth_getUncleByBlockNumberAndIndex`](/docs/chain-apis/metis/metis-api-endpoints/eth-get-uncle-by-block-number-and-index) | [`eth_getUncleCountByBlockHash`](/docs/chain-apis/metis/metis-api-endpoints/eth-get-uncle-count-by-block-hash) |
+| [`eth_getUncleCountByBlockNumber`](/docs/chain-apis/metis/metis-api-endpoints/eth-get-uncle-count-by-block-number) | [`eth_newBlockFilter`](/docs/chain-apis/metis/metis-api-endpoints/eth-new-block-filter)           |
+| [`eth_newFilter`](/docs/chain-apis/metis/metis-api-endpoints/eth-new-filter)                          | [`eth_protocolVersion`](/docs/chain-apis/metis/metis-api-endpoints/eth-protocol-version)          |
+| [`eth_sendRawTransaction`](/docs/chain-apis/metis/metis-api-endpoints/eth-send-raw-transaction)       | [`eth_submitWork`](/docs/chain-apis/metis/metis-api-endpoints/eth-submit-work)                    |
+| [`eth_subscribe`](/docs/chain-apis/metis/metis-api-endpoints/eth-subscribe)                           | [`eth_syncing`](/docs/chain-apis/metis/metis-api-endpoints/eth-syncing)                           |
+| [`eth_uninstallFilter`](/docs/chain-apis/metis/metis-api-endpoints/eth-uninstall-filter)              | [`eth_unsubscribe`](/docs/chain-apis/metis/metis-api-endpoints/eth-unsubscribe)                   |
+| [`net_version`](/docs/chain-apis/metis/metis-api-endpoints/net-version)                               | [`web3_clientVersion`](/docs/chain-apis/metis/metis-api-endpoints/web-3-client-version)           |
+| [`web3_sha3`](/docs/chain-apis/metis/metis-api-endpoints/web-3-sha-3)                                 |                                                                                             |
 
 ## Mode APIs
 
@@ -863,23 +863,23 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_blockNumber`](/docs/node/mode/mode-api-endpoints/eth-block-number)                        | [`eth_call`](/docs/node/mode/mode-api-endpoints/eth-call)                                   |
-| [`eth_callMany`](/docs/node/mode/mode-api-endpoints/eth-call-many)                              | [`eth_chainId`](/docs/node/mode/mode-api-endpoints/eth-chain-id)                            |
-| [`eth_estimateGas`](/docs/node/mode/mode-api-endpoints/eth-estimate-gas)                        | [`eth_gasPrice`](/docs/node/mode/mode-api-endpoints/eth-gas-price)                          |
-| [`eth_getAccount`](/docs/node/mode/mode-api-endpoints/eth-get-account)                          | [`eth_getBalance`](/docs/node/mode/mode-api-endpoints/eth-get-balance)                      |
-| [`eth_getBlockByHash`](/docs/node/mode/mode-api-endpoints/eth-get-block-by-hash)                | [`eth_getBlockByNumber`](/docs/node/mode/mode-api-endpoints/eth-get-block-by-number)        |
-| [`eth_getBlockTransactionCountByHash`](/docs/node/mode/mode-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/node/mode/mode-api-endpoints/eth-get-block-transaction-count-by-number) |
-| [`eth_getCode`](/docs/node/mode/mode-api-endpoints/eth-get-code)                                | [`eth_getFilterChanges`](/docs/node/mode/mode-api-endpoints/eth-get-filter-changes)         |
-| [`eth_getFilterLogs`](/docs/node/mode/mode-api-endpoints/eth-get-filter-logs)                   | [`eth_getLogs`](/docs/node/mode/mode-api-endpoints/eth-get-logs)                            |
-| [`eth_getStorageAt`](/docs/node/mode/mode-api-endpoints/eth-get-storage-at)                     | [`eth_getTransactionByBlockHashAndIndex`](/docs/node/mode/mode-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
-| [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/mode/mode-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/node/mode/mode-api-endpoints/eth-get-transaction-by-hash) |
-| [`eth_getTransactionCount`](/docs/node/mode/mode-api-endpoints/eth-get-transaction-count)       | [`eth_getTransactionReceipt`](/docs/node/mode/mode-api-endpoints/eth-get-transaction-receipt) |
-| [`eth_newBlockFilter`](/docs/node/mode/mode-api-endpoints/eth-new-block-filter)                 | [`eth_newFilter`](/docs/node/mode/mode-api-endpoints/eth-new-filter)                        |
-| [`eth_sendRawTransaction`](/docs/node/mode/mode-api-endpoints/eth-send-raw-transaction)         | [`eth_simulateV1`](/docs/node/mode/mode-api-endpoints/eth-simulate-v-1)                     |
-| [`eth_submitWork`](/docs/node/mode/mode-api-endpoints/eth-submit-work)                          | [`eth_subscribe`](/docs/node/mode/mode-api-endpoints/eth-subscribe)                         |
-| [`eth_uninstallFilter`](/docs/node/mode/mode-api-endpoints/eth-uninstall-filter)                | [`eth_unsubscribe`](/docs/node/mode/mode-api-endpoints/eth-unsubscribe)                     |
-| [`net_version`](/docs/node/mode/mode-api-endpoints/net-version)                                 | [`web3_clientVersion`](/docs/node/mode/mode-api-endpoints/web-3-client-version)             |
-| [`web3_sha3`](/docs/node/mode/mode-api-endpoints/web-3-sha-3)                                   |                                                                                             |
+| [`eth_blockNumber`](/docs/chain-apis/mode/mode-api-endpoints/eth-block-number)                        | [`eth_call`](/docs/chain-apis/mode/mode-api-endpoints/eth-call)                                   |
+| [`eth_callMany`](/docs/chain-apis/mode/mode-api-endpoints/eth-call-many)                              | [`eth_chainId`](/docs/chain-apis/mode/mode-api-endpoints/eth-chain-id)                            |
+| [`eth_estimateGas`](/docs/chain-apis/mode/mode-api-endpoints/eth-estimate-gas)                        | [`eth_gasPrice`](/docs/chain-apis/mode/mode-api-endpoints/eth-gas-price)                          |
+| [`eth_getAccount`](/docs/chain-apis/mode/mode-api-endpoints/eth-get-account)                          | [`eth_getBalance`](/docs/chain-apis/mode/mode-api-endpoints/eth-get-balance)                      |
+| [`eth_getBlockByHash`](/docs/chain-apis/mode/mode-api-endpoints/eth-get-block-by-hash)                | [`eth_getBlockByNumber`](/docs/chain-apis/mode/mode-api-endpoints/eth-get-block-by-number)        |
+| [`eth_getBlockTransactionCountByHash`](/docs/chain-apis/mode/mode-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/chain-apis/mode/mode-api-endpoints/eth-get-block-transaction-count-by-number) |
+| [`eth_getCode`](/docs/chain-apis/mode/mode-api-endpoints/eth-get-code)                                | [`eth_getFilterChanges`](/docs/chain-apis/mode/mode-api-endpoints/eth-get-filter-changes)         |
+| [`eth_getFilterLogs`](/docs/chain-apis/mode/mode-api-endpoints/eth-get-filter-logs)                   | [`eth_getLogs`](/docs/chain-apis/mode/mode-api-endpoints/eth-get-logs)                            |
+| [`eth_getStorageAt`](/docs/chain-apis/mode/mode-api-endpoints/eth-get-storage-at)                     | [`eth_getTransactionByBlockHashAndIndex`](/docs/chain-apis/mode/mode-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
+| [`eth_getTransactionByBlockNumberAndIndex`](/docs/chain-apis/mode/mode-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/chain-apis/mode/mode-api-endpoints/eth-get-transaction-by-hash) |
+| [`eth_getTransactionCount`](/docs/chain-apis/mode/mode-api-endpoints/eth-get-transaction-count)       | [`eth_getTransactionReceipt`](/docs/chain-apis/mode/mode-api-endpoints/eth-get-transaction-receipt) |
+| [`eth_newBlockFilter`](/docs/chain-apis/mode/mode-api-endpoints/eth-new-block-filter)                 | [`eth_newFilter`](/docs/chain-apis/mode/mode-api-endpoints/eth-new-filter)                        |
+| [`eth_sendRawTransaction`](/docs/chain-apis/mode/mode-api-endpoints/eth-send-raw-transaction)         | [`eth_simulateV1`](/docs/chain-apis/mode/mode-api-endpoints/eth-simulate-v-1)                     |
+| [`eth_submitWork`](/docs/chain-apis/mode/mode-api-endpoints/eth-submit-work)                          | [`eth_subscribe`](/docs/chain-apis/mode/mode-api-endpoints/eth-subscribe)                         |
+| [`eth_uninstallFilter`](/docs/chain-apis/mode/mode-api-endpoints/eth-uninstall-filter)                | [`eth_unsubscribe`](/docs/chain-apis/mode/mode-api-endpoints/eth-unsubscribe)                     |
+| [`net_version`](/docs/chain-apis/mode/mode-api-endpoints/net-version)                                 | [`web3_clientVersion`](/docs/chain-apis/mode/mode-api-endpoints/web-3-client-version)             |
+| [`web3_sha3`](/docs/chain-apis/mode/mode-api-endpoints/web-3-sha-3)                                   |                                                                                             |
 
 ## Monad APIs
 
@@ -887,22 +887,22 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_blockNumber`](/docs/node/monad/monad-api-endpoints/eth-block-number)                      | [`eth_call`](/docs/node/monad/monad-api-endpoints/eth-call)                                 |
-| [`eth_callMany`](/docs/node/monad/monad-api-endpoints/eth-call-many)                            | [`eth_chainId`](/docs/node/monad/monad-api-endpoints/eth-chain-id)                          |
-| [`eth_estimateGas`](/docs/node/monad/monad-api-endpoints/eth-estimate-gas)                      | [`eth_gasPrice`](/docs/node/monad/monad-api-endpoints/eth-gas-price)                        |
-| [`eth_getAccount`](/docs/node/monad/monad-api-endpoints/eth-get-account)                        | [`eth_getBalance`](/docs/node/monad/monad-api-endpoints/eth-get-balance)                    |
-| [`eth_getBlockByHash`](/docs/node/monad/monad-api-endpoints/eth-get-block-by-hash)              | [`eth_getBlockByNumber`](/docs/node/monad/monad-api-endpoints/eth-get-block-by-number)      |
-| [`eth_getBlockTransactionCountByHash`](/docs/node/monad/monad-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/node/monad/monad-api-endpoints/eth-get-block-transaction-count-by-number) |
-| [`eth_getCode`](/docs/node/monad/monad-api-endpoints/eth-get-code)                              | [`eth_getFilterChanges`](/docs/node/monad/monad-api-endpoints/eth-get-filter-changes)       |
-| [`eth_getFilterLogs`](/docs/node/monad/monad-api-endpoints/eth-get-filter-logs)                 | [`eth_getLogs`](/docs/node/monad/monad-api-endpoints/eth-get-logs)                          |
-| [`eth_getStorageAt`](/docs/node/monad/monad-api-endpoints/eth-get-storage-at)                   | [`eth_getTransactionByBlockHashAndIndex`](/docs/node/monad/monad-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
-| [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/monad/monad-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/node/monad/monad-api-endpoints/eth-get-transaction-by-hash) |
-| [`eth_getTransactionCount`](/docs/node/monad/monad-api-endpoints/eth-get-transaction-count)     | [`eth_getTransactionReceipt`](/docs/node/monad/monad-api-endpoints/eth-get-transaction-receipt) |
-| [`eth_newBlockFilter`](/docs/node/monad/monad-api-endpoints/eth-new-block-filter)               | [`eth_newFilter`](/docs/node/monad/monad-api-endpoints/eth-new-filter)                      |
-| [`eth_sendRawTransaction`](/docs/node/monad/monad-api-endpoints/eth-send-raw-transaction)       | [`eth_submitWork`](/docs/node/monad/monad-api-endpoints/eth-submit-work)                    |
-| [`eth_subscribe`](/docs/node/monad/monad-api-endpoints/eth-subscribe)                           | [`eth_uninstallFilter`](/docs/node/monad/monad-api-endpoints/eth-uninstall-filter)          |
-| [`eth_unsubscribe`](/docs/node/monad/monad-api-endpoints/eth-unsubscribe)                       | [`net_version`](/docs/node/monad/monad-api-endpoints/net-version)                           |
-| [`web3_clientVersion`](/docs/node/monad/monad-api-endpoints/web-3-client-version)               | [`web3_sha3`](/docs/node/monad/monad-api-endpoints/web-3-sha-3)                             |
+| [`eth_blockNumber`](/docs/chain-apis/monad/monad-api-endpoints/eth-block-number)                      | [`eth_call`](/docs/chain-apis/monad/monad-api-endpoints/eth-call)                                 |
+| [`eth_callMany`](/docs/chain-apis/monad/monad-api-endpoints/eth-call-many)                            | [`eth_chainId`](/docs/chain-apis/monad/monad-api-endpoints/eth-chain-id)                          |
+| [`eth_estimateGas`](/docs/chain-apis/monad/monad-api-endpoints/eth-estimate-gas)                      | [`eth_gasPrice`](/docs/chain-apis/monad/monad-api-endpoints/eth-gas-price)                        |
+| [`eth_getAccount`](/docs/chain-apis/monad/monad-api-endpoints/eth-get-account)                        | [`eth_getBalance`](/docs/chain-apis/monad/monad-api-endpoints/eth-get-balance)                    |
+| [`eth_getBlockByHash`](/docs/chain-apis/monad/monad-api-endpoints/eth-get-block-by-hash)              | [`eth_getBlockByNumber`](/docs/chain-apis/monad/monad-api-endpoints/eth-get-block-by-number)      |
+| [`eth_getBlockTransactionCountByHash`](/docs/chain-apis/monad/monad-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/chain-apis/monad/monad-api-endpoints/eth-get-block-transaction-count-by-number) |
+| [`eth_getCode`](/docs/chain-apis/monad/monad-api-endpoints/eth-get-code)                              | [`eth_getFilterChanges`](/docs/chain-apis/monad/monad-api-endpoints/eth-get-filter-changes)       |
+| [`eth_getFilterLogs`](/docs/chain-apis/monad/monad-api-endpoints/eth-get-filter-logs)                 | [`eth_getLogs`](/docs/chain-apis/monad/monad-api-endpoints/eth-get-logs)                          |
+| [`eth_getStorageAt`](/docs/chain-apis/monad/monad-api-endpoints/eth-get-storage-at)                   | [`eth_getTransactionByBlockHashAndIndex`](/docs/chain-apis/monad/monad-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
+| [`eth_getTransactionByBlockNumberAndIndex`](/docs/chain-apis/monad/monad-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/chain-apis/monad/monad-api-endpoints/eth-get-transaction-by-hash) |
+| [`eth_getTransactionCount`](/docs/chain-apis/monad/monad-api-endpoints/eth-get-transaction-count)     | [`eth_getTransactionReceipt`](/docs/chain-apis/monad/monad-api-endpoints/eth-get-transaction-receipt) |
+| [`eth_newBlockFilter`](/docs/chain-apis/monad/monad-api-endpoints/eth-new-block-filter)               | [`eth_newFilter`](/docs/chain-apis/monad/monad-api-endpoints/eth-new-filter)                      |
+| [`eth_sendRawTransaction`](/docs/chain-apis/monad/monad-api-endpoints/eth-send-raw-transaction)       | [`eth_submitWork`](/docs/chain-apis/monad/monad-api-endpoints/eth-submit-work)                    |
+| [`eth_subscribe`](/docs/chain-apis/monad/monad-api-endpoints/eth-subscribe)                           | [`eth_uninstallFilter`](/docs/chain-apis/monad/monad-api-endpoints/eth-uninstall-filter)          |
+| [`eth_unsubscribe`](/docs/chain-apis/monad/monad-api-endpoints/eth-unsubscribe)                       | [`net_version`](/docs/chain-apis/monad/monad-api-endpoints/net-version)                           |
+| [`web3_clientVersion`](/docs/chain-apis/monad/monad-api-endpoints/web-3-client-version)               | [`web3_sha3`](/docs/chain-apis/monad/monad-api-endpoints/web-3-sha-3)                             |
 
 ## Moonbeam APIs
 
@@ -910,22 +910,22 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_blockNumber`](/docs/node/moonbeam/moonbeam-api-endpoints/eth-block-number)                | [`eth_call`](/docs/node/moonbeam/moonbeam-api-endpoints/eth-call)                           |
-| [`eth_callMany`](/docs/node/moonbeam/moonbeam-api-endpoints/eth-call-many)                      | [`eth_chainId`](/docs/node/moonbeam/moonbeam-api-endpoints/eth-chain-id)                    |
-| [`eth_estimateGas`](/docs/node/moonbeam/moonbeam-api-endpoints/eth-estimate-gas)                | [`eth_gasPrice`](/docs/node/moonbeam/moonbeam-api-endpoints/eth-gas-price)                  |
-| [`eth_getAccount`](/docs/node/moonbeam/moonbeam-api-endpoints/eth-get-account)                  | [`eth_getBalance`](/docs/node/moonbeam/moonbeam-api-endpoints/eth-get-balance)              |
-| [`eth_getBlockByHash`](/docs/node/moonbeam/moonbeam-api-endpoints/eth-get-block-by-hash)        | [`eth_getBlockByNumber`](/docs/node/moonbeam/moonbeam-api-endpoints/eth-get-block-by-number) |
-| [`eth_getBlockTransactionCountByHash`](/docs/node/moonbeam/moonbeam-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/node/moonbeam/moonbeam-api-endpoints/eth-get-block-transaction-count-by-number) |
-| [`eth_getCode`](/docs/node/moonbeam/moonbeam-api-endpoints/eth-get-code)                        | [`eth_getFilterChanges`](/docs/node/moonbeam/moonbeam-api-endpoints/eth-get-filter-changes) |
-| [`eth_getFilterLogs`](/docs/node/moonbeam/moonbeam-api-endpoints/eth-get-filter-logs)           | [`eth_getLogs`](/docs/node/moonbeam/moonbeam-api-endpoints/eth-get-logs)                    |
-| [`eth_getStorageAt`](/docs/node/moonbeam/moonbeam-api-endpoints/eth-get-storage-at)             | [`eth_getTransactionByBlockHashAndIndex`](/docs/node/moonbeam/moonbeam-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
-| [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/moonbeam/moonbeam-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/node/moonbeam/moonbeam-api-endpoints/eth-get-transaction-by-hash) |
-| [`eth_getTransactionCount`](/docs/node/moonbeam/moonbeam-api-endpoints/eth-get-transaction-count) | [`eth_getTransactionReceipt`](/docs/node/moonbeam/moonbeam-api-endpoints/eth-get-transaction-receipt) |
-| [`eth_newBlockFilter`](/docs/node/moonbeam/moonbeam-api-endpoints/eth-new-block-filter)         | [`eth_newFilter`](/docs/node/moonbeam/moonbeam-api-endpoints/eth-new-filter)                |
-| [`eth_sendRawTransaction`](/docs/node/moonbeam/moonbeam-api-endpoints/eth-send-raw-transaction) | [`eth_submitWork`](/docs/node/moonbeam/moonbeam-api-endpoints/eth-submit-work)              |
-| [`eth_subscribe`](/docs/node/moonbeam/moonbeam-api-endpoints/eth-subscribe)                     | [`eth_uninstallFilter`](/docs/node/moonbeam/moonbeam-api-endpoints/eth-uninstall-filter)    |
-| [`eth_unsubscribe`](/docs/node/moonbeam/moonbeam-api-endpoints/eth-unsubscribe)                 | [`net_version`](/docs/node/moonbeam/moonbeam-api-endpoints/net-version)                     |
-| [`web3_clientVersion`](/docs/node/moonbeam/moonbeam-api-endpoints/web-3-client-version)         | [`web3_sha3`](/docs/node/moonbeam/moonbeam-api-endpoints/web-3-sha-3)                       |
+| [`eth_blockNumber`](/docs/chain-apis/moonbeam/moonbeam-api-endpoints/eth-block-number)                | [`eth_call`](/docs/chain-apis/moonbeam/moonbeam-api-endpoints/eth-call)                           |
+| [`eth_callMany`](/docs/chain-apis/moonbeam/moonbeam-api-endpoints/eth-call-many)                      | [`eth_chainId`](/docs/chain-apis/moonbeam/moonbeam-api-endpoints/eth-chain-id)                    |
+| [`eth_estimateGas`](/docs/chain-apis/moonbeam/moonbeam-api-endpoints/eth-estimate-gas)                | [`eth_gasPrice`](/docs/chain-apis/moonbeam/moonbeam-api-endpoints/eth-gas-price)                  |
+| [`eth_getAccount`](/docs/chain-apis/moonbeam/moonbeam-api-endpoints/eth-get-account)                  | [`eth_getBalance`](/docs/chain-apis/moonbeam/moonbeam-api-endpoints/eth-get-balance)              |
+| [`eth_getBlockByHash`](/docs/chain-apis/moonbeam/moonbeam-api-endpoints/eth-get-block-by-hash)        | [`eth_getBlockByNumber`](/docs/chain-apis/moonbeam/moonbeam-api-endpoints/eth-get-block-by-number) |
+| [`eth_getBlockTransactionCountByHash`](/docs/chain-apis/moonbeam/moonbeam-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/chain-apis/moonbeam/moonbeam-api-endpoints/eth-get-block-transaction-count-by-number) |
+| [`eth_getCode`](/docs/chain-apis/moonbeam/moonbeam-api-endpoints/eth-get-code)                        | [`eth_getFilterChanges`](/docs/chain-apis/moonbeam/moonbeam-api-endpoints/eth-get-filter-changes) |
+| [`eth_getFilterLogs`](/docs/chain-apis/moonbeam/moonbeam-api-endpoints/eth-get-filter-logs)           | [`eth_getLogs`](/docs/chain-apis/moonbeam/moonbeam-api-endpoints/eth-get-logs)                    |
+| [`eth_getStorageAt`](/docs/chain-apis/moonbeam/moonbeam-api-endpoints/eth-get-storage-at)             | [`eth_getTransactionByBlockHashAndIndex`](/docs/chain-apis/moonbeam/moonbeam-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
+| [`eth_getTransactionByBlockNumberAndIndex`](/docs/chain-apis/moonbeam/moonbeam-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/chain-apis/moonbeam/moonbeam-api-endpoints/eth-get-transaction-by-hash) |
+| [`eth_getTransactionCount`](/docs/chain-apis/moonbeam/moonbeam-api-endpoints/eth-get-transaction-count) | [`eth_getTransactionReceipt`](/docs/chain-apis/moonbeam/moonbeam-api-endpoints/eth-get-transaction-receipt) |
+| [`eth_newBlockFilter`](/docs/chain-apis/moonbeam/moonbeam-api-endpoints/eth-new-block-filter)         | [`eth_newFilter`](/docs/chain-apis/moonbeam/moonbeam-api-endpoints/eth-new-filter)                |
+| [`eth_sendRawTransaction`](/docs/chain-apis/moonbeam/moonbeam-api-endpoints/eth-send-raw-transaction) | [`eth_submitWork`](/docs/chain-apis/moonbeam/moonbeam-api-endpoints/eth-submit-work)              |
+| [`eth_subscribe`](/docs/chain-apis/moonbeam/moonbeam-api-endpoints/eth-subscribe)                     | [`eth_uninstallFilter`](/docs/chain-apis/moonbeam/moonbeam-api-endpoints/eth-uninstall-filter)    |
+| [`eth_unsubscribe`](/docs/chain-apis/moonbeam/moonbeam-api-endpoints/eth-unsubscribe)                 | [`net_version`](/docs/chain-apis/moonbeam/moonbeam-api-endpoints/net-version)                     |
+| [`web3_clientVersion`](/docs/chain-apis/moonbeam/moonbeam-api-endpoints/web-3-client-version)         | [`web3_sha3`](/docs/chain-apis/moonbeam/moonbeam-api-endpoints/web-3-sha-3)                       |
 
 ## OP Mainnet APIs
 
@@ -933,29 +933,29 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_accounts`](/docs/node/op-mainnet/op-mainnet-api-endpoints/eth-accounts)                   | [`eth_blockNumber`](/docs/node/op-mainnet/op-mainnet-api-endpoints/eth-block-number)        |
-| [`eth_call`](/docs/node/op-mainnet/op-mainnet-api-endpoints/eth-call)                           | [`eth_callMany`](/docs/node/op-mainnet/op-mainnet-api-endpoints/eth-call-many)              |
-| [`eth_chainId`](/docs/node/op-mainnet/op-mainnet-api-endpoints/eth-chain-id)                    | [`eth_createAccessList`](/docs/node/op-mainnet/op-mainnet-api-endpoints/eth-create-access-list) |
-| [`eth_estimateGas`](/docs/node/op-mainnet/op-mainnet-api-endpoints/eth-estimate-gas)            | [`eth_feeHistory`](/docs/node/op-mainnet/op-mainnet-api-endpoints/eth-fee-history)          |
-| [`eth_gasPrice`](/docs/node/op-mainnet/op-mainnet-api-endpoints/eth-gas-price)                  | [`eth_getAccount`](/docs/node/op-mainnet/op-mainnet-api-endpoints/eth-get-account)          |
-| [`eth_getBalance`](/docs/node/op-mainnet/op-mainnet-api-endpoints/eth-get-balance)              | [`eth_getBlockByHash`](/docs/node/op-mainnet/op-mainnet-api-endpoints/eth-get-block-by-hash) |
-| [`eth_getBlockByNumber`](/docs/node/op-mainnet/op-mainnet-api-endpoints/eth-get-block-by-number) | [`eth_getBlockReceipts`](/docs/node/op-mainnet/op-mainnet-api-endpoints/eth-get-block-receipts) |
-| [`eth_getBlockTransactionCountByHash`](/docs/node/op-mainnet/op-mainnet-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/node/op-mainnet/op-mainnet-api-endpoints/eth-get-block-transaction-count-by-number) |
-| [`eth_getCode`](/docs/node/op-mainnet/op-mainnet-api-endpoints/eth-get-code)                    | [`eth_getFilterChanges`](/docs/node/op-mainnet/op-mainnet-api-endpoints/eth-get-filter-changes) |
-| [`eth_getFilterLogs`](/docs/node/op-mainnet/op-mainnet-api-endpoints/eth-get-filter-logs)       | [`eth_getLogs`](/docs/node/op-mainnet/op-mainnet-api-endpoints/eth-get-logs)                |
-| [`eth_getProof`](/docs/node/op-mainnet/op-mainnet-api-endpoints/eth-get-proof)                  | [`eth_getStorageAt`](/docs/node/op-mainnet/op-mainnet-api-endpoints/eth-get-storage-at)     |
-| [`eth_getTransactionByBlockHashAndIndex`](/docs/node/op-mainnet/op-mainnet-api-endpoints/eth-get-transaction-by-block-hash-and-index) | [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/op-mainnet/op-mainnet-api-endpoints/eth-get-transaction-by-block-number-and-index) |
-| [`eth_getTransactionByHash`](/docs/node/op-mainnet/op-mainnet-api-endpoints/eth-get-transaction-by-hash) | [`eth_getTransactionCount`](/docs/node/op-mainnet/op-mainnet-api-endpoints/eth-get-transaction-count) |
-| [`eth_getTransactionReceipt`](/docs/node/op-mainnet/op-mainnet-api-endpoints/eth-get-transaction-receipt) | [`eth_getUncleByBlockHashAndIndex`](/docs/node/op-mainnet/op-mainnet-api-endpoints/eth-get-uncle-by-block-hash-and-index) |
-| [`eth_getUncleByBlockNumberAndIndex`](/docs/node/op-mainnet/op-mainnet-api-endpoints/eth-get-uncle-by-block-number-and-index) | [`eth_getUncleCountByBlockHash`](/docs/node/op-mainnet/op-mainnet-api-endpoints/eth-get-uncle-count-by-block-hash) |
-| [`eth_getUncleCountByBlockNumber`](/docs/node/op-mainnet/op-mainnet-api-endpoints/eth-get-uncle-count-by-block-number) | [`eth_maxPriorityFeePerGas`](/docs/node/op-mainnet/op-mainnet-api-endpoints/eth-max-priority-fee-per-gas) |
-| [`eth_newBlockFilter`](/docs/node/op-mainnet/op-mainnet-api-endpoints/eth-new-block-filter)     | [`eth_newFilter`](/docs/node/op-mainnet/op-mainnet-api-endpoints/eth-new-filter)            |
-| [`eth_protocolVersion`](/docs/node/op-mainnet/op-mainnet-api-endpoints/eth-protocol-version)    | [`eth_sendRawTransaction`](/docs/node/op-mainnet/op-mainnet-api-endpoints/eth-send-raw-transaction) |
-| [`eth_sendRawTransactionSync`](/docs/node/op-mainnet/op-mainnet-api-endpoints/eth-send-raw-transaction-sync) | [`eth_simulateV1`](/docs/node/op-mainnet/op-mainnet-api-endpoints/eth-simulate-v-1)         |
-| [`eth_submitWork`](/docs/node/op-mainnet/op-mainnet-api-endpoints/eth-submit-work)              | [`eth_subscribe`](/docs/node/op-mainnet/op-mainnet-api-endpoints/eth-subscribe)             |
-| [`eth_syncing`](/docs/node/op-mainnet/op-mainnet-api-endpoints/eth-syncing)                     | [`eth_uninstallFilter`](/docs/node/op-mainnet/op-mainnet-api-endpoints/eth-uninstall-filter) |
-| [`eth_unsubscribe`](/docs/node/op-mainnet/op-mainnet-api-endpoints/eth-unsubscribe)             | [`net_version`](/docs/node/op-mainnet/op-mainnet-api-endpoints/net-version)                 |
-| [`web3_clientVersion`](/docs/node/op-mainnet/op-mainnet-api-endpoints/web-3-client-version)     | [`web3_sha3`](/docs/node/op-mainnet/op-mainnet-api-endpoints/web-3-sha-3)                   |
+| [`eth_accounts`](/docs/chain-apis/op-mainnet/op-mainnet-api-endpoints/eth-accounts)                   | [`eth_blockNumber`](/docs/chain-apis/op-mainnet/op-mainnet-api-endpoints/eth-block-number)        |
+| [`eth_call`](/docs/chain-apis/op-mainnet/op-mainnet-api-endpoints/eth-call)                           | [`eth_callMany`](/docs/chain-apis/op-mainnet/op-mainnet-api-endpoints/eth-call-many)              |
+| [`eth_chainId`](/docs/chain-apis/op-mainnet/op-mainnet-api-endpoints/eth-chain-id)                    | [`eth_createAccessList`](/docs/chain-apis/op-mainnet/op-mainnet-api-endpoints/eth-create-access-list) |
+| [`eth_estimateGas`](/docs/chain-apis/op-mainnet/op-mainnet-api-endpoints/eth-estimate-gas)            | [`eth_feeHistory`](/docs/chain-apis/op-mainnet/op-mainnet-api-endpoints/eth-fee-history)          |
+| [`eth_gasPrice`](/docs/chain-apis/op-mainnet/op-mainnet-api-endpoints/eth-gas-price)                  | [`eth_getAccount`](/docs/chain-apis/op-mainnet/op-mainnet-api-endpoints/eth-get-account)          |
+| [`eth_getBalance`](/docs/chain-apis/op-mainnet/op-mainnet-api-endpoints/eth-get-balance)              | [`eth_getBlockByHash`](/docs/chain-apis/op-mainnet/op-mainnet-api-endpoints/eth-get-block-by-hash) |
+| [`eth_getBlockByNumber`](/docs/chain-apis/op-mainnet/op-mainnet-api-endpoints/eth-get-block-by-number) | [`eth_getBlockReceipts`](/docs/chain-apis/op-mainnet/op-mainnet-api-endpoints/eth-get-block-receipts) |
+| [`eth_getBlockTransactionCountByHash`](/docs/chain-apis/op-mainnet/op-mainnet-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/chain-apis/op-mainnet/op-mainnet-api-endpoints/eth-get-block-transaction-count-by-number) |
+| [`eth_getCode`](/docs/chain-apis/op-mainnet/op-mainnet-api-endpoints/eth-get-code)                    | [`eth_getFilterChanges`](/docs/chain-apis/op-mainnet/op-mainnet-api-endpoints/eth-get-filter-changes) |
+| [`eth_getFilterLogs`](/docs/chain-apis/op-mainnet/op-mainnet-api-endpoints/eth-get-filter-logs)       | [`eth_getLogs`](/docs/chain-apis/op-mainnet/op-mainnet-api-endpoints/eth-get-logs)                |
+| [`eth_getProof`](/docs/chain-apis/op-mainnet/op-mainnet-api-endpoints/eth-get-proof)                  | [`eth_getStorageAt`](/docs/chain-apis/op-mainnet/op-mainnet-api-endpoints/eth-get-storage-at)     |
+| [`eth_getTransactionByBlockHashAndIndex`](/docs/chain-apis/op-mainnet/op-mainnet-api-endpoints/eth-get-transaction-by-block-hash-and-index) | [`eth_getTransactionByBlockNumberAndIndex`](/docs/chain-apis/op-mainnet/op-mainnet-api-endpoints/eth-get-transaction-by-block-number-and-index) |
+| [`eth_getTransactionByHash`](/docs/chain-apis/op-mainnet/op-mainnet-api-endpoints/eth-get-transaction-by-hash) | [`eth_getTransactionCount`](/docs/chain-apis/op-mainnet/op-mainnet-api-endpoints/eth-get-transaction-count) |
+| [`eth_getTransactionReceipt`](/docs/chain-apis/op-mainnet/op-mainnet-api-endpoints/eth-get-transaction-receipt) | [`eth_getUncleByBlockHashAndIndex`](/docs/chain-apis/op-mainnet/op-mainnet-api-endpoints/eth-get-uncle-by-block-hash-and-index) |
+| [`eth_getUncleByBlockNumberAndIndex`](/docs/chain-apis/op-mainnet/op-mainnet-api-endpoints/eth-get-uncle-by-block-number-and-index) | [`eth_getUncleCountByBlockHash`](/docs/chain-apis/op-mainnet/op-mainnet-api-endpoints/eth-get-uncle-count-by-block-hash) |
+| [`eth_getUncleCountByBlockNumber`](/docs/chain-apis/op-mainnet/op-mainnet-api-endpoints/eth-get-uncle-count-by-block-number) | [`eth_maxPriorityFeePerGas`](/docs/chain-apis/op-mainnet/op-mainnet-api-endpoints/eth-max-priority-fee-per-gas) |
+| [`eth_newBlockFilter`](/docs/chain-apis/op-mainnet/op-mainnet-api-endpoints/eth-new-block-filter)     | [`eth_newFilter`](/docs/chain-apis/op-mainnet/op-mainnet-api-endpoints/eth-new-filter)            |
+| [`eth_protocolVersion`](/docs/chain-apis/op-mainnet/op-mainnet-api-endpoints/eth-protocol-version)    | [`eth_sendRawTransaction`](/docs/chain-apis/op-mainnet/op-mainnet-api-endpoints/eth-send-raw-transaction) |
+| [`eth_sendRawTransactionSync`](/docs/chain-apis/op-mainnet/op-mainnet-api-endpoints/eth-send-raw-transaction-sync) | [`eth_simulateV1`](/docs/chain-apis/op-mainnet/op-mainnet-api-endpoints/eth-simulate-v-1)         |
+| [`eth_submitWork`](/docs/chain-apis/op-mainnet/op-mainnet-api-endpoints/eth-submit-work)              | [`eth_subscribe`](/docs/chain-apis/op-mainnet/op-mainnet-api-endpoints/eth-subscribe)             |
+| [`eth_syncing`](/docs/chain-apis/op-mainnet/op-mainnet-api-endpoints/eth-syncing)                     | [`eth_uninstallFilter`](/docs/chain-apis/op-mainnet/op-mainnet-api-endpoints/eth-uninstall-filter) |
+| [`eth_unsubscribe`](/docs/chain-apis/op-mainnet/op-mainnet-api-endpoints/eth-unsubscribe)             | [`net_version`](/docs/chain-apis/op-mainnet/op-mainnet-api-endpoints/net-version)                 |
+| [`web3_clientVersion`](/docs/chain-apis/op-mainnet/op-mainnet-api-endpoints/web-3-client-version)     | [`web3_sha3`](/docs/chain-apis/op-mainnet/op-mainnet-api-endpoints/web-3-sha-3)                   |
 
 ## opBNB APIs
 
@@ -963,27 +963,27 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_blockNumber`](/docs/node/opbnb/op-bnb-api-endpoints/eth-block-number)                     | [`eth_call`](/docs/node/opbnb/op-bnb-api-endpoints/eth-call)                                |
-| [`eth_callMany`](/docs/node/opbnb/op-bnb-api-endpoints/eth-call-many)                           | [`eth_chainId`](/docs/node/opbnb/op-bnb-api-endpoints/eth-chain-id)                         |
-| [`eth_createAccessList`](/docs/node/opbnb/op-bnb-api-endpoints/eth-create-access-list)          | [`eth_estimateGas`](/docs/node/opbnb/op-bnb-api-endpoints/eth-estimate-gas)                 |
-| [`eth_feeHistory`](/docs/node/opbnb/op-bnb-api-endpoints/eth-fee-history)                       | [`eth_gasPrice`](/docs/node/opbnb/op-bnb-api-endpoints/eth-gas-price)                       |
-| [`eth_getAccount`](/docs/node/opbnb/op-bnb-api-endpoints/eth-get-account)                       | [`eth_getBalance`](/docs/node/opbnb/op-bnb-api-endpoints/eth-get-balance)                   |
-| [`eth_getBlockByHash`](/docs/node/opbnb/op-bnb-api-endpoints/eth-get-block-by-hash)             | [`eth_getBlockByNumber`](/docs/node/opbnb/op-bnb-api-endpoints/eth-get-block-by-number)     |
-| [`eth_getBlockReceipts`](/docs/node/opbnb/op-bnb-api-endpoints/eth-get-block-receipts)          | [`eth_getBlockTransactionCountByHash`](/docs/node/opbnb/op-bnb-api-endpoints/eth-get-block-transaction-count-by-hash) |
-| [`eth_getBlockTransactionCountByNumber`](/docs/node/opbnb/op-bnb-api-endpoints/eth-get-block-transaction-count-by-number) | [`eth_getCode`](/docs/node/opbnb/op-bnb-api-endpoints/eth-get-code)                         |
-| [`eth_getFilterChanges`](/docs/node/opbnb/op-bnb-api-endpoints/eth-get-filter-changes)          | [`eth_getFilterLogs`](/docs/node/opbnb/op-bnb-api-endpoints/eth-get-filter-logs)            |
-| [`eth_getLogs`](/docs/node/opbnb/op-bnb-api-endpoints/eth-get-logs)                             | [`eth_getProof`](/docs/node/opbnb/op-bnb-api-endpoints/eth-get-proof)                       |
-| [`eth_getStorageAt`](/docs/node/opbnb/op-bnb-api-endpoints/eth-get-storage-at)                  | [`eth_getTransactionByBlockHashAndIndex`](/docs/node/opbnb/op-bnb-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
-| [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/opbnb/op-bnb-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/node/opbnb/op-bnb-api-endpoints/eth-get-transaction-by-hash) |
-| [`eth_getTransactionCount`](/docs/node/opbnb/op-bnb-api-endpoints/eth-get-transaction-count)    | [`eth_getTransactionReceipt`](/docs/node/opbnb/op-bnb-api-endpoints/eth-get-transaction-receipt) |
-| [`eth_getUncleByBlockHashAndIndex`](/docs/node/opbnb/op-bnb-api-endpoints/eth-get-uncle-by-block-hash-and-index) | [`eth_getUncleByBlockNumberAndIndex`](/docs/node/opbnb/op-bnb-api-endpoints/eth-get-uncle-by-block-number-and-index) |
-| [`eth_getUncleCountByBlockHash`](/docs/node/opbnb/op-bnb-api-endpoints/eth-get-uncle-count-by-block-hash) | [`eth_getUncleCountByBlockNumber`](/docs/node/opbnb/op-bnb-api-endpoints/eth-get-uncle-count-by-block-number) |
-| [`eth_maxPriorityFeePerGas`](/docs/node/opbnb/op-bnb-api-endpoints/eth-max-priority-fee-per-gas) | [`eth_newBlockFilter`](/docs/node/opbnb/op-bnb-api-endpoints/eth-new-block-filter)          |
-| [`eth_newFilter`](/docs/node/opbnb/op-bnb-api-endpoints/eth-new-filter)                         | [`eth_sendRawTransaction`](/docs/node/opbnb/op-bnb-api-endpoints/eth-send-raw-transaction)  |
-| [`eth_submitWork`](/docs/node/opbnb/op-bnb-api-endpoints/eth-submit-work)                       | [`eth_subscribe`](/docs/node/opbnb/op-bnb-api-endpoints/eth-subscribe)                      |
-| [`eth_syncing`](/docs/node/opbnb/op-bnb-api-endpoints/eth-syncing)                              | [`eth_uninstallFilter`](/docs/node/opbnb/op-bnb-api-endpoints/eth-uninstall-filter)         |
-| [`eth_unsubscribe`](/docs/node/opbnb/op-bnb-api-endpoints/eth-unsubscribe)                      | [`net_version`](/docs/node/opbnb/op-bnb-api-endpoints/net-version)                          |
-| [`web3_clientVersion`](/docs/node/opbnb/op-bnb-api-endpoints/web-3-client-version)              | [`web3_sha3`](/docs/node/opbnb/op-bnb-api-endpoints/web-3-sha-3)                            |
+| [`eth_blockNumber`](/docs/chain-apis/opbnb/op-bnb-api-endpoints/eth-block-number)                     | [`eth_call`](/docs/chain-apis/opbnb/op-bnb-api-endpoints/eth-call)                                |
+| [`eth_callMany`](/docs/chain-apis/opbnb/op-bnb-api-endpoints/eth-call-many)                           | [`eth_chainId`](/docs/chain-apis/opbnb/op-bnb-api-endpoints/eth-chain-id)                         |
+| [`eth_createAccessList`](/docs/chain-apis/opbnb/op-bnb-api-endpoints/eth-create-access-list)          | [`eth_estimateGas`](/docs/chain-apis/opbnb/op-bnb-api-endpoints/eth-estimate-gas)                 |
+| [`eth_feeHistory`](/docs/chain-apis/opbnb/op-bnb-api-endpoints/eth-fee-history)                       | [`eth_gasPrice`](/docs/chain-apis/opbnb/op-bnb-api-endpoints/eth-gas-price)                       |
+| [`eth_getAccount`](/docs/chain-apis/opbnb/op-bnb-api-endpoints/eth-get-account)                       | [`eth_getBalance`](/docs/chain-apis/opbnb/op-bnb-api-endpoints/eth-get-balance)                   |
+| [`eth_getBlockByHash`](/docs/chain-apis/opbnb/op-bnb-api-endpoints/eth-get-block-by-hash)             | [`eth_getBlockByNumber`](/docs/chain-apis/opbnb/op-bnb-api-endpoints/eth-get-block-by-number)     |
+| [`eth_getBlockReceipts`](/docs/chain-apis/opbnb/op-bnb-api-endpoints/eth-get-block-receipts)          | [`eth_getBlockTransactionCountByHash`](/docs/chain-apis/opbnb/op-bnb-api-endpoints/eth-get-block-transaction-count-by-hash) |
+| [`eth_getBlockTransactionCountByNumber`](/docs/chain-apis/opbnb/op-bnb-api-endpoints/eth-get-block-transaction-count-by-number) | [`eth_getCode`](/docs/chain-apis/opbnb/op-bnb-api-endpoints/eth-get-code)                         |
+| [`eth_getFilterChanges`](/docs/chain-apis/opbnb/op-bnb-api-endpoints/eth-get-filter-changes)          | [`eth_getFilterLogs`](/docs/chain-apis/opbnb/op-bnb-api-endpoints/eth-get-filter-logs)            |
+| [`eth_getLogs`](/docs/chain-apis/opbnb/op-bnb-api-endpoints/eth-get-logs)                             | [`eth_getProof`](/docs/chain-apis/opbnb/op-bnb-api-endpoints/eth-get-proof)                       |
+| [`eth_getStorageAt`](/docs/chain-apis/opbnb/op-bnb-api-endpoints/eth-get-storage-at)                  | [`eth_getTransactionByBlockHashAndIndex`](/docs/chain-apis/opbnb/op-bnb-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
+| [`eth_getTransactionByBlockNumberAndIndex`](/docs/chain-apis/opbnb/op-bnb-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/chain-apis/opbnb/op-bnb-api-endpoints/eth-get-transaction-by-hash) |
+| [`eth_getTransactionCount`](/docs/chain-apis/opbnb/op-bnb-api-endpoints/eth-get-transaction-count)    | [`eth_getTransactionReceipt`](/docs/chain-apis/opbnb/op-bnb-api-endpoints/eth-get-transaction-receipt) |
+| [`eth_getUncleByBlockHashAndIndex`](/docs/chain-apis/opbnb/op-bnb-api-endpoints/eth-get-uncle-by-block-hash-and-index) | [`eth_getUncleByBlockNumberAndIndex`](/docs/chain-apis/opbnb/op-bnb-api-endpoints/eth-get-uncle-by-block-number-and-index) |
+| [`eth_getUncleCountByBlockHash`](/docs/chain-apis/opbnb/op-bnb-api-endpoints/eth-get-uncle-count-by-block-hash) | [`eth_getUncleCountByBlockNumber`](/docs/chain-apis/opbnb/op-bnb-api-endpoints/eth-get-uncle-count-by-block-number) |
+| [`eth_maxPriorityFeePerGas`](/docs/chain-apis/opbnb/op-bnb-api-endpoints/eth-max-priority-fee-per-gas) | [`eth_newBlockFilter`](/docs/chain-apis/opbnb/op-bnb-api-endpoints/eth-new-block-filter)          |
+| [`eth_newFilter`](/docs/chain-apis/opbnb/op-bnb-api-endpoints/eth-new-filter)                         | [`eth_sendRawTransaction`](/docs/chain-apis/opbnb/op-bnb-api-endpoints/eth-send-raw-transaction)  |
+| [`eth_submitWork`](/docs/chain-apis/opbnb/op-bnb-api-endpoints/eth-submit-work)                       | [`eth_subscribe`](/docs/chain-apis/opbnb/op-bnb-api-endpoints/eth-subscribe)                      |
+| [`eth_syncing`](/docs/chain-apis/opbnb/op-bnb-api-endpoints/eth-syncing)                              | [`eth_uninstallFilter`](/docs/chain-apis/opbnb/op-bnb-api-endpoints/eth-uninstall-filter)         |
+| [`eth_unsubscribe`](/docs/chain-apis/opbnb/op-bnb-api-endpoints/eth-unsubscribe)                      | [`net_version`](/docs/chain-apis/opbnb/op-bnb-api-endpoints/net-version)                          |
+| [`web3_clientVersion`](/docs/chain-apis/opbnb/op-bnb-api-endpoints/web-3-client-version)              | [`web3_sha3`](/docs/chain-apis/opbnb/op-bnb-api-endpoints/web-3-sha-3)                            |
 
 ## Plasma APIs
 
@@ -991,23 +991,23 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_blockNumber`](/docs/node/plasma/plasma-api-endpoints/eth-block-number)                    | [`eth_call`](/docs/node/plasma/plasma-api-endpoints/eth-call)                               |
-| [`eth_callMany`](/docs/node/plasma/plasma-api-endpoints/eth-call-many)                          | [`eth_chainId`](/docs/node/plasma/plasma-api-endpoints/eth-chain-id)                        |
-| [`eth_estimateGas`](/docs/node/plasma/plasma-api-endpoints/eth-estimate-gas)                    | [`eth_feeHistory`](/docs/node/plasma/plasma-api-endpoints/eth-fee-history)                  |
-| [`eth_gasPrice`](/docs/node/plasma/plasma-api-endpoints/eth-gas-price)                          | [`eth_getAccount`](/docs/node/plasma/plasma-api-endpoints/eth-get-account)                  |
-| [`eth_getBalance`](/docs/node/plasma/plasma-api-endpoints/eth-get-balance)                      | [`eth_getBlockByHash`](/docs/node/plasma/plasma-api-endpoints/eth-get-block-by-hash)        |
-| [`eth_getBlockByNumber`](/docs/node/plasma/plasma-api-endpoints/eth-get-block-by-number)        | [`eth_getBlockTransactionCountByHash`](/docs/node/plasma/plasma-api-endpoints/eth-get-block-transaction-count-by-hash) |
-| [`eth_getBlockTransactionCountByNumber`](/docs/node/plasma/plasma-api-endpoints/eth-get-block-transaction-count-by-number) | [`eth_getCode`](/docs/node/plasma/plasma-api-endpoints/eth-get-code)                        |
-| [`eth_getFilterChanges`](/docs/node/plasma/plasma-api-endpoints/eth-get-filter-changes)         | [`eth_getFilterLogs`](/docs/node/plasma/plasma-api-endpoints/eth-get-filter-logs)           |
-| [`eth_getLogs`](/docs/node/plasma/plasma-api-endpoints/eth-get-logs)                            | [`eth_getStorageAt`](/docs/node/plasma/plasma-api-endpoints/eth-get-storage-at)             |
-| [`eth_getTransactionByBlockHashAndIndex`](/docs/node/plasma/plasma-api-endpoints/eth-get-transaction-by-block-hash-and-index) | [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/plasma/plasma-api-endpoints/eth-get-transaction-by-block-number-and-index) |
-| [`eth_getTransactionByHash`](/docs/node/plasma/plasma-api-endpoints/eth-get-transaction-by-hash) | [`eth_getTransactionCount`](/docs/node/plasma/plasma-api-endpoints/eth-get-transaction-count) |
-| [`eth_getTransactionReceipt`](/docs/node/plasma/plasma-api-endpoints/eth-get-transaction-receipt) | [`eth_maxPriorityFeePerGas`](/docs/node/plasma/plasma-api-endpoints/eth-max-priority-fee-per-gas) |
-| [`eth_newBlockFilter`](/docs/node/plasma/plasma-api-endpoints/eth-new-block-filter)             | [`eth_newFilter`](/docs/node/plasma/plasma-api-endpoints/eth-new-filter)                    |
-| [`eth_sendRawTransaction`](/docs/node/plasma/plasma-api-endpoints/eth-send-raw-transaction)     | [`eth_submitWork`](/docs/node/plasma/plasma-api-endpoints/eth-submit-work)                  |
-| [`eth_subscribe`](/docs/node/plasma/plasma-api-endpoints/eth-subscribe)                         | [`eth_uninstallFilter`](/docs/node/plasma/plasma-api-endpoints/eth-uninstall-filter)        |
-| [`eth_unsubscribe`](/docs/node/plasma/plasma-api-endpoints/eth-unsubscribe)                     | [`net_version`](/docs/node/plasma/plasma-api-endpoints/net-version)                         |
-| [`web3_clientVersion`](/docs/node/plasma/plasma-api-endpoints/web-3-client-version)             | [`web3_sha3`](/docs/node/plasma/plasma-api-endpoints/web-3-sha-3)                           |
+| [`eth_blockNumber`](/docs/chain-apis/plasma/plasma-api-endpoints/eth-block-number)                    | [`eth_call`](/docs/chain-apis/plasma/plasma-api-endpoints/eth-call)                               |
+| [`eth_callMany`](/docs/chain-apis/plasma/plasma-api-endpoints/eth-call-many)                          | [`eth_chainId`](/docs/chain-apis/plasma/plasma-api-endpoints/eth-chain-id)                        |
+| [`eth_estimateGas`](/docs/chain-apis/plasma/plasma-api-endpoints/eth-estimate-gas)                    | [`eth_feeHistory`](/docs/chain-apis/plasma/plasma-api-endpoints/eth-fee-history)                  |
+| [`eth_gasPrice`](/docs/chain-apis/plasma/plasma-api-endpoints/eth-gas-price)                          | [`eth_getAccount`](/docs/chain-apis/plasma/plasma-api-endpoints/eth-get-account)                  |
+| [`eth_getBalance`](/docs/chain-apis/plasma/plasma-api-endpoints/eth-get-balance)                      | [`eth_getBlockByHash`](/docs/chain-apis/plasma/plasma-api-endpoints/eth-get-block-by-hash)        |
+| [`eth_getBlockByNumber`](/docs/chain-apis/plasma/plasma-api-endpoints/eth-get-block-by-number)        | [`eth_getBlockTransactionCountByHash`](/docs/chain-apis/plasma/plasma-api-endpoints/eth-get-block-transaction-count-by-hash) |
+| [`eth_getBlockTransactionCountByNumber`](/docs/chain-apis/plasma/plasma-api-endpoints/eth-get-block-transaction-count-by-number) | [`eth_getCode`](/docs/chain-apis/plasma/plasma-api-endpoints/eth-get-code)                        |
+| [`eth_getFilterChanges`](/docs/chain-apis/plasma/plasma-api-endpoints/eth-get-filter-changes)         | [`eth_getFilterLogs`](/docs/chain-apis/plasma/plasma-api-endpoints/eth-get-filter-logs)           |
+| [`eth_getLogs`](/docs/chain-apis/plasma/plasma-api-endpoints/eth-get-logs)                            | [`eth_getStorageAt`](/docs/chain-apis/plasma/plasma-api-endpoints/eth-get-storage-at)             |
+| [`eth_getTransactionByBlockHashAndIndex`](/docs/chain-apis/plasma/plasma-api-endpoints/eth-get-transaction-by-block-hash-and-index) | [`eth_getTransactionByBlockNumberAndIndex`](/docs/chain-apis/plasma/plasma-api-endpoints/eth-get-transaction-by-block-number-and-index) |
+| [`eth_getTransactionByHash`](/docs/chain-apis/plasma/plasma-api-endpoints/eth-get-transaction-by-hash) | [`eth_getTransactionCount`](/docs/chain-apis/plasma/plasma-api-endpoints/eth-get-transaction-count) |
+| [`eth_getTransactionReceipt`](/docs/chain-apis/plasma/plasma-api-endpoints/eth-get-transaction-receipt) | [`eth_maxPriorityFeePerGas`](/docs/chain-apis/plasma/plasma-api-endpoints/eth-max-priority-fee-per-gas) |
+| [`eth_newBlockFilter`](/docs/chain-apis/plasma/plasma-api-endpoints/eth-new-block-filter)             | [`eth_newFilter`](/docs/chain-apis/plasma/plasma-api-endpoints/eth-new-filter)                    |
+| [`eth_sendRawTransaction`](/docs/chain-apis/plasma/plasma-api-endpoints/eth-send-raw-transaction)     | [`eth_submitWork`](/docs/chain-apis/plasma/plasma-api-endpoints/eth-submit-work)                  |
+| [`eth_subscribe`](/docs/chain-apis/plasma/plasma-api-endpoints/eth-subscribe)                         | [`eth_uninstallFilter`](/docs/chain-apis/plasma/plasma-api-endpoints/eth-uninstall-filter)        |
+| [`eth_unsubscribe`](/docs/chain-apis/plasma/plasma-api-endpoints/eth-unsubscribe)                     | [`net_version`](/docs/chain-apis/plasma/plasma-api-endpoints/net-version)                         |
+| [`web3_clientVersion`](/docs/chain-apis/plasma/plasma-api-endpoints/web-3-client-version)             | [`web3_sha3`](/docs/chain-apis/plasma/plasma-api-endpoints/web-3-sha-3)                           |
 
 ## Polygon PoS APIs
 
@@ -1015,33 +1015,33 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`bor_getAuthor`](/docs/node/polygon-pos/polygon-po-s-api-endpoints/bor-get-author)             | [`bor_getCurrentProposer`](/docs/node/polygon-pos/polygon-po-s-api-endpoints/bor-get-current-proposer) |
-| [`bor_getCurrentValidators`](/docs/node/polygon-pos/polygon-po-s-api-endpoints/bor-get-current-validators) | [`bor_getRootHash`](/docs/node/polygon-pos/polygon-po-s-api-endpoints/bor-get-root-hash)    |
-| [`bor_getSignersAtHash`](/docs/node/polygon-pos/polygon-po-s-api-endpoints/bor-get-signers-at-hash) | [`eth_accounts`](/docs/node/polygon-pos/polygon-po-s-api-endpoints/eth-accounts)            |
-| [`eth_blockNumber`](/docs/node/polygon-pos/polygon-po-s-api-endpoints/eth-block-number)         | [`eth_call`](/docs/node/polygon-pos/polygon-po-s-api-endpoints/eth-call)                    |
-| [`eth_callMany`](/docs/node/polygon-pos/polygon-po-s-api-endpoints/eth-call-many)               | [`eth_chainId`](/docs/node/polygon-pos/polygon-po-s-api-endpoints/eth-chain-id)             |
-| [`eth_createAccessList`](/docs/node/polygon-pos/polygon-po-s-api-endpoints/eth-create-access-list) | [`eth_estimateGas`](/docs/node/polygon-pos/polygon-po-s-api-endpoints/eth-estimate-gas)     |
-| [`eth_feeHistory`](/docs/node/polygon-pos/polygon-po-s-api-endpoints/eth-fee-history)           | [`eth_gasPrice`](/docs/node/polygon-pos/polygon-po-s-api-endpoints/eth-gas-price)           |
-| [`eth_getAccount`](/docs/node/polygon-pos/polygon-po-s-api-endpoints/eth-get-account)           | [`eth_getBalance`](/docs/node/polygon-pos/polygon-po-s-api-endpoints/eth-get-balance)       |
-| [`eth_getBlockByHash`](/docs/node/polygon-pos/polygon-po-s-api-endpoints/eth-get-block-by-hash) | [`eth_getBlockByNumber`](/docs/node/polygon-pos/polygon-po-s-api-endpoints/eth-get-block-by-number) |
-| [`eth_getBlockReceipts`](/docs/node/polygon-pos/polygon-po-s-api-endpoints/eth-get-block-receipts) | [`eth_getBlockTransactionCountByHash`](/docs/node/polygon-pos/polygon-po-s-api-endpoints/eth-get-block-transaction-count-by-hash) |
-| [`eth_getBlockTransactionCountByNumber`](/docs/node/polygon-pos/polygon-po-s-api-endpoints/eth-get-block-transaction-count-by-number) | [`eth_getCode`](/docs/node/polygon-pos/polygon-po-s-api-endpoints/eth-get-code)             |
-| [`eth_getFilterChanges`](/docs/node/polygon-pos/polygon-po-s-api-endpoints/eth-get-filter-changes) | [`eth_getFilterLogs`](/docs/node/polygon-pos/polygon-po-s-api-endpoints/eth-get-filter-logs) |
-| [`eth_getLogs`](/docs/node/polygon-pos/polygon-po-s-api-endpoints/eth-get-logs)                 | [`eth_getProof`](/docs/node/polygon-pos/polygon-po-s-api-endpoints/eth-get-proof)           |
-| [`eth_getRootHash`](/docs/node/polygon-pos/polygon-po-s-api-endpoints/eth-get-root-hash)        | [`eth_getStorageAt`](/docs/node/polygon-pos/polygon-po-s-api-endpoints/eth-get-storage-at)  |
-| [`eth_getTdByNumber`](/docs/node/polygon-pos/polygon-po-s-api-endpoints/eth-get-td-by-number)   | [`eth_getTransactionByBlockHashAndIndex`](/docs/node/polygon-pos/polygon-po-s-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
-| [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/polygon-pos/polygon-po-s-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/node/polygon-pos/polygon-po-s-api-endpoints/eth-get-transaction-by-hash) |
-| [`eth_getTransactionCount`](/docs/node/polygon-pos/polygon-po-s-api-endpoints/eth-get-transaction-count) | [`eth_getTransactionReceipt`](/docs/node/polygon-pos/polygon-po-s-api-endpoints/eth-get-transaction-receipt) |
-| [`eth_getTransactionReceiptsByBlock`](/docs/node/polygon-pos/polygon-po-s-api-endpoints/eth-get-transaction-receipts-by-block) | [`eth_getUncleByBlockHashAndIndex`](/docs/node/polygon-pos/polygon-po-s-api-endpoints/eth-get-uncle-by-block-hash-and-index) |
-| [`eth_getUncleByBlockNumberAndIndex`](/docs/node/polygon-pos/polygon-po-s-api-endpoints/eth-get-uncle-by-block-number-and-index) | [`eth_getUncleCountByBlockHash`](/docs/node/polygon-pos/polygon-po-s-api-endpoints/eth-get-uncle-count-by-block-hash) |
-| [`eth_getUncleCountByBlockNumber`](/docs/node/polygon-pos/polygon-po-s-api-endpoints/eth-get-uncle-count-by-block-number) | [`eth_maxPriorityFeePerGas`](/docs/node/polygon-pos/polygon-po-s-api-endpoints/eth-max-priority-fee-per-gas) |
-| [`eth_newBlockFilter`](/docs/node/polygon-pos/polygon-po-s-api-endpoints/eth-new-block-filter)  | [`eth_newFilter`](/docs/node/polygon-pos/polygon-po-s-api-endpoints/eth-new-filter)         |
-| [`eth_newPendingTransactionFilter`](/docs/node/polygon-pos/polygon-po-s-api-endpoints/eth-new-pending-transaction-filter) | [`eth_sendRawTransaction`](/docs/node/polygon-pos/polygon-po-s-api-endpoints/eth-send-raw-transaction) |
-| [`eth_sendRawTransactionSync`](/docs/node/polygon-pos/polygon-po-s-api-endpoints/eth-send-raw-transaction-sync) | [`eth_submitWork`](/docs/node/polygon-pos/polygon-po-s-api-endpoints/eth-submit-work)       |
-| [`eth_subscribe`](/docs/node/polygon-pos/polygon-po-s-api-endpoints/eth-subscribe)              | [`eth_syncing`](/docs/node/polygon-pos/polygon-po-s-api-endpoints/eth-syncing)              |
-| [`eth_uninstallFilter`](/docs/node/polygon-pos/polygon-po-s-api-endpoints/eth-uninstall-filter) | [`eth_unsubscribe`](/docs/node/polygon-pos/polygon-po-s-api-endpoints/eth-unsubscribe)      |
-| [`net_version`](/docs/node/polygon-pos/polygon-po-s-api-endpoints/net-version)                  | [`web3_clientVersion`](/docs/node/polygon-pos/polygon-po-s-api-endpoints/web-3-client-version) |
-| [`web3_sha3`](/docs/node/polygon-pos/polygon-po-s-api-endpoints/web-3-sha-3)                    |                                                                                             |
+| [`bor_getAuthor`](/docs/chain-apis/polygon-pos/polygon-po-s-api-endpoints/bor-get-author)             | [`bor_getCurrentProposer`](/docs/chain-apis/polygon-pos/polygon-po-s-api-endpoints/bor-get-current-proposer) |
+| [`bor_getCurrentValidators`](/docs/chain-apis/polygon-pos/polygon-po-s-api-endpoints/bor-get-current-validators) | [`bor_getRootHash`](/docs/chain-apis/polygon-pos/polygon-po-s-api-endpoints/bor-get-root-hash)    |
+| [`bor_getSignersAtHash`](/docs/chain-apis/polygon-pos/polygon-po-s-api-endpoints/bor-get-signers-at-hash) | [`eth_accounts`](/docs/chain-apis/polygon-pos/polygon-po-s-api-endpoints/eth-accounts)            |
+| [`eth_blockNumber`](/docs/chain-apis/polygon-pos/polygon-po-s-api-endpoints/eth-block-number)         | [`eth_call`](/docs/chain-apis/polygon-pos/polygon-po-s-api-endpoints/eth-call)                    |
+| [`eth_callMany`](/docs/chain-apis/polygon-pos/polygon-po-s-api-endpoints/eth-call-many)               | [`eth_chainId`](/docs/chain-apis/polygon-pos/polygon-po-s-api-endpoints/eth-chain-id)             |
+| [`eth_createAccessList`](/docs/chain-apis/polygon-pos/polygon-po-s-api-endpoints/eth-create-access-list) | [`eth_estimateGas`](/docs/chain-apis/polygon-pos/polygon-po-s-api-endpoints/eth-estimate-gas)     |
+| [`eth_feeHistory`](/docs/chain-apis/polygon-pos/polygon-po-s-api-endpoints/eth-fee-history)           | [`eth_gasPrice`](/docs/chain-apis/polygon-pos/polygon-po-s-api-endpoints/eth-gas-price)           |
+| [`eth_getAccount`](/docs/chain-apis/polygon-pos/polygon-po-s-api-endpoints/eth-get-account)           | [`eth_getBalance`](/docs/chain-apis/polygon-pos/polygon-po-s-api-endpoints/eth-get-balance)       |
+| [`eth_getBlockByHash`](/docs/chain-apis/polygon-pos/polygon-po-s-api-endpoints/eth-get-block-by-hash) | [`eth_getBlockByNumber`](/docs/chain-apis/polygon-pos/polygon-po-s-api-endpoints/eth-get-block-by-number) |
+| [`eth_getBlockReceipts`](/docs/chain-apis/polygon-pos/polygon-po-s-api-endpoints/eth-get-block-receipts) | [`eth_getBlockTransactionCountByHash`](/docs/chain-apis/polygon-pos/polygon-po-s-api-endpoints/eth-get-block-transaction-count-by-hash) |
+| [`eth_getBlockTransactionCountByNumber`](/docs/chain-apis/polygon-pos/polygon-po-s-api-endpoints/eth-get-block-transaction-count-by-number) | [`eth_getCode`](/docs/chain-apis/polygon-pos/polygon-po-s-api-endpoints/eth-get-code)             |
+| [`eth_getFilterChanges`](/docs/chain-apis/polygon-pos/polygon-po-s-api-endpoints/eth-get-filter-changes) | [`eth_getFilterLogs`](/docs/chain-apis/polygon-pos/polygon-po-s-api-endpoints/eth-get-filter-logs) |
+| [`eth_getLogs`](/docs/chain-apis/polygon-pos/polygon-po-s-api-endpoints/eth-get-logs)                 | [`eth_getProof`](/docs/chain-apis/polygon-pos/polygon-po-s-api-endpoints/eth-get-proof)           |
+| [`eth_getRootHash`](/docs/chain-apis/polygon-pos/polygon-po-s-api-endpoints/eth-get-root-hash)        | [`eth_getStorageAt`](/docs/chain-apis/polygon-pos/polygon-po-s-api-endpoints/eth-get-storage-at)  |
+| [`eth_getTdByNumber`](/docs/chain-apis/polygon-pos/polygon-po-s-api-endpoints/eth-get-td-by-number)   | [`eth_getTransactionByBlockHashAndIndex`](/docs/chain-apis/polygon-pos/polygon-po-s-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
+| [`eth_getTransactionByBlockNumberAndIndex`](/docs/chain-apis/polygon-pos/polygon-po-s-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/chain-apis/polygon-pos/polygon-po-s-api-endpoints/eth-get-transaction-by-hash) |
+| [`eth_getTransactionCount`](/docs/chain-apis/polygon-pos/polygon-po-s-api-endpoints/eth-get-transaction-count) | [`eth_getTransactionReceipt`](/docs/chain-apis/polygon-pos/polygon-po-s-api-endpoints/eth-get-transaction-receipt) |
+| [`eth_getTransactionReceiptsByBlock`](/docs/chain-apis/polygon-pos/polygon-po-s-api-endpoints/eth-get-transaction-receipts-by-block) | [`eth_getUncleByBlockHashAndIndex`](/docs/chain-apis/polygon-pos/polygon-po-s-api-endpoints/eth-get-uncle-by-block-hash-and-index) |
+| [`eth_getUncleByBlockNumberAndIndex`](/docs/chain-apis/polygon-pos/polygon-po-s-api-endpoints/eth-get-uncle-by-block-number-and-index) | [`eth_getUncleCountByBlockHash`](/docs/chain-apis/polygon-pos/polygon-po-s-api-endpoints/eth-get-uncle-count-by-block-hash) |
+| [`eth_getUncleCountByBlockNumber`](/docs/chain-apis/polygon-pos/polygon-po-s-api-endpoints/eth-get-uncle-count-by-block-number) | [`eth_maxPriorityFeePerGas`](/docs/chain-apis/polygon-pos/polygon-po-s-api-endpoints/eth-max-priority-fee-per-gas) |
+| [`eth_newBlockFilter`](/docs/chain-apis/polygon-pos/polygon-po-s-api-endpoints/eth-new-block-filter)  | [`eth_newFilter`](/docs/chain-apis/polygon-pos/polygon-po-s-api-endpoints/eth-new-filter)         |
+| [`eth_newPendingTransactionFilter`](/docs/chain-apis/polygon-pos/polygon-po-s-api-endpoints/eth-new-pending-transaction-filter) | [`eth_sendRawTransaction`](/docs/chain-apis/polygon-pos/polygon-po-s-api-endpoints/eth-send-raw-transaction) |
+| [`eth_sendRawTransactionSync`](/docs/chain-apis/polygon-pos/polygon-po-s-api-endpoints/eth-send-raw-transaction-sync) | [`eth_submitWork`](/docs/chain-apis/polygon-pos/polygon-po-s-api-endpoints/eth-submit-work)       |
+| [`eth_subscribe`](/docs/chain-apis/polygon-pos/polygon-po-s-api-endpoints/eth-subscribe)              | [`eth_syncing`](/docs/chain-apis/polygon-pos/polygon-po-s-api-endpoints/eth-syncing)              |
+| [`eth_uninstallFilter`](/docs/chain-apis/polygon-pos/polygon-po-s-api-endpoints/eth-uninstall-filter) | [`eth_unsubscribe`](/docs/chain-apis/polygon-pos/polygon-po-s-api-endpoints/eth-unsubscribe)      |
+| [`net_version`](/docs/chain-apis/polygon-pos/polygon-po-s-api-endpoints/net-version)                  | [`web3_clientVersion`](/docs/chain-apis/polygon-pos/polygon-po-s-api-endpoints/web-3-client-version) |
+| [`web3_sha3`](/docs/chain-apis/polygon-pos/polygon-po-s-api-endpoints/web-3-sha-3)                    |                                                                                             |
 
 ## Polygon zkEVM APIs
 
@@ -1049,33 +1049,33 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_accounts`](/docs/node/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-accounts)            | [`eth_blockNumber`](/docs/node/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-block-number) |
-| [`eth_call`](/docs/node/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-call)                    | [`eth_callMany`](/docs/node/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-call-many)       |
-| [`eth_chainId`](/docs/node/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-chain-id)             | [`eth_estimateGas`](/docs/node/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-estimate-gas) |
-| [`eth_gasPrice`](/docs/node/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-gas-price)           | [`eth_getAccount`](/docs/node/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-get-account)   |
-| [`eth_getBalance`](/docs/node/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-get-balance)       | [`eth_getBlockByHash`](/docs/node/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-get-block-by-hash) |
-| [`eth_getBlockByNumber`](/docs/node/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-get-block-by-number) | [`eth_getBlockReceipts`](/docs/node/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-get-block-receipts) |
-| [`eth_getBlockTransactionCountByHash`](/docs/node/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/node/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-get-block-transaction-count-by-number) |
-| [`eth_getCode`](/docs/node/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-get-code)             | [`eth_getCompilers`](/docs/node/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-get-compilers) |
-| [`eth_getFilterChanges`](/docs/node/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-get-filter-changes) | [`eth_getFilterLogs`](/docs/node/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-get-filter-logs) |
-| [`eth_getLogs`](/docs/node/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-get-logs)             | [`eth_getStorageAt`](/docs/node/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-get-storage-at) |
-| [`eth_getTransactionByBlockHashAndIndex`](/docs/node/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-get-transaction-by-block-hash-and-index) | [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-get-transaction-by-block-number-and-index) |
-| [`eth_getTransactionByHash`](/docs/node/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-get-transaction-by-hash) | [`eth_getTransactionCount`](/docs/node/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-get-transaction-count) |
-| [`eth_getTransactionReceipt`](/docs/node/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-get-transaction-receipt) | [`eth_getUncleByBlockHashAndIndex`](/docs/node/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-get-uncle-by-block-hash-and-index) |
-| [`eth_getUncleByBlockNumberAndIndex`](/docs/node/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-get-uncle-by-block-number-and-index) | [`eth_getUncleCountByBlockHash`](/docs/node/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-get-uncle-count-by-block-hash) |
-| [`eth_getUncleCountByBlockNumber`](/docs/node/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-get-uncle-count-by-block-number) | [`eth_newBlockFilter`](/docs/node/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-new-block-filter) |
-| [`eth_newFilter`](/docs/node/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-new-filter)         | [`eth_newPendingTransactionFilter`](/docs/node/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-new-pending-transaction-filter) |
-| [`eth_protocolVersion`](/docs/node/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-protocol-version) | [`eth_sendRawTransaction`](/docs/node/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-send-raw-transaction) |
-| [`eth_submitWork`](/docs/node/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-submit-work)       | [`eth_subscribe`](/docs/node/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-subscribe)      |
-| [`eth_syncing`](/docs/node/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-syncing)              | [`eth_uninstallFilter`](/docs/node/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-uninstall-filter) |
-| [`eth_unsubscribe`](/docs/node/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-unsubscribe)      | [`net_version`](/docs/node/polygon-zkevm/polygon-zk-evm-api-endpoints/net-version)          |
-| [`web3_clientVersion`](/docs/node/polygon-zkevm/polygon-zk-evm-api-endpoints/web-3-client-version) | [`web3_sha3`](/docs/node/polygon-zkevm/polygon-zk-evm-api-endpoints/web-3-sha-3)            |
-| [`zkevm_batchNumber`](/docs/node/polygon-zkevm/polygon-zk-evm-api-endpoints/zkevm-batch-number) | [`zkevm_batchNumberByBlockNumber`](/docs/node/polygon-zkevm/polygon-zk-evm-api-endpoints/zkevm-batch-number-by-block-number) |
-| [`zkevm_consolidatedBlockNumber`](/docs/node/polygon-zkevm/polygon-zk-evm-api-endpoints/zkevm-consolidated-block-number) | [`zkevm_estimateFee`](/docs/node/polygon-zkevm/polygon-zk-evm-api-endpoints/zkevm-estimate-fee) |
-| [`zkevm_estimateGasPrice`](/docs/node/polygon-zkevm/polygon-zk-evm-api-endpoints/zkevm-estimate-gas-price) | [`zkevm_getBatchByNumber`](/docs/node/polygon-zkevm/polygon-zk-evm-api-endpoints/zkevm-get-batch-by-number) |
-| [`zkevm_getBroadcastURI`](/docs/node/polygon-zkevm/polygon-zk-evm-api-endpoints/zkevm-get-broadcast-uri) | [`zkevm_isBlockConsolidated`](/docs/node/polygon-zkevm/polygon-zk-evm-api-endpoints/zkevm-is-block-consolidated) |
-| [`zkevm_isBlockVirtualized`](/docs/node/polygon-zkevm/polygon-zk-evm-api-endpoints/zkevm-is-block-virtualized) | [`zkevm_verifiedBatchNumber`](/docs/node/polygon-zkevm/polygon-zk-evm-api-endpoints/zkevm-verified-batch-number) |
-| [`zkevm_virtualBatchNumber`](/docs/node/polygon-zkevm/polygon-zk-evm-api-endpoints/zkevm-virtual-batch-number) |                                                                                             |
+| [`eth_accounts`](/docs/chain-apis/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-accounts)            | [`eth_blockNumber`](/docs/chain-apis/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-block-number) |
+| [`eth_call`](/docs/chain-apis/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-call)                    | [`eth_callMany`](/docs/chain-apis/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-call-many)       |
+| [`eth_chainId`](/docs/chain-apis/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-chain-id)             | [`eth_estimateGas`](/docs/chain-apis/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-estimate-gas) |
+| [`eth_gasPrice`](/docs/chain-apis/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-gas-price)           | [`eth_getAccount`](/docs/chain-apis/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-get-account)   |
+| [`eth_getBalance`](/docs/chain-apis/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-get-balance)       | [`eth_getBlockByHash`](/docs/chain-apis/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-get-block-by-hash) |
+| [`eth_getBlockByNumber`](/docs/chain-apis/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-get-block-by-number) | [`eth_getBlockReceipts`](/docs/chain-apis/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-get-block-receipts) |
+| [`eth_getBlockTransactionCountByHash`](/docs/chain-apis/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/chain-apis/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-get-block-transaction-count-by-number) |
+| [`eth_getCode`](/docs/chain-apis/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-get-code)             | [`eth_getCompilers`](/docs/chain-apis/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-get-compilers) |
+| [`eth_getFilterChanges`](/docs/chain-apis/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-get-filter-changes) | [`eth_getFilterLogs`](/docs/chain-apis/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-get-filter-logs) |
+| [`eth_getLogs`](/docs/chain-apis/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-get-logs)             | [`eth_getStorageAt`](/docs/chain-apis/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-get-storage-at) |
+| [`eth_getTransactionByBlockHashAndIndex`](/docs/chain-apis/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-get-transaction-by-block-hash-and-index) | [`eth_getTransactionByBlockNumberAndIndex`](/docs/chain-apis/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-get-transaction-by-block-number-and-index) |
+| [`eth_getTransactionByHash`](/docs/chain-apis/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-get-transaction-by-hash) | [`eth_getTransactionCount`](/docs/chain-apis/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-get-transaction-count) |
+| [`eth_getTransactionReceipt`](/docs/chain-apis/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-get-transaction-receipt) | [`eth_getUncleByBlockHashAndIndex`](/docs/chain-apis/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-get-uncle-by-block-hash-and-index) |
+| [`eth_getUncleByBlockNumberAndIndex`](/docs/chain-apis/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-get-uncle-by-block-number-and-index) | [`eth_getUncleCountByBlockHash`](/docs/chain-apis/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-get-uncle-count-by-block-hash) |
+| [`eth_getUncleCountByBlockNumber`](/docs/chain-apis/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-get-uncle-count-by-block-number) | [`eth_newBlockFilter`](/docs/chain-apis/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-new-block-filter) |
+| [`eth_newFilter`](/docs/chain-apis/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-new-filter)         | [`eth_newPendingTransactionFilter`](/docs/chain-apis/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-new-pending-transaction-filter) |
+| [`eth_protocolVersion`](/docs/chain-apis/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-protocol-version) | [`eth_sendRawTransaction`](/docs/chain-apis/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-send-raw-transaction) |
+| [`eth_submitWork`](/docs/chain-apis/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-submit-work)       | [`eth_subscribe`](/docs/chain-apis/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-subscribe)      |
+| [`eth_syncing`](/docs/chain-apis/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-syncing)              | [`eth_uninstallFilter`](/docs/chain-apis/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-uninstall-filter) |
+| [`eth_unsubscribe`](/docs/chain-apis/polygon-zkevm/polygon-zk-evm-api-endpoints/eth-unsubscribe)      | [`net_version`](/docs/chain-apis/polygon-zkevm/polygon-zk-evm-api-endpoints/net-version)          |
+| [`web3_clientVersion`](/docs/chain-apis/polygon-zkevm/polygon-zk-evm-api-endpoints/web-3-client-version) | [`web3_sha3`](/docs/chain-apis/polygon-zkevm/polygon-zk-evm-api-endpoints/web-3-sha-3)            |
+| [`zkevm_batchNumber`](/docs/chain-apis/polygon-zkevm/polygon-zk-evm-api-endpoints/zkevm-batch-number) | [`zkevm_batchNumberByBlockNumber`](/docs/chain-apis/polygon-zkevm/polygon-zk-evm-api-endpoints/zkevm-batch-number-by-block-number) |
+| [`zkevm_consolidatedBlockNumber`](/docs/chain-apis/polygon-zkevm/polygon-zk-evm-api-endpoints/zkevm-consolidated-block-number) | [`zkevm_estimateFee`](/docs/chain-apis/polygon-zkevm/polygon-zk-evm-api-endpoints/zkevm-estimate-fee) |
+| [`zkevm_estimateGasPrice`](/docs/chain-apis/polygon-zkevm/polygon-zk-evm-api-endpoints/zkevm-estimate-gas-price) | [`zkevm_getBatchByNumber`](/docs/chain-apis/polygon-zkevm/polygon-zk-evm-api-endpoints/zkevm-get-batch-by-number) |
+| [`zkevm_getBroadcastURI`](/docs/chain-apis/polygon-zkevm/polygon-zk-evm-api-endpoints/zkevm-get-broadcast-uri) | [`zkevm_isBlockConsolidated`](/docs/chain-apis/polygon-zkevm/polygon-zk-evm-api-endpoints/zkevm-is-block-consolidated) |
+| [`zkevm_isBlockVirtualized`](/docs/chain-apis/polygon-zkevm/polygon-zk-evm-api-endpoints/zkevm-is-block-virtualized) | [`zkevm_verifiedBatchNumber`](/docs/chain-apis/polygon-zkevm/polygon-zk-evm-api-endpoints/zkevm-verified-batch-number) |
+| [`zkevm_virtualBatchNumber`](/docs/chain-apis/polygon-zkevm/polygon-zk-evm-api-endpoints/zkevm-virtual-batch-number) |                                                                                             |
 
 ## Rise APIs
 
@@ -1083,23 +1083,23 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_blockNumber`](/docs/node/rise/rise-api-endpoints/eth-block-number)                        | [`eth_call`](/docs/node/rise/rise-api-endpoints/eth-call)                                   |
-| [`eth_callMany`](/docs/node/rise/rise-api-endpoints/eth-call-many)                              | [`eth_chainId`](/docs/node/rise/rise-api-endpoints/eth-chain-id)                            |
-| [`eth_estimateGas`](/docs/node/rise/rise-api-endpoints/eth-estimate-gas)                        | [`eth_gasPrice`](/docs/node/rise/rise-api-endpoints/eth-gas-price)                          |
-| [`eth_getAccount`](/docs/node/rise/rise-api-endpoints/eth-get-account)                          | [`eth_getBalance`](/docs/node/rise/rise-api-endpoints/eth-get-balance)                      |
-| [`eth_getBlockByHash`](/docs/node/rise/rise-api-endpoints/eth-get-block-by-hash)                | [`eth_getBlockByNumber`](/docs/node/rise/rise-api-endpoints/eth-get-block-by-number)        |
-| [`eth_getBlockTransactionCountByHash`](/docs/node/rise/rise-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/node/rise/rise-api-endpoints/eth-get-block-transaction-count-by-number) |
-| [`eth_getCode`](/docs/node/rise/rise-api-endpoints/eth-get-code)                                | [`eth_getFilterChanges`](/docs/node/rise/rise-api-endpoints/eth-get-filter-changes)         |
-| [`eth_getFilterLogs`](/docs/node/rise/rise-api-endpoints/eth-get-filter-logs)                   | [`eth_getLogs`](/docs/node/rise/rise-api-endpoints/eth-get-logs)                            |
-| [`eth_getStorageAt`](/docs/node/rise/rise-api-endpoints/eth-get-storage-at)                     | [`eth_getTransactionByBlockHashAndIndex`](/docs/node/rise/rise-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
-| [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/rise/rise-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/node/rise/rise-api-endpoints/eth-get-transaction-by-hash) |
-| [`eth_getTransactionCount`](/docs/node/rise/rise-api-endpoints/eth-get-transaction-count)       | [`eth_getTransactionReceipt`](/docs/node/rise/rise-api-endpoints/eth-get-transaction-receipt) |
-| [`eth_newBlockFilter`](/docs/node/rise/rise-api-endpoints/eth-new-block-filter)                 | [`eth_newFilter`](/docs/node/rise/rise-api-endpoints/eth-new-filter)                        |
-| [`eth_sendRawTransaction`](/docs/node/rise/rise-api-endpoints/eth-send-raw-transaction)         | [`eth_sendRawTransactionSync`](/docs/node/rise/rise-api-endpoints/eth-send-raw-transaction-sync) |
-| [`eth_submitWork`](/docs/node/rise/rise-api-endpoints/eth-submit-work)                          | [`eth_subscribe`](/docs/node/rise/rise-api-endpoints/eth-subscribe)                         |
-| [`eth_uninstallFilter`](/docs/node/rise/rise-api-endpoints/eth-uninstall-filter)                | [`eth_unsubscribe`](/docs/node/rise/rise-api-endpoints/eth-unsubscribe)                     |
-| [`net_version`](/docs/node/rise/rise-api-endpoints/net-version)                                 | [`web3_clientVersion`](/docs/node/rise/rise-api-endpoints/web-3-client-version)             |
-| [`web3_sha3`](/docs/node/rise/rise-api-endpoints/web-3-sha-3)                                   |                                                                                             |
+| [`eth_blockNumber`](/docs/chain-apis/rise/rise-api-endpoints/eth-block-number)                        | [`eth_call`](/docs/chain-apis/rise/rise-api-endpoints/eth-call)                                   |
+| [`eth_callMany`](/docs/chain-apis/rise/rise-api-endpoints/eth-call-many)                              | [`eth_chainId`](/docs/chain-apis/rise/rise-api-endpoints/eth-chain-id)                            |
+| [`eth_estimateGas`](/docs/chain-apis/rise/rise-api-endpoints/eth-estimate-gas)                        | [`eth_gasPrice`](/docs/chain-apis/rise/rise-api-endpoints/eth-gas-price)                          |
+| [`eth_getAccount`](/docs/chain-apis/rise/rise-api-endpoints/eth-get-account)                          | [`eth_getBalance`](/docs/chain-apis/rise/rise-api-endpoints/eth-get-balance)                      |
+| [`eth_getBlockByHash`](/docs/chain-apis/rise/rise-api-endpoints/eth-get-block-by-hash)                | [`eth_getBlockByNumber`](/docs/chain-apis/rise/rise-api-endpoints/eth-get-block-by-number)        |
+| [`eth_getBlockTransactionCountByHash`](/docs/chain-apis/rise/rise-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/chain-apis/rise/rise-api-endpoints/eth-get-block-transaction-count-by-number) |
+| [`eth_getCode`](/docs/chain-apis/rise/rise-api-endpoints/eth-get-code)                                | [`eth_getFilterChanges`](/docs/chain-apis/rise/rise-api-endpoints/eth-get-filter-changes)         |
+| [`eth_getFilterLogs`](/docs/chain-apis/rise/rise-api-endpoints/eth-get-filter-logs)                   | [`eth_getLogs`](/docs/chain-apis/rise/rise-api-endpoints/eth-get-logs)                            |
+| [`eth_getStorageAt`](/docs/chain-apis/rise/rise-api-endpoints/eth-get-storage-at)                     | [`eth_getTransactionByBlockHashAndIndex`](/docs/chain-apis/rise/rise-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
+| [`eth_getTransactionByBlockNumberAndIndex`](/docs/chain-apis/rise/rise-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/chain-apis/rise/rise-api-endpoints/eth-get-transaction-by-hash) |
+| [`eth_getTransactionCount`](/docs/chain-apis/rise/rise-api-endpoints/eth-get-transaction-count)       | [`eth_getTransactionReceipt`](/docs/chain-apis/rise/rise-api-endpoints/eth-get-transaction-receipt) |
+| [`eth_newBlockFilter`](/docs/chain-apis/rise/rise-api-endpoints/eth-new-block-filter)                 | [`eth_newFilter`](/docs/chain-apis/rise/rise-api-endpoints/eth-new-filter)                        |
+| [`eth_sendRawTransaction`](/docs/chain-apis/rise/rise-api-endpoints/eth-send-raw-transaction)         | [`eth_sendRawTransactionSync`](/docs/chain-apis/rise/rise-api-endpoints/eth-send-raw-transaction-sync) |
+| [`eth_submitWork`](/docs/chain-apis/rise/rise-api-endpoints/eth-submit-work)                          | [`eth_subscribe`](/docs/chain-apis/rise/rise-api-endpoints/eth-subscribe)                         |
+| [`eth_uninstallFilter`](/docs/chain-apis/rise/rise-api-endpoints/eth-uninstall-filter)                | [`eth_unsubscribe`](/docs/chain-apis/rise/rise-api-endpoints/eth-unsubscribe)                     |
+| [`net_version`](/docs/chain-apis/rise/rise-api-endpoints/net-version)                                 | [`web3_clientVersion`](/docs/chain-apis/rise/rise-api-endpoints/web-3-client-version)             |
+| [`web3_sha3`](/docs/chain-apis/rise/rise-api-endpoints/web-3-sha-3)                                   |                                                                                             |
 
 ## Ronin APIs
 
@@ -1107,23 +1107,23 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_blockNumber`](/docs/node/ronin/ronin-api-endpoints/eth-block-number)                      | [`eth_call`](/docs/node/ronin/ronin-api-endpoints/eth-call)                                 |
-| [`eth_callMany`](/docs/node/ronin/ronin-api-endpoints/eth-call-many)                            | [`eth_chainId`](/docs/node/ronin/ronin-api-endpoints/eth-chain-id)                          |
-| [`eth_estimateGas`](/docs/node/ronin/ronin-api-endpoints/eth-estimate-gas)                      | [`eth_gasPrice`](/docs/node/ronin/ronin-api-endpoints/eth-gas-price)                        |
-| [`eth_getAccount`](/docs/node/ronin/ronin-api-endpoints/eth-get-account)                        | [`eth_getBalance`](/docs/node/ronin/ronin-api-endpoints/eth-get-balance)                    |
-| [`eth_getBlockByHash`](/docs/node/ronin/ronin-api-endpoints/eth-get-block-by-hash)              | [`eth_getBlockByNumber`](/docs/node/ronin/ronin-api-endpoints/eth-get-block-by-number)      |
-| [`eth_getBlockTransactionCountByHash`](/docs/node/ronin/ronin-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/node/ronin/ronin-api-endpoints/eth-get-block-transaction-count-by-number) |
-| [`eth_getCode`](/docs/node/ronin/ronin-api-endpoints/eth-get-code)                              | [`eth_getFilterChanges`](/docs/node/ronin/ronin-api-endpoints/eth-get-filter-changes)       |
-| [`eth_getFilterLogs`](/docs/node/ronin/ronin-api-endpoints/eth-get-filter-logs)                 | [`eth_getLogs`](/docs/node/ronin/ronin-api-endpoints/eth-get-logs)                          |
-| [`eth_getStorageAt`](/docs/node/ronin/ronin-api-endpoints/eth-get-storage-at)                   | [`eth_getTransactionByBlockHashAndIndex`](/docs/node/ronin/ronin-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
-| [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/ronin/ronin-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/node/ronin/ronin-api-endpoints/eth-get-transaction-by-hash) |
-| [`eth_getTransactionCount`](/docs/node/ronin/ronin-api-endpoints/eth-get-transaction-count)     | [`eth_getTransactionReceipt`](/docs/node/ronin/ronin-api-endpoints/eth-get-transaction-receipt) |
-| [`eth_newBlockFilter`](/docs/node/ronin/ronin-api-endpoints/eth-new-block-filter)               | [`eth_newFilter`](/docs/node/ronin/ronin-api-endpoints/eth-new-filter)                      |
-| [`eth_sendRawTransaction`](/docs/node/ronin/ronin-api-endpoints/eth-send-raw-transaction)       | [`eth_simulateV1`](/docs/node/ronin/ronin-api-endpoints/eth-simulate-v-1)                   |
-| [`eth_submitWork`](/docs/node/ronin/ronin-api-endpoints/eth-submit-work)                        | [`eth_subscribe`](/docs/node/ronin/ronin-api-endpoints/eth-subscribe)                       |
-| [`eth_uninstallFilter`](/docs/node/ronin/ronin-api-endpoints/eth-uninstall-filter)              | [`eth_unsubscribe`](/docs/node/ronin/ronin-api-endpoints/eth-unsubscribe)                   |
-| [`net_version`](/docs/node/ronin/ronin-api-endpoints/net-version)                               | [`web3_clientVersion`](/docs/node/ronin/ronin-api-endpoints/web-3-client-version)           |
-| [`web3_sha3`](/docs/node/ronin/ronin-api-endpoints/web-3-sha-3)                                 |                                                                                             |
+| [`eth_blockNumber`](/docs/chain-apis/ronin/ronin-api-endpoints/eth-block-number)                      | [`eth_call`](/docs/chain-apis/ronin/ronin-api-endpoints/eth-call)                                 |
+| [`eth_callMany`](/docs/chain-apis/ronin/ronin-api-endpoints/eth-call-many)                            | [`eth_chainId`](/docs/chain-apis/ronin/ronin-api-endpoints/eth-chain-id)                          |
+| [`eth_estimateGas`](/docs/chain-apis/ronin/ronin-api-endpoints/eth-estimate-gas)                      | [`eth_gasPrice`](/docs/chain-apis/ronin/ronin-api-endpoints/eth-gas-price)                        |
+| [`eth_getAccount`](/docs/chain-apis/ronin/ronin-api-endpoints/eth-get-account)                        | [`eth_getBalance`](/docs/chain-apis/ronin/ronin-api-endpoints/eth-get-balance)                    |
+| [`eth_getBlockByHash`](/docs/chain-apis/ronin/ronin-api-endpoints/eth-get-block-by-hash)              | [`eth_getBlockByNumber`](/docs/chain-apis/ronin/ronin-api-endpoints/eth-get-block-by-number)      |
+| [`eth_getBlockTransactionCountByHash`](/docs/chain-apis/ronin/ronin-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/chain-apis/ronin/ronin-api-endpoints/eth-get-block-transaction-count-by-number) |
+| [`eth_getCode`](/docs/chain-apis/ronin/ronin-api-endpoints/eth-get-code)                              | [`eth_getFilterChanges`](/docs/chain-apis/ronin/ronin-api-endpoints/eth-get-filter-changes)       |
+| [`eth_getFilterLogs`](/docs/chain-apis/ronin/ronin-api-endpoints/eth-get-filter-logs)                 | [`eth_getLogs`](/docs/chain-apis/ronin/ronin-api-endpoints/eth-get-logs)                          |
+| [`eth_getStorageAt`](/docs/chain-apis/ronin/ronin-api-endpoints/eth-get-storage-at)                   | [`eth_getTransactionByBlockHashAndIndex`](/docs/chain-apis/ronin/ronin-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
+| [`eth_getTransactionByBlockNumberAndIndex`](/docs/chain-apis/ronin/ronin-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/chain-apis/ronin/ronin-api-endpoints/eth-get-transaction-by-hash) |
+| [`eth_getTransactionCount`](/docs/chain-apis/ronin/ronin-api-endpoints/eth-get-transaction-count)     | [`eth_getTransactionReceipt`](/docs/chain-apis/ronin/ronin-api-endpoints/eth-get-transaction-receipt) |
+| [`eth_newBlockFilter`](/docs/chain-apis/ronin/ronin-api-endpoints/eth-new-block-filter)               | [`eth_newFilter`](/docs/chain-apis/ronin/ronin-api-endpoints/eth-new-filter)                      |
+| [`eth_sendRawTransaction`](/docs/chain-apis/ronin/ronin-api-endpoints/eth-send-raw-transaction)       | [`eth_simulateV1`](/docs/chain-apis/ronin/ronin-api-endpoints/eth-simulate-v-1)                   |
+| [`eth_submitWork`](/docs/chain-apis/ronin/ronin-api-endpoints/eth-submit-work)                        | [`eth_subscribe`](/docs/chain-apis/ronin/ronin-api-endpoints/eth-subscribe)                       |
+| [`eth_uninstallFilter`](/docs/chain-apis/ronin/ronin-api-endpoints/eth-uninstall-filter)              | [`eth_unsubscribe`](/docs/chain-apis/ronin/ronin-api-endpoints/eth-unsubscribe)                   |
+| [`net_version`](/docs/chain-apis/ronin/ronin-api-endpoints/net-version)                               | [`web3_clientVersion`](/docs/chain-apis/ronin/ronin-api-endpoints/web-3-client-version)           |
+| [`web3_sha3`](/docs/chain-apis/ronin/ronin-api-endpoints/web-3-sha-3)                                 |                                                                                             |
 
 ## Rootstock APIs
 
@@ -1131,22 +1131,22 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_blockNumber`](/docs/node/rootstock/rootstock-api-endpoints/eth-block-number)              | [`eth_call`](/docs/node/rootstock/rootstock-api-endpoints/eth-call)                         |
-| [`eth_callMany`](/docs/node/rootstock/rootstock-api-endpoints/eth-call-many)                    | [`eth_chainId`](/docs/node/rootstock/rootstock-api-endpoints/eth-chain-id)                  |
-| [`eth_estimateGas`](/docs/node/rootstock/rootstock-api-endpoints/eth-estimate-gas)              | [`eth_gasPrice`](/docs/node/rootstock/rootstock-api-endpoints/eth-gas-price)                |
-| [`eth_getAccount`](/docs/node/rootstock/rootstock-api-endpoints/eth-get-account)                | [`eth_getBalance`](/docs/node/rootstock/rootstock-api-endpoints/eth-get-balance)            |
-| [`eth_getBlockByHash`](/docs/node/rootstock/rootstock-api-endpoints/eth-get-block-by-hash)      | [`eth_getBlockByNumber`](/docs/node/rootstock/rootstock-api-endpoints/eth-get-block-by-number) |
-| [`eth_getBlockTransactionCountByHash`](/docs/node/rootstock/rootstock-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/node/rootstock/rootstock-api-endpoints/eth-get-block-transaction-count-by-number) |
-| [`eth_getCode`](/docs/node/rootstock/rootstock-api-endpoints/eth-get-code)                      | [`eth_getFilterChanges`](/docs/node/rootstock/rootstock-api-endpoints/eth-get-filter-changes) |
-| [`eth_getFilterLogs`](/docs/node/rootstock/rootstock-api-endpoints/eth-get-filter-logs)         | [`eth_getLogs`](/docs/node/rootstock/rootstock-api-endpoints/eth-get-logs)                  |
-| [`eth_getStorageAt`](/docs/node/rootstock/rootstock-api-endpoints/eth-get-storage-at)           | [`eth_getTransactionByBlockHashAndIndex`](/docs/node/rootstock/rootstock-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
-| [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/rootstock/rootstock-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/node/rootstock/rootstock-api-endpoints/eth-get-transaction-by-hash) |
-| [`eth_getTransactionCount`](/docs/node/rootstock/rootstock-api-endpoints/eth-get-transaction-count) | [`eth_getTransactionReceipt`](/docs/node/rootstock/rootstock-api-endpoints/eth-get-transaction-receipt) |
-| [`eth_newBlockFilter`](/docs/node/rootstock/rootstock-api-endpoints/eth-new-block-filter)       | [`eth_newFilter`](/docs/node/rootstock/rootstock-api-endpoints/eth-new-filter)              |
-| [`eth_sendRawTransaction`](/docs/node/rootstock/rootstock-api-endpoints/eth-send-raw-transaction) | [`eth_submitWork`](/docs/node/rootstock/rootstock-api-endpoints/eth-submit-work)            |
-| [`eth_subscribe`](/docs/node/rootstock/rootstock-api-endpoints/eth-subscribe)                   | [`eth_uninstallFilter`](/docs/node/rootstock/rootstock-api-endpoints/eth-uninstall-filter)  |
-| [`eth_unsubscribe`](/docs/node/rootstock/rootstock-api-endpoints/eth-unsubscribe)               | [`net_version`](/docs/node/rootstock/rootstock-api-endpoints/net-version)                   |
-| [`web3_clientVersion`](/docs/node/rootstock/rootstock-api-endpoints/web-3-client-version)       | [`web3_sha3`](/docs/node/rootstock/rootstock-api-endpoints/web-3-sha-3)                     |
+| [`eth_blockNumber`](/docs/chain-apis/rootstock/rootstock-api-endpoints/eth-block-number)              | [`eth_call`](/docs/chain-apis/rootstock/rootstock-api-endpoints/eth-call)                         |
+| [`eth_callMany`](/docs/chain-apis/rootstock/rootstock-api-endpoints/eth-call-many)                    | [`eth_chainId`](/docs/chain-apis/rootstock/rootstock-api-endpoints/eth-chain-id)                  |
+| [`eth_estimateGas`](/docs/chain-apis/rootstock/rootstock-api-endpoints/eth-estimate-gas)              | [`eth_gasPrice`](/docs/chain-apis/rootstock/rootstock-api-endpoints/eth-gas-price)                |
+| [`eth_getAccount`](/docs/chain-apis/rootstock/rootstock-api-endpoints/eth-get-account)                | [`eth_getBalance`](/docs/chain-apis/rootstock/rootstock-api-endpoints/eth-get-balance)            |
+| [`eth_getBlockByHash`](/docs/chain-apis/rootstock/rootstock-api-endpoints/eth-get-block-by-hash)      | [`eth_getBlockByNumber`](/docs/chain-apis/rootstock/rootstock-api-endpoints/eth-get-block-by-number) |
+| [`eth_getBlockTransactionCountByHash`](/docs/chain-apis/rootstock/rootstock-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/chain-apis/rootstock/rootstock-api-endpoints/eth-get-block-transaction-count-by-number) |
+| [`eth_getCode`](/docs/chain-apis/rootstock/rootstock-api-endpoints/eth-get-code)                      | [`eth_getFilterChanges`](/docs/chain-apis/rootstock/rootstock-api-endpoints/eth-get-filter-changes) |
+| [`eth_getFilterLogs`](/docs/chain-apis/rootstock/rootstock-api-endpoints/eth-get-filter-logs)         | [`eth_getLogs`](/docs/chain-apis/rootstock/rootstock-api-endpoints/eth-get-logs)                  |
+| [`eth_getStorageAt`](/docs/chain-apis/rootstock/rootstock-api-endpoints/eth-get-storage-at)           | [`eth_getTransactionByBlockHashAndIndex`](/docs/chain-apis/rootstock/rootstock-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
+| [`eth_getTransactionByBlockNumberAndIndex`](/docs/chain-apis/rootstock/rootstock-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/chain-apis/rootstock/rootstock-api-endpoints/eth-get-transaction-by-hash) |
+| [`eth_getTransactionCount`](/docs/chain-apis/rootstock/rootstock-api-endpoints/eth-get-transaction-count) | [`eth_getTransactionReceipt`](/docs/chain-apis/rootstock/rootstock-api-endpoints/eth-get-transaction-receipt) |
+| [`eth_newBlockFilter`](/docs/chain-apis/rootstock/rootstock-api-endpoints/eth-new-block-filter)       | [`eth_newFilter`](/docs/chain-apis/rootstock/rootstock-api-endpoints/eth-new-filter)              |
+| [`eth_sendRawTransaction`](/docs/chain-apis/rootstock/rootstock-api-endpoints/eth-send-raw-transaction) | [`eth_submitWork`](/docs/chain-apis/rootstock/rootstock-api-endpoints/eth-submit-work)            |
+| [`eth_subscribe`](/docs/chain-apis/rootstock/rootstock-api-endpoints/eth-subscribe)                   | [`eth_uninstallFilter`](/docs/chain-apis/rootstock/rootstock-api-endpoints/eth-uninstall-filter)  |
+| [`eth_unsubscribe`](/docs/chain-apis/rootstock/rootstock-api-endpoints/eth-unsubscribe)               | [`net_version`](/docs/chain-apis/rootstock/rootstock-api-endpoints/net-version)                   |
+| [`web3_clientVersion`](/docs/chain-apis/rootstock/rootstock-api-endpoints/web-3-client-version)       | [`web3_sha3`](/docs/chain-apis/rootstock/rootstock-api-endpoints/web-3-sha-3)                     |
 
 ## Scroll APIs
 
@@ -1154,27 +1154,27 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_blockNumber`](/docs/node/scroll/scroll-api-endpoints/eth-block-number)                    | [`eth_call`](/docs/node/scroll/scroll-api-endpoints/eth-call)                               |
-| [`eth_callMany`](/docs/node/scroll/scroll-api-endpoints/eth-call-many)                          | [`eth_chainId`](/docs/node/scroll/scroll-api-endpoints/eth-chain-id)                        |
-| [`eth_createAccessList`](/docs/node/scroll/scroll-api-endpoints/eth-create-access-list)         | [`eth_estimateGas`](/docs/node/scroll/scroll-api-endpoints/eth-estimate-gas)                |
-| [`eth_feeHistory`](/docs/node/scroll/scroll-api-endpoints/eth-fee-history)                      | [`eth_gasPrice`](/docs/node/scroll/scroll-api-endpoints/eth-gas-price)                      |
-| [`eth_getAccount`](/docs/node/scroll/scroll-api-endpoints/eth-get-account)                      | [`eth_getBalance`](/docs/node/scroll/scroll-api-endpoints/eth-get-balance)                  |
-| [`eth_getBlockByHash`](/docs/node/scroll/scroll-api-endpoints/eth-get-block-by-hash)            | [`eth_getBlockByNumber`](/docs/node/scroll/scroll-api-endpoints/eth-get-block-by-number)    |
-| [`eth_getBlockReceipts`](/docs/node/scroll/scroll-api-endpoints/eth-get-block-receipts)         | [`eth_getBlockTransactionCountByHash`](/docs/node/scroll/scroll-api-endpoints/eth-get-block-transaction-count-by-hash) |
-| [`eth_getBlockTransactionCountByNumber`](/docs/node/scroll/scroll-api-endpoints/eth-get-block-transaction-count-by-number) | [`eth_getCode`](/docs/node/scroll/scroll-api-endpoints/eth-get-code)                        |
-| [`eth_getFilterChanges`](/docs/node/scroll/scroll-api-endpoints/eth-get-filter-changes)         | [`eth_getFilterLogs`](/docs/node/scroll/scroll-api-endpoints/eth-get-filter-logs)           |
-| [`eth_getLogs`](/docs/node/scroll/scroll-api-endpoints/eth-get-logs)                            | [`eth_getProof`](/docs/node/scroll/scroll-api-endpoints/eth-get-proof)                      |
-| [`eth_getStorageAt`](/docs/node/scroll/scroll-api-endpoints/eth-get-storage-at)                 | [`eth_getTransactionByBlockHashAndIndex`](/docs/node/scroll/scroll-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
-| [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/scroll/scroll-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/node/scroll/scroll-api-endpoints/eth-get-transaction-by-hash) |
-| [`eth_getTransactionCount`](/docs/node/scroll/scroll-api-endpoints/eth-get-transaction-count)   | [`eth_getTransactionReceipt`](/docs/node/scroll/scroll-api-endpoints/eth-get-transaction-receipt) |
-| [`eth_getUncleByBlockHashAndIndex`](/docs/node/scroll/scroll-api-endpoints/eth-get-uncle-by-block-hash-and-index) | [`eth_getUncleByBlockNumberAndIndex`](/docs/node/scroll/scroll-api-endpoints/eth-get-uncle-by-block-number-and-index) |
-| [`eth_getUncleCountByBlockHash`](/docs/node/scroll/scroll-api-endpoints/eth-get-uncle-count-by-block-hash) | [`eth_getUncleCountByBlockNumber`](/docs/node/scroll/scroll-api-endpoints/eth-get-uncle-count-by-block-number) |
-| [`eth_maxPriorityFeePerGas`](/docs/node/scroll/scroll-api-endpoints/eth-max-priority-fee-per-gas) | [`eth_newBlockFilter`](/docs/node/scroll/scroll-api-endpoints/eth-new-block-filter)         |
-| [`eth_newFilter`](/docs/node/scroll/scroll-api-endpoints/eth-new-filter)                        | [`eth_sendRawTransaction`](/docs/node/scroll/scroll-api-endpoints/eth-send-raw-transaction) |
-| [`eth_submitWork`](/docs/node/scroll/scroll-api-endpoints/eth-submit-work)                      | [`eth_subscribe`](/docs/node/scroll/scroll-api-endpoints/eth-subscribe)                     |
-| [`eth_syncing`](/docs/node/scroll/scroll-api-endpoints/eth-syncing)                             | [`eth_uninstallFilter`](/docs/node/scroll/scroll-api-endpoints/eth-uninstall-filter)        |
-| [`eth_unsubscribe`](/docs/node/scroll/scroll-api-endpoints/eth-unsubscribe)                     | [`net_version`](/docs/node/scroll/scroll-api-endpoints/net-version)                         |
-| [`web3_clientVersion`](/docs/node/scroll/scroll-api-endpoints/web-3-client-version)             | [`web3_sha3`](/docs/node/scroll/scroll-api-endpoints/web-3-sha-3)                           |
+| [`eth_blockNumber`](/docs/chain-apis/scroll/scroll-api-endpoints/eth-block-number)                    | [`eth_call`](/docs/chain-apis/scroll/scroll-api-endpoints/eth-call)                               |
+| [`eth_callMany`](/docs/chain-apis/scroll/scroll-api-endpoints/eth-call-many)                          | [`eth_chainId`](/docs/chain-apis/scroll/scroll-api-endpoints/eth-chain-id)                        |
+| [`eth_createAccessList`](/docs/chain-apis/scroll/scroll-api-endpoints/eth-create-access-list)         | [`eth_estimateGas`](/docs/chain-apis/scroll/scroll-api-endpoints/eth-estimate-gas)                |
+| [`eth_feeHistory`](/docs/chain-apis/scroll/scroll-api-endpoints/eth-fee-history)                      | [`eth_gasPrice`](/docs/chain-apis/scroll/scroll-api-endpoints/eth-gas-price)                      |
+| [`eth_getAccount`](/docs/chain-apis/scroll/scroll-api-endpoints/eth-get-account)                      | [`eth_getBalance`](/docs/chain-apis/scroll/scroll-api-endpoints/eth-get-balance)                  |
+| [`eth_getBlockByHash`](/docs/chain-apis/scroll/scroll-api-endpoints/eth-get-block-by-hash)            | [`eth_getBlockByNumber`](/docs/chain-apis/scroll/scroll-api-endpoints/eth-get-block-by-number)    |
+| [`eth_getBlockReceipts`](/docs/chain-apis/scroll/scroll-api-endpoints/eth-get-block-receipts)         | [`eth_getBlockTransactionCountByHash`](/docs/chain-apis/scroll/scroll-api-endpoints/eth-get-block-transaction-count-by-hash) |
+| [`eth_getBlockTransactionCountByNumber`](/docs/chain-apis/scroll/scroll-api-endpoints/eth-get-block-transaction-count-by-number) | [`eth_getCode`](/docs/chain-apis/scroll/scroll-api-endpoints/eth-get-code)                        |
+| [`eth_getFilterChanges`](/docs/chain-apis/scroll/scroll-api-endpoints/eth-get-filter-changes)         | [`eth_getFilterLogs`](/docs/chain-apis/scroll/scroll-api-endpoints/eth-get-filter-logs)           |
+| [`eth_getLogs`](/docs/chain-apis/scroll/scroll-api-endpoints/eth-get-logs)                            | [`eth_getProof`](/docs/chain-apis/scroll/scroll-api-endpoints/eth-get-proof)                      |
+| [`eth_getStorageAt`](/docs/chain-apis/scroll/scroll-api-endpoints/eth-get-storage-at)                 | [`eth_getTransactionByBlockHashAndIndex`](/docs/chain-apis/scroll/scroll-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
+| [`eth_getTransactionByBlockNumberAndIndex`](/docs/chain-apis/scroll/scroll-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/chain-apis/scroll/scroll-api-endpoints/eth-get-transaction-by-hash) |
+| [`eth_getTransactionCount`](/docs/chain-apis/scroll/scroll-api-endpoints/eth-get-transaction-count)   | [`eth_getTransactionReceipt`](/docs/chain-apis/scroll/scroll-api-endpoints/eth-get-transaction-receipt) |
+| [`eth_getUncleByBlockHashAndIndex`](/docs/chain-apis/scroll/scroll-api-endpoints/eth-get-uncle-by-block-hash-and-index) | [`eth_getUncleByBlockNumberAndIndex`](/docs/chain-apis/scroll/scroll-api-endpoints/eth-get-uncle-by-block-number-and-index) |
+| [`eth_getUncleCountByBlockHash`](/docs/chain-apis/scroll/scroll-api-endpoints/eth-get-uncle-count-by-block-hash) | [`eth_getUncleCountByBlockNumber`](/docs/chain-apis/scroll/scroll-api-endpoints/eth-get-uncle-count-by-block-number) |
+| [`eth_maxPriorityFeePerGas`](/docs/chain-apis/scroll/scroll-api-endpoints/eth-max-priority-fee-per-gas) | [`eth_newBlockFilter`](/docs/chain-apis/scroll/scroll-api-endpoints/eth-new-block-filter)         |
+| [`eth_newFilter`](/docs/chain-apis/scroll/scroll-api-endpoints/eth-new-filter)                        | [`eth_sendRawTransaction`](/docs/chain-apis/scroll/scroll-api-endpoints/eth-send-raw-transaction) |
+| [`eth_submitWork`](/docs/chain-apis/scroll/scroll-api-endpoints/eth-submit-work)                      | [`eth_subscribe`](/docs/chain-apis/scroll/scroll-api-endpoints/eth-subscribe)                     |
+| [`eth_syncing`](/docs/chain-apis/scroll/scroll-api-endpoints/eth-syncing)                             | [`eth_uninstallFilter`](/docs/chain-apis/scroll/scroll-api-endpoints/eth-uninstall-filter)        |
+| [`eth_unsubscribe`](/docs/chain-apis/scroll/scroll-api-endpoints/eth-unsubscribe)                     | [`net_version`](/docs/chain-apis/scroll/scroll-api-endpoints/net-version)                         |
+| [`web3_clientVersion`](/docs/chain-apis/scroll/scroll-api-endpoints/web-3-client-version)             | [`web3_sha3`](/docs/chain-apis/scroll/scroll-api-endpoints/web-3-sha-3)                           |
 
 ## Sei APIs
 
@@ -1182,22 +1182,22 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_blockNumber`](/docs/node/sei/sei-api-endpoints/eth-block-number)                          | [`eth_call`](/docs/node/sei/sei-api-endpoints/eth-call)                                     |
-| [`eth_callMany`](/docs/node/sei/sei-api-endpoints/eth-call-many)                                | [`eth_chainId`](/docs/node/sei/sei-api-endpoints/eth-chain-id)                              |
-| [`eth_estimateGas`](/docs/node/sei/sei-api-endpoints/eth-estimate-gas)                          | [`eth_gasPrice`](/docs/node/sei/sei-api-endpoints/eth-gas-price)                            |
-| [`eth_getAccount`](/docs/node/sei/sei-api-endpoints/eth-get-account)                            | [`eth_getBalance`](/docs/node/sei/sei-api-endpoints/eth-get-balance)                        |
-| [`eth_getBlockByHash`](/docs/node/sei/sei-api-endpoints/eth-get-block-by-hash)                  | [`eth_getBlockByNumber`](/docs/node/sei/sei-api-endpoints/eth-get-block-by-number)          |
-| [`eth_getBlockTransactionCountByHash`](/docs/node/sei/sei-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/node/sei/sei-api-endpoints/eth-get-block-transaction-count-by-number) |
-| [`eth_getCode`](/docs/node/sei/sei-api-endpoints/eth-get-code)                                  | [`eth_getFilterChanges`](/docs/node/sei/sei-api-endpoints/eth-get-filter-changes)           |
-| [`eth_getFilterLogs`](/docs/node/sei/sei-api-endpoints/eth-get-filter-logs)                     | [`eth_getLogs`](/docs/node/sei/sei-api-endpoints/eth-get-logs)                              |
-| [`eth_getStorageAt`](/docs/node/sei/sei-api-endpoints/eth-get-storage-at)                       | [`eth_getTransactionByBlockHashAndIndex`](/docs/node/sei/sei-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
-| [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/sei/sei-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/node/sei/sei-api-endpoints/eth-get-transaction-by-hash)  |
-| [`eth_getTransactionCount`](/docs/node/sei/sei-api-endpoints/eth-get-transaction-count)         | [`eth_getTransactionReceipt`](/docs/node/sei/sei-api-endpoints/eth-get-transaction-receipt) |
-| [`eth_newBlockFilter`](/docs/node/sei/sei-api-endpoints/eth-new-block-filter)                   | [`eth_newFilter`](/docs/node/sei/sei-api-endpoints/eth-new-filter)                          |
-| [`eth_sendRawTransaction`](/docs/node/sei/sei-api-endpoints/eth-send-raw-transaction)           | [`eth_submitWork`](/docs/node/sei/sei-api-endpoints/eth-submit-work)                        |
-| [`eth_subscribe`](/docs/node/sei/sei-api-endpoints/eth-subscribe)                               | [`eth_uninstallFilter`](/docs/node/sei/sei-api-endpoints/eth-uninstall-filter)              |
-| [`eth_unsubscribe`](/docs/node/sei/sei-api-endpoints/eth-unsubscribe)                           | [`net_version`](/docs/node/sei/sei-api-endpoints/net-version)                               |
-| [`web3_clientVersion`](/docs/node/sei/sei-api-endpoints/web-3-client-version)                   | [`web3_sha3`](/docs/node/sei/sei-api-endpoints/web-3-sha-3)                                 |
+| [`eth_blockNumber`](/docs/chain-apis/sei/sei-api-endpoints/eth-block-number)                          | [`eth_call`](/docs/chain-apis/sei/sei-api-endpoints/eth-call)                                     |
+| [`eth_callMany`](/docs/chain-apis/sei/sei-api-endpoints/eth-call-many)                                | [`eth_chainId`](/docs/chain-apis/sei/sei-api-endpoints/eth-chain-id)                              |
+| [`eth_estimateGas`](/docs/chain-apis/sei/sei-api-endpoints/eth-estimate-gas)                          | [`eth_gasPrice`](/docs/chain-apis/sei/sei-api-endpoints/eth-gas-price)                            |
+| [`eth_getAccount`](/docs/chain-apis/sei/sei-api-endpoints/eth-get-account)                            | [`eth_getBalance`](/docs/chain-apis/sei/sei-api-endpoints/eth-get-balance)                        |
+| [`eth_getBlockByHash`](/docs/chain-apis/sei/sei-api-endpoints/eth-get-block-by-hash)                  | [`eth_getBlockByNumber`](/docs/chain-apis/sei/sei-api-endpoints/eth-get-block-by-number)          |
+| [`eth_getBlockTransactionCountByHash`](/docs/chain-apis/sei/sei-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/chain-apis/sei/sei-api-endpoints/eth-get-block-transaction-count-by-number) |
+| [`eth_getCode`](/docs/chain-apis/sei/sei-api-endpoints/eth-get-code)                                  | [`eth_getFilterChanges`](/docs/chain-apis/sei/sei-api-endpoints/eth-get-filter-changes)           |
+| [`eth_getFilterLogs`](/docs/chain-apis/sei/sei-api-endpoints/eth-get-filter-logs)                     | [`eth_getLogs`](/docs/chain-apis/sei/sei-api-endpoints/eth-get-logs)                              |
+| [`eth_getStorageAt`](/docs/chain-apis/sei/sei-api-endpoints/eth-get-storage-at)                       | [`eth_getTransactionByBlockHashAndIndex`](/docs/chain-apis/sei/sei-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
+| [`eth_getTransactionByBlockNumberAndIndex`](/docs/chain-apis/sei/sei-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/chain-apis/sei/sei-api-endpoints/eth-get-transaction-by-hash)  |
+| [`eth_getTransactionCount`](/docs/chain-apis/sei/sei-api-endpoints/eth-get-transaction-count)         | [`eth_getTransactionReceipt`](/docs/chain-apis/sei/sei-api-endpoints/eth-get-transaction-receipt) |
+| [`eth_newBlockFilter`](/docs/chain-apis/sei/sei-api-endpoints/eth-new-block-filter)                   | [`eth_newFilter`](/docs/chain-apis/sei/sei-api-endpoints/eth-new-filter)                          |
+| [`eth_sendRawTransaction`](/docs/chain-apis/sei/sei-api-endpoints/eth-send-raw-transaction)           | [`eth_submitWork`](/docs/chain-apis/sei/sei-api-endpoints/eth-submit-work)                        |
+| [`eth_subscribe`](/docs/chain-apis/sei/sei-api-endpoints/eth-subscribe)                               | [`eth_uninstallFilter`](/docs/chain-apis/sei/sei-api-endpoints/eth-uninstall-filter)              |
+| [`eth_unsubscribe`](/docs/chain-apis/sei/sei-api-endpoints/eth-unsubscribe)                           | [`net_version`](/docs/chain-apis/sei/sei-api-endpoints/net-version)                               |
+| [`web3_clientVersion`](/docs/chain-apis/sei/sei-api-endpoints/web-3-client-version)                   | [`web3_sha3`](/docs/chain-apis/sei/sei-api-endpoints/web-3-sha-3)                                 |
 
 ## Settlus APIs
 
@@ -1205,22 +1205,22 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_blockNumber`](/docs/node/settlus/settlus-api-endpoints/eth-block-number)                  | [`eth_call`](/docs/node/settlus/settlus-api-endpoints/eth-call)                             |
-| [`eth_callMany`](/docs/node/settlus/settlus-api-endpoints/eth-call-many)                        | [`eth_chainId`](/docs/node/settlus/settlus-api-endpoints/eth-chain-id)                      |
-| [`eth_estimateGas`](/docs/node/settlus/settlus-api-endpoints/eth-estimate-gas)                  | [`eth_gasPrice`](/docs/node/settlus/settlus-api-endpoints/eth-gas-price)                    |
-| [`eth_getAccount`](/docs/node/settlus/settlus-api-endpoints/eth-get-account)                    | [`eth_getBalance`](/docs/node/settlus/settlus-api-endpoints/eth-get-balance)                |
-| [`eth_getBlockByHash`](/docs/node/settlus/settlus-api-endpoints/eth-get-block-by-hash)          | [`eth_getBlockByNumber`](/docs/node/settlus/settlus-api-endpoints/eth-get-block-by-number)  |
-| [`eth_getBlockTransactionCountByHash`](/docs/node/settlus/settlus-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/node/settlus/settlus-api-endpoints/eth-get-block-transaction-count-by-number) |
-| [`eth_getCode`](/docs/node/settlus/settlus-api-endpoints/eth-get-code)                          | [`eth_getFilterChanges`](/docs/node/settlus/settlus-api-endpoints/eth-get-filter-changes)   |
-| [`eth_getFilterLogs`](/docs/node/settlus/settlus-api-endpoints/eth-get-filter-logs)             | [`eth_getLogs`](/docs/node/settlus/settlus-api-endpoints/eth-get-logs)                      |
-| [`eth_getStorageAt`](/docs/node/settlus/settlus-api-endpoints/eth-get-storage-at)               | [`eth_getTransactionByBlockHashAndIndex`](/docs/node/settlus/settlus-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
-| [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/settlus/settlus-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/node/settlus/settlus-api-endpoints/eth-get-transaction-by-hash) |
-| [`eth_getTransactionCount`](/docs/node/settlus/settlus-api-endpoints/eth-get-transaction-count) | [`eth_getTransactionReceipt`](/docs/node/settlus/settlus-api-endpoints/eth-get-transaction-receipt) |
-| [`eth_newBlockFilter`](/docs/node/settlus/settlus-api-endpoints/eth-new-block-filter)           | [`eth_newFilter`](/docs/node/settlus/settlus-api-endpoints/eth-new-filter)                  |
-| [`eth_sendRawTransaction`](/docs/node/settlus/settlus-api-endpoints/eth-send-raw-transaction)   | [`eth_submitWork`](/docs/node/settlus/settlus-api-endpoints/eth-submit-work)                |
-| [`eth_subscribe`](/docs/node/settlus/settlus-api-endpoints/eth-subscribe)                       | [`eth_uninstallFilter`](/docs/node/settlus/settlus-api-endpoints/eth-uninstall-filter)      |
-| [`eth_unsubscribe`](/docs/node/settlus/settlus-api-endpoints/eth-unsubscribe)                   | [`net_version`](/docs/node/settlus/settlus-api-endpoints/net-version)                       |
-| [`web3_clientVersion`](/docs/node/settlus/settlus-api-endpoints/web-3-client-version)           | [`web3_sha3`](/docs/node/settlus/settlus-api-endpoints/web-3-sha-3)                         |
+| [`eth_blockNumber`](/docs/chain-apis/settlus/settlus-api-endpoints/eth-block-number)                  | [`eth_call`](/docs/chain-apis/settlus/settlus-api-endpoints/eth-call)                             |
+| [`eth_callMany`](/docs/chain-apis/settlus/settlus-api-endpoints/eth-call-many)                        | [`eth_chainId`](/docs/chain-apis/settlus/settlus-api-endpoints/eth-chain-id)                      |
+| [`eth_estimateGas`](/docs/chain-apis/settlus/settlus-api-endpoints/eth-estimate-gas)                  | [`eth_gasPrice`](/docs/chain-apis/settlus/settlus-api-endpoints/eth-gas-price)                    |
+| [`eth_getAccount`](/docs/chain-apis/settlus/settlus-api-endpoints/eth-get-account)                    | [`eth_getBalance`](/docs/chain-apis/settlus/settlus-api-endpoints/eth-get-balance)                |
+| [`eth_getBlockByHash`](/docs/chain-apis/settlus/settlus-api-endpoints/eth-get-block-by-hash)          | [`eth_getBlockByNumber`](/docs/chain-apis/settlus/settlus-api-endpoints/eth-get-block-by-number)  |
+| [`eth_getBlockTransactionCountByHash`](/docs/chain-apis/settlus/settlus-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/chain-apis/settlus/settlus-api-endpoints/eth-get-block-transaction-count-by-number) |
+| [`eth_getCode`](/docs/chain-apis/settlus/settlus-api-endpoints/eth-get-code)                          | [`eth_getFilterChanges`](/docs/chain-apis/settlus/settlus-api-endpoints/eth-get-filter-changes)   |
+| [`eth_getFilterLogs`](/docs/chain-apis/settlus/settlus-api-endpoints/eth-get-filter-logs)             | [`eth_getLogs`](/docs/chain-apis/settlus/settlus-api-endpoints/eth-get-logs)                      |
+| [`eth_getStorageAt`](/docs/chain-apis/settlus/settlus-api-endpoints/eth-get-storage-at)               | [`eth_getTransactionByBlockHashAndIndex`](/docs/chain-apis/settlus/settlus-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
+| [`eth_getTransactionByBlockNumberAndIndex`](/docs/chain-apis/settlus/settlus-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/chain-apis/settlus/settlus-api-endpoints/eth-get-transaction-by-hash) |
+| [`eth_getTransactionCount`](/docs/chain-apis/settlus/settlus-api-endpoints/eth-get-transaction-count) | [`eth_getTransactionReceipt`](/docs/chain-apis/settlus/settlus-api-endpoints/eth-get-transaction-receipt) |
+| [`eth_newBlockFilter`](/docs/chain-apis/settlus/settlus-api-endpoints/eth-new-block-filter)           | [`eth_newFilter`](/docs/chain-apis/settlus/settlus-api-endpoints/eth-new-filter)                  |
+| [`eth_sendRawTransaction`](/docs/chain-apis/settlus/settlus-api-endpoints/eth-send-raw-transaction)   | [`eth_submitWork`](/docs/chain-apis/settlus/settlus-api-endpoints/eth-submit-work)                |
+| [`eth_subscribe`](/docs/chain-apis/settlus/settlus-api-endpoints/eth-subscribe)                       | [`eth_uninstallFilter`](/docs/chain-apis/settlus/settlus-api-endpoints/eth-uninstall-filter)      |
+| [`eth_unsubscribe`](/docs/chain-apis/settlus/settlus-api-endpoints/eth-unsubscribe)                   | [`net_version`](/docs/chain-apis/settlus/settlus-api-endpoints/net-version)                       |
+| [`web3_clientVersion`](/docs/chain-apis/settlus/settlus-api-endpoints/web-3-client-version)           | [`web3_sha3`](/docs/chain-apis/settlus/settlus-api-endpoints/web-3-sha-3)                         |
 
 ## Shape APIs
 
@@ -1228,29 +1228,29 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_accounts`](/docs/node/shape/shape-api-endpoints/eth-accounts)                             | [`eth_blobBaseFee`](/docs/node/shape/shape-api-endpoints/eth-blob-base-fee)                 |
-| [`eth_blockNumber`](/docs/node/shape/shape-api-endpoints/eth-block-number)                      | [`eth_call`](/docs/node/shape/shape-api-endpoints/eth-call)                                 |
-| [`eth_callMany`](/docs/node/shape/shape-api-endpoints/eth-call-many)                            | [`eth_chainId`](/docs/node/shape/shape-api-endpoints/eth-chain-id)                          |
-| [`eth_estimateGas`](/docs/node/shape/shape-api-endpoints/eth-estimate-gas)                      | [`eth_feeHistory`](/docs/node/shape/shape-api-endpoints/eth-fee-history)                    |
-| [`eth_gasPrice`](/docs/node/shape/shape-api-endpoints/eth-gas-price)                            | [`eth_getAccount`](/docs/node/shape/shape-api-endpoints/eth-get-account)                    |
-| [`eth_getBalance`](/docs/node/shape/shape-api-endpoints/eth-get-balance)                        | [`eth_getBlockByHash`](/docs/node/shape/shape-api-endpoints/eth-get-block-by-hash)          |
-| [`eth_getBlockByNumber`](/docs/node/shape/shape-api-endpoints/eth-get-block-by-number)          | [`eth_getBlockReceipts`](/docs/node/shape/shape-api-endpoints/eth-get-block-receipts)       |
-| [`eth_getBlockTransactionCountByHash`](/docs/node/shape/shape-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/node/shape/shape-api-endpoints/eth-get-block-transaction-count-by-number) |
-| [`eth_getCode`](/docs/node/shape/shape-api-endpoints/eth-get-code)                              | [`eth_getFilterChanges`](/docs/node/shape/shape-api-endpoints/eth-get-filter-changes)       |
-| [`eth_getFilterLogs`](/docs/node/shape/shape-api-endpoints/eth-get-filter-logs)                 | [`eth_getLogs`](/docs/node/shape/shape-api-endpoints/eth-get-logs)                          |
-| [`eth_getProof`](/docs/node/shape/shape-api-endpoints/eth-get-proof)                            | [`eth_getStorageAt`](/docs/node/shape/shape-api-endpoints/eth-get-storage-at)               |
-| [`eth_getTransactionByBlockHashAndIndex`](/docs/node/shape/shape-api-endpoints/eth-get-transaction-by-block-hash-and-index) | [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/shape/shape-api-endpoints/eth-get-transaction-by-block-number-and-index) |
-| [`eth_getTransactionByHash`](/docs/node/shape/shape-api-endpoints/eth-get-transaction-by-hash)  | [`eth_getTransactionCount`](/docs/node/shape/shape-api-endpoints/eth-get-transaction-count) |
-| [`eth_getTransactionReceipt`](/docs/node/shape/shape-api-endpoints/eth-get-transaction-receipt) | [`eth_getUncleByBlockHashAndIndex`](/docs/node/shape/shape-api-endpoints/eth-get-uncle-by-block-hash-and-index) |
-| [`eth_getUncleByBlockNumberAndIndex`](/docs/node/shape/shape-api-endpoints/eth-get-uncle-by-block-number-and-index) | [`eth_getUncleCountByBlockHash`](/docs/node/shape/shape-api-endpoints/eth-get-uncle-count-by-block-hash) |
-| [`eth_getUncleCountByBlockNumber`](/docs/node/shape/shape-api-endpoints/eth-get-uncle-count-by-block-number) | [`eth_maxPriorityFeePerGas`](/docs/node/shape/shape-api-endpoints/eth-max-priority-fee-per-gas) |
-| [`eth_newBlockFilter`](/docs/node/shape/shape-api-endpoints/eth-new-block-filter)               | [`eth_newFilter`](/docs/node/shape/shape-api-endpoints/eth-new-filter)                      |
-| [`eth_newPendingTransactionFilter`](/docs/node/shape/shape-api-endpoints/eth-new-pending-transaction-filter) | [`eth_protocolVersion`](/docs/node/shape/shape-api-endpoints/eth-protocol-version)          |
-| [`eth_sendRawTransaction`](/docs/node/shape/shape-api-endpoints/eth-send-raw-transaction)       | [`eth_submitWork`](/docs/node/shape/shape-api-endpoints/eth-submit-work)                    |
-| [`eth_subscribe`](/docs/node/shape/shape-api-endpoints/eth-subscribe)                           | [`eth_syncing`](/docs/node/shape/shape-api-endpoints/eth-syncing)                           |
-| [`eth_uninstallFilter`](/docs/node/shape/shape-api-endpoints/eth-uninstall-filter)              | [`eth_unsubscribe`](/docs/node/shape/shape-api-endpoints/eth-unsubscribe)                   |
-| [`net_version`](/docs/node/shape/shape-api-endpoints/net-version)                               | [`web3_clientVersion`](/docs/node/shape/shape-api-endpoints/web-3-client-version)           |
-| [`web3_sha3`](/docs/node/shape/shape-api-endpoints/web-3-sha-3)                                 |                                                                                             |
+| [`eth_accounts`](/docs/chain-apis/shape/shape-api-endpoints/eth-accounts)                             | [`eth_blobBaseFee`](/docs/chain-apis/shape/shape-api-endpoints/eth-blob-base-fee)                 |
+| [`eth_blockNumber`](/docs/chain-apis/shape/shape-api-endpoints/eth-block-number)                      | [`eth_call`](/docs/chain-apis/shape/shape-api-endpoints/eth-call)                                 |
+| [`eth_callMany`](/docs/chain-apis/shape/shape-api-endpoints/eth-call-many)                            | [`eth_chainId`](/docs/chain-apis/shape/shape-api-endpoints/eth-chain-id)                          |
+| [`eth_estimateGas`](/docs/chain-apis/shape/shape-api-endpoints/eth-estimate-gas)                      | [`eth_feeHistory`](/docs/chain-apis/shape/shape-api-endpoints/eth-fee-history)                    |
+| [`eth_gasPrice`](/docs/chain-apis/shape/shape-api-endpoints/eth-gas-price)                            | [`eth_getAccount`](/docs/chain-apis/shape/shape-api-endpoints/eth-get-account)                    |
+| [`eth_getBalance`](/docs/chain-apis/shape/shape-api-endpoints/eth-get-balance)                        | [`eth_getBlockByHash`](/docs/chain-apis/shape/shape-api-endpoints/eth-get-block-by-hash)          |
+| [`eth_getBlockByNumber`](/docs/chain-apis/shape/shape-api-endpoints/eth-get-block-by-number)          | [`eth_getBlockReceipts`](/docs/chain-apis/shape/shape-api-endpoints/eth-get-block-receipts)       |
+| [`eth_getBlockTransactionCountByHash`](/docs/chain-apis/shape/shape-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/chain-apis/shape/shape-api-endpoints/eth-get-block-transaction-count-by-number) |
+| [`eth_getCode`](/docs/chain-apis/shape/shape-api-endpoints/eth-get-code)                              | [`eth_getFilterChanges`](/docs/chain-apis/shape/shape-api-endpoints/eth-get-filter-changes)       |
+| [`eth_getFilterLogs`](/docs/chain-apis/shape/shape-api-endpoints/eth-get-filter-logs)                 | [`eth_getLogs`](/docs/chain-apis/shape/shape-api-endpoints/eth-get-logs)                          |
+| [`eth_getProof`](/docs/chain-apis/shape/shape-api-endpoints/eth-get-proof)                            | [`eth_getStorageAt`](/docs/chain-apis/shape/shape-api-endpoints/eth-get-storage-at)               |
+| [`eth_getTransactionByBlockHashAndIndex`](/docs/chain-apis/shape/shape-api-endpoints/eth-get-transaction-by-block-hash-and-index) | [`eth_getTransactionByBlockNumberAndIndex`](/docs/chain-apis/shape/shape-api-endpoints/eth-get-transaction-by-block-number-and-index) |
+| [`eth_getTransactionByHash`](/docs/chain-apis/shape/shape-api-endpoints/eth-get-transaction-by-hash)  | [`eth_getTransactionCount`](/docs/chain-apis/shape/shape-api-endpoints/eth-get-transaction-count) |
+| [`eth_getTransactionReceipt`](/docs/chain-apis/shape/shape-api-endpoints/eth-get-transaction-receipt) | [`eth_getUncleByBlockHashAndIndex`](/docs/chain-apis/shape/shape-api-endpoints/eth-get-uncle-by-block-hash-and-index) |
+| [`eth_getUncleByBlockNumberAndIndex`](/docs/chain-apis/shape/shape-api-endpoints/eth-get-uncle-by-block-number-and-index) | [`eth_getUncleCountByBlockHash`](/docs/chain-apis/shape/shape-api-endpoints/eth-get-uncle-count-by-block-hash) |
+| [`eth_getUncleCountByBlockNumber`](/docs/chain-apis/shape/shape-api-endpoints/eth-get-uncle-count-by-block-number) | [`eth_maxPriorityFeePerGas`](/docs/chain-apis/shape/shape-api-endpoints/eth-max-priority-fee-per-gas) |
+| [`eth_newBlockFilter`](/docs/chain-apis/shape/shape-api-endpoints/eth-new-block-filter)               | [`eth_newFilter`](/docs/chain-apis/shape/shape-api-endpoints/eth-new-filter)                      |
+| [`eth_newPendingTransactionFilter`](/docs/chain-apis/shape/shape-api-endpoints/eth-new-pending-transaction-filter) | [`eth_protocolVersion`](/docs/chain-apis/shape/shape-api-endpoints/eth-protocol-version)          |
+| [`eth_sendRawTransaction`](/docs/chain-apis/shape/shape-api-endpoints/eth-send-raw-transaction)       | [`eth_submitWork`](/docs/chain-apis/shape/shape-api-endpoints/eth-submit-work)                    |
+| [`eth_subscribe`](/docs/chain-apis/shape/shape-api-endpoints/eth-subscribe)                           | [`eth_syncing`](/docs/chain-apis/shape/shape-api-endpoints/eth-syncing)                           |
+| [`eth_uninstallFilter`](/docs/chain-apis/shape/shape-api-endpoints/eth-uninstall-filter)              | [`eth_unsubscribe`](/docs/chain-apis/shape/shape-api-endpoints/eth-unsubscribe)                   |
+| [`net_version`](/docs/chain-apis/shape/shape-api-endpoints/net-version)                               | [`web3_clientVersion`](/docs/chain-apis/shape/shape-api-endpoints/web-3-client-version)           |
+| [`web3_sha3`](/docs/chain-apis/shape/shape-api-endpoints/web-3-sha-3)                                 |                                                                                             |
 
 ## Solana APIs
 
@@ -1258,32 +1258,32 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`getAccountInfo`](/docs/node/solana/solana-api-endpoints/get-account-info)                     | [`getBalance`](/docs/node/solana/solana-api-endpoints/get-balance)                          |
-| [`getBlock`](/docs/node/solana/solana-api-endpoints/get-block)                                  | [`getBlockCommitment`](/docs/node/solana/solana-api-endpoints/get-block-commitment)         |
-| [`getBlockHeight`](/docs/node/solana/solana-api-endpoints/get-block-height)                     | [`getBlockProduction`](/docs/node/solana/solana-api-endpoints/get-block-production)         |
-| [`getBlocks`](/docs/node/solana/solana-api-endpoints/get-blocks)                                | [`getBlocksWithLimit`](/docs/node/solana/solana-api-endpoints/get-blocks-with-limit)        |
-| [`getBlockTime`](/docs/node/solana/solana-api-endpoints/get-block-time)                         | [`getClusterNodes`](/docs/node/solana/solana-api-endpoints/get-cluster-nodes)               |
-| [`getEpochInfo`](/docs/node/solana/solana-api-endpoints/get-epoch-info)                         | [`getEpochSchedule`](/docs/node/solana/solana-api-endpoints/get-epoch-schedule)             |
-| [`getFeeForMessage`](/docs/node/solana/solana-api-endpoints/get-fee-for-message)                | [`getFirstAvailableBlock`](/docs/node/solana/solana-api-endpoints/get-first-available-block) |
-| [`getGenesisHash`](/docs/node/solana/solana-api-endpoints/get-genesis-hash)                     | [`getHealth`](/docs/node/solana/solana-api-endpoints/get-health)                            |
-| [`getHighestSnapshotSlot`](/docs/node/solana/solana-api-endpoints/get-highest-snapshot-slot)    | [`getIdentity`](/docs/node/solana/solana-api-endpoints/get-identity)                        |
-| [`getInflationGovernor`](/docs/node/solana/solana-api-endpoints/get-inflation-governor)         | [`getInflationRate`](/docs/node/solana/solana-api-endpoints/get-inflation-rate)             |
-| [`getInflationReward`](/docs/node/solana/solana-api-endpoints/get-inflation-reward)             | [`getLargestAccounts`](/docs/node/solana/solana-api-endpoints/get-largest-accounts)         |
-| [`getLatestBlockhash`](/docs/node/solana/solana-api-endpoints/get-latest-blockhash)             | [`getLeaderSchedule`](/docs/node/solana/solana-api-endpoints/get-leader-schedule)           |
-| [`getMaxRetransmitSlot`](/docs/node/solana/solana-api-endpoints/get-max-retransmit-slot)        | [`getMaxShredInsertSlot`](/docs/node/solana/solana-api-endpoints/get-max-shred-insert-slot) |
-| [`getMinimumBalanceForRentExemption`](/docs/node/solana/solana-api-endpoints/get-minimum-balance-for-rent-exemption) | [`getMultipleAccounts`](/docs/node/solana/solana-api-endpoints/get-multiple-accounts)       |
-| [`getProgramAccounts`](/docs/node/solana/solana-api-endpoints/get-program-accounts)             | [`getRecentPerformanceSamples`](/docs/node/solana/solana-api-endpoints/get-recent-performance-samples) |
-| [`getRecentPrioritizationFees`](/docs/node/solana/solana-api-endpoints/get-recent-prioritization-fees) | [`getSignaturesForAddress`](/docs/node/solana/solana-api-endpoints/get-signatures-for-address) |
-| [`getSignatureStatuses`](/docs/node/solana/solana-api-endpoints/get-signature-statuses)         | [`getSlot`](/docs/node/solana/solana-api-endpoints/get-slot)                                |
-| [`getSlotLeader`](/docs/node/solana/solana-api-endpoints/get-slot-leader)                       | [`getSlotLeaders`](/docs/node/solana/solana-api-endpoints/get-slot-leaders)                 |
-| [`getStakeActivation`](/docs/node/solana/solana-api-endpoints/get-stake-activation)             | [`getSupply`](/docs/node/solana/solana-api-endpoints/get-supply)                            |
-| [`getTokenAccountBalance`](/docs/node/solana/solana-api-endpoints/get-token-account-balance)    | [`getTokenAccountsByDelegate`](/docs/node/solana/solana-api-endpoints/get-token-accounts-by-delegate) |
-| [`getTokenAccountsByOwner`](/docs/node/solana/solana-api-endpoints/get-token-accounts-by-owner) | [`getTokenLargestAccounts`](/docs/node/solana/solana-api-endpoints/get-token-largest-accounts) |
-| [`getTokenSupply`](/docs/node/solana/solana-api-endpoints/get-token-supply)                     | [`getTransaction`](/docs/node/solana/solana-api-endpoints/get-transaction)                  |
-| [`getTransactionCount`](/docs/node/solana/solana-api-endpoints/get-transaction-count)           | [`getVersion`](/docs/node/solana/solana-api-endpoints/get-version)                          |
-| [`getVoteAccounts`](/docs/node/solana/solana-api-endpoints/get-vote-accounts)                   | [`isBlockhashValid`](/docs/node/solana/solana-api-endpoints/is-blockhash-valid)             |
-| [`minimumLedgerSlot`](/docs/node/solana/solana-api-endpoints/minimum-ledger-slot)               | [`requestAirdrop`](/docs/node/solana/solana-api-endpoints/request-airdrop)                  |
-| [`sendTransaction`](/docs/node/solana/solana-api-endpoints/send-transaction)                    | [`simulateTransaction`](/docs/node/solana/solana-api-endpoints/simulate-transaction)        |
+| [`getAccountInfo`](/docs/chain-apis/solana/solana-api-endpoints/get-account-info)                     | [`getBalance`](/docs/chain-apis/solana/solana-api-endpoints/get-balance)                          |
+| [`getBlock`](/docs/chain-apis/solana/solana-api-endpoints/get-block)                                  | [`getBlockCommitment`](/docs/chain-apis/solana/solana-api-endpoints/get-block-commitment)         |
+| [`getBlockHeight`](/docs/chain-apis/solana/solana-api-endpoints/get-block-height)                     | [`getBlockProduction`](/docs/chain-apis/solana/solana-api-endpoints/get-block-production)         |
+| [`getBlocks`](/docs/chain-apis/solana/solana-api-endpoints/get-blocks)                                | [`getBlocksWithLimit`](/docs/chain-apis/solana/solana-api-endpoints/get-blocks-with-limit)        |
+| [`getBlockTime`](/docs/chain-apis/solana/solana-api-endpoints/get-block-time)                         | [`getClusterNodes`](/docs/chain-apis/solana/solana-api-endpoints/get-cluster-nodes)               |
+| [`getEpochInfo`](/docs/chain-apis/solana/solana-api-endpoints/get-epoch-info)                         | [`getEpochSchedule`](/docs/chain-apis/solana/solana-api-endpoints/get-epoch-schedule)             |
+| [`getFeeForMessage`](/docs/chain-apis/solana/solana-api-endpoints/get-fee-for-message)                | [`getFirstAvailableBlock`](/docs/chain-apis/solana/solana-api-endpoints/get-first-available-block) |
+| [`getGenesisHash`](/docs/chain-apis/solana/solana-api-endpoints/get-genesis-hash)                     | [`getHealth`](/docs/chain-apis/solana/solana-api-endpoints/get-health)                            |
+| [`getHighestSnapshotSlot`](/docs/chain-apis/solana/solana-api-endpoints/get-highest-snapshot-slot)    | [`getIdentity`](/docs/chain-apis/solana/solana-api-endpoints/get-identity)                        |
+| [`getInflationGovernor`](/docs/chain-apis/solana/solana-api-endpoints/get-inflation-governor)         | [`getInflationRate`](/docs/chain-apis/solana/solana-api-endpoints/get-inflation-rate)             |
+| [`getInflationReward`](/docs/chain-apis/solana/solana-api-endpoints/get-inflation-reward)             | [`getLargestAccounts`](/docs/chain-apis/solana/solana-api-endpoints/get-largest-accounts)         |
+| [`getLatestBlockhash`](/docs/chain-apis/solana/solana-api-endpoints/get-latest-blockhash)             | [`getLeaderSchedule`](/docs/chain-apis/solana/solana-api-endpoints/get-leader-schedule)           |
+| [`getMaxRetransmitSlot`](/docs/chain-apis/solana/solana-api-endpoints/get-max-retransmit-slot)        | [`getMaxShredInsertSlot`](/docs/chain-apis/solana/solana-api-endpoints/get-max-shred-insert-slot) |
+| [`getMinimumBalanceForRentExemption`](/docs/chain-apis/solana/solana-api-endpoints/get-minimum-balance-for-rent-exemption) | [`getMultipleAccounts`](/docs/chain-apis/solana/solana-api-endpoints/get-multiple-accounts)       |
+| [`getProgramAccounts`](/docs/chain-apis/solana/solana-api-endpoints/get-program-accounts)             | [`getRecentPerformanceSamples`](/docs/chain-apis/solana/solana-api-endpoints/get-recent-performance-samples) |
+| [`getRecentPrioritizationFees`](/docs/chain-apis/solana/solana-api-endpoints/get-recent-prioritization-fees) | [`getSignaturesForAddress`](/docs/chain-apis/solana/solana-api-endpoints/get-signatures-for-address) |
+| [`getSignatureStatuses`](/docs/chain-apis/solana/solana-api-endpoints/get-signature-statuses)         | [`getSlot`](/docs/chain-apis/solana/solana-api-endpoints/get-slot)                                |
+| [`getSlotLeader`](/docs/chain-apis/solana/solana-api-endpoints/get-slot-leader)                       | [`getSlotLeaders`](/docs/chain-apis/solana/solana-api-endpoints/get-slot-leaders)                 |
+| [`getStakeActivation`](/docs/chain-apis/solana/solana-api-endpoints/get-stake-activation)             | [`getSupply`](/docs/chain-apis/solana/solana-api-endpoints/get-supply)                            |
+| [`getTokenAccountBalance`](/docs/chain-apis/solana/solana-api-endpoints/get-token-account-balance)    | [`getTokenAccountsByDelegate`](/docs/chain-apis/solana/solana-api-endpoints/get-token-accounts-by-delegate) |
+| [`getTokenAccountsByOwner`](/docs/chain-apis/solana/solana-api-endpoints/get-token-accounts-by-owner) | [`getTokenLargestAccounts`](/docs/chain-apis/solana/solana-api-endpoints/get-token-largest-accounts) |
+| [`getTokenSupply`](/docs/chain-apis/solana/solana-api-endpoints/get-token-supply)                     | [`getTransaction`](/docs/chain-apis/solana/solana-api-endpoints/get-transaction)                  |
+| [`getTransactionCount`](/docs/chain-apis/solana/solana-api-endpoints/get-transaction-count)           | [`getVersion`](/docs/chain-apis/solana/solana-api-endpoints/get-version)                          |
+| [`getVoteAccounts`](/docs/chain-apis/solana/solana-api-endpoints/get-vote-accounts)                   | [`isBlockhashValid`](/docs/chain-apis/solana/solana-api-endpoints/is-blockhash-valid)             |
+| [`minimumLedgerSlot`](/docs/chain-apis/solana/solana-api-endpoints/minimum-ledger-slot)               | [`requestAirdrop`](/docs/chain-apis/solana/solana-api-endpoints/request-airdrop)                  |
+| [`sendTransaction`](/docs/chain-apis/solana/solana-api-endpoints/send-transaction)                    | [`simulateTransaction`](/docs/chain-apis/solana/solana-api-endpoints/simulate-transaction)        |
 
 ## Soneium APIs
 
@@ -1291,23 +1291,23 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_blockNumber`](/docs/node/soneium/soneium-api-endpoints/eth-block-number)                  | [`eth_call`](/docs/node/soneium/soneium-api-endpoints/eth-call)                             |
-| [`eth_callMany`](/docs/node/soneium/soneium-api-endpoints/eth-call-many)                        | [`eth_chainId`](/docs/node/soneium/soneium-api-endpoints/eth-chain-id)                      |
-| [`eth_estimateGas`](/docs/node/soneium/soneium-api-endpoints/eth-estimate-gas)                  | [`eth_gasPrice`](/docs/node/soneium/soneium-api-endpoints/eth-gas-price)                    |
-| [`eth_getAccount`](/docs/node/soneium/soneium-api-endpoints/eth-get-account)                    | [`eth_getBalance`](/docs/node/soneium/soneium-api-endpoints/eth-get-balance)                |
-| [`eth_getBlockByHash`](/docs/node/soneium/soneium-api-endpoints/eth-get-block-by-hash)          | [`eth_getBlockByNumber`](/docs/node/soneium/soneium-api-endpoints/eth-get-block-by-number)  |
-| [`eth_getBlockTransactionCountByHash`](/docs/node/soneium/soneium-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/node/soneium/soneium-api-endpoints/eth-get-block-transaction-count-by-number) |
-| [`eth_getCode`](/docs/node/soneium/soneium-api-endpoints/eth-get-code)                          | [`eth_getFilterChanges`](/docs/node/soneium/soneium-api-endpoints/eth-get-filter-changes)   |
-| [`eth_getFilterLogs`](/docs/node/soneium/soneium-api-endpoints/eth-get-filter-logs)             | [`eth_getLogs`](/docs/node/soneium/soneium-api-endpoints/eth-get-logs)                      |
-| [`eth_getStorageAt`](/docs/node/soneium/soneium-api-endpoints/eth-get-storage-at)               | [`eth_getTransactionByBlockHashAndIndex`](/docs/node/soneium/soneium-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
-| [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/soneium/soneium-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/node/soneium/soneium-api-endpoints/eth-get-transaction-by-hash) |
-| [`eth_getTransactionCount`](/docs/node/soneium/soneium-api-endpoints/eth-get-transaction-count) | [`eth_getTransactionReceipt`](/docs/node/soneium/soneium-api-endpoints/eth-get-transaction-receipt) |
-| [`eth_newBlockFilter`](/docs/node/soneium/soneium-api-endpoints/eth-new-block-filter)           | [`eth_newFilter`](/docs/node/soneium/soneium-api-endpoints/eth-new-filter)                  |
-| [`eth_sendRawTransaction`](/docs/node/soneium/soneium-api-endpoints/eth-send-raw-transaction)   | [`eth_sendRawTransactionSync`](/docs/node/soneium/soneium-api-endpoints/eth-send-raw-transaction-sync) |
-| [`eth_simulateV1`](/docs/node/soneium/soneium-api-endpoints/eth-simulate-v-1)                   | [`eth_submitWork`](/docs/node/soneium/soneium-api-endpoints/eth-submit-work)                |
-| [`eth_subscribe`](/docs/node/soneium/soneium-api-endpoints/eth-subscribe)                       | [`eth_uninstallFilter`](/docs/node/soneium/soneium-api-endpoints/eth-uninstall-filter)      |
-| [`eth_unsubscribe`](/docs/node/soneium/soneium-api-endpoints/eth-unsubscribe)                   | [`net_version`](/docs/node/soneium/soneium-api-endpoints/net-version)                       |
-| [`web3_clientVersion`](/docs/node/soneium/soneium-api-endpoints/web-3-client-version)           | [`web3_sha3`](/docs/node/soneium/soneium-api-endpoints/web-3-sha-3)                         |
+| [`eth_blockNumber`](/docs/chain-apis/soneium/soneium-api-endpoints/eth-block-number)                  | [`eth_call`](/docs/chain-apis/soneium/soneium-api-endpoints/eth-call)                             |
+| [`eth_callMany`](/docs/chain-apis/soneium/soneium-api-endpoints/eth-call-many)                        | [`eth_chainId`](/docs/chain-apis/soneium/soneium-api-endpoints/eth-chain-id)                      |
+| [`eth_estimateGas`](/docs/chain-apis/soneium/soneium-api-endpoints/eth-estimate-gas)                  | [`eth_gasPrice`](/docs/chain-apis/soneium/soneium-api-endpoints/eth-gas-price)                    |
+| [`eth_getAccount`](/docs/chain-apis/soneium/soneium-api-endpoints/eth-get-account)                    | [`eth_getBalance`](/docs/chain-apis/soneium/soneium-api-endpoints/eth-get-balance)                |
+| [`eth_getBlockByHash`](/docs/chain-apis/soneium/soneium-api-endpoints/eth-get-block-by-hash)          | [`eth_getBlockByNumber`](/docs/chain-apis/soneium/soneium-api-endpoints/eth-get-block-by-number)  |
+| [`eth_getBlockTransactionCountByHash`](/docs/chain-apis/soneium/soneium-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/chain-apis/soneium/soneium-api-endpoints/eth-get-block-transaction-count-by-number) |
+| [`eth_getCode`](/docs/chain-apis/soneium/soneium-api-endpoints/eth-get-code)                          | [`eth_getFilterChanges`](/docs/chain-apis/soneium/soneium-api-endpoints/eth-get-filter-changes)   |
+| [`eth_getFilterLogs`](/docs/chain-apis/soneium/soneium-api-endpoints/eth-get-filter-logs)             | [`eth_getLogs`](/docs/chain-apis/soneium/soneium-api-endpoints/eth-get-logs)                      |
+| [`eth_getStorageAt`](/docs/chain-apis/soneium/soneium-api-endpoints/eth-get-storage-at)               | [`eth_getTransactionByBlockHashAndIndex`](/docs/chain-apis/soneium/soneium-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
+| [`eth_getTransactionByBlockNumberAndIndex`](/docs/chain-apis/soneium/soneium-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/chain-apis/soneium/soneium-api-endpoints/eth-get-transaction-by-hash) |
+| [`eth_getTransactionCount`](/docs/chain-apis/soneium/soneium-api-endpoints/eth-get-transaction-count) | [`eth_getTransactionReceipt`](/docs/chain-apis/soneium/soneium-api-endpoints/eth-get-transaction-receipt) |
+| [`eth_newBlockFilter`](/docs/chain-apis/soneium/soneium-api-endpoints/eth-new-block-filter)           | [`eth_newFilter`](/docs/chain-apis/soneium/soneium-api-endpoints/eth-new-filter)                  |
+| [`eth_sendRawTransaction`](/docs/chain-apis/soneium/soneium-api-endpoints/eth-send-raw-transaction)   | [`eth_sendRawTransactionSync`](/docs/chain-apis/soneium/soneium-api-endpoints/eth-send-raw-transaction-sync) |
+| [`eth_simulateV1`](/docs/chain-apis/soneium/soneium-api-endpoints/eth-simulate-v-1)                   | [`eth_submitWork`](/docs/chain-apis/soneium/soneium-api-endpoints/eth-submit-work)                |
+| [`eth_subscribe`](/docs/chain-apis/soneium/soneium-api-endpoints/eth-subscribe)                       | [`eth_uninstallFilter`](/docs/chain-apis/soneium/soneium-api-endpoints/eth-uninstall-filter)      |
+| [`eth_unsubscribe`](/docs/chain-apis/soneium/soneium-api-endpoints/eth-unsubscribe)                   | [`net_version`](/docs/chain-apis/soneium/soneium-api-endpoints/net-version)                       |
+| [`web3_clientVersion`](/docs/chain-apis/soneium/soneium-api-endpoints/web-3-client-version)           | [`web3_sha3`](/docs/chain-apis/soneium/soneium-api-endpoints/web-3-sha-3)                         |
 
 ## Sonic APIs
 
@@ -1315,22 +1315,22 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_blockNumber`](/docs/node/sonic/sonic-api-endpoints/eth-block-number)                      | [`eth_call`](/docs/node/sonic/sonic-api-endpoints/eth-call)                                 |
-| [`eth_callMany`](/docs/node/sonic/sonic-api-endpoints/eth-call-many)                            | [`eth_chainId`](/docs/node/sonic/sonic-api-endpoints/eth-chain-id)                          |
-| [`eth_estimateGas`](/docs/node/sonic/sonic-api-endpoints/eth-estimate-gas)                      | [`eth_gasPrice`](/docs/node/sonic/sonic-api-endpoints/eth-gas-price)                        |
-| [`eth_getAccount`](/docs/node/sonic/sonic-api-endpoints/eth-get-account)                        | [`eth_getBalance`](/docs/node/sonic/sonic-api-endpoints/eth-get-balance)                    |
-| [`eth_getBlockByHash`](/docs/node/sonic/sonic-api-endpoints/eth-get-block-by-hash)              | [`eth_getBlockByNumber`](/docs/node/sonic/sonic-api-endpoints/eth-get-block-by-number)      |
-| [`eth_getBlockTransactionCountByHash`](/docs/node/sonic/sonic-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/node/sonic/sonic-api-endpoints/eth-get-block-transaction-count-by-number) |
-| [`eth_getCode`](/docs/node/sonic/sonic-api-endpoints/eth-get-code)                              | [`eth_getFilterChanges`](/docs/node/sonic/sonic-api-endpoints/eth-get-filter-changes)       |
-| [`eth_getFilterLogs`](/docs/node/sonic/sonic-api-endpoints/eth-get-filter-logs)                 | [`eth_getLogs`](/docs/node/sonic/sonic-api-endpoints/eth-get-logs)                          |
-| [`eth_getStorageAt`](/docs/node/sonic/sonic-api-endpoints/eth-get-storage-at)                   | [`eth_getTransactionByBlockHashAndIndex`](/docs/node/sonic/sonic-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
-| [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/sonic/sonic-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/node/sonic/sonic-api-endpoints/eth-get-transaction-by-hash) |
-| [`eth_getTransactionCount`](/docs/node/sonic/sonic-api-endpoints/eth-get-transaction-count)     | [`eth_getTransactionReceipt`](/docs/node/sonic/sonic-api-endpoints/eth-get-transaction-receipt) |
-| [`eth_newBlockFilter`](/docs/node/sonic/sonic-api-endpoints/eth-new-block-filter)               | [`eth_newFilter`](/docs/node/sonic/sonic-api-endpoints/eth-new-filter)                      |
-| [`eth_sendRawTransaction`](/docs/node/sonic/sonic-api-endpoints/eth-send-raw-transaction)       | [`eth_submitWork`](/docs/node/sonic/sonic-api-endpoints/eth-submit-work)                    |
-| [`eth_subscribe`](/docs/node/sonic/sonic-api-endpoints/eth-subscribe)                           | [`eth_uninstallFilter`](/docs/node/sonic/sonic-api-endpoints/eth-uninstall-filter)          |
-| [`eth_unsubscribe`](/docs/node/sonic/sonic-api-endpoints/eth-unsubscribe)                       | [`net_version`](/docs/node/sonic/sonic-api-endpoints/net-version)                           |
-| [`web3_clientVersion`](/docs/node/sonic/sonic-api-endpoints/web-3-client-version)               | [`web3_sha3`](/docs/node/sonic/sonic-api-endpoints/web-3-sha-3)                             |
+| [`eth_blockNumber`](/docs/chain-apis/sonic/sonic-api-endpoints/eth-block-number)                      | [`eth_call`](/docs/chain-apis/sonic/sonic-api-endpoints/eth-call)                                 |
+| [`eth_callMany`](/docs/chain-apis/sonic/sonic-api-endpoints/eth-call-many)                            | [`eth_chainId`](/docs/chain-apis/sonic/sonic-api-endpoints/eth-chain-id)                          |
+| [`eth_estimateGas`](/docs/chain-apis/sonic/sonic-api-endpoints/eth-estimate-gas)                      | [`eth_gasPrice`](/docs/chain-apis/sonic/sonic-api-endpoints/eth-gas-price)                        |
+| [`eth_getAccount`](/docs/chain-apis/sonic/sonic-api-endpoints/eth-get-account)                        | [`eth_getBalance`](/docs/chain-apis/sonic/sonic-api-endpoints/eth-get-balance)                    |
+| [`eth_getBlockByHash`](/docs/chain-apis/sonic/sonic-api-endpoints/eth-get-block-by-hash)              | [`eth_getBlockByNumber`](/docs/chain-apis/sonic/sonic-api-endpoints/eth-get-block-by-number)      |
+| [`eth_getBlockTransactionCountByHash`](/docs/chain-apis/sonic/sonic-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/chain-apis/sonic/sonic-api-endpoints/eth-get-block-transaction-count-by-number) |
+| [`eth_getCode`](/docs/chain-apis/sonic/sonic-api-endpoints/eth-get-code)                              | [`eth_getFilterChanges`](/docs/chain-apis/sonic/sonic-api-endpoints/eth-get-filter-changes)       |
+| [`eth_getFilterLogs`](/docs/chain-apis/sonic/sonic-api-endpoints/eth-get-filter-logs)                 | [`eth_getLogs`](/docs/chain-apis/sonic/sonic-api-endpoints/eth-get-logs)                          |
+| [`eth_getStorageAt`](/docs/chain-apis/sonic/sonic-api-endpoints/eth-get-storage-at)                   | [`eth_getTransactionByBlockHashAndIndex`](/docs/chain-apis/sonic/sonic-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
+| [`eth_getTransactionByBlockNumberAndIndex`](/docs/chain-apis/sonic/sonic-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/chain-apis/sonic/sonic-api-endpoints/eth-get-transaction-by-hash) |
+| [`eth_getTransactionCount`](/docs/chain-apis/sonic/sonic-api-endpoints/eth-get-transaction-count)     | [`eth_getTransactionReceipt`](/docs/chain-apis/sonic/sonic-api-endpoints/eth-get-transaction-receipt) |
+| [`eth_newBlockFilter`](/docs/chain-apis/sonic/sonic-api-endpoints/eth-new-block-filter)               | [`eth_newFilter`](/docs/chain-apis/sonic/sonic-api-endpoints/eth-new-filter)                      |
+| [`eth_sendRawTransaction`](/docs/chain-apis/sonic/sonic-api-endpoints/eth-send-raw-transaction)       | [`eth_submitWork`](/docs/chain-apis/sonic/sonic-api-endpoints/eth-submit-work)                    |
+| [`eth_subscribe`](/docs/chain-apis/sonic/sonic-api-endpoints/eth-subscribe)                           | [`eth_uninstallFilter`](/docs/chain-apis/sonic/sonic-api-endpoints/eth-uninstall-filter)          |
+| [`eth_unsubscribe`](/docs/chain-apis/sonic/sonic-api-endpoints/eth-unsubscribe)                       | [`net_version`](/docs/chain-apis/sonic/sonic-api-endpoints/net-version)                           |
+| [`web3_clientVersion`](/docs/chain-apis/sonic/sonic-api-endpoints/web-3-client-version)               | [`web3_sha3`](/docs/chain-apis/sonic/sonic-api-endpoints/web-3-sha-3)                             |
 
 ## Starknet APIs
 
@@ -1338,24 +1338,24 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`pathfinder_getTransactionStatus`](/docs/node/starknet/starknet-api-endpoints/pathfinder-get-transaction-status) | [`pathfinder_lastL1AcceptedBlockHashAndNumber`](/docs/node/starknet/starknet-api-endpoints/pathfinder-last-l-1-accepted-block-hash-and-number) |
-| [`starknet_addDeclareTransaction`](/docs/node/starknet/starknet-api-endpoints/starknet-add-declare-transaction) | [`starknet_addDeployAccountTransaction`](/docs/node/starknet/starknet-api-endpoints/starknet-add-deploy-account-transaction) |
-| [`starknet_addInvokeTransaction`](/docs/node/starknet/starknet-api-endpoints/starknet-add-invoke-transaction) | [`starknet_blockHashAndNumber`](/docs/node/starknet/starknet-api-endpoints/starknet-block-hash-and-number) |
-| [`starknet_blockNumber`](/docs/node/starknet/starknet-api-endpoints/starknet-block-number)      | [`starknet_call`](/docs/node/starknet/starknet-api-endpoints/starknet-call)                 |
-| [`starknet_chainId`](/docs/node/starknet/starknet-api-endpoints/starknet-chain-id)              | [`starknet_estimateFee`](/docs/node/starknet/starknet-api-endpoints/starknet-estimate-fee)  |
-| [`starknet_estimateMessageFee`](/docs/node/starknet/starknet-api-endpoints/starknet-estimate-message-fee) | [`starknet_getBlockTransactionCount`](/docs/node/starknet/starknet-api-endpoints/starknet-get-block-transaction-count) |
-| [`starknet_getBlockWithReceipts`](/docs/node/starknet/starknet-api-endpoints/starknet-get-block-with-receipts) | [`starknet_getBlockWithTxHashes`](/docs/node/starknet/starknet-api-endpoints/starknet-get-block-with-tx-hashes) |
-| [`starknet_getBlockWithTxs`](/docs/node/starknet/starknet-api-endpoints/starknet-get-block-with-txs) | [`starknet_getClass`](/docs/node/starknet/starknet-api-endpoints/starknet-get-class)        |
-| [`starknet_getClassAt`](/docs/node/starknet/starknet-api-endpoints/starknet-get-class-at)       | [`starknet_getClassHashAt`](/docs/node/starknet/starknet-api-endpoints/starknet-get-class-hash-at) |
-| [`starknet_getCompiledCasm`](/docs/node/starknet/starknet-api-endpoints/starknet-get-compiled-casm) | [`starknet_getEvents`](/docs/node/starknet/starknet-api-endpoints/starknet-get-events)      |
-| [`starknet_getMessagesStatus`](/docs/node/starknet/starknet-api-endpoints/starknet-get-messages-status) | [`starknet_getNonce`](/docs/node/starknet/starknet-api-endpoints/starknet-get-nonce)        |
-| [`starknet_getStateUpdate`](/docs/node/starknet/starknet-api-endpoints/starknet-get-state-update) | [`starknet_getStorageAt`](/docs/node/starknet/starknet-api-endpoints/starknet-get-storage-at) |
-| [`starknet_getStorageProof`](/docs/node/starknet/starknet-api-endpoints/starknet-get-storage-proof) | [`starknet_getTransactionByBlockIdAndIndex`](/docs/node/starknet/starknet-api-endpoints/starknet-get-transaction-by-block-id-and-index) |
-| [`starknet_getTransactionByHash`](/docs/node/starknet/starknet-api-endpoints/starknet-get-transaction-by-hash) | [`starknet_getTransactionReceipt`](/docs/node/starknet/starknet-api-endpoints/starknet-get-transaction-receipt) |
-| [`starknet_getTransactionStatus`](/docs/node/starknet/starknet-api-endpoints/starknet-get-transaction-status) | [`starknet_pendingTransactions`](/docs/node/starknet/starknet-api-endpoints/starknet-pending-transactions) |
-| [`starknet_simulateTransactions`](/docs/node/starknet/starknet-api-endpoints/starknet-simulate-transactions) | [`starknet_specVersion`](/docs/node/starknet/starknet-api-endpoints/starknet-spec-version)  |
-| [`starknet_syncing`](/docs/node/starknet/starknet-api-endpoints/starknet-syncing)               | [`starknet_traceBlockTransactions`](/docs/node/starknet/starknet-api-endpoints/starknet-trace-block-transactions) |
-| [`starknet_traceTransaction`](/docs/node/starknet/starknet-api-endpoints/starknet-trace-transaction) |                                                                                             |
+| [`pathfinder_getTransactionStatus`](/docs/chain-apis/starknet/starknet-api-endpoints/pathfinder-get-transaction-status) | [`pathfinder_lastL1AcceptedBlockHashAndNumber`](/docs/chain-apis/starknet/starknet-api-endpoints/pathfinder-last-l-1-accepted-block-hash-and-number) |
+| [`starknet_addDeclareTransaction`](/docs/chain-apis/starknet/starknet-api-endpoints/starknet-add-declare-transaction) | [`starknet_addDeployAccountTransaction`](/docs/chain-apis/starknet/starknet-api-endpoints/starknet-add-deploy-account-transaction) |
+| [`starknet_addInvokeTransaction`](/docs/chain-apis/starknet/starknet-api-endpoints/starknet-add-invoke-transaction) | [`starknet_blockHashAndNumber`](/docs/chain-apis/starknet/starknet-api-endpoints/starknet-block-hash-and-number) |
+| [`starknet_blockNumber`](/docs/chain-apis/starknet/starknet-api-endpoints/starknet-block-number)      | [`starknet_call`](/docs/chain-apis/starknet/starknet-api-endpoints/starknet-call)                 |
+| [`starknet_chainId`](/docs/chain-apis/starknet/starknet-api-endpoints/starknet-chain-id)              | [`starknet_estimateFee`](/docs/chain-apis/starknet/starknet-api-endpoints/starknet-estimate-fee)  |
+| [`starknet_estimateMessageFee`](/docs/chain-apis/starknet/starknet-api-endpoints/starknet-estimate-message-fee) | [`starknet_getBlockTransactionCount`](/docs/chain-apis/starknet/starknet-api-endpoints/starknet-get-block-transaction-count) |
+| [`starknet_getBlockWithReceipts`](/docs/chain-apis/starknet/starknet-api-endpoints/starknet-get-block-with-receipts) | [`starknet_getBlockWithTxHashes`](/docs/chain-apis/starknet/starknet-api-endpoints/starknet-get-block-with-tx-hashes) |
+| [`starknet_getBlockWithTxs`](/docs/chain-apis/starknet/starknet-api-endpoints/starknet-get-block-with-txs) | [`starknet_getClass`](/docs/chain-apis/starknet/starknet-api-endpoints/starknet-get-class)        |
+| [`starknet_getClassAt`](/docs/chain-apis/starknet/starknet-api-endpoints/starknet-get-class-at)       | [`starknet_getClassHashAt`](/docs/chain-apis/starknet/starknet-api-endpoints/starknet-get-class-hash-at) |
+| [`starknet_getCompiledCasm`](/docs/chain-apis/starknet/starknet-api-endpoints/starknet-get-compiled-casm) | [`starknet_getEvents`](/docs/chain-apis/starknet/starknet-api-endpoints/starknet-get-events)      |
+| [`starknet_getMessagesStatus`](/docs/chain-apis/starknet/starknet-api-endpoints/starknet-get-messages-status) | [`starknet_getNonce`](/docs/chain-apis/starknet/starknet-api-endpoints/starknet-get-nonce)        |
+| [`starknet_getStateUpdate`](/docs/chain-apis/starknet/starknet-api-endpoints/starknet-get-state-update) | [`starknet_getStorageAt`](/docs/chain-apis/starknet/starknet-api-endpoints/starknet-get-storage-at) |
+| [`starknet_getStorageProof`](/docs/chain-apis/starknet/starknet-api-endpoints/starknet-get-storage-proof) | [`starknet_getTransactionByBlockIdAndIndex`](/docs/chain-apis/starknet/starknet-api-endpoints/starknet-get-transaction-by-block-id-and-index) |
+| [`starknet_getTransactionByHash`](/docs/chain-apis/starknet/starknet-api-endpoints/starknet-get-transaction-by-hash) | [`starknet_getTransactionReceipt`](/docs/chain-apis/starknet/starknet-api-endpoints/starknet-get-transaction-receipt) |
+| [`starknet_getTransactionStatus`](/docs/chain-apis/starknet/starknet-api-endpoints/starknet-get-transaction-status) | [`starknet_pendingTransactions`](/docs/chain-apis/starknet/starknet-api-endpoints/starknet-pending-transactions) |
+| [`starknet_simulateTransactions`](/docs/chain-apis/starknet/starknet-api-endpoints/starknet-simulate-transactions) | [`starknet_specVersion`](/docs/chain-apis/starknet/starknet-api-endpoints/starknet-spec-version)  |
+| [`starknet_syncing`](/docs/chain-apis/starknet/starknet-api-endpoints/starknet-syncing)               | [`starknet_traceBlockTransactions`](/docs/chain-apis/starknet/starknet-api-endpoints/starknet-trace-block-transactions) |
+| [`starknet_traceTransaction`](/docs/chain-apis/starknet/starknet-api-endpoints/starknet-trace-transaction) |                                                                                             |
 
 ## Story APIs
 
@@ -1363,22 +1363,22 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_blockNumber`](/docs/node/story/story-api-endpoints/eth-block-number)                      | [`eth_call`](/docs/node/story/story-api-endpoints/eth-call)                                 |
-| [`eth_callMany`](/docs/node/story/story-api-endpoints/eth-call-many)                            | [`eth_chainId`](/docs/node/story/story-api-endpoints/eth-chain-id)                          |
-| [`eth_estimateGas`](/docs/node/story/story-api-endpoints/eth-estimate-gas)                      | [`eth_gasPrice`](/docs/node/story/story-api-endpoints/eth-gas-price)                        |
-| [`eth_getAccount`](/docs/node/story/story-api-endpoints/eth-get-account)                        | [`eth_getBalance`](/docs/node/story/story-api-endpoints/eth-get-balance)                    |
-| [`eth_getBlockByHash`](/docs/node/story/story-api-endpoints/eth-get-block-by-hash)              | [`eth_getBlockByNumber`](/docs/node/story/story-api-endpoints/eth-get-block-by-number)      |
-| [`eth_getBlockTransactionCountByHash`](/docs/node/story/story-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/node/story/story-api-endpoints/eth-get-block-transaction-count-by-number) |
-| [`eth_getCode`](/docs/node/story/story-api-endpoints/eth-get-code)                              | [`eth_getFilterChanges`](/docs/node/story/story-api-endpoints/eth-get-filter-changes)       |
-| [`eth_getFilterLogs`](/docs/node/story/story-api-endpoints/eth-get-filter-logs)                 | [`eth_getLogs`](/docs/node/story/story-api-endpoints/eth-get-logs)                          |
-| [`eth_getStorageAt`](/docs/node/story/story-api-endpoints/eth-get-storage-at)                   | [`eth_getTransactionByBlockHashAndIndex`](/docs/node/story/story-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
-| [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/story/story-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/node/story/story-api-endpoints/eth-get-transaction-by-hash) |
-| [`eth_getTransactionCount`](/docs/node/story/story-api-endpoints/eth-get-transaction-count)     | [`eth_getTransactionReceipt`](/docs/node/story/story-api-endpoints/eth-get-transaction-receipt) |
-| [`eth_newBlockFilter`](/docs/node/story/story-api-endpoints/eth-new-block-filter)               | [`eth_newFilter`](/docs/node/story/story-api-endpoints/eth-new-filter)                      |
-| [`eth_sendRawTransaction`](/docs/node/story/story-api-endpoints/eth-send-raw-transaction)       | [`eth_submitWork`](/docs/node/story/story-api-endpoints/eth-submit-work)                    |
-| [`eth_subscribe`](/docs/node/story/story-api-endpoints/eth-subscribe)                           | [`eth_uninstallFilter`](/docs/node/story/story-api-endpoints/eth-uninstall-filter)          |
-| [`eth_unsubscribe`](/docs/node/story/story-api-endpoints/eth-unsubscribe)                       | [`net_version`](/docs/node/story/story-api-endpoints/net-version)                           |
-| [`web3_clientVersion`](/docs/node/story/story-api-endpoints/web-3-client-version)               | [`web3_sha3`](/docs/node/story/story-api-endpoints/web-3-sha-3)                             |
+| [`eth_blockNumber`](/docs/chain-apis/story/story-api-endpoints/eth-block-number)                      | [`eth_call`](/docs/chain-apis/story/story-api-endpoints/eth-call)                                 |
+| [`eth_callMany`](/docs/chain-apis/story/story-api-endpoints/eth-call-many)                            | [`eth_chainId`](/docs/chain-apis/story/story-api-endpoints/eth-chain-id)                          |
+| [`eth_estimateGas`](/docs/chain-apis/story/story-api-endpoints/eth-estimate-gas)                      | [`eth_gasPrice`](/docs/chain-apis/story/story-api-endpoints/eth-gas-price)                        |
+| [`eth_getAccount`](/docs/chain-apis/story/story-api-endpoints/eth-get-account)                        | [`eth_getBalance`](/docs/chain-apis/story/story-api-endpoints/eth-get-balance)                    |
+| [`eth_getBlockByHash`](/docs/chain-apis/story/story-api-endpoints/eth-get-block-by-hash)              | [`eth_getBlockByNumber`](/docs/chain-apis/story/story-api-endpoints/eth-get-block-by-number)      |
+| [`eth_getBlockTransactionCountByHash`](/docs/chain-apis/story/story-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/chain-apis/story/story-api-endpoints/eth-get-block-transaction-count-by-number) |
+| [`eth_getCode`](/docs/chain-apis/story/story-api-endpoints/eth-get-code)                              | [`eth_getFilterChanges`](/docs/chain-apis/story/story-api-endpoints/eth-get-filter-changes)       |
+| [`eth_getFilterLogs`](/docs/chain-apis/story/story-api-endpoints/eth-get-filter-logs)                 | [`eth_getLogs`](/docs/chain-apis/story/story-api-endpoints/eth-get-logs)                          |
+| [`eth_getStorageAt`](/docs/chain-apis/story/story-api-endpoints/eth-get-storage-at)                   | [`eth_getTransactionByBlockHashAndIndex`](/docs/chain-apis/story/story-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
+| [`eth_getTransactionByBlockNumberAndIndex`](/docs/chain-apis/story/story-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/chain-apis/story/story-api-endpoints/eth-get-transaction-by-hash) |
+| [`eth_getTransactionCount`](/docs/chain-apis/story/story-api-endpoints/eth-get-transaction-count)     | [`eth_getTransactionReceipt`](/docs/chain-apis/story/story-api-endpoints/eth-get-transaction-receipt) |
+| [`eth_newBlockFilter`](/docs/chain-apis/story/story-api-endpoints/eth-new-block-filter)               | [`eth_newFilter`](/docs/chain-apis/story/story-api-endpoints/eth-new-filter)                      |
+| [`eth_sendRawTransaction`](/docs/chain-apis/story/story-api-endpoints/eth-send-raw-transaction)       | [`eth_submitWork`](/docs/chain-apis/story/story-api-endpoints/eth-submit-work)                    |
+| [`eth_subscribe`](/docs/chain-apis/story/story-api-endpoints/eth-subscribe)                           | [`eth_uninstallFilter`](/docs/chain-apis/story/story-api-endpoints/eth-uninstall-filter)          |
+| [`eth_unsubscribe`](/docs/chain-apis/story/story-api-endpoints/eth-unsubscribe)                       | [`net_version`](/docs/chain-apis/story/story-api-endpoints/net-version)                           |
+| [`web3_clientVersion`](/docs/chain-apis/story/story-api-endpoints/web-3-client-version)               | [`web3_sha3`](/docs/chain-apis/story/story-api-endpoints/web-3-sha-3)                             |
 
 ## Superseed APIs
 
@@ -1386,22 +1386,22 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_blockNumber`](/docs/node/superseed/superseed-api-endpoints/eth-block-number)              | [`eth_call`](/docs/node/superseed/superseed-api-endpoints/eth-call)                         |
-| [`eth_callMany`](/docs/node/superseed/superseed-api-endpoints/eth-call-many)                    | [`eth_chainId`](/docs/node/superseed/superseed-api-endpoints/eth-chain-id)                  |
-| [`eth_estimateGas`](/docs/node/superseed/superseed-api-endpoints/eth-estimate-gas)              | [`eth_gasPrice`](/docs/node/superseed/superseed-api-endpoints/eth-gas-price)                |
-| [`eth_getAccount`](/docs/node/superseed/superseed-api-endpoints/eth-get-account)                | [`eth_getBalance`](/docs/node/superseed/superseed-api-endpoints/eth-get-balance)            |
-| [`eth_getBlockByHash`](/docs/node/superseed/superseed-api-endpoints/eth-get-block-by-hash)      | [`eth_getBlockByNumber`](/docs/node/superseed/superseed-api-endpoints/eth-get-block-by-number) |
-| [`eth_getBlockTransactionCountByHash`](/docs/node/superseed/superseed-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/node/superseed/superseed-api-endpoints/eth-get-block-transaction-count-by-number) |
-| [`eth_getCode`](/docs/node/superseed/superseed-api-endpoints/eth-get-code)                      | [`eth_getFilterChanges`](/docs/node/superseed/superseed-api-endpoints/eth-get-filter-changes) |
-| [`eth_getFilterLogs`](/docs/node/superseed/superseed-api-endpoints/eth-get-filter-logs)         | [`eth_getLogs`](/docs/node/superseed/superseed-api-endpoints/eth-get-logs)                  |
-| [`eth_getStorageAt`](/docs/node/superseed/superseed-api-endpoints/eth-get-storage-at)           | [`eth_getTransactionByBlockHashAndIndex`](/docs/node/superseed/superseed-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
-| [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/superseed/superseed-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/node/superseed/superseed-api-endpoints/eth-get-transaction-by-hash) |
-| [`eth_getTransactionCount`](/docs/node/superseed/superseed-api-endpoints/eth-get-transaction-count) | [`eth_getTransactionReceipt`](/docs/node/superseed/superseed-api-endpoints/eth-get-transaction-receipt) |
-| [`eth_newBlockFilter`](/docs/node/superseed/superseed-api-endpoints/eth-new-block-filter)       | [`eth_newFilter`](/docs/node/superseed/superseed-api-endpoints/eth-new-filter)              |
-| [`eth_sendRawTransaction`](/docs/node/superseed/superseed-api-endpoints/eth-send-raw-transaction) | [`eth_submitWork`](/docs/node/superseed/superseed-api-endpoints/eth-submit-work)            |
-| [`eth_subscribe`](/docs/node/superseed/superseed-api-endpoints/eth-subscribe)                   | [`eth_uninstallFilter`](/docs/node/superseed/superseed-api-endpoints/eth-uninstall-filter)  |
-| [`eth_unsubscribe`](/docs/node/superseed/superseed-api-endpoints/eth-unsubscribe)               | [`net_version`](/docs/node/superseed/superseed-api-endpoints/net-version)                   |
-| [`web3_clientVersion`](/docs/node/superseed/superseed-api-endpoints/web-3-client-version)       | [`web3_sha3`](/docs/node/superseed/superseed-api-endpoints/web-3-sha-3)                     |
+| [`eth_blockNumber`](/docs/chain-apis/superseed/superseed-api-endpoints/eth-block-number)              | [`eth_call`](/docs/chain-apis/superseed/superseed-api-endpoints/eth-call)                         |
+| [`eth_callMany`](/docs/chain-apis/superseed/superseed-api-endpoints/eth-call-many)                    | [`eth_chainId`](/docs/chain-apis/superseed/superseed-api-endpoints/eth-chain-id)                  |
+| [`eth_estimateGas`](/docs/chain-apis/superseed/superseed-api-endpoints/eth-estimate-gas)              | [`eth_gasPrice`](/docs/chain-apis/superseed/superseed-api-endpoints/eth-gas-price)                |
+| [`eth_getAccount`](/docs/chain-apis/superseed/superseed-api-endpoints/eth-get-account)                | [`eth_getBalance`](/docs/chain-apis/superseed/superseed-api-endpoints/eth-get-balance)            |
+| [`eth_getBlockByHash`](/docs/chain-apis/superseed/superseed-api-endpoints/eth-get-block-by-hash)      | [`eth_getBlockByNumber`](/docs/chain-apis/superseed/superseed-api-endpoints/eth-get-block-by-number) |
+| [`eth_getBlockTransactionCountByHash`](/docs/chain-apis/superseed/superseed-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/chain-apis/superseed/superseed-api-endpoints/eth-get-block-transaction-count-by-number) |
+| [`eth_getCode`](/docs/chain-apis/superseed/superseed-api-endpoints/eth-get-code)                      | [`eth_getFilterChanges`](/docs/chain-apis/superseed/superseed-api-endpoints/eth-get-filter-changes) |
+| [`eth_getFilterLogs`](/docs/chain-apis/superseed/superseed-api-endpoints/eth-get-filter-logs)         | [`eth_getLogs`](/docs/chain-apis/superseed/superseed-api-endpoints/eth-get-logs)                  |
+| [`eth_getStorageAt`](/docs/chain-apis/superseed/superseed-api-endpoints/eth-get-storage-at)           | [`eth_getTransactionByBlockHashAndIndex`](/docs/chain-apis/superseed/superseed-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
+| [`eth_getTransactionByBlockNumberAndIndex`](/docs/chain-apis/superseed/superseed-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/chain-apis/superseed/superseed-api-endpoints/eth-get-transaction-by-hash) |
+| [`eth_getTransactionCount`](/docs/chain-apis/superseed/superseed-api-endpoints/eth-get-transaction-count) | [`eth_getTransactionReceipt`](/docs/chain-apis/superseed/superseed-api-endpoints/eth-get-transaction-receipt) |
+| [`eth_newBlockFilter`](/docs/chain-apis/superseed/superseed-api-endpoints/eth-new-block-filter)       | [`eth_newFilter`](/docs/chain-apis/superseed/superseed-api-endpoints/eth-new-filter)              |
+| [`eth_sendRawTransaction`](/docs/chain-apis/superseed/superseed-api-endpoints/eth-send-raw-transaction) | [`eth_submitWork`](/docs/chain-apis/superseed/superseed-api-endpoints/eth-submit-work)            |
+| [`eth_subscribe`](/docs/chain-apis/superseed/superseed-api-endpoints/eth-subscribe)                   | [`eth_uninstallFilter`](/docs/chain-apis/superseed/superseed-api-endpoints/eth-uninstall-filter)  |
+| [`eth_unsubscribe`](/docs/chain-apis/superseed/superseed-api-endpoints/eth-unsubscribe)               | [`net_version`](/docs/chain-apis/superseed/superseed-api-endpoints/net-version)                   |
+| [`web3_clientVersion`](/docs/chain-apis/superseed/superseed-api-endpoints/web-3-client-version)       | [`web3_sha3`](/docs/chain-apis/superseed/superseed-api-endpoints/web-3-sha-3)                     |
 
 ## Tea APIs
 
@@ -1409,22 +1409,22 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_blockNumber`](/docs/node/tea/tea-api-endpoints/eth-block-number)                          | [`eth_call`](/docs/node/tea/tea-api-endpoints/eth-call)                                     |
-| [`eth_callMany`](/docs/node/tea/tea-api-endpoints/eth-call-many)                                | [`eth_chainId`](/docs/node/tea/tea-api-endpoints/eth-chain-id)                              |
-| [`eth_estimateGas`](/docs/node/tea/tea-api-endpoints/eth-estimate-gas)                          | [`eth_gasPrice`](/docs/node/tea/tea-api-endpoints/eth-gas-price)                            |
-| [`eth_getAccount`](/docs/node/tea/tea-api-endpoints/eth-get-account)                            | [`eth_getBalance`](/docs/node/tea/tea-api-endpoints/eth-get-balance)                        |
-| [`eth_getBlockByHash`](/docs/node/tea/tea-api-endpoints/eth-get-block-by-hash)                  | [`eth_getBlockByNumber`](/docs/node/tea/tea-api-endpoints/eth-get-block-by-number)          |
-| [`eth_getBlockTransactionCountByHash`](/docs/node/tea/tea-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/node/tea/tea-api-endpoints/eth-get-block-transaction-count-by-number) |
-| [`eth_getCode`](/docs/node/tea/tea-api-endpoints/eth-get-code)                                  | [`eth_getFilterChanges`](/docs/node/tea/tea-api-endpoints/eth-get-filter-changes)           |
-| [`eth_getFilterLogs`](/docs/node/tea/tea-api-endpoints/eth-get-filter-logs)                     | [`eth_getLogs`](/docs/node/tea/tea-api-endpoints/eth-get-logs)                              |
-| [`eth_getStorageAt`](/docs/node/tea/tea-api-endpoints/eth-get-storage-at)                       | [`eth_getTransactionByBlockHashAndIndex`](/docs/node/tea/tea-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
-| [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/tea/tea-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/node/tea/tea-api-endpoints/eth-get-transaction-by-hash)  |
-| [`eth_getTransactionCount`](/docs/node/tea/tea-api-endpoints/eth-get-transaction-count)         | [`eth_getTransactionReceipt`](/docs/node/tea/tea-api-endpoints/eth-get-transaction-receipt) |
-| [`eth_newBlockFilter`](/docs/node/tea/tea-api-endpoints/eth-new-block-filter)                   | [`eth_newFilter`](/docs/node/tea/tea-api-endpoints/eth-new-filter)                          |
-| [`eth_sendRawTransaction`](/docs/node/tea/tea-api-endpoints/eth-send-raw-transaction)           | [`eth_submitWork`](/docs/node/tea/tea-api-endpoints/eth-submit-work)                        |
-| [`eth_subscribe`](/docs/node/tea/tea-api-endpoints/eth-subscribe)                               | [`eth_uninstallFilter`](/docs/node/tea/tea-api-endpoints/eth-uninstall-filter)              |
-| [`eth_unsubscribe`](/docs/node/tea/tea-api-endpoints/eth-unsubscribe)                           | [`net_version`](/docs/node/tea/tea-api-endpoints/net-version)                               |
-| [`web3_clientVersion`](/docs/node/tea/tea-api-endpoints/web-3-client-version)                   | [`web3_sha3`](/docs/node/tea/tea-api-endpoints/web-3-sha-3)                                 |
+| [`eth_blockNumber`](/docs/chain-apis/tea/tea-api-endpoints/eth-block-number)                          | [`eth_call`](/docs/chain-apis/tea/tea-api-endpoints/eth-call)                                     |
+| [`eth_callMany`](/docs/chain-apis/tea/tea-api-endpoints/eth-call-many)                                | [`eth_chainId`](/docs/chain-apis/tea/tea-api-endpoints/eth-chain-id)                              |
+| [`eth_estimateGas`](/docs/chain-apis/tea/tea-api-endpoints/eth-estimate-gas)                          | [`eth_gasPrice`](/docs/chain-apis/tea/tea-api-endpoints/eth-gas-price)                            |
+| [`eth_getAccount`](/docs/chain-apis/tea/tea-api-endpoints/eth-get-account)                            | [`eth_getBalance`](/docs/chain-apis/tea/tea-api-endpoints/eth-get-balance)                        |
+| [`eth_getBlockByHash`](/docs/chain-apis/tea/tea-api-endpoints/eth-get-block-by-hash)                  | [`eth_getBlockByNumber`](/docs/chain-apis/tea/tea-api-endpoints/eth-get-block-by-number)          |
+| [`eth_getBlockTransactionCountByHash`](/docs/chain-apis/tea/tea-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/chain-apis/tea/tea-api-endpoints/eth-get-block-transaction-count-by-number) |
+| [`eth_getCode`](/docs/chain-apis/tea/tea-api-endpoints/eth-get-code)                                  | [`eth_getFilterChanges`](/docs/chain-apis/tea/tea-api-endpoints/eth-get-filter-changes)           |
+| [`eth_getFilterLogs`](/docs/chain-apis/tea/tea-api-endpoints/eth-get-filter-logs)                     | [`eth_getLogs`](/docs/chain-apis/tea/tea-api-endpoints/eth-get-logs)                              |
+| [`eth_getStorageAt`](/docs/chain-apis/tea/tea-api-endpoints/eth-get-storage-at)                       | [`eth_getTransactionByBlockHashAndIndex`](/docs/chain-apis/tea/tea-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
+| [`eth_getTransactionByBlockNumberAndIndex`](/docs/chain-apis/tea/tea-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/chain-apis/tea/tea-api-endpoints/eth-get-transaction-by-hash)  |
+| [`eth_getTransactionCount`](/docs/chain-apis/tea/tea-api-endpoints/eth-get-transaction-count)         | [`eth_getTransactionReceipt`](/docs/chain-apis/tea/tea-api-endpoints/eth-get-transaction-receipt) |
+| [`eth_newBlockFilter`](/docs/chain-apis/tea/tea-api-endpoints/eth-new-block-filter)                   | [`eth_newFilter`](/docs/chain-apis/tea/tea-api-endpoints/eth-new-filter)                          |
+| [`eth_sendRawTransaction`](/docs/chain-apis/tea/tea-api-endpoints/eth-send-raw-transaction)           | [`eth_submitWork`](/docs/chain-apis/tea/tea-api-endpoints/eth-submit-work)                        |
+| [`eth_subscribe`](/docs/chain-apis/tea/tea-api-endpoints/eth-subscribe)                               | [`eth_uninstallFilter`](/docs/chain-apis/tea/tea-api-endpoints/eth-uninstall-filter)              |
+| [`eth_unsubscribe`](/docs/chain-apis/tea/tea-api-endpoints/eth-unsubscribe)                           | [`net_version`](/docs/chain-apis/tea/tea-api-endpoints/net-version)                               |
+| [`web3_clientVersion`](/docs/chain-apis/tea/tea-api-endpoints/web-3-client-version)                   | [`web3_sha3`](/docs/chain-apis/tea/tea-api-endpoints/web-3-sha-3)                                 |
 
 ## Unichain APIs
 
@@ -1432,23 +1432,23 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_blockNumber`](/docs/node/unichain/unichain-api-endpoints/eth-block-number)                | [`eth_call`](/docs/node/unichain/unichain-api-endpoints/eth-call)                           |
-| [`eth_callMany`](/docs/node/unichain/unichain-api-endpoints/eth-call-many)                      | [`eth_chainId`](/docs/node/unichain/unichain-api-endpoints/eth-chain-id)                    |
-| [`eth_estimateGas`](/docs/node/unichain/unichain-api-endpoints/eth-estimate-gas)                | [`eth_gasPrice`](/docs/node/unichain/unichain-api-endpoints/eth-gas-price)                  |
-| [`eth_getAccount`](/docs/node/unichain/unichain-api-endpoints/eth-get-account)                  | [`eth_getBalance`](/docs/node/unichain/unichain-api-endpoints/eth-get-balance)              |
-| [`eth_getBlockByHash`](/docs/node/unichain/unichain-api-endpoints/eth-get-block-by-hash)        | [`eth_getBlockByNumber`](/docs/node/unichain/unichain-api-endpoints/eth-get-block-by-number) |
-| [`eth_getBlockTransactionCountByHash`](/docs/node/unichain/unichain-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/node/unichain/unichain-api-endpoints/eth-get-block-transaction-count-by-number) |
-| [`eth_getCode`](/docs/node/unichain/unichain-api-endpoints/eth-get-code)                        | [`eth_getFilterChanges`](/docs/node/unichain/unichain-api-endpoints/eth-get-filter-changes) |
-| [`eth_getFilterLogs`](/docs/node/unichain/unichain-api-endpoints/eth-get-filter-logs)           | [`eth_getLogs`](/docs/node/unichain/unichain-api-endpoints/eth-get-logs)                    |
-| [`eth_getStorageAt`](/docs/node/unichain/unichain-api-endpoints/eth-get-storage-at)             | [`eth_getTransactionByBlockHashAndIndex`](/docs/node/unichain/unichain-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
-| [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/unichain/unichain-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/node/unichain/unichain-api-endpoints/eth-get-transaction-by-hash) |
-| [`eth_getTransactionCount`](/docs/node/unichain/unichain-api-endpoints/eth-get-transaction-count) | [`eth_getTransactionReceipt`](/docs/node/unichain/unichain-api-endpoints/eth-get-transaction-receipt) |
-| [`eth_newBlockFilter`](/docs/node/unichain/unichain-api-endpoints/eth-new-block-filter)         | [`eth_newFilter`](/docs/node/unichain/unichain-api-endpoints/eth-new-filter)                |
-| [`eth_sendRawTransaction`](/docs/node/unichain/unichain-api-endpoints/eth-send-raw-transaction) | [`eth_sendRawTransactionSync`](/docs/node/unichain/unichain-api-endpoints/eth-send-raw-transaction-sync) |
-| [`eth_simulateV1`](/docs/node/unichain/unichain-api-endpoints/eth-simulate-v-1)                 | [`eth_submitWork`](/docs/node/unichain/unichain-api-endpoints/eth-submit-work)              |
-| [`eth_subscribe`](/docs/node/unichain/unichain-api-endpoints/eth-subscribe)                     | [`eth_uninstallFilter`](/docs/node/unichain/unichain-api-endpoints/eth-uninstall-filter)    |
-| [`eth_unsubscribe`](/docs/node/unichain/unichain-api-endpoints/eth-unsubscribe)                 | [`net_version`](/docs/node/unichain/unichain-api-endpoints/net-version)                     |
-| [`web3_clientVersion`](/docs/node/unichain/unichain-api-endpoints/web-3-client-version)         | [`web3_sha3`](/docs/node/unichain/unichain-api-endpoints/web-3-sha-3)                       |
+| [`eth_blockNumber`](/docs/chain-apis/unichain/unichain-api-endpoints/eth-block-number)                | [`eth_call`](/docs/chain-apis/unichain/unichain-api-endpoints/eth-call)                           |
+| [`eth_callMany`](/docs/chain-apis/unichain/unichain-api-endpoints/eth-call-many)                      | [`eth_chainId`](/docs/chain-apis/unichain/unichain-api-endpoints/eth-chain-id)                    |
+| [`eth_estimateGas`](/docs/chain-apis/unichain/unichain-api-endpoints/eth-estimate-gas)                | [`eth_gasPrice`](/docs/chain-apis/unichain/unichain-api-endpoints/eth-gas-price)                  |
+| [`eth_getAccount`](/docs/chain-apis/unichain/unichain-api-endpoints/eth-get-account)                  | [`eth_getBalance`](/docs/chain-apis/unichain/unichain-api-endpoints/eth-get-balance)              |
+| [`eth_getBlockByHash`](/docs/chain-apis/unichain/unichain-api-endpoints/eth-get-block-by-hash)        | [`eth_getBlockByNumber`](/docs/chain-apis/unichain/unichain-api-endpoints/eth-get-block-by-number) |
+| [`eth_getBlockTransactionCountByHash`](/docs/chain-apis/unichain/unichain-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/chain-apis/unichain/unichain-api-endpoints/eth-get-block-transaction-count-by-number) |
+| [`eth_getCode`](/docs/chain-apis/unichain/unichain-api-endpoints/eth-get-code)                        | [`eth_getFilterChanges`](/docs/chain-apis/unichain/unichain-api-endpoints/eth-get-filter-changes) |
+| [`eth_getFilterLogs`](/docs/chain-apis/unichain/unichain-api-endpoints/eth-get-filter-logs)           | [`eth_getLogs`](/docs/chain-apis/unichain/unichain-api-endpoints/eth-get-logs)                    |
+| [`eth_getStorageAt`](/docs/chain-apis/unichain/unichain-api-endpoints/eth-get-storage-at)             | [`eth_getTransactionByBlockHashAndIndex`](/docs/chain-apis/unichain/unichain-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
+| [`eth_getTransactionByBlockNumberAndIndex`](/docs/chain-apis/unichain/unichain-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/chain-apis/unichain/unichain-api-endpoints/eth-get-transaction-by-hash) |
+| [`eth_getTransactionCount`](/docs/chain-apis/unichain/unichain-api-endpoints/eth-get-transaction-count) | [`eth_getTransactionReceipt`](/docs/chain-apis/unichain/unichain-api-endpoints/eth-get-transaction-receipt) |
+| [`eth_newBlockFilter`](/docs/chain-apis/unichain/unichain-api-endpoints/eth-new-block-filter)         | [`eth_newFilter`](/docs/chain-apis/unichain/unichain-api-endpoints/eth-new-filter)                |
+| [`eth_sendRawTransaction`](/docs/chain-apis/unichain/unichain-api-endpoints/eth-send-raw-transaction) | [`eth_sendRawTransactionSync`](/docs/chain-apis/unichain/unichain-api-endpoints/eth-send-raw-transaction-sync) |
+| [`eth_simulateV1`](/docs/chain-apis/unichain/unichain-api-endpoints/eth-simulate-v-1)                 | [`eth_submitWork`](/docs/chain-apis/unichain/unichain-api-endpoints/eth-submit-work)              |
+| [`eth_subscribe`](/docs/chain-apis/unichain/unichain-api-endpoints/eth-subscribe)                     | [`eth_uninstallFilter`](/docs/chain-apis/unichain/unichain-api-endpoints/eth-uninstall-filter)    |
+| [`eth_unsubscribe`](/docs/chain-apis/unichain/unichain-api-endpoints/eth-unsubscribe)                 | [`net_version`](/docs/chain-apis/unichain/unichain-api-endpoints/net-version)                     |
+| [`web3_clientVersion`](/docs/chain-apis/unichain/unichain-api-endpoints/web-3-client-version)         | [`web3_sha3`](/docs/chain-apis/unichain/unichain-api-endpoints/web-3-sha-3)                       |
 
 ## World Chain APIs
 
@@ -1456,30 +1456,30 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_accounts`](/docs/node/world-chain/world-chain-api-endpoints/eth-accounts)                 | [`eth_blobBaseFee`](/docs/node/world-chain/world-chain-api-endpoints/eth-blob-base-fee)     |
-| [`eth_blockNumber`](/docs/node/world-chain/world-chain-api-endpoints/eth-block-number)          | [`eth_call`](/docs/node/world-chain/world-chain-api-endpoints/eth-call)                     |
-| [`eth_callBundle`](/docs/node/world-chain/world-chain-api-endpoints/eth-call-bundle)            | [`eth_callMany`](/docs/node/world-chain/world-chain-api-endpoints/eth-call-many)            |
-| [`eth_chainId`](/docs/node/world-chain/world-chain-api-endpoints/eth-chain-id)                  | [`eth_estimateGas`](/docs/node/world-chain/world-chain-api-endpoints/eth-estimate-gas)      |
-| [`eth_feeHistory`](/docs/node/world-chain/world-chain-api-endpoints/eth-fee-history)            | [`eth_gasPrice`](/docs/node/world-chain/world-chain-api-endpoints/eth-gas-price)            |
-| [`eth_getAccount`](/docs/node/world-chain/world-chain-api-endpoints/eth-get-account)            | [`eth_getBalance`](/docs/node/world-chain/world-chain-api-endpoints/eth-get-balance)        |
-| [`eth_getBlockByHash`](/docs/node/world-chain/world-chain-api-endpoints/eth-get-block-by-hash)  | [`eth_getBlockByNumber`](/docs/node/world-chain/world-chain-api-endpoints/eth-get-block-by-number) |
-| [`eth_getBlockReceipts`](/docs/node/world-chain/world-chain-api-endpoints/eth-get-block-receipts) | [`eth_getBlockTransactionCountByHash`](/docs/node/world-chain/world-chain-api-endpoints/eth-get-block-transaction-count-by-hash) |
-| [`eth_getBlockTransactionCountByNumber`](/docs/node/world-chain/world-chain-api-endpoints/eth-get-block-transaction-count-by-number) | [`eth_getCode`](/docs/node/world-chain/world-chain-api-endpoints/eth-get-code)              |
-| [`eth_getFilterChanges`](/docs/node/world-chain/world-chain-api-endpoints/eth-get-filter-changes) | [`eth_getFilterLogs`](/docs/node/world-chain/world-chain-api-endpoints/eth-get-filter-logs) |
-| [`eth_getLogs`](/docs/node/world-chain/world-chain-api-endpoints/eth-get-logs)                  | [`eth_getProof`](/docs/node/world-chain/world-chain-api-endpoints/eth-get-proof)            |
-| [`eth_getStorageAt`](/docs/node/world-chain/world-chain-api-endpoints/eth-get-storage-at)       | [`eth_getTransactionByBlockHashAndIndex`](/docs/node/world-chain/world-chain-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
-| [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/world-chain/world-chain-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/node/world-chain/world-chain-api-endpoints/eth-get-transaction-by-hash) |
-| [`eth_getTransactionCount`](/docs/node/world-chain/world-chain-api-endpoints/eth-get-transaction-count) | [`eth_getTransactionReceipt`](/docs/node/world-chain/world-chain-api-endpoints/eth-get-transaction-receipt) |
-| [`eth_getUncleByBlockHashAndIndex`](/docs/node/world-chain/world-chain-api-endpoints/eth-get-uncle-by-block-hash-and-index) | [`eth_getUncleByBlockNumberAndIndex`](/docs/node/world-chain/world-chain-api-endpoints/eth-get-uncle-by-block-number-and-index) |
-| [`eth_getUncleCountByBlockHash`](/docs/node/world-chain/world-chain-api-endpoints/eth-get-uncle-count-by-block-hash) | [`eth_getUncleCountByBlockNumber`](/docs/node/world-chain/world-chain-api-endpoints/eth-get-uncle-count-by-block-number) |
-| [`eth_maxPriorityFeePerGas`](/docs/node/world-chain/world-chain-api-endpoints/eth-max-priority-fee-per-gas) | [`eth_newBlockFilter`](/docs/node/world-chain/world-chain-api-endpoints/eth-new-block-filter) |
-| [`eth_newFilter`](/docs/node/world-chain/world-chain-api-endpoints/eth-new-filter)              | [`eth_newPendingTransactionFilter`](/docs/node/world-chain/world-chain-api-endpoints/eth-new-pending-transaction-filter) |
-| [`eth_protocolVersion`](/docs/node/world-chain/world-chain-api-endpoints/eth-protocol-version)  | [`eth_sendRawTransaction`](/docs/node/world-chain/world-chain-api-endpoints/eth-send-raw-transaction) |
-| [`eth_sendRawTransactionSync`](/docs/node/world-chain/world-chain-api-endpoints/eth-send-raw-transaction-sync) | [`eth_simulateV1`](/docs/node/world-chain/world-chain-api-endpoints/eth-simulate-v-1)       |
-| [`eth_submitWork`](/docs/node/world-chain/world-chain-api-endpoints/eth-submit-work)            | [`eth_subscribe`](/docs/node/world-chain/world-chain-api-endpoints/eth-subscribe)           |
-| [`eth_syncing`](/docs/node/world-chain/world-chain-api-endpoints/eth-syncing)                   | [`eth_uninstallFilter`](/docs/node/world-chain/world-chain-api-endpoints/eth-uninstall-filter) |
-| [`eth_unsubscribe`](/docs/node/world-chain/world-chain-api-endpoints/eth-unsubscribe)           | [`net_version`](/docs/node/world-chain/world-chain-api-endpoints/net-version)               |
-| [`web3_clientVersion`](/docs/node/world-chain/world-chain-api-endpoints/web-3-client-version)   | [`web3_sha3`](/docs/node/world-chain/world-chain-api-endpoints/web-3-sha-3)                 |
+| [`eth_accounts`](/docs/chain-apis/world-chain/world-chain-api-endpoints/eth-accounts)                 | [`eth_blobBaseFee`](/docs/chain-apis/world-chain/world-chain-api-endpoints/eth-blob-base-fee)     |
+| [`eth_blockNumber`](/docs/chain-apis/world-chain/world-chain-api-endpoints/eth-block-number)          | [`eth_call`](/docs/chain-apis/world-chain/world-chain-api-endpoints/eth-call)                     |
+| [`eth_callBundle`](/docs/chain-apis/world-chain/world-chain-api-endpoints/eth-call-bundle)            | [`eth_callMany`](/docs/chain-apis/world-chain/world-chain-api-endpoints/eth-call-many)            |
+| [`eth_chainId`](/docs/chain-apis/world-chain/world-chain-api-endpoints/eth-chain-id)                  | [`eth_estimateGas`](/docs/chain-apis/world-chain/world-chain-api-endpoints/eth-estimate-gas)      |
+| [`eth_feeHistory`](/docs/chain-apis/world-chain/world-chain-api-endpoints/eth-fee-history)            | [`eth_gasPrice`](/docs/chain-apis/world-chain/world-chain-api-endpoints/eth-gas-price)            |
+| [`eth_getAccount`](/docs/chain-apis/world-chain/world-chain-api-endpoints/eth-get-account)            | [`eth_getBalance`](/docs/chain-apis/world-chain/world-chain-api-endpoints/eth-get-balance)        |
+| [`eth_getBlockByHash`](/docs/chain-apis/world-chain/world-chain-api-endpoints/eth-get-block-by-hash)  | [`eth_getBlockByNumber`](/docs/chain-apis/world-chain/world-chain-api-endpoints/eth-get-block-by-number) |
+| [`eth_getBlockReceipts`](/docs/chain-apis/world-chain/world-chain-api-endpoints/eth-get-block-receipts) | [`eth_getBlockTransactionCountByHash`](/docs/chain-apis/world-chain/world-chain-api-endpoints/eth-get-block-transaction-count-by-hash) |
+| [`eth_getBlockTransactionCountByNumber`](/docs/chain-apis/world-chain/world-chain-api-endpoints/eth-get-block-transaction-count-by-number) | [`eth_getCode`](/docs/chain-apis/world-chain/world-chain-api-endpoints/eth-get-code)              |
+| [`eth_getFilterChanges`](/docs/chain-apis/world-chain/world-chain-api-endpoints/eth-get-filter-changes) | [`eth_getFilterLogs`](/docs/chain-apis/world-chain/world-chain-api-endpoints/eth-get-filter-logs) |
+| [`eth_getLogs`](/docs/chain-apis/world-chain/world-chain-api-endpoints/eth-get-logs)                  | [`eth_getProof`](/docs/chain-apis/world-chain/world-chain-api-endpoints/eth-get-proof)            |
+| [`eth_getStorageAt`](/docs/chain-apis/world-chain/world-chain-api-endpoints/eth-get-storage-at)       | [`eth_getTransactionByBlockHashAndIndex`](/docs/chain-apis/world-chain/world-chain-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
+| [`eth_getTransactionByBlockNumberAndIndex`](/docs/chain-apis/world-chain/world-chain-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/chain-apis/world-chain/world-chain-api-endpoints/eth-get-transaction-by-hash) |
+| [`eth_getTransactionCount`](/docs/chain-apis/world-chain/world-chain-api-endpoints/eth-get-transaction-count) | [`eth_getTransactionReceipt`](/docs/chain-apis/world-chain/world-chain-api-endpoints/eth-get-transaction-receipt) |
+| [`eth_getUncleByBlockHashAndIndex`](/docs/chain-apis/world-chain/world-chain-api-endpoints/eth-get-uncle-by-block-hash-and-index) | [`eth_getUncleByBlockNumberAndIndex`](/docs/chain-apis/world-chain/world-chain-api-endpoints/eth-get-uncle-by-block-number-and-index) |
+| [`eth_getUncleCountByBlockHash`](/docs/chain-apis/world-chain/world-chain-api-endpoints/eth-get-uncle-count-by-block-hash) | [`eth_getUncleCountByBlockNumber`](/docs/chain-apis/world-chain/world-chain-api-endpoints/eth-get-uncle-count-by-block-number) |
+| [`eth_maxPriorityFeePerGas`](/docs/chain-apis/world-chain/world-chain-api-endpoints/eth-max-priority-fee-per-gas) | [`eth_newBlockFilter`](/docs/chain-apis/world-chain/world-chain-api-endpoints/eth-new-block-filter) |
+| [`eth_newFilter`](/docs/chain-apis/world-chain/world-chain-api-endpoints/eth-new-filter)              | [`eth_newPendingTransactionFilter`](/docs/chain-apis/world-chain/world-chain-api-endpoints/eth-new-pending-transaction-filter) |
+| [`eth_protocolVersion`](/docs/chain-apis/world-chain/world-chain-api-endpoints/eth-protocol-version)  | [`eth_sendRawTransaction`](/docs/chain-apis/world-chain/world-chain-api-endpoints/eth-send-raw-transaction) |
+| [`eth_sendRawTransactionSync`](/docs/chain-apis/world-chain/world-chain-api-endpoints/eth-send-raw-transaction-sync) | [`eth_simulateV1`](/docs/chain-apis/world-chain/world-chain-api-endpoints/eth-simulate-v-1)       |
+| [`eth_submitWork`](/docs/chain-apis/world-chain/world-chain-api-endpoints/eth-submit-work)            | [`eth_subscribe`](/docs/chain-apis/world-chain/world-chain-api-endpoints/eth-subscribe)           |
+| [`eth_syncing`](/docs/chain-apis/world-chain/world-chain-api-endpoints/eth-syncing)                   | [`eth_uninstallFilter`](/docs/chain-apis/world-chain/world-chain-api-endpoints/eth-uninstall-filter) |
+| [`eth_unsubscribe`](/docs/chain-apis/world-chain/world-chain-api-endpoints/eth-unsubscribe)           | [`net_version`](/docs/chain-apis/world-chain/world-chain-api-endpoints/net-version)               |
+| [`web3_clientVersion`](/docs/chain-apis/world-chain/world-chain-api-endpoints/web-3-client-version)   | [`web3_sha3`](/docs/chain-apis/world-chain/world-chain-api-endpoints/web-3-sha-3)                 |
 
 ## World Mobile Chain APIs
 
@@ -1487,22 +1487,22 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_blockNumber`](/docs/node/world-mobile-chain/world-mobile-chain-api-endpoints/eth-block-number) | [`eth_call`](/docs/node/world-mobile-chain/world-mobile-chain-api-endpoints/eth-call)       |
-| [`eth_callMany`](/docs/node/world-mobile-chain/world-mobile-chain-api-endpoints/eth-call-many)  | [`eth_chainId`](/docs/node/world-mobile-chain/world-mobile-chain-api-endpoints/eth-chain-id) |
-| [`eth_estimateGas`](/docs/node/world-mobile-chain/world-mobile-chain-api-endpoints/eth-estimate-gas) | [`eth_gasPrice`](/docs/node/world-mobile-chain/world-mobile-chain-api-endpoints/eth-gas-price) |
-| [`eth_getAccount`](/docs/node/world-mobile-chain/world-mobile-chain-api-endpoints/eth-get-account) | [`eth_getBalance`](/docs/node/world-mobile-chain/world-mobile-chain-api-endpoints/eth-get-balance) |
-| [`eth_getBlockByHash`](/docs/node/world-mobile-chain/world-mobile-chain-api-endpoints/eth-get-block-by-hash) | [`eth_getBlockByNumber`](/docs/node/world-mobile-chain/world-mobile-chain-api-endpoints/eth-get-block-by-number) |
-| [`eth_getBlockTransactionCountByHash`](/docs/node/world-mobile-chain/world-mobile-chain-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/node/world-mobile-chain/world-mobile-chain-api-endpoints/eth-get-block-transaction-count-by-number) |
-| [`eth_getCode`](/docs/node/world-mobile-chain/world-mobile-chain-api-endpoints/eth-get-code)    | [`eth_getFilterChanges`](/docs/node/world-mobile-chain/world-mobile-chain-api-endpoints/eth-get-filter-changes) |
-| [`eth_getFilterLogs`](/docs/node/world-mobile-chain/world-mobile-chain-api-endpoints/eth-get-filter-logs) | [`eth_getLogs`](/docs/node/world-mobile-chain/world-mobile-chain-api-endpoints/eth-get-logs) |
-| [`eth_getStorageAt`](/docs/node/world-mobile-chain/world-mobile-chain-api-endpoints/eth-get-storage-at) | [`eth_getTransactionByBlockHashAndIndex`](/docs/node/world-mobile-chain/world-mobile-chain-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
-| [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/world-mobile-chain/world-mobile-chain-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/node/world-mobile-chain/world-mobile-chain-api-endpoints/eth-get-transaction-by-hash) |
-| [`eth_getTransactionCount`](/docs/node/world-mobile-chain/world-mobile-chain-api-endpoints/eth-get-transaction-count) | [`eth_getTransactionReceipt`](/docs/node/world-mobile-chain/world-mobile-chain-api-endpoints/eth-get-transaction-receipt) |
-| [`eth_newBlockFilter`](/docs/node/world-mobile-chain/world-mobile-chain-api-endpoints/eth-new-block-filter) | [`eth_newFilter`](/docs/node/world-mobile-chain/world-mobile-chain-api-endpoints/eth-new-filter) |
-| [`eth_sendRawTransaction`](/docs/node/world-mobile-chain/world-mobile-chain-api-endpoints/eth-send-raw-transaction) | [`eth_submitWork`](/docs/node/world-mobile-chain/world-mobile-chain-api-endpoints/eth-submit-work) |
-| [`eth_subscribe`](/docs/node/world-mobile-chain/world-mobile-chain-api-endpoints/eth-subscribe) | [`eth_uninstallFilter`](/docs/node/world-mobile-chain/world-mobile-chain-api-endpoints/eth-uninstall-filter) |
-| [`eth_unsubscribe`](/docs/node/world-mobile-chain/world-mobile-chain-api-endpoints/eth-unsubscribe) | [`net_version`](/docs/node/world-mobile-chain/world-mobile-chain-api-endpoints/net-version) |
-| [`web3_clientVersion`](/docs/node/world-mobile-chain/world-mobile-chain-api-endpoints/web-3-client-version) | [`web3_sha3`](/docs/node/world-mobile-chain/world-mobile-chain-api-endpoints/web-3-sha-3)   |
+| [`eth_blockNumber`](/docs/chain-apis/world-mobile-chain/world-mobile-chain-api-endpoints/eth-block-number) | [`eth_call`](/docs/chain-apis/world-mobile-chain/world-mobile-chain-api-endpoints/eth-call)       |
+| [`eth_callMany`](/docs/chain-apis/world-mobile-chain/world-mobile-chain-api-endpoints/eth-call-many)  | [`eth_chainId`](/docs/chain-apis/world-mobile-chain/world-mobile-chain-api-endpoints/eth-chain-id) |
+| [`eth_estimateGas`](/docs/chain-apis/world-mobile-chain/world-mobile-chain-api-endpoints/eth-estimate-gas) | [`eth_gasPrice`](/docs/chain-apis/world-mobile-chain/world-mobile-chain-api-endpoints/eth-gas-price) |
+| [`eth_getAccount`](/docs/chain-apis/world-mobile-chain/world-mobile-chain-api-endpoints/eth-get-account) | [`eth_getBalance`](/docs/chain-apis/world-mobile-chain/world-mobile-chain-api-endpoints/eth-get-balance) |
+| [`eth_getBlockByHash`](/docs/chain-apis/world-mobile-chain/world-mobile-chain-api-endpoints/eth-get-block-by-hash) | [`eth_getBlockByNumber`](/docs/chain-apis/world-mobile-chain/world-mobile-chain-api-endpoints/eth-get-block-by-number) |
+| [`eth_getBlockTransactionCountByHash`](/docs/chain-apis/world-mobile-chain/world-mobile-chain-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/chain-apis/world-mobile-chain/world-mobile-chain-api-endpoints/eth-get-block-transaction-count-by-number) |
+| [`eth_getCode`](/docs/chain-apis/world-mobile-chain/world-mobile-chain-api-endpoints/eth-get-code)    | [`eth_getFilterChanges`](/docs/chain-apis/world-mobile-chain/world-mobile-chain-api-endpoints/eth-get-filter-changes) |
+| [`eth_getFilterLogs`](/docs/chain-apis/world-mobile-chain/world-mobile-chain-api-endpoints/eth-get-filter-logs) | [`eth_getLogs`](/docs/chain-apis/world-mobile-chain/world-mobile-chain-api-endpoints/eth-get-logs) |
+| [`eth_getStorageAt`](/docs/chain-apis/world-mobile-chain/world-mobile-chain-api-endpoints/eth-get-storage-at) | [`eth_getTransactionByBlockHashAndIndex`](/docs/chain-apis/world-mobile-chain/world-mobile-chain-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
+| [`eth_getTransactionByBlockNumberAndIndex`](/docs/chain-apis/world-mobile-chain/world-mobile-chain-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/chain-apis/world-mobile-chain/world-mobile-chain-api-endpoints/eth-get-transaction-by-hash) |
+| [`eth_getTransactionCount`](/docs/chain-apis/world-mobile-chain/world-mobile-chain-api-endpoints/eth-get-transaction-count) | [`eth_getTransactionReceipt`](/docs/chain-apis/world-mobile-chain/world-mobile-chain-api-endpoints/eth-get-transaction-receipt) |
+| [`eth_newBlockFilter`](/docs/chain-apis/world-mobile-chain/world-mobile-chain-api-endpoints/eth-new-block-filter) | [`eth_newFilter`](/docs/chain-apis/world-mobile-chain/world-mobile-chain-api-endpoints/eth-new-filter) |
+| [`eth_sendRawTransaction`](/docs/chain-apis/world-mobile-chain/world-mobile-chain-api-endpoints/eth-send-raw-transaction) | [`eth_submitWork`](/docs/chain-apis/world-mobile-chain/world-mobile-chain-api-endpoints/eth-submit-work) |
+| [`eth_subscribe`](/docs/chain-apis/world-mobile-chain/world-mobile-chain-api-endpoints/eth-subscribe) | [`eth_uninstallFilter`](/docs/chain-apis/world-mobile-chain/world-mobile-chain-api-endpoints/eth-uninstall-filter) |
+| [`eth_unsubscribe`](/docs/chain-apis/world-mobile-chain/world-mobile-chain-api-endpoints/eth-unsubscribe) | [`net_version`](/docs/chain-apis/world-mobile-chain/world-mobile-chain-api-endpoints/net-version) |
+| [`web3_clientVersion`](/docs/chain-apis/world-mobile-chain/world-mobile-chain-api-endpoints/web-3-client-version) | [`web3_sha3`](/docs/chain-apis/world-mobile-chain/world-mobile-chain-api-endpoints/web-3-sha-3)   |
 
 ## XMTP APIs
 
@@ -1510,22 +1510,22 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_blockNumber`](/docs/node/xmtp/xmtp-api-endpoints/eth-block-number)                        | [`eth_call`](/docs/node/xmtp/xmtp-api-endpoints/eth-call)                                   |
-| [`eth_callMany`](/docs/node/xmtp/xmtp-api-endpoints/eth-call-many)                              | [`eth_chainId`](/docs/node/xmtp/xmtp-api-endpoints/eth-chain-id)                            |
-| [`eth_estimateGas`](/docs/node/xmtp/xmtp-api-endpoints/eth-estimate-gas)                        | [`eth_gasPrice`](/docs/node/xmtp/xmtp-api-endpoints/eth-gas-price)                          |
-| [`eth_getAccount`](/docs/node/xmtp/xmtp-api-endpoints/eth-get-account)                          | [`eth_getBalance`](/docs/node/xmtp/xmtp-api-endpoints/eth-get-balance)                      |
-| [`eth_getBlockByHash`](/docs/node/xmtp/xmtp-api-endpoints/eth-get-block-by-hash)                | [`eth_getBlockByNumber`](/docs/node/xmtp/xmtp-api-endpoints/eth-get-block-by-number)        |
-| [`eth_getBlockTransactionCountByHash`](/docs/node/xmtp/xmtp-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/node/xmtp/xmtp-api-endpoints/eth-get-block-transaction-count-by-number) |
-| [`eth_getCode`](/docs/node/xmtp/xmtp-api-endpoints/eth-get-code)                                | [`eth_getFilterChanges`](/docs/node/xmtp/xmtp-api-endpoints/eth-get-filter-changes)         |
-| [`eth_getFilterLogs`](/docs/node/xmtp/xmtp-api-endpoints/eth-get-filter-logs)                   | [`eth_getLogs`](/docs/node/xmtp/xmtp-api-endpoints/eth-get-logs)                            |
-| [`eth_getStorageAt`](/docs/node/xmtp/xmtp-api-endpoints/eth-get-storage-at)                     | [`eth_getTransactionByBlockHashAndIndex`](/docs/node/xmtp/xmtp-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
-| [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/xmtp/xmtp-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/node/xmtp/xmtp-api-endpoints/eth-get-transaction-by-hash) |
-| [`eth_getTransactionCount`](/docs/node/xmtp/xmtp-api-endpoints/eth-get-transaction-count)       | [`eth_getTransactionReceipt`](/docs/node/xmtp/xmtp-api-endpoints/eth-get-transaction-receipt) |
-| [`eth_newBlockFilter`](/docs/node/xmtp/xmtp-api-endpoints/eth-new-block-filter)                 | [`eth_newFilter`](/docs/node/xmtp/xmtp-api-endpoints/eth-new-filter)                        |
-| [`eth_sendRawTransaction`](/docs/node/xmtp/xmtp-api-endpoints/eth-send-raw-transaction)         | [`eth_submitWork`](/docs/node/xmtp/xmtp-api-endpoints/eth-submit-work)                      |
-| [`eth_subscribe`](/docs/node/xmtp/xmtp-api-endpoints/eth-subscribe)                             | [`eth_uninstallFilter`](/docs/node/xmtp/xmtp-api-endpoints/eth-uninstall-filter)            |
-| [`eth_unsubscribe`](/docs/node/xmtp/xmtp-api-endpoints/eth-unsubscribe)                         | [`net_version`](/docs/node/xmtp/xmtp-api-endpoints/net-version)                             |
-| [`web3_clientVersion`](/docs/node/xmtp/xmtp-api-endpoints/web-3-client-version)                 | [`web3_sha3`](/docs/node/xmtp/xmtp-api-endpoints/web-3-sha-3)                               |
+| [`eth_blockNumber`](/docs/chain-apis/xmtp/xmtp-api-endpoints/eth-block-number)                        | [`eth_call`](/docs/chain-apis/xmtp/xmtp-api-endpoints/eth-call)                                   |
+| [`eth_callMany`](/docs/chain-apis/xmtp/xmtp-api-endpoints/eth-call-many)                              | [`eth_chainId`](/docs/chain-apis/xmtp/xmtp-api-endpoints/eth-chain-id)                            |
+| [`eth_estimateGas`](/docs/chain-apis/xmtp/xmtp-api-endpoints/eth-estimate-gas)                        | [`eth_gasPrice`](/docs/chain-apis/xmtp/xmtp-api-endpoints/eth-gas-price)                          |
+| [`eth_getAccount`](/docs/chain-apis/xmtp/xmtp-api-endpoints/eth-get-account)                          | [`eth_getBalance`](/docs/chain-apis/xmtp/xmtp-api-endpoints/eth-get-balance)                      |
+| [`eth_getBlockByHash`](/docs/chain-apis/xmtp/xmtp-api-endpoints/eth-get-block-by-hash)                | [`eth_getBlockByNumber`](/docs/chain-apis/xmtp/xmtp-api-endpoints/eth-get-block-by-number)        |
+| [`eth_getBlockTransactionCountByHash`](/docs/chain-apis/xmtp/xmtp-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/chain-apis/xmtp/xmtp-api-endpoints/eth-get-block-transaction-count-by-number) |
+| [`eth_getCode`](/docs/chain-apis/xmtp/xmtp-api-endpoints/eth-get-code)                                | [`eth_getFilterChanges`](/docs/chain-apis/xmtp/xmtp-api-endpoints/eth-get-filter-changes)         |
+| [`eth_getFilterLogs`](/docs/chain-apis/xmtp/xmtp-api-endpoints/eth-get-filter-logs)                   | [`eth_getLogs`](/docs/chain-apis/xmtp/xmtp-api-endpoints/eth-get-logs)                            |
+| [`eth_getStorageAt`](/docs/chain-apis/xmtp/xmtp-api-endpoints/eth-get-storage-at)                     | [`eth_getTransactionByBlockHashAndIndex`](/docs/chain-apis/xmtp/xmtp-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
+| [`eth_getTransactionByBlockNumberAndIndex`](/docs/chain-apis/xmtp/xmtp-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/chain-apis/xmtp/xmtp-api-endpoints/eth-get-transaction-by-hash) |
+| [`eth_getTransactionCount`](/docs/chain-apis/xmtp/xmtp-api-endpoints/eth-get-transaction-count)       | [`eth_getTransactionReceipt`](/docs/chain-apis/xmtp/xmtp-api-endpoints/eth-get-transaction-receipt) |
+| [`eth_newBlockFilter`](/docs/chain-apis/xmtp/xmtp-api-endpoints/eth-new-block-filter)                 | [`eth_newFilter`](/docs/chain-apis/xmtp/xmtp-api-endpoints/eth-new-filter)                        |
+| [`eth_sendRawTransaction`](/docs/chain-apis/xmtp/xmtp-api-endpoints/eth-send-raw-transaction)         | [`eth_submitWork`](/docs/chain-apis/xmtp/xmtp-api-endpoints/eth-submit-work)                      |
+| [`eth_subscribe`](/docs/chain-apis/xmtp/xmtp-api-endpoints/eth-subscribe)                             | [`eth_uninstallFilter`](/docs/chain-apis/xmtp/xmtp-api-endpoints/eth-uninstall-filter)            |
+| [`eth_unsubscribe`](/docs/chain-apis/xmtp/xmtp-api-endpoints/eth-unsubscribe)                         | [`net_version`](/docs/chain-apis/xmtp/xmtp-api-endpoints/net-version)                             |
+| [`web3_clientVersion`](/docs/chain-apis/xmtp/xmtp-api-endpoints/web-3-client-version)                 | [`web3_sha3`](/docs/chain-apis/xmtp/xmtp-api-endpoints/web-3-sha-3)                               |
 
 ## ZetaChain APIs
 
@@ -1533,27 +1533,27 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_blockNumber`](/docs/node/zetachain/zeta-chain-api-endpoints/eth-block-number)             | [`eth_call`](/docs/node/zetachain/zeta-chain-api-endpoints/eth-call)                        |
-| [`eth_callMany`](/docs/node/zetachain/zeta-chain-api-endpoints/eth-call-many)                   | [`eth_chainId`](/docs/node/zetachain/zeta-chain-api-endpoints/eth-chain-id)                 |
-| [`eth_estimateGas`](/docs/node/zetachain/zeta-chain-api-endpoints/eth-estimate-gas)             | [`eth_feeHistory`](/docs/node/zetachain/zeta-chain-api-endpoints/eth-fee-history)           |
-| [`eth_gasPrice`](/docs/node/zetachain/zeta-chain-api-endpoints/eth-gas-price)                   | [`eth_getAccount`](/docs/node/zetachain/zeta-chain-api-endpoints/eth-get-account)           |
-| [`eth_getBalance`](/docs/node/zetachain/zeta-chain-api-endpoints/eth-get-balance)               | [`eth_getBlockByHash`](/docs/node/zetachain/zeta-chain-api-endpoints/eth-get-block-by-hash) |
-| [`eth_getBlockByNumber`](/docs/node/zetachain/zeta-chain-api-endpoints/eth-get-block-by-number) | [`eth_getBlockReceipts`](/docs/node/zetachain/zeta-chain-api-endpoints/eth-get-block-receipts) |
-| [`eth_getBlockTransactionCountByHash`](/docs/node/zetachain/zeta-chain-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/node/zetachain/zeta-chain-api-endpoints/eth-get-block-transaction-count-by-number) |
-| [`eth_getCode`](/docs/node/zetachain/zeta-chain-api-endpoints/eth-get-code)                     | [`eth_getFilterChanges`](/docs/node/zetachain/zeta-chain-api-endpoints/eth-get-filter-changes) |
-| [`eth_getFilterLogs`](/docs/node/zetachain/zeta-chain-api-endpoints/eth-get-filter-logs)        | [`eth_getLogs`](/docs/node/zetachain/zeta-chain-api-endpoints/eth-get-logs)                 |
-| [`eth_getProof`](/docs/node/zetachain/zeta-chain-api-endpoints/eth-get-proof)                   | [`eth_getStorageAt`](/docs/node/zetachain/zeta-chain-api-endpoints/eth-get-storage-at)      |
-| [`eth_getTransactionByBlockHashAndIndex`](/docs/node/zetachain/zeta-chain-api-endpoints/eth-get-transaction-by-block-hash-and-index) | [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/zetachain/zeta-chain-api-endpoints/eth-get-transaction-by-block-number-and-index) |
-| [`eth_getTransactionByHash`](/docs/node/zetachain/zeta-chain-api-endpoints/eth-get-transaction-by-hash) | [`eth_getTransactionCount`](/docs/node/zetachain/zeta-chain-api-endpoints/eth-get-transaction-count) |
-| [`eth_getTransactionReceipt`](/docs/node/zetachain/zeta-chain-api-endpoints/eth-get-transaction-receipt) | [`eth_getUncleByBlockHashAndIndex`](/docs/node/zetachain/zeta-chain-api-endpoints/eth-get-uncle-by-block-hash-and-index) |
-| [`eth_getUncleByBlockNumberAndIndex`](/docs/node/zetachain/zeta-chain-api-endpoints/eth-get-uncle-by-block-number-and-index) | [`eth_getUncleCountByBlockHash`](/docs/node/zetachain/zeta-chain-api-endpoints/eth-get-uncle-count-by-block-hash) |
-| [`eth_getUncleCountByBlockNumber`](/docs/node/zetachain/zeta-chain-api-endpoints/eth-get-uncle-count-by-block-number) | [`eth_maxPriorityFeePerGas`](/docs/node/zetachain/zeta-chain-api-endpoints/eth-max-priority-fee-per-gas) |
-| [`eth_newBlockFilter`](/docs/node/zetachain/zeta-chain-api-endpoints/eth-new-block-filter)      | [`eth_newFilter`](/docs/node/zetachain/zeta-chain-api-endpoints/eth-new-filter)             |
-| [`eth_protocolVersion`](/docs/node/zetachain/zeta-chain-api-endpoints/eth-protocol-version)     | [`eth_sendRawTransaction`](/docs/node/zetachain/zeta-chain-api-endpoints/eth-send-raw-transaction) |
-| [`eth_submitWork`](/docs/node/zetachain/zeta-chain-api-endpoints/eth-submit-work)               | [`eth_subscribe`](/docs/node/zetachain/zeta-chain-api-endpoints/eth-subscribe)              |
-| [`eth_syncing`](/docs/node/zetachain/zeta-chain-api-endpoints/eth-syncing)                      | [`eth_uninstallFilter`](/docs/node/zetachain/zeta-chain-api-endpoints/eth-uninstall-filter) |
-| [`eth_unsubscribe`](/docs/node/zetachain/zeta-chain-api-endpoints/eth-unsubscribe)              | [`net_version`](/docs/node/zetachain/zeta-chain-api-endpoints/net-version)                  |
-| [`web3_clientVersion`](/docs/node/zetachain/zeta-chain-api-endpoints/web-3-client-version)      | [`web3_sha3`](/docs/node/zetachain/zeta-chain-api-endpoints/web-3-sha-3)                    |
+| [`eth_blockNumber`](/docs/chain-apis/zetachain/zeta-chain-api-endpoints/eth-block-number)             | [`eth_call`](/docs/chain-apis/zetachain/zeta-chain-api-endpoints/eth-call)                        |
+| [`eth_callMany`](/docs/chain-apis/zetachain/zeta-chain-api-endpoints/eth-call-many)                   | [`eth_chainId`](/docs/chain-apis/zetachain/zeta-chain-api-endpoints/eth-chain-id)                 |
+| [`eth_estimateGas`](/docs/chain-apis/zetachain/zeta-chain-api-endpoints/eth-estimate-gas)             | [`eth_feeHistory`](/docs/chain-apis/zetachain/zeta-chain-api-endpoints/eth-fee-history)           |
+| [`eth_gasPrice`](/docs/chain-apis/zetachain/zeta-chain-api-endpoints/eth-gas-price)                   | [`eth_getAccount`](/docs/chain-apis/zetachain/zeta-chain-api-endpoints/eth-get-account)           |
+| [`eth_getBalance`](/docs/chain-apis/zetachain/zeta-chain-api-endpoints/eth-get-balance)               | [`eth_getBlockByHash`](/docs/chain-apis/zetachain/zeta-chain-api-endpoints/eth-get-block-by-hash) |
+| [`eth_getBlockByNumber`](/docs/chain-apis/zetachain/zeta-chain-api-endpoints/eth-get-block-by-number) | [`eth_getBlockReceipts`](/docs/chain-apis/zetachain/zeta-chain-api-endpoints/eth-get-block-receipts) |
+| [`eth_getBlockTransactionCountByHash`](/docs/chain-apis/zetachain/zeta-chain-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/chain-apis/zetachain/zeta-chain-api-endpoints/eth-get-block-transaction-count-by-number) |
+| [`eth_getCode`](/docs/chain-apis/zetachain/zeta-chain-api-endpoints/eth-get-code)                     | [`eth_getFilterChanges`](/docs/chain-apis/zetachain/zeta-chain-api-endpoints/eth-get-filter-changes) |
+| [`eth_getFilterLogs`](/docs/chain-apis/zetachain/zeta-chain-api-endpoints/eth-get-filter-logs)        | [`eth_getLogs`](/docs/chain-apis/zetachain/zeta-chain-api-endpoints/eth-get-logs)                 |
+| [`eth_getProof`](/docs/chain-apis/zetachain/zeta-chain-api-endpoints/eth-get-proof)                   | [`eth_getStorageAt`](/docs/chain-apis/zetachain/zeta-chain-api-endpoints/eth-get-storage-at)      |
+| [`eth_getTransactionByBlockHashAndIndex`](/docs/chain-apis/zetachain/zeta-chain-api-endpoints/eth-get-transaction-by-block-hash-and-index) | [`eth_getTransactionByBlockNumberAndIndex`](/docs/chain-apis/zetachain/zeta-chain-api-endpoints/eth-get-transaction-by-block-number-and-index) |
+| [`eth_getTransactionByHash`](/docs/chain-apis/zetachain/zeta-chain-api-endpoints/eth-get-transaction-by-hash) | [`eth_getTransactionCount`](/docs/chain-apis/zetachain/zeta-chain-api-endpoints/eth-get-transaction-count) |
+| [`eth_getTransactionReceipt`](/docs/chain-apis/zetachain/zeta-chain-api-endpoints/eth-get-transaction-receipt) | [`eth_getUncleByBlockHashAndIndex`](/docs/chain-apis/zetachain/zeta-chain-api-endpoints/eth-get-uncle-by-block-hash-and-index) |
+| [`eth_getUncleByBlockNumberAndIndex`](/docs/chain-apis/zetachain/zeta-chain-api-endpoints/eth-get-uncle-by-block-number-and-index) | [`eth_getUncleCountByBlockHash`](/docs/chain-apis/zetachain/zeta-chain-api-endpoints/eth-get-uncle-count-by-block-hash) |
+| [`eth_getUncleCountByBlockNumber`](/docs/chain-apis/zetachain/zeta-chain-api-endpoints/eth-get-uncle-count-by-block-number) | [`eth_maxPriorityFeePerGas`](/docs/chain-apis/zetachain/zeta-chain-api-endpoints/eth-max-priority-fee-per-gas) |
+| [`eth_newBlockFilter`](/docs/chain-apis/zetachain/zeta-chain-api-endpoints/eth-new-block-filter)      | [`eth_newFilter`](/docs/chain-apis/zetachain/zeta-chain-api-endpoints/eth-new-filter)             |
+| [`eth_protocolVersion`](/docs/chain-apis/zetachain/zeta-chain-api-endpoints/eth-protocol-version)     | [`eth_sendRawTransaction`](/docs/chain-apis/zetachain/zeta-chain-api-endpoints/eth-send-raw-transaction) |
+| [`eth_submitWork`](/docs/chain-apis/zetachain/zeta-chain-api-endpoints/eth-submit-work)               | [`eth_subscribe`](/docs/chain-apis/zetachain/zeta-chain-api-endpoints/eth-subscribe)              |
+| [`eth_syncing`](/docs/chain-apis/zetachain/zeta-chain-api-endpoints/eth-syncing)                      | [`eth_uninstallFilter`](/docs/chain-apis/zetachain/zeta-chain-api-endpoints/eth-uninstall-filter) |
+| [`eth_unsubscribe`](/docs/chain-apis/zetachain/zeta-chain-api-endpoints/eth-unsubscribe)              | [`net_version`](/docs/chain-apis/zetachain/zeta-chain-api-endpoints/net-version)                  |
+| [`web3_clientVersion`](/docs/chain-apis/zetachain/zeta-chain-api-endpoints/web-3-client-version)      | [`web3_sha3`](/docs/chain-apis/zetachain/zeta-chain-api-endpoints/web-3-sha-3)                    |
 
 ## ZKsync APIs
 
@@ -1561,38 +1561,38 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_accounts`](/docs/node/zksync/z-ksync-api-endpoints/eth-accounts)                          | [`eth_blockNumber`](/docs/node/zksync/z-ksync-api-endpoints/eth-block-number)               |
-| [`eth_call`](/docs/node/zksync/z-ksync-api-endpoints/eth-call)                                  | [`eth_callMany`](/docs/node/zksync/z-ksync-api-endpoints/eth-call-many)                     |
-| [`eth_chainId`](/docs/node/zksync/z-ksync-api-endpoints/eth-chain-id)                           | [`eth_estimateGas`](/docs/node/zksync/z-ksync-api-endpoints/eth-estimate-gas)               |
-| [`eth_feeHistory`](/docs/node/zksync/z-ksync-api-endpoints/eth-fee-history)                     | [`eth_gasPrice`](/docs/node/zksync/z-ksync-api-endpoints/eth-gas-price)                     |
-| [`eth_getAccount`](/docs/node/zksync/z-ksync-api-endpoints/eth-get-account)                     | [`eth_getBalance`](/docs/node/zksync/z-ksync-api-endpoints/eth-get-balance)                 |
-| [`eth_getBlockByHash`](/docs/node/zksync/z-ksync-api-endpoints/eth-get-block-by-hash)           | [`eth_getBlockByNumber`](/docs/node/zksync/z-ksync-api-endpoints/eth-get-block-by-number)   |
-| [`eth_getBlockReceipts`](/docs/node/zksync/z-ksync-api-endpoints/eth-get-block-receipts)        | [`eth_getBlockTransactionCountByHash`](/docs/node/zksync/z-ksync-api-endpoints/eth-get-block-transaction-count-by-hash) |
-| [`eth_getBlockTransactionCountByNumber`](/docs/node/zksync/z-ksync-api-endpoints/eth-get-block-transaction-count-by-number) | [`eth_getCode`](/docs/node/zksync/z-ksync-api-endpoints/eth-get-code)                       |
-| [`eth_getFilterChanges`](/docs/node/zksync/z-ksync-api-endpoints/eth-get-filter-changes)        | [`eth_getFilterLogs`](/docs/node/zksync/z-ksync-api-endpoints/eth-get-filter-logs)          |
-| [`eth_getLogs`](/docs/node/zksync/z-ksync-api-endpoints/eth-get-logs)                           | [`eth_getStorageAt`](/docs/node/zksync/z-ksync-api-endpoints/eth-get-storage-at)            |
-| [`eth_getTransactionByBlockHashAndIndex`](/docs/node/zksync/z-ksync-api-endpoints/eth-get-transaction-by-block-hash-and-index) | [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/zksync/z-ksync-api-endpoints/eth-get-transaction-by-block-number-and-index) |
-| [`eth_getTransactionByHash`](/docs/node/zksync/z-ksync-api-endpoints/eth-get-transaction-by-hash) | [`eth_getTransactionCount`](/docs/node/zksync/z-ksync-api-endpoints/eth-get-transaction-count) |
-| [`eth_getTransactionReceipt`](/docs/node/zksync/z-ksync-api-endpoints/eth-get-transaction-receipt) | [`eth_getUncleCountByBlockHash`](/docs/node/zksync/z-ksync-api-endpoints/eth-get-uncle-count-by-block-hash) |
-| [`eth_getUncleCountByBlockNumber`](/docs/node/zksync/z-ksync-api-endpoints/eth-get-uncle-count-by-block-number) | [`eth_newBlockFilter`](/docs/node/zksync/z-ksync-api-endpoints/eth-new-block-filter)        |
-| [`eth_newFilter`](/docs/node/zksync/z-ksync-api-endpoints/eth-new-filter)                       | [`eth_sendRawTransaction`](/docs/node/zksync/z-ksync-api-endpoints/eth-send-raw-transaction) |
-| [`eth_sendRawTransactionSync`](/docs/node/zksync/z-ksync-api-endpoints/eth-send-raw-transaction-sync) | [`eth_submitWork`](/docs/node/zksync/z-ksync-api-endpoints/eth-submit-work)                 |
-| [`eth_subscribe`](/docs/node/zksync/z-ksync-api-endpoints/eth-subscribe)                        | [`eth_syncing`](/docs/node/zksync/z-ksync-api-endpoints/eth-syncing)                        |
-| [`eth_uninstallFilter`](/docs/node/zksync/z-ksync-api-endpoints/eth-uninstall-filter)           | [`eth_unsubscribe`](/docs/node/zksync/z-ksync-api-endpoints/eth-unsubscribe)                |
-| [`net_version`](/docs/node/zksync/z-ksync-api-endpoints/net-version)                            | [`web3_clientVersion`](/docs/node/zksync/z-ksync-api-endpoints/web-3-client-version)        |
-| [`web3_sha3`](/docs/node/zksync/z-ksync-api-endpoints/web-3-sha-3)                              | [`zks_estimateFee`](/docs/node/zksync/z-ksync-api-endpoints/zks-estimate-fee)               |
-| [`zks_estimateGasL1ToL2`](/docs/node/zksync/z-ksync-api-endpoints/zks-estimate-gas-l-1-to-l-2)  | [`zks_getAllAccountBalances`](/docs/node/zksync/z-ksync-api-endpoints/zks-get-all-account-balances) |
-| [`zks_getBaseTokenL1Address`](/docs/node/zksync/z-ksync-api-endpoints/zks-get-base-token-l-1-address) | [`zks_getBlockDetails`](/docs/node/zksync/z-ksync-api-endpoints/zks-get-block-details)      |
-| [`zks_getBridgeContracts`](/docs/node/zksync/z-ksync-api-endpoints/zks-get-bridge-contracts)    | [`zks_getBridgehubContract`](/docs/node/zksync/z-ksync-api-endpoints/zks-get-bridgehub-contract) |
-| [`zks_getBytecodeByHash`](/docs/node/zksync/z-ksync-api-endpoints/zks-get-bytecode-by-hash)     | [`zks_getConfirmedTokens`](/docs/node/zksync/z-ksync-api-endpoints/zks-get-confirmed-tokens) |
-| [`zks_getFeeParams`](/docs/node/zksync/z-ksync-api-endpoints/zks-get-fee-params)                | [`zks_getL1BatchBlockRange`](/docs/node/zksync/z-ksync-api-endpoints/zks-get-l-1-batch-block-range) |
-| [`zks_getL1BatchDetails`](/docs/node/zksync/z-ksync-api-endpoints/zks-get-l-1-batch-details)    | [`zks_getL1GasPrice`](/docs/node/zksync/z-ksync-api-endpoints/zks-get-l-1-gas-price)        |
-| [`zks_getL2ToL1LogProof`](/docs/node/zksync/z-ksync-api-endpoints/zks-get-l-2-to-l-1-log-proof) | [`zks_getL2ToL1MsgProof`](/docs/node/zksync/z-ksync-api-endpoints/zks-get-l-2-to-l-1-msg-proof) |
-| [`zks_getMainContract`](/docs/node/zksync/z-ksync-api-endpoints/zks-get-main-contract)          | [`zks_getProof`](/docs/node/zksync/z-ksync-api-endpoints/zks-get-proof)                     |
-| [`zks_getProtocolVersion`](/docs/node/zksync/z-ksync-api-endpoints/zks-get-protocol-version)    | [`zks_getRawBlockTransactions`](/docs/node/zksync/z-ksync-api-endpoints/zks-get-raw-block-transactions) |
-| [`zks_getTestnetPaymaster`](/docs/node/zksync/z-ksync-api-endpoints/zks-get-testnet-paymaster)  | [`zks_getTransactionDetails`](/docs/node/zksync/z-ksync-api-endpoints/zks-get-transaction-details) |
-| [`zks_L1BatchNumber`](/docs/node/zksync/z-ksync-api-endpoints/zks-l-1-batch-number)             | [`zks_L1ChainId`](/docs/node/zksync/z-ksync-api-endpoints/zks-l-1-chain-id)                 |
-| [`zks_sendRawTransactionWithDetailedOutput`](/docs/node/zksync/z-ksync-api-endpoints/zks-send-raw-transaction-with-detailed-output) |                                                                                             |
+| [`eth_accounts`](/docs/chain-apis/zksync/z-ksync-api-endpoints/eth-accounts)                          | [`eth_blockNumber`](/docs/chain-apis/zksync/z-ksync-api-endpoints/eth-block-number)               |
+| [`eth_call`](/docs/chain-apis/zksync/z-ksync-api-endpoints/eth-call)                                  | [`eth_callMany`](/docs/chain-apis/zksync/z-ksync-api-endpoints/eth-call-many)                     |
+| [`eth_chainId`](/docs/chain-apis/zksync/z-ksync-api-endpoints/eth-chain-id)                           | [`eth_estimateGas`](/docs/chain-apis/zksync/z-ksync-api-endpoints/eth-estimate-gas)               |
+| [`eth_feeHistory`](/docs/chain-apis/zksync/z-ksync-api-endpoints/eth-fee-history)                     | [`eth_gasPrice`](/docs/chain-apis/zksync/z-ksync-api-endpoints/eth-gas-price)                     |
+| [`eth_getAccount`](/docs/chain-apis/zksync/z-ksync-api-endpoints/eth-get-account)                     | [`eth_getBalance`](/docs/chain-apis/zksync/z-ksync-api-endpoints/eth-get-balance)                 |
+| [`eth_getBlockByHash`](/docs/chain-apis/zksync/z-ksync-api-endpoints/eth-get-block-by-hash)           | [`eth_getBlockByNumber`](/docs/chain-apis/zksync/z-ksync-api-endpoints/eth-get-block-by-number)   |
+| [`eth_getBlockReceipts`](/docs/chain-apis/zksync/z-ksync-api-endpoints/eth-get-block-receipts)        | [`eth_getBlockTransactionCountByHash`](/docs/chain-apis/zksync/z-ksync-api-endpoints/eth-get-block-transaction-count-by-hash) |
+| [`eth_getBlockTransactionCountByNumber`](/docs/chain-apis/zksync/z-ksync-api-endpoints/eth-get-block-transaction-count-by-number) | [`eth_getCode`](/docs/chain-apis/zksync/z-ksync-api-endpoints/eth-get-code)                       |
+| [`eth_getFilterChanges`](/docs/chain-apis/zksync/z-ksync-api-endpoints/eth-get-filter-changes)        | [`eth_getFilterLogs`](/docs/chain-apis/zksync/z-ksync-api-endpoints/eth-get-filter-logs)          |
+| [`eth_getLogs`](/docs/chain-apis/zksync/z-ksync-api-endpoints/eth-get-logs)                           | [`eth_getStorageAt`](/docs/chain-apis/zksync/z-ksync-api-endpoints/eth-get-storage-at)            |
+| [`eth_getTransactionByBlockHashAndIndex`](/docs/chain-apis/zksync/z-ksync-api-endpoints/eth-get-transaction-by-block-hash-and-index) | [`eth_getTransactionByBlockNumberAndIndex`](/docs/chain-apis/zksync/z-ksync-api-endpoints/eth-get-transaction-by-block-number-and-index) |
+| [`eth_getTransactionByHash`](/docs/chain-apis/zksync/z-ksync-api-endpoints/eth-get-transaction-by-hash) | [`eth_getTransactionCount`](/docs/chain-apis/zksync/z-ksync-api-endpoints/eth-get-transaction-count) |
+| [`eth_getTransactionReceipt`](/docs/chain-apis/zksync/z-ksync-api-endpoints/eth-get-transaction-receipt) | [`eth_getUncleCountByBlockHash`](/docs/chain-apis/zksync/z-ksync-api-endpoints/eth-get-uncle-count-by-block-hash) |
+| [`eth_getUncleCountByBlockNumber`](/docs/chain-apis/zksync/z-ksync-api-endpoints/eth-get-uncle-count-by-block-number) | [`eth_newBlockFilter`](/docs/chain-apis/zksync/z-ksync-api-endpoints/eth-new-block-filter)        |
+| [`eth_newFilter`](/docs/chain-apis/zksync/z-ksync-api-endpoints/eth-new-filter)                       | [`eth_sendRawTransaction`](/docs/chain-apis/zksync/z-ksync-api-endpoints/eth-send-raw-transaction) |
+| [`eth_sendRawTransactionSync`](/docs/chain-apis/zksync/z-ksync-api-endpoints/eth-send-raw-transaction-sync) | [`eth_submitWork`](/docs/chain-apis/zksync/z-ksync-api-endpoints/eth-submit-work)                 |
+| [`eth_subscribe`](/docs/chain-apis/zksync/z-ksync-api-endpoints/eth-subscribe)                        | [`eth_syncing`](/docs/chain-apis/zksync/z-ksync-api-endpoints/eth-syncing)                        |
+| [`eth_uninstallFilter`](/docs/chain-apis/zksync/z-ksync-api-endpoints/eth-uninstall-filter)           | [`eth_unsubscribe`](/docs/chain-apis/zksync/z-ksync-api-endpoints/eth-unsubscribe)                |
+| [`net_version`](/docs/chain-apis/zksync/z-ksync-api-endpoints/net-version)                            | [`web3_clientVersion`](/docs/chain-apis/zksync/z-ksync-api-endpoints/web-3-client-version)        |
+| [`web3_sha3`](/docs/chain-apis/zksync/z-ksync-api-endpoints/web-3-sha-3)                              | [`zks_estimateFee`](/docs/chain-apis/zksync/z-ksync-api-endpoints/zks-estimate-fee)               |
+| [`zks_estimateGasL1ToL2`](/docs/chain-apis/zksync/z-ksync-api-endpoints/zks-estimate-gas-l-1-to-l-2)  | [`zks_getAllAccountBalances`](/docs/chain-apis/zksync/z-ksync-api-endpoints/zks-get-all-account-balances) |
+| [`zks_getBaseTokenL1Address`](/docs/chain-apis/zksync/z-ksync-api-endpoints/zks-get-base-token-l-1-address) | [`zks_getBlockDetails`](/docs/chain-apis/zksync/z-ksync-api-endpoints/zks-get-block-details)      |
+| [`zks_getBridgeContracts`](/docs/chain-apis/zksync/z-ksync-api-endpoints/zks-get-bridge-contracts)    | [`zks_getBridgehubContract`](/docs/chain-apis/zksync/z-ksync-api-endpoints/zks-get-bridgehub-contract) |
+| [`zks_getBytecodeByHash`](/docs/chain-apis/zksync/z-ksync-api-endpoints/zks-get-bytecode-by-hash)     | [`zks_getConfirmedTokens`](/docs/chain-apis/zksync/z-ksync-api-endpoints/zks-get-confirmed-tokens) |
+| [`zks_getFeeParams`](/docs/chain-apis/zksync/z-ksync-api-endpoints/zks-get-fee-params)                | [`zks_getL1BatchBlockRange`](/docs/chain-apis/zksync/z-ksync-api-endpoints/zks-get-l-1-batch-block-range) |
+| [`zks_getL1BatchDetails`](/docs/chain-apis/zksync/z-ksync-api-endpoints/zks-get-l-1-batch-details)    | [`zks_getL1GasPrice`](/docs/chain-apis/zksync/z-ksync-api-endpoints/zks-get-l-1-gas-price)        |
+| [`zks_getL2ToL1LogProof`](/docs/chain-apis/zksync/z-ksync-api-endpoints/zks-get-l-2-to-l-1-log-proof) | [`zks_getL2ToL1MsgProof`](/docs/chain-apis/zksync/z-ksync-api-endpoints/zks-get-l-2-to-l-1-msg-proof) |
+| [`zks_getMainContract`](/docs/chain-apis/zksync/z-ksync-api-endpoints/zks-get-main-contract)          | [`zks_getProof`](/docs/chain-apis/zksync/z-ksync-api-endpoints/zks-get-proof)                     |
+| [`zks_getProtocolVersion`](/docs/chain-apis/zksync/z-ksync-api-endpoints/zks-get-protocol-version)    | [`zks_getRawBlockTransactions`](/docs/chain-apis/zksync/z-ksync-api-endpoints/zks-get-raw-block-transactions) |
+| [`zks_getTestnetPaymaster`](/docs/chain-apis/zksync/z-ksync-api-endpoints/zks-get-testnet-paymaster)  | [`zks_getTransactionDetails`](/docs/chain-apis/zksync/z-ksync-api-endpoints/zks-get-transaction-details) |
+| [`zks_L1BatchNumber`](/docs/chain-apis/zksync/z-ksync-api-endpoints/zks-l-1-batch-number)             | [`zks_L1ChainId`](/docs/chain-apis/zksync/z-ksync-api-endpoints/zks-l-1-chain-id)                 |
+| [`zks_sendRawTransactionWithDetailedOutput`](/docs/chain-apis/zksync/z-ksync-api-endpoints/zks-send-raw-transaction-with-detailed-output) |                                                                                             |
 
 ## Zora APIs
 
@@ -1600,24 +1600,24 @@ Dive into each API's detailed documentation by following the links below, organi
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_blockNumber`](/docs/node/zora/zora-api-endpoints/eth-block-number)                        | [`eth_call`](/docs/node/zora/zora-api-endpoints/eth-call)                                   |
-| [`eth_callMany`](/docs/node/zora/zora-api-endpoints/eth-call-many)                              | [`eth_chainId`](/docs/node/zora/zora-api-endpoints/eth-chain-id)                            |
-| [`eth_estimateGas`](/docs/node/zora/zora-api-endpoints/eth-estimate-gas)                        | [`eth_feeHistory`](/docs/node/zora/zora-api-endpoints/eth-fee-history)                      |
-| [`eth_gasPrice`](/docs/node/zora/zora-api-endpoints/eth-gas-price)                              | [`eth_getAccount`](/docs/node/zora/zora-api-endpoints/eth-get-account)                      |
-| [`eth_getBalance`](/docs/node/zora/zora-api-endpoints/eth-get-balance)                          | [`eth_getBlockByHash`](/docs/node/zora/zora-api-endpoints/eth-get-block-by-hash)            |
-| [`eth_getBlockByNumber`](/docs/node/zora/zora-api-endpoints/eth-get-block-by-number)            | [`eth_getBlockReceipts`](/docs/node/zora/zora-api-endpoints/eth-get-block-receipts)         |
-| [`eth_getBlockTransactionCountByHash`](/docs/node/zora/zora-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/node/zora/zora-api-endpoints/eth-get-block-transaction-count-by-number) |
-| [`eth_getCode`](/docs/node/zora/zora-api-endpoints/eth-get-code)                                | [`eth_getFilterChanges`](/docs/node/zora/zora-api-endpoints/eth-get-filter-changes)         |
-| [`eth_getFilterLogs`](/docs/node/zora/zora-api-endpoints/eth-get-filter-logs)                   | [`eth_getLogs`](/docs/node/zora/zora-api-endpoints/eth-get-logs)                            |
-| [`eth_getStorageAt`](/docs/node/zora/zora-api-endpoints/eth-get-storage-at)                     | [`eth_getTransactionByBlockHashAndIndex`](/docs/node/zora/zora-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
-| [`eth_getTransactionByBlockNumberAndIndex`](/docs/node/zora/zora-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/node/zora/zora-api-endpoints/eth-get-transaction-by-hash) |
-| [`eth_getTransactionCount`](/docs/node/zora/zora-api-endpoints/eth-get-transaction-count)       | [`eth_getTransactionReceipt`](/docs/node/zora/zora-api-endpoints/eth-get-transaction-receipt) |
-| [`eth_newBlockFilter`](/docs/node/zora/zora-api-endpoints/eth-new-block-filter)                 | [`eth_newFilter`](/docs/node/zora/zora-api-endpoints/eth-new-filter)                        |
-| [`eth_sendRawTransaction`](/docs/node/zora/zora-api-endpoints/eth-send-raw-transaction)         | [`eth_sendRawTransactionSync`](/docs/node/zora/zora-api-endpoints/eth-send-raw-transaction-sync) |
-| [`eth_simulateV1`](/docs/node/zora/zora-api-endpoints/eth-simulate-v-1)                         | [`eth_submitWork`](/docs/node/zora/zora-api-endpoints/eth-submit-work)                      |
-| [`eth_subscribe`](/docs/node/zora/zora-api-endpoints/eth-subscribe)                             | [`eth_uninstallFilter`](/docs/node/zora/zora-api-endpoints/eth-uninstall-filter)            |
-| [`eth_unsubscribe`](/docs/node/zora/zora-api-endpoints/eth-unsubscribe)                         | [`net_version`](/docs/node/zora/zora-api-endpoints/net-version)                             |
-| [`web3_clientVersion`](/docs/node/zora/zora-api-endpoints/web-3-client-version)                 | [`web3_sha3`](/docs/node/zora/zora-api-endpoints/web-3-sha-3)                               |
+| [`eth_blockNumber`](/docs/chain-apis/zora/zora-api-endpoints/eth-block-number)                        | [`eth_call`](/docs/chain-apis/zora/zora-api-endpoints/eth-call)                                   |
+| [`eth_callMany`](/docs/chain-apis/zora/zora-api-endpoints/eth-call-many)                              | [`eth_chainId`](/docs/chain-apis/zora/zora-api-endpoints/eth-chain-id)                            |
+| [`eth_estimateGas`](/docs/chain-apis/zora/zora-api-endpoints/eth-estimate-gas)                        | [`eth_feeHistory`](/docs/chain-apis/zora/zora-api-endpoints/eth-fee-history)                      |
+| [`eth_gasPrice`](/docs/chain-apis/zora/zora-api-endpoints/eth-gas-price)                              | [`eth_getAccount`](/docs/chain-apis/zora/zora-api-endpoints/eth-get-account)                      |
+| [`eth_getBalance`](/docs/chain-apis/zora/zora-api-endpoints/eth-get-balance)                          | [`eth_getBlockByHash`](/docs/chain-apis/zora/zora-api-endpoints/eth-get-block-by-hash)            |
+| [`eth_getBlockByNumber`](/docs/chain-apis/zora/zora-api-endpoints/eth-get-block-by-number)            | [`eth_getBlockReceipts`](/docs/chain-apis/zora/zora-api-endpoints/eth-get-block-receipts)         |
+| [`eth_getBlockTransactionCountByHash`](/docs/chain-apis/zora/zora-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/chain-apis/zora/zora-api-endpoints/eth-get-block-transaction-count-by-number) |
+| [`eth_getCode`](/docs/chain-apis/zora/zora-api-endpoints/eth-get-code)                                | [`eth_getFilterChanges`](/docs/chain-apis/zora/zora-api-endpoints/eth-get-filter-changes)         |
+| [`eth_getFilterLogs`](/docs/chain-apis/zora/zora-api-endpoints/eth-get-filter-logs)                   | [`eth_getLogs`](/docs/chain-apis/zora/zora-api-endpoints/eth-get-logs)                            |
+| [`eth_getStorageAt`](/docs/chain-apis/zora/zora-api-endpoints/eth-get-storage-at)                     | [`eth_getTransactionByBlockHashAndIndex`](/docs/chain-apis/zora/zora-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
+| [`eth_getTransactionByBlockNumberAndIndex`](/docs/chain-apis/zora/zora-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/chain-apis/zora/zora-api-endpoints/eth-get-transaction-by-hash) |
+| [`eth_getTransactionCount`](/docs/chain-apis/zora/zora-api-endpoints/eth-get-transaction-count)       | [`eth_getTransactionReceipt`](/docs/chain-apis/zora/zora-api-endpoints/eth-get-transaction-receipt) |
+| [`eth_newBlockFilter`](/docs/chain-apis/zora/zora-api-endpoints/eth-new-block-filter)                 | [`eth_newFilter`](/docs/chain-apis/zora/zora-api-endpoints/eth-new-filter)                        |
+| [`eth_sendRawTransaction`](/docs/chain-apis/zora/zora-api-endpoints/eth-send-raw-transaction)         | [`eth_sendRawTransactionSync`](/docs/chain-apis/zora/zora-api-endpoints/eth-send-raw-transaction-sync) |
+| [`eth_simulateV1`](/docs/chain-apis/zora/zora-api-endpoints/eth-simulate-v-1)                         | [`eth_submitWork`](/docs/chain-apis/zora/zora-api-endpoints/eth-submit-work)                      |
+| [`eth_subscribe`](/docs/chain-apis/zora/zora-api-endpoints/eth-subscribe)                             | [`eth_uninstallFilter`](/docs/chain-apis/zora/zora-api-endpoints/eth-uninstall-filter)            |
+| [`eth_unsubscribe`](/docs/chain-apis/zora/zora-api-endpoints/eth-unsubscribe)                         | [`net_version`](/docs/chain-apis/zora/zora-api-endpoints/net-version)                             |
+| [`web3_clientVersion`](/docs/chain-apis/zora/zora-api-endpoints/web-3-client-version)                 | [`web3_sha3`](/docs/chain-apis/zora/zora-api-endpoints/web-3-sha-3)                               |
 {/* END AUTOGENERATED SECTION */}
 
 ## Debug and Trace APIs

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -100,8 +100,11 @@ tabs:
     display-name: Get Started
     slug: tutorials
   node:
-    display-name: Node
+    display-name: Node RPC
     slug: node
+  chain-apis:
+    display-name: Chains
+    slug: chain-apis
   data:
     display-name: Data
     slug: data
@@ -928,15 +931,6 @@ navigation:
             path: api-reference/pricing-resources/pricing/pricing-plans.mdx
         slug: introduction
 
-      - section: Chain APIs
-        contents:
-          - page: Chain APIs Overview
-            path: api-reference/node-api/chain-apis-overview.mdx
-          - page: Supported Chains
-            path: api-reference/node-api/node-supported-chains.mdx
-          - page: MEV Protection
-            path: api-reference/node-api/mev-protection.mdx
-
       - section: WebSockets
         contents:
           - page: Subscription API Overview
@@ -1037,6 +1031,17 @@ navigation:
           - api: Debug API Endpoints
             api-name: debug
         slug: debug-api
+  - tab: chain-apis
+    layout:
+      - section: Chain APIs
+        contents:
+          - page: Chain APIs Overview
+            path: api-reference/node-api/chain-apis-overview.mdx
+          - page: Supported Chains
+            path: api-reference/node-api/node-supported-chains.mdx
+          - page: MEV Protection
+            path: api-reference/node-api/mev-protection.mdx
+
       - section: Ethereum
         contents:
           - page: Ethereum API Quickstart


### PR DESCRIPTION
## Summary
- rename the Chain APIs tab to "Chains" in the header navigation
- keep the Ethereum sidebar section only under the Chains tab instead of Node RPC

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68f1328b4b308329bf6f183849dabdda