### PR TITLE
fix: removes dropped transactions language in webhooks sections

### DIFF
--- a/fern/api-reference/data/data-api-reference.mdx
+++ b/fern/api-reference/data/data-api-reference.mdx
@@ -62,7 +62,7 @@ Alchemy currently supports the following endpoints:
 
 ## [Notify API](/reference/notify-api-quickstart)
 
-Alchemy provides a set of webhooks for tracking address activity, mined transactions, dropped transactions, and gas prices on several blockchains.
+Alchemy provides a set of webhooks for tracking address activity, mined transactions, and gas prices on several blockchains.
 
 Developers can manually create webhooks from within the dashboard, or programmatically create webhooks to track activity for 10+ addresses using the Notify API.
 

--- a/fern/api-reference/introduction/alchemy-api-reference-overview/enhanced-apis-overview.mdx
+++ b/fern/api-reference/introduction/alchemy-api-reference-overview/enhanced-apis-overview.mdx
@@ -62,7 +62,7 @@ Alchemy currently supports the following endpoints:
 
 ## [Notify API](/reference/notify-api-quickstart)
 
-Alchemy provides a set of webhooks for tracking address activity, mined transactions, dropped transactions, and gas prices on several blockchains.
+Alchemy provides a set of webhooks for tracking address activity, mined transactions, and gas prices on several blockchains.
 
 Developers can manually create webhooks from within the dashboard, or programmatically create webhooks to track activity for 10+ addresses using the Notify API.
 

--- a/fern/tutorials/learn-about-alchemy/core-products/alchemy-notify.mdx
+++ b/fern/tutorials/learn-about-alchemy/core-products/alchemy-notify.mdx
@@ -23,7 +23,7 @@ No crazy infrastructure or complicated processes, engage your users in less than
 
 ### 3. 🔍 Rich Developer Insights
 
-Get access to all of the events your users care about, like mined and dropped transactions, plus powerful webhooks to instantly notify you when these events happen.
+Get access to all of the events your users care about, like mined transactions, plus powerful webhooks to instantly notify you when these events happen.
 
 ***
 
@@ -31,14 +31,13 @@ Get access to all of the events your users care about, like mined and dropped tr
 
 * UX and lack of relevant notifications are one of the biggest inhibitors to the growth of blockchain apps.
 * Getting the information required to notify users about web3 events is complicated and requires large amounts of dev time and extra infrastructure.
-* It’s impossible for developers to trigger notifications for important events like dropped transactions.
 
 ## 😃 Solution: Alchemy Notify
 
 Alchemy Notify enables you to send relevant, timely notifications on the most important Web3 events with the following benefits:
 
 * Starts working with a two-click creation process, doing all the hard work for you.
-* Has built-in notifications for mined transactions, dropped transactions, and smart contract events.
+* Has built-in notifications for mined transactions and smart contract events.
 
 ***
 
@@ -47,10 +46,6 @@ Alchemy Notify enables you to send relevant, timely notifications on the most im
 ### ⛏ [Mined Transactions](/reference/notify-api-quickstart#1-mined-transaction)
 
 Let your users know exactly when their deposits, purchases, in-game actions, or other on-chain activity has officially occurred — the perfect time to re-engage and keep using your application.
-
-### 🕳 [Dropped Transactions](/reference/notify-api-quickstart#2-dropped-transactions)
-
-Let your users respond immediately when transactions fail, eliminating the most frustrating part of blockchain UX. No more missed trades, lost auctions, or disappearing tokens.
 
 ### 💸 [Address Activity](/reference/notify-api-quickstart#3-address-activity)
 

--- a/fern/tutorials/streaming-data/transaction-notifications/building-a-dapp-with-real-time-transaction-notifications.mdx
+++ b/fern/tutorials/streaming-data/transaction-notifications/building-a-dapp-with-real-time-transaction-notifications.mdx
@@ -15,7 +15,7 @@ Without these notifications, trades can be missed, critical actions are forgotte
 
 Until [Alchemy Notify](https://alchemy.com/notify?r=affiliate:ba2189be-b27d-4ce9-9d52-78ce131fdc2d), building these real-time notifications into your dApp has traditionally been complicated, time-consuming, and error-prone.
 
-With Alchemy, sending real-time push notifications to your users for critical events such as [dropped & pending](/docs/ethereum-transactions-pending-mined-dropped-replaced), wallet activity, and even gas price changes is straightforward, easy, and reliable.
+With Alchemy, sending real-time push notifications to your users for critical events such as pending transactions, wallet activity, and even gas price changes is straightforward, easy, and reliable.
 
 <Info>
   Learn about [the differences between Alchemy Notify v1 and v2](https://alchemy.com/blog/launching-notify-v2-with-improvements-to-reliability-scalability-and-security) in our announcement.
@@ -135,10 +135,9 @@ For our example, we’ll work with both! Let’s start by looking at the dashboa
 
 Once you have an account, go to the dashboard and select “Notify” from the top menu.
 
-Here you’ll see the different kinds of notifications you can set up:
+Here you'll see the different kinds of notifications you can set up:
 
 * Address Activity
-* Dropped Transactions
 * Mined Transaction
 * Gas Price
 

--- a/fern/tutorials/streaming-data/transaction-notifications/how-to-track-mined-and-pending-ethereum-transactions.mdx
+++ b/fern/tutorials/streaming-data/transaction-notifications/how-to-track-mined-and-pending-ethereum-transactions.mdx
@@ -181,10 +181,9 @@ First, let's look at how notifications with Alchemy work. There are two ways to 
   If you don’t already have one, you’ll first need to [create an account on Alchemy](https://alchemy.com/?r=affiliate:ba2189be-b27d-4ce9-9d52-78ce131fdc2d). The free version will work fine for getting started.
 </Info>
 
-Once you have an account, go to the dashboard and select “Notify” from the header section. Here you’ll see the different kinds of notifications you can set up:
+Once you have an account, go to the dashboard and select “Notify” from the header section. Here you'll see the different kinds of notifications you can set up:
 
 * Address Activity
-* Dropped Transactions
 * Mined Transaction
 * Gas Price
 

--- a/fern/tutorials/transactions/understanding-transactions/ethereum-transactions-pending-mined-dropped-replaced.mdx
+++ b/fern/tutorials/transactions/understanding-transactions/ethereum-transactions-pending-mined-dropped-replaced.mdx
@@ -85,7 +85,7 @@ Using the Mempool Watcher, web3 developers using Alchemy can now see all their t
 
 Web3 developers can also use the Alchemy Notify API (webhook alerts for transaction activity) to:
 
-* [Create notifications for dropped and mined transactions](docs/how-to-track-mined-and-pending-ethereum-transactions)
+* [Create notifications for mined transactions](docs/how-to-track-mined-and-pending-ethereum-transactions)
 * [Send transaction status notifications with Zapier](/docs/alchemy/enhanced-apis/notify-api/integrate-alchemy-zapier)
 * [Integrate transaction notifications with a dApp](/docs/alchemy/enhanced-apis/notify-api/building-a-dapp-with-real-time-transaction-notifications)
 


### PR DESCRIPTION
## Description

removes dropped transactions language in webhooks sections

* \[x] I have tested these changes locally
* \[x] I have run the validation scripts (`pnpm run validate`)
* \[x] I have checked that the documentation builds correctly
