### PR TITLE
fix: removes addresses from the webhoooks address 

### DIFF
--- a/src/openapi/notify/notify.yaml
+++ b/src/openapi/notify/notify.yaml
@@ -522,11 +522,6 @@ components:
         time_created:
           type: integer
           description: "Timestamp when the webhook was created."
-        addresses:
-          type: array
-          description: "List of addresses being tracked (null if not an address activity webhook)."
-          items:
-            type: string
         version:
           type: string
           description: "Webhook version (v1 or v2)"


### PR DESCRIPTION
## Description

The `addresses` array is not returned on any of the endpoints, and my understanding from asking is that this is expected behavior. This is true for all affected endpoints `create-webhook`, `update-webhook`, `team-webhooks`

## Testing

* \[x] I have tested these changes locally
* \[x] I have run the validation scripts (`pnpm run validate`)
* \[x] I have checked that the documentation builds correctly
