### PR TITLE
Docs on call: Add v0_9 support to starknet faqs and change Sei pricing

### DIFF
--- a/fern/api-reference/starknet/starknet-api-faq.mdx
+++ b/fern/api-reference/starknet/starknet-api-faq.mdx
@@ -19,7 +19,7 @@ Explained in the [Starknet API Quickstart Guide](/reference/starknet-api-quickst
 
 ## What versions of Starknet API are supported?
 
-Alchemy currently supports `v0_6`, `v0_7`, and `v0_8`. We strongly recommend using `v0_8`.
+Alchemy currently supports `v0_6`, `v0_7`, `v0_8`, and `v0_9`. We strongly recommend using the latest version, `v0_9`.
 
 To access `v0_6` (**notice the underscore**) you can use the following URLs to make requests:
 * Mainnet: `https://starknet-mainnet.g.alchemy.com/starknet/version/rpc/v0_6/{apiKey}`
@@ -32,6 +32,10 @@ To access `v0_7` (**notice the underscore**) you can use the following URLs to m
 To access `v0_8` (**notice the underscore**) you can use the following URLs to make requests:
 * Mainnet: `https://starknet-mainnet.g.alchemy.com/starknet/version/rpc/v0_8/{apiKey}`
 * Testnet: `https://starknet-sepolia.g.alchemy.com/starknet/version/rpc/v0_8/{apiKey}`
+
+To access `v0_9` (**notice the underscore**) you can use the following URLs to make requests:
+* Mainnet: `https://starknet-mainnet.g.alchemy.com/starknet/version/rpc/v0_9/{apiKey}`
+* Testnet: `https://starknet-sepolia.g.alchemy.com/starknet/version/rpc/v0_9/{apiKey}`
 
 You can also directly try these APIs from browser in our [API references for Starknet](/reference/starknet-api-endpoints)
 

--- a/src/openrpc/chains/_components/evm/methods.yaml
+++ b/src/openrpc/chains/_components/evm/methods.yaml
@@ -809,10 +809,11 @@ components:
         |-------|------|---------------|------------|
         | Ethereum, Base, Optimism, Arbitrum, Worldchain, zkSync | 10 | unlimited | unlimited |
         | Polygon | 10 | 2000 | unlimited |
-        | BSC, Sei, Unichain | 10 | 10,000 | 10,000 |
+        | BSC, Unichain | 10 | 10,000 | 10,000 |
         | Berachain, Plasma | 10 | 10,000 | 100,000 |
         | Monad | 10 | 1000 | 1000 |
         | Polygon zkEVM | 10 | 10,000 | 20,000 |
+        | Sei | 10 | 2000 | 2000 |
         | All Other Chains | 10 | 10,000 | uncapped*** |
       params:
         - name: Filter


### PR DESCRIPTION
- Add `v0_9` support to Starknet FAQs.
- Change Sei pricing to 2000 for PAYG/Enterprise.