### PR TITLE
fix hyperliquid breaking endpoints urls

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -1510,7 +1510,7 @@ navigation:
           - api: Botanix API Endpoints
             api-name: botanix
         slug: botanix
-      - section: HyperEVM
+      - section: Hyperliquid
         contents:
           - page: Hyperevm API Quickstart
             path: api-reference/hyperliquid/hyperliquid-api-quickstart.mdx
@@ -6577,6 +6577,6 @@ redirects:
   - source: "/docs/data/webhooks/custom-webhook-api-methods/custom-webhook-api-methods/notify-api-methods/:method"
     destination: "/docs/data/webhooks/webhooks-api-endpoints/notify-api-endpoints/:method"
     permanent: true
-  - source: "/docs/node/hyperliquid/hyperliquid-api-endpoints/:path*"
-    destination: "/docs/node/hyperevm/hyper-evm-api-endpoints/:path*"
+  - source: "/docs/node/hyperevm/hyper-evm-api-endpoints/:path*"
+    destination: "/docs/node/hyperliquid/hyperliquid-api-endpoints/:path*"
     permanent: true


### PR DESCRIPTION
currently the urls for all hyperliquid endpoints break because of the reverse redirect, fixing that!