### PR TITLE
fix 404 links

### DIFF
--- a/fern/api-reference/alchemy-transact/transaction-simulation/simulation-asset-changes.mdx
+++ b/fern/api-reference/alchemy-transact/transaction-simulation/simulation-asset-changes.mdx
@@ -6,7 +6,7 @@ slug: reference/simulation-asset-changes
 ---
 
 <Info>
-  Try it out - [alchemy\_simulateAssetChanges](/reference/alchemy-simulateassetchanges).
+  Try it out - [alchemy_simulateAssetChanges](https://www.alchemy.com/docs/data/simulation-apis/transaction-simulation-endpoints/alchemy-simulate-asset-changes).
 </Info>
 
 ## How does it work?

--- a/fern/api-reference/alchemy-transact/transaction-simulation/simulation-bundle.mdx
+++ b/fern/api-reference/alchemy-transact/transaction-simulation/simulation-bundle.mdx
@@ -6,7 +6,7 @@ slug: reference/simulation-bundle
 ---
 
 <Info>
-  Try it out - [alchemy\_simulateAssetChangesBundle](/reference/alchemy-simulateassetchangesbundle) and [alchemy\_simulateExecutionBundle](/reference/alchemy-simulateexecutionbundle).
+  Try it out - [alchemy_simulateAssetChangesBundle](https://www.alchemy.com/docs/data/simulation-apis/transaction-simulation-endpoints/alchemy-simulate-asset-changes-bundle) and [alchemy_simulateExecutionBundle](https://www.alchemy.com/docs/data/simulation-apis/transaction-simulation-endpoints/alchemy-simulate-execution-bundle).
 </Info>
 
 With [Asset Changes](/reference/alchemy-simulateassetchanges) and [Execution Simulation](/reference/alchemy-simulateexecution), you are able to simulate 1 transaction and get asset changes, decoded logs, decoded traces and more.

--- a/fern/api-reference/alchemy-transact/transaction-simulation/simulation-examples.mdx
+++ b/fern/api-reference/alchemy-transact/transaction-simulation/simulation-examples.mdx
@@ -9,10 +9,10 @@ You'll find some examples to get you started below!
 
 You can also try out the APIs yourself using our API playgrounds directly:
 
-* [alchemy\_simulateAssetChanges](/reference/alchemy-simulateassetchanges)
-* [alchemy\_simulateAssetChangesBundle](/reference/alchemy-simulateassetchangesbundle)
-* [alchemy\_simulateExecution](/reference/alchemy-simulateexecution)
-* [alchemy\_simulateExecutionBundle](/reference/alchemy-simulateexecutionbundle)
+* [alchemy_simulateAssetChanges](https://www.alchemy.com/docs/data/simulation-apis/transaction-simulation-endpoints/alchemy-simulate-asset-changes)
+* [alchemy_simulateAssetChangesBundle](https://www.alchemy.com/docs/data/simulation-apis/transaction-simulation-endpoints/alchemy-simulate-asset-changes-bundle)
+* [alchemy_simulateExecution](https://www.alchemy.com/docs/data/simulation-apis/transaction-simulation-endpoints/alchemy-simulate-execution)
+* [alchemy_simulateExecutionBundle](https://www.alchemy.com/docs/data/simulation-apis/transaction-simulation-endpoints/alchemy-simulate-execution-bundle)
 
 <Check>
   The examples below are for Eth Mainnet and Polygon Mainnet. Simulation also works on Arbitrum and testnets - more examples coming soon!

--- a/fern/api-reference/alchemy-transact/transaction-simulation/simulation-execution.mdx
+++ b/fern/api-reference/alchemy-transact/transaction-simulation/simulation-execution.mdx
@@ -6,7 +6,7 @@ slug: reference/simulation-execution
 ---
 
 <Info>
-  Try it out - [alchemy\_simulateExecution](/reference/alchemy-simulateexecution).
+  Try it out - [alchemy_simulateExecution](https://www.alchemy.com/docs/data/simulation-apis/transaction-simulation-endpoints/alchemy-simulate-execution).
 </Info>
 
 ## How does it work?


### PR DESCRIPTION
Fixed broken links in the Simulation API documentation. The “Try it out” links under the following sections were previously redirecting to 404 pages and have been updated to point to their correct, live references.