### PR TITLE
Reorder compute unit cost sections and update titles

### DIFF
--- a/fern/api-reference/pricing-resources/pricing/compute-unit-costs.mdx
+++ b/fern/api-reference/pricing-resources/pricing/compute-unit-costs.mdx
@@ -12,7 +12,7 @@ slug: "reference/compute-unit-costs"
 
 For more details, please check out the [Compute Units](/reference/compute-units#what-are-compute-units) section and the [Throughput Compute Units](/reference/compute-units#what-are-throughput-compute-units) section.
 
-# Standard EVM JSON-RPC Methods
+# EVM: Standard JSON-RPC Methods
 
 | Method                                   | CU                          | Throughput CU |
 | ---------------------------------------- | --------------------------- | ------------- |
@@ -69,249 +69,7 @@ For more details, please check out the [Compute Units](/reference/compute-units#
 
 * To view the batch request breakdown in the dashboard, click on "raw request"
 
-# NFT API
-
-We want builders to be able to use as much of the NFT API as they need without worrying about throughput. Because of that, we have discounted how NFT API requests count towards your applications’ guaranteed throughput by 6-10x. This means you can make more concurrent NFT API requests, and use the “Throughput CU” below to calculate how much you can use!
-
-| Method                   | CU   | Throughput CU |
-| ------------------------ | ---- | ------------- |
-| getNFTMetadata           | 80   | 10            |
-| getContractMetadata      | 160  | 10            |
-| getCollectionMetadata    | 240  | 10            |
-| getNFTsForOwner          | 480  | 100           |
-| getContractsForOwner     | 320  | 100           |
-| getCollectionsForOwner   | 360  | 100           |
-| getNFTsForContract       | 480  | 50            |
-| getOwnersForNFT          | 80   | 10            |
-| getOwnersForContract     | 480  | 20            |
-| getFloorPrice            | 80   | 10            |
-| getNFTSales              | 160  | 10            |
-| computeRarity            | 80   | 10            |
-| summarizeNFTAttributes   | 80   | 10            |
-| isHolderOfContract       | 80   | 10            |
-| searchContractMetadata   | 480  | 50            |
-| getNFTMetadataBatch      | 480  | 100           |
-| getContractMetadataBatch | 480  | 100           |
-| getSpamContracts         | 480  | 10            |
-| isSpamContract           | 80   | 10            |
-| isAirdropNFT             | 80   | 10            |
-| invalidateContract       | 80   | 80            |
-| refreshNftMetadata       | 40   | 10            |
-| reportSpam               | 0    | 10            |
-
-# 🆕 Solana DAS (NFT/Token) APIs
-
-| Method               | CU  | Throughput CU |
-| -------------------- | --- | ------------- |
-| getAsset             | 80  | 200           |
-| getAssets            | 480 | 200           |
-| getAssetProof        | 160 | 200           |
-| getAssetProofs       | 480 | 200           |
-| getAssetsByAuthority | 480 | 200           |
-| getAssetsByOwner     | 480 | 200           |
-| getAssetsByGroup     | 480 | 200           |
-| getAssetsByCreator   | 480 | 200           |
-| searchAssets         | 480 | 200           |
-| getAssetSignatures   | 160 | 200           |
-| getNftEditions       | 160 | 200           |
-| getTokenAccounts     | 160 | 200           |
-
-# Transfers API
-
-| Method                     | CU  |
-| -------------------------- | --- |
-| alchemy\_getAssetTransfers | 120 |
-
-# Portfolio API
-
-| Method                            | CU   |
-| --------------------------------- | ---- |
-| assets/nfts/by-address            | 1000 |
-| assets/nfts/contracts/by-address  | 600  |
-| assets/tokens/by-address          | 360  |
-| assets/tokens/balances/by-address | 200  |
-| /transactions/history/by-address  | 1000 |
-
-# Token API
-
-| Method                     | CU  |
-| -------------------------- | --- |
-| alchemy\_getTokenBalances  | 20  |
-| alchemy\_getTokenMetadata  | 10  |
-| alchemy\_getTokenAllowance | 20  |
-
-# Prices API
-
-| Method            | CU |
-| ----------------- | -- |
-| tokens/by-symbol  | 40 |
-| tokens/by-address | 40 |
-| tokens/historical | 40 |
-
-# Utility API
-
-| Method                          | CU  |
-| ------------------------------- | --- |
-| blocks/by-timestamp             | 10  |
-| alchemy\_getTransactionReceipts | 250 |
-
-# Transact
-
-| Method                                    | CU   |
-| ----------------------------------------- | ---- |
-| alchemy\_sendGasOptimizedTransaction      | 2500 |
-| alchemy\_getGasOptimizedTransactionStatus | 25   |
-| alchemy\_simulateAssetChanges             | 2500 |
-| alchemy\_simulateExecution                | 2500 |
-
-# Debug API
-
-| Method                    | CU | Throughput CU |
-| ------------------------- | -- | ------------- |
-| debug\_traceTransaction   | 40 | 1000          |
-| debug\_traceCall          | 40 | 1000          |
-| debug\_traceBlockByHash   | 40 | 1000          |
-| debug\_traceBlockByNumber | 40 | 1000          |
-
-# Trace API
-
-| Method                         | CU | Throughput CU |
-| ------------------------------ | -- | ------------- |
-| trace\_get                     | 20 | 20            |
-| trace\_block                   | 20 | 20            |
-| trace\_transaction             | 40 | 40            |
-| trace\_call                    | 40 | 40            |
-| trace\_rawTransaction          | 40 | 40            |
-| trace\_filter                  | 40 | 40            |
-| trace\_replayTransaction       | 80 | 3000          |
-| trace\_replayBlockTransactions | 80 | 3000          |
-
-# Polygon PoS Specific Methods
-
-| Method                    | CU |
-| ------------------------- | -- |
-| bor\_getAuthor            | 10 |
-| bor\_getCurrentProposer   | 10 |
-| bor\_getCurrentValidators | 10 |
-| bor\_getRootHash          | 10 |
-| bor\_getSignersAtHash     | 10 |
-
-# Polygon zkEVM Specific Methods
-
-| Method                          | CU |
-| ------------------------------- | -- |
-| zkevm\_batchNumber              | 10 |
-| zkevm\_batchNumberByBlockNumber | 10 |
-| zkevm\_consolidatedBlockNumber  | 10 |
-| zkevm\_getBatchByNumber         | 10 |
-| zkevm\_getBroadcastURI          | 10 |
-| zkevm\_isBlockConsolidated      | 10 |
-| zkevm\_isBlockVirtualized       | 10 |
-| zkevm\_verifiedBatchNumber      | 10 |
-| zkevm\_virtualBatchNumber       | 10 |
-| zkevm\_estimateFee              | 40 |
-| zkevm\_estimateGasPrice         | 40 |
-
-# zkSync Era Specific Methods
-
-All zkSync Era specific methods cost 10 CUs, this includes the methods listed below:
-
-* [zks-estimatefee-zksync](/reference/zks-estimatefee-zksync)
-* [zks-estimategasl1tol2-zksync](/reference/zks-estimategasl1tol2-zksync)
-* [zks-getallaccountbalances-zksync](/reference/zks-getallaccountbalances-zksync)
-* [zks-getblockdetails-zksync](/reference/zks-getblockdetails-zksync)
-* [zks-getbridgecontracts-zksync](/reference/zks-getbridgecontracts-zksync)
-* [zks-getbytecodebyhash-zksync](/reference/zks-getbytecodebyhash-zksync)
-* [zks-getl1batchblockrange-zksync](/reference/zks-getl1batchblockrange-zksync)
-* [zks-getl1batchdetails-zksync](/reference/zks-getl1batchdetails-zksync)
-* [zks-getl2tol1logproof-zksync](/reference/zks-getl2tol1logproof-zksync)
-* [zks-getl2tol1msgproof-zksync](/reference/zks-getl2tol1msgproof-zksync)
-* [zks-getmaincontract-zksync](/reference/zks-getmaincontract-zksync)
-* [zks-getproof-zksync](/reference/zks-getproof-zksync)
-* [zks-getrawblocktransactions-zksync](/reference/zks-getrawblocktransactions-zksync)
-* [zks-gettestnetpaymaster-zksync](/reference/zks-gettestnetpaymaster-zksync)
-* [zks-gettransactiondetails-zksync](/reference/zks-gettransactiondetails-zksync)
-* [zks-l1batchnumber-zksync](/reference/zks-l1batchnumber-zksync)
-* [zks-l1chainid-zksync](/reference/zks-l1chainid-zksync)
-
-# Gas Manager & Bundler APIs
-
-Similar to the [NFT API](/reference/compute-unit-costs#nft-api), the Gas Manager & Bundler APIs implement "Throughput CU" to count separately toward your applications' throughput!
-
-| Method                                     | CU   | Throughput CU |
-| ------------------------------------------ | ---- | ------------- |
-| eth\_sendUserOperation                     | 1000 | 100           |
-| eth\_estimateUserOperationGas              | 500  | 50            |
-| eth\_getUserOperationByHash                | 20   | 17            |
-| eth\_getUserOperationReceipt               | 20   | 15            |
-| eth\_supportedEntryPoints                  | 10   | 5             |
-| rundler\_maxPriorityFeePerGas              | 10   | 10            |
-| alchemy\_simulateUserOperationAssetChanges | 2500 | 2500          |
-| alchemy\_requestPaymasterAndData           | 1000 | 100           |
-| alchemy\_requestGasAndPaymasterAndData     | 1250 | 125           |
-| alchemy\_requestFeePayer                   | 1000 | 100           |
-
-# Wallet APIs
-
-Similar to the [NFT API](/reference/compute-unit-costs#nft-api), the Wallet APIs implement "Throughput CU" to count separately toward your applications' throughput!
-
-| Method                                     | CU   | Throughput CU |
-| ------------------------------------------ | ---- | ------------- |
-| wallet_requestAccount                      | 50   | -             |
-| wallet_prepareCalls                        | 700  | 50            |
-| wallet_sendPreparedCalls                   | 1000 | 100           |
-| wallet_createAccount                       | 50   | -             |
-| wallet_createSession                       | 50   | -             |
-| wallet_getCallsStatus                      | 20   | -             |
-| wallet_listAccounts                        | 10   | -             |
-
-# Embedded Account APIs
-
-Similar to the [NFT API](/reference/compute-unit-costs#nft-api), the Embedded Account APIs implement "Throughput CU" to count separately toward your applications' throughput!
-
-| Method               | CU   | Throughput CU |
-| -------------------- | ---- | ------------- |
-| /signer/auth         | 100  | 50            |
-| /signer/lookup       | 100  | 50            |
-| /signer/signup       | 1000 | 300           |
-| /signer/sign-payload | 6000 | 300           |
-| /signer/whoami       | 100  | 20            |
-
-# Standard Starknet JSON-RPC Methods
-
-| Method                                    | CU   |
-| ----------------------------------------- | ---- |
-| starknet\_getBlockWithTxHashes            | 20   |
-| starknet\_getBlockWithTxs                 | 20   |
-| starknet\_getStateUpdate                  | 20   |
-| starknet\_getStorageAt                    | 20   |
-| starknet\_getTransactionByHash            | 20   |
-| starknet\_getTransactionByBlockIdAndIndex | 20   |
-| starknet\_getTransactionReceipt           | 20   |
-| starknet\_getClass                        | 20   |
-| starknet\_getClassHashAt                  | 20   |
-| starknet\_getClassAt                      | 20   |
-| starknet\_getBlockTransactionCount        | 20   |
-| starknet\_call                            | 20   |
-| starknet\_blockNumber                     | 20   |
-| starknet\_blockHashAndNumber              | 20   |
-| starknet\_chainId                         | 0    |
-| starknet\_pendingTransactions             | 20   |
-| starknet\_syncing                         | 0    |
-| starknet\_getNonce                        | 20   |
-| starknet\_getEvents                       | 20   |
-| starknet\_estimateFee                     | 20   |
-| starknet\_addInvokeTransaction            | 160  |
-| starknet\_addDeclareTransaction           | 160  |
-| starknet\_addDeployAccountTransaction     | 160  |
-| starknet\_estimateMessageFee              | 20   |
-| starknet\_getBlockWithReceipts            | 20   |
-| starknet\_traceBlockTransactions          | 80   |
-| starknet\_specVersion                     | 10   |
-| starknet\_getTransactionStatus            | 20   |
-| starknet\_simulateTransactions            | 20   |
-
-# Standard Solana JSON-RPC Methods
+# Solana: Standard JSON-RPC Methods
 
 | Method                            | CU                          |
 | --------------------------------- | --------------------------- |
@@ -377,6 +135,174 @@ Similar to the [NFT API](/reference/compute-unit-costs#nft-api), the Embedded Ac
 
 * To view the batch request breakdown in the dashboard, click on "raw request"
 
+# Solana: DAS APIs (NFT/Token)
+
+| Method               | CU  | Throughput CU |
+| -------------------- | --- | ------------- |
+| getAsset             | 80  | 200           |
+| getAssets            | 480 | 200           |
+| getAssetProof        | 160 | 200           |
+| getAssetProofs       | 480 | 200           |
+| getAssetsByAuthority | 480 | 200           |
+| getAssetsByOwner     | 480 | 200           |
+| getAssetsByGroup     | 480 | 200           |
+| getAssetsByCreator   | 480 | 200           |
+| searchAssets         | 480 | 200           |
+| getAssetSignatures   | 160 | 200           |
+| getNftEditions       | 160 | 200           |
+| getTokenAccounts     | 160 | 200           |
+
+# Solana: Yellowstone gRPC
+
+[Yellowstone gRPC](/reference/yellowstone-grpc-overview) is a high-performance streaming service for Solana that delivers real-time blockchain data via gRPC. Pricing is based on **bandwidth:** the amount of data delivered as part of the stream.
+
+| Bandwidth | CU     |
+| --------- | ------ |
+| 1 byte    | 0.0001 |
+
+# Debug API
+
+| Method                    | CU | Throughput CU |
+| ------------------------- | -- | ------------- |
+| debug\_traceTransaction   | 40 | 1000          |
+| debug\_traceCall          | 40 | 1000          |
+| debug\_traceBlockByHash   | 40 | 1000          |
+| debug\_traceBlockByNumber | 40 | 1000          |
+
+# Embedded Account APIs
+
+Similar to the [NFT API](/reference/compute-unit-costs#nft-api), the Embedded Account APIs implement "Throughput CU" to count separately toward your applications' throughput!
+
+| Method               | CU   | Throughput CU |
+| -------------------- | ---- | ------------- |
+| /signer/auth         | 100  | 50            |
+| /signer/lookup       | 100  | 50            |
+| /signer/signup       | 1000 | 300           |
+| /signer/sign-payload | 6000 | 300           |
+| /signer/whoami       | 100  | 20            |
+
+# Gas Manager & Bundler APIs
+
+Similar to the [NFT API](/reference/compute-unit-costs#nft-api), the Gas Manager & Bundler APIs implement "Throughput CU" to count separately toward your applications' throughput!
+
+| Method                                     | CU   | Throughput CU |
+| ------------------------------------------ | ---- | ------------- |
+| eth\_sendUserOperation                     | 1000 | 100           |
+| eth\_estimateUserOperationGas              | 500  | 50            |
+| eth\_getUserOperationByHash                | 20   | 17            |
+| eth\_getUserOperationReceipt               | 20   | 15            |
+| eth\_supportedEntryPoints                  | 10   | 5             |
+| rundler\_maxPriorityFeePerGas              | 10   | 10            |
+| alchemy\_simulateUserOperationAssetChanges | 2500 | 2500          |
+| alchemy\_requestPaymasterAndData           | 1000 | 100           |
+| alchemy\_requestGasAndPaymasterAndData     | 1250 | 125           |
+| alchemy\_requestFeePayer                   | 1000 | 100           |
+
+# NFT API
+
+We want builders to be able to use as much of the NFT API as they need without worrying about throughput. Because of that, we have discounted how NFT API requests count towards your applications’ guaranteed throughput by 6-10x. This means you can make more concurrent NFT API requests, and use the “Throughput CU” below to calculate how much you can use!
+
+| Method                   | CU   | Throughput CU |
+| ------------------------ | ---- | ------------- |
+| getNFTMetadata           | 80   | 10            |
+| getContractMetadata      | 160  | 10            |
+| getCollectionMetadata    | 240  | 10            |
+| getNFTsForOwner          | 480  | 100           |
+| getContractsForOwner     | 320  | 100           |
+| getCollectionsForOwner   | 360  | 100           |
+| getNFTsForContract       | 480  | 50            |
+| getOwnersForNFT          | 80   | 10            |
+| getOwnersForContract     | 480  | 20            |
+| getFloorPrice            | 80   | 10            |
+| getNFTSales              | 160  | 10            |
+| computeRarity            | 80   | 10            |
+| summarizeNFTAttributes   | 80   | 10            |
+| isHolderOfContract       | 80   | 10            |
+| searchContractMetadata   | 480  | 50            |
+| getNFTMetadataBatch      | 480  | 100           |
+| getContractMetadataBatch | 480  | 100           |
+| getSpamContracts         | 480  | 10            |
+| isSpamContract           | 80   | 10            |
+| isAirdropNFT             | 80   | 10            |
+| invalidateContract       | 80   | 80            |
+| refreshNftMetadata       | 40   | 10            |
+| reportSpam               | 0    | 10            |
+
+# Portfolio API
+
+| Method                            | CU   |
+| --------------------------------- | ---- |
+| assets/nfts/by-address            | 1000 |
+| assets/nfts/contracts/by-address  | 600  |
+| assets/tokens/by-address          | 360  |
+| assets/tokens/balances/by-address | 200  |
+| /transactions/history/by-address  | 1000 |
+
+# Prices API
+
+| Method            | CU |
+| ----------------- | -- |
+| tokens/by-symbol  | 40 |
+| tokens/by-address | 40 |
+| tokens/historical | 40 |
+
+# Token API
+
+| Method                     | CU  |
+| -------------------------- | --- |
+| alchemy\_getTokenBalances  | 20  |
+| alchemy\_getTokenMetadata  | 10  |
+| alchemy\_getTokenAllowance | 20  |
+
+# Trace API
+
+| Method                         | CU | Throughput CU |
+| ------------------------------ | -- | ------------- |
+| trace\_get                     | 20 | 20            |
+| trace\_block                   | 20 | 20            |
+| trace\_transaction             | 40 | 40            |
+| trace\_call                    | 40 | 40            |
+| trace\_rawTransaction          | 40 | 40            |
+| trace\_filter                  | 40 | 40            |
+| trace\_replayTransaction       | 80 | 3000          |
+| trace\_replayBlockTransactions | 80 | 3000          |
+
+# Transact
+
+| Method                                    | CU   |
+| ----------------------------------------- | ---- |
+| alchemy\_sendGasOptimizedTransaction      | 2500 |
+| alchemy\_getGasOptimizedTransactionStatus | 25   |
+| alchemy\_simulateAssetChanges             | 2500 |
+| alchemy\_simulateExecution                | 2500 |
+
+# Transfers API
+
+| Method                     | CU  |
+| -------------------------- | --- |
+| alchemy\_getAssetTransfers | 120 |
+
+# Utility API
+
+| Method                          | CU  |
+| ------------------------------- | --- |
+| blocks/by-timestamp             | 10  |
+| alchemy\_getTransactionReceipts | 250 |
+
+# Wallet APIs
+
+Similar to the [NFT API](/reference/compute-unit-costs#nft-api), the Wallet APIs implement "Throughput CU" to count separately toward your applications' throughput!
+
+| Method                                     | CU   | Throughput CU |
+| ------------------------------------------ | ---- | ------------- |
+| wallet_requestAccount                      | 50   | -             |
+| wallet_prepareCalls                        | 700  | 50            |
+| wallet_sendPreparedCalls                   | 1000 | 100           |
+| wallet_createAccount                       | 50   | -             |
+| wallet_createSession                       | 50   | -             |
+| wallet_getCallsStatus                      | 20   | -             |
+| wallet_listAccounts                        | 10   | -             |
+
 # Webhooks and Subscription APIs
 
 [Webhooks](/reference/notify-api-quickstart) and [WebSocket Subscriptions](/docs/websocket-subscriptions) on Alchemy are priced based on **bandwidth:** the amount of data delivered as part of the subscription.
@@ -389,13 +315,87 @@ Each subscription type is priced identically per byte:
 
 On average, a typical webhook or WebSocket subscription event is about 1000 bytes, so it would consume 40 compute units. Note that this can vary significantly based on the specific event delivered [Subscription API Quickstart](/reference/subscription-api)
 
-# Yellowstone gRPC
+# Polygon PoS: Specific Methods
 
-[Yellowstone gRPC](/reference/yellowstone-grpc-overview) is a high-performance streaming service for Solana that delivers real-time blockchain data via gRPC. Pricing is based on **bandwidth:** the amount of data delivered as part of the stream.
+| Method                    | CU |
+| ------------------------- | -- |
+| bor\_getAuthor            | 10 |
+| bor\_getCurrentProposer   | 10 |
+| bor\_getCurrentValidators | 10 |
+| bor\_getRootHash          | 10 |
+| bor\_getSignersAtHash     | 10 |
 
-| Bandwidth | CU     |
-| --------- | ------ |
-| 1 byte    | 0.0001 |
+# Polygon zkEVM: Specific Methods
+
+| Method                          | CU |
+| ------------------------------- | -- |
+| zkevm\_batchNumber              | 10 |
+| zkevm\_batchNumberByBlockNumber | 10 |
+| zkevm\_consolidatedBlockNumber  | 10 |
+| zkevm\_getBatchByNumber         | 10 |
+| zkevm\_getBroadcastURI          | 10 |
+| zkevm\_isBlockConsolidated      | 10 |
+| zkevm\_isBlockVirtualized       | 10 |
+| zkevm\_verifiedBatchNumber      | 10 |
+| zkevm\_virtualBatchNumber       | 10 |
+| zkevm\_estimateFee              | 40 |
+| zkevm\_estimateGasPrice         | 40 |
+
+# Starknet: Standard JSON-RPC Methods
+
+| Method                                    | CU   |
+| ----------------------------------------- | ---- |
+| starknet\_getBlockWithTxHashes            | 20   |
+| starknet\_getBlockWithTxs                 | 20   |
+| starknet\_getStateUpdate                  | 20   |
+| starknet\_getStorageAt                    | 20   |
+| starknet\_getTransactionByHash            | 20   |
+| starknet\_getTransactionByBlockIdAndIndex | 20   |
+| starknet\_getTransactionReceipt           | 20   |
+| starknet\_getClass                        | 20   |
+| starknet\_getClassHashAt                  | 20   |
+| starknet\_getClassAt                      | 20   |
+| starknet\_getBlockTransactionCount        | 20   |
+| starknet\_call                            | 20   |
+| starknet\_blockNumber                     | 20   |
+| starknet\_blockHashAndNumber              | 20   |
+| starknet\_chainId                         | 0    |
+| starknet\_pendingTransactions             | 20   |
+| starknet\_syncing                         | 0    |
+| starknet\_getNonce                        | 20   |
+| starknet\_getEvents                       | 20   |
+| starknet\_estimateFee                     | 20   |
+| starknet\_addInvokeTransaction            | 160  |
+| starknet\_addDeclareTransaction           | 160  |
+| starknet\_addDeployAccountTransaction     | 160  |
+| starknet\_estimateMessageFee              | 20   |
+| starknet\_getBlockWithReceipts            | 20   |
+| starknet\_traceBlockTransactions          | 80   |
+| starknet\_specVersion                     | 10   |
+| starknet\_getTransactionStatus            | 20   |
+| starknet\_simulateTransactions            | 20   |
+
+# zkSync Era: Specific Methods
+
+All zkSync Era specific methods cost 10 CUs, this includes the methods listed below:
+
+* [zks-estimatefee-zksync](/reference/zks-estimatefee-zksync)
+* [zks-estimategasl1tol2-zksync](/reference/zks-estimategasl1tol2-zksync)
+* [zks-getallaccountbalances-zksync](/reference/zks-getallaccountbalances-zksync)
+* [zks-getblockdetails-zksync](/reference/zks-getblockdetails-zksync)
+* [zks-getbridgecontracts-zksync](/reference/zks-getbridgecontracts-zksync)
+* [zks-getbytecodebyhash-zksync](/reference/zks-getbytecodebyhash-zksync)
+* [zks-getl1batchblockrange-zksync](/reference/zks-getl1batchblockrange-zksync)
+* [zks-getl1batchdetails-zksync](/reference/zks-getl1batchdetails-zksync)
+* [zks-getl2tol1logproof-zksync](/reference/zks-getl2tol1logproof-zksync)
+* [zks-getl2tol1msgproof-zksync](/reference/zks-getl2tol1msgproof-zksync)
+* [zks-getmaincontract-zksync](/reference/zks-getmaincontract-zksync)
+* [zks-getproof-zksync](/reference/zks-getproof-zksync)
+* [zks-getrawblocktransactions-zksync](/reference/zks-getrawblocktransactions-zksync)
+* [zks-gettestnetpaymaster-zksync](/reference/zks-gettestnetpaymaster-zksync)
+* [zks-gettransactiondetails-zksync](/reference/zks-gettransactiondetails-zksync)
+* [zks-l1batchnumber-zksync](/reference/zks-l1batchnumber-zksync)
+* [zks-l1chainid-zksync](/reference/zks-l1chainid-zksync)
 
 # Compute unit cost for error codes
 


### PR DESCRIPTION
## Summary
- reorder the compute unit cost sections to match the requested table of contents order
- rename Solana and other chain-specific headings to the `{Chain name}: {section topic}` format

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_690a318cca708329aff6b55321826fc0