### PR TITLE
fix: enable http snippets

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -28,7 +28,7 @@ metadata:
   canonical-host: "www.alchemy.com"
 
 settings:
-  http-snippets: false
+  http-snippets: true
 
 logo:
   href: /docs


### PR DESCRIPTION
## Description

This PR fixes a production issue where endpoints snippets are not rendering, by re-enabling `http-snippets` in `docs.yml`.

Before:
<img width="1411" height="299" alt="image" src="https://github.com/user-attachments/assets/1b69efce-469a-41a9-9277-a8dba5988c99" />


After:
<img width="1409" height="505" alt="image" src="https://github.com/user-attachments/assets/7abbccdf-fc48-45c1-b211-9ff80c78f712" />

## Testing

<!-- Describe the tests that you ran to verify your changes -->

* \[x] I have tested these changes locally
* \[x] I have run the validation scripts (`pnpm run validate`)
* \[x] I have checked that the documentation builds correctly
