### PR TITLE
Expand compute unit cost page with new chains and endpoints

### DIFF
--- a/fern/api-reference/pricing-resources/pricing/compute-unit-costs.mdx
+++ b/fern/api-reference/pricing-resources/pricing/compute-unit-costs.mdx
@@ -423,67 +423,67 @@ All zkSync Era specific methods cost 10 CUs, this includes the methods listed be
 
 # Ethereum Beacon: Standard HTTP API Methods
 
-| Method                                                        | CU  |
-| ------------------------------------------------------------- | --- |
-| /eth/v2/beacon/blocks/\{block\_id}/attestations               | 20  |
-| /eth/v1/beacon/blocks/\{block\_id}/root                       | 20  |
-| /eth/v1/beacon/blinded\_blocks/\{slot}                        | 20  |
+| Method                                                         | CU  |
+| -------------------------------------------------------------- | --- |
+| /eth/v2/beacon/blocks/\{block\_id}/attestations                | 20  |
+| /eth/v1/beacon/blocks/\{block\_id}/root                        | 20  |
+| /eth/v1/beacon/blinded\_blocks/\{slot}                         | 20  |
 | /eth/v1/beacon/blob\_sidecars/\{block\_id}                     | 20  |
-| /eth/v1/beacon/genesis                                        | 20  |
-| /eth/v1/beacon/headers                                        | 20  |
-| /eth/v1/beacon/headers/\{block\_id}                           | 20  |
+| /eth/v1/beacon/genesis                                         | 20  |
+| /eth/v1/beacon/headers                                         | 20  |
+| /eth/v1/beacon/headers/\{block\_id}                            | 20  |
 | /eth/v1/beacon/pool/voluntary\_exits                           | 20  |
-| /eth/v1/beacon/states/\{state\_id}/committees                 | 20  |
+| /eth/v1/beacon/states/\{state\_id}/committees                  | 20  |
 | /eth/v1/beacon/states/\{state\_id}/finality\_checkpoints       | 20  |
-| /eth/v1/beacon/states/\{state\_id}/fork                       | 20  |
+| /eth/v1/beacon/states/\{state\_id}/fork                        | 20  |
 | /eth/v1/beacon/states/\{state\_id}/pending\_consolidations     | 20  |
-| /eth/v1/beacon/states/\{state\_id}/root                       | 20  |
+| /eth/v1/beacon/states/\{state\_id}/root                        | 20  |
 | /eth/v1/beacon/states/\{state\_id}/sync\_committees            | 20  |
 | /eth/v1/beacon/states/\{state\_id}/validator\_balances         | 20  |
-| /eth/v1/beacon/states/\{state\_id}/validators                 | 20  |
-| /eth/v1/beacon/states/\{state\_id}/validators/\{validator\_id}| 20  |
+| /eth/v1/beacon/states/\{state\_id}/validators                  | 20  |
+| /eth/v1/beacon/states/\{state\_id}/validators/\{validator\_id} | 20  |
 | /eth/v1/beacon/rewards/sync\_committee/\{block\_id}            | 20  |
-| /eth/v1/beacon/rewards/blocks/\{block\_id}                    | 20  |
-| /eth/v1/beacon/rewards/attestations/\{epoch}                 | 20  |
+| /eth/v1/beacon/rewards/blocks/\{block\_id}                     | 20  |
+| /eth/v1/beacon/rewards/attestations/\{epoch}                   | 20  |
 | /eth/v1/config/deposit\_contract                               | 20  |
 | /eth/v1/config/fork\_schedule                                  | 20  |
-| /eth/v1/config/spec                                           | 20  |
+| /eth/v1/config/spec                                            | 20  |
 | /eth/v1/node/peer\_count                                       | 20  |
-| /eth/v1/node/peers                                            | 20  |
-| /eth/v1/node/syncing                                          | 20  |
-| /eth/v1/node/version                                          | 20  |
+| /eth/v1/node/peers                                             | 20  |
+| /eth/v1/node/syncing                                           | 20  |
+| /eth/v1/node/version                                           | 20  |
 | /eth/v2/validator/aggregate\_attestation                       | 20  |
-| /eth/v1/validator/duties/attester/\{epoch}                   | 20  |
-| /eth/v1/validator/duties/proposer/\{epoch}                   | 20  |
-| /eth/v1/validator/duties/sync/\{epoch}                       | 20  |
-| /eth/v1/validator/sync\_committee\_contribution                 | 20  |
-| /eth/v2/beacon/blocks/\{block\_id}                            | 20  |
+| /eth/v1/validator/duties/attester/\{epoch}                     | 20  |
+| /eth/v1/validator/duties/proposer/\{epoch}                     | 20  |
+| /eth/v1/validator/duties/sync/\{epoch}                         | 20  |
+| /eth/v1/validator/sync\_committee\_contribution                | 20  |
+| /eth/v2/beacon/blocks/\{block\_id}                             | 20  |
 
 # Aptos: Standard REST API Methods
 
 | Method                                                         | CU  |
 | -------------------------------------------------------------- | --- |
 | /v1/                                                           | 20  |
-| /v1/accounts/\{address}                                       | 20  |
-| /v1/accounts/\{address}/events/\{creation\_number}            | 20  |
-| /v1/accounts/\{address}/events/\{event\_handle}/\{field\_name}| 20  |
-| /v1/accounts/\{address}/module/\{module\_name}                | 20  |
-| /v1/accounts/\{address}/modules                               | 20  |
-| /v1/accounts/\{address}/resource/\{resource\_type}            | 20  |
-| /v1/accounts/\{address}/resources                             | 20  |
-| /v1/accounts/\{address}/transactions                          | 20  |
-| /v1/blocks/by\_height/\{block\_height}                          | 20  |
+| /v1/accounts/\{address}                                        | 20  |
+| /v1/accounts/\{address}/events/\{creation\_number}             | 20  |
+| /v1/accounts/\{address}/events/\{event\_handle}/\{field\_name} | 20  |
+| /v1/accounts/\{address}/module/\{module\_name}                 | 20  |
+| /v1/accounts/\{address}/modules                                | 20  |
+| /v1/accounts/\{address}/resource/\{resource\_type}             | 20  |
+| /v1/accounts/\{address}/resources                              | 20  |
+| /v1/accounts/\{address}/transactions                           | 20  |
+| /v1/blocks/by\_height/\{block\_height}                         | 20  |
 | /v1/blocks/by\_version/\{version}                              | 20  |
-| /v1/estimate\_gas\_price                                         | 20  |
+| /v1/estimate\_gas\_price                                       | 20  |
 | /v1/-/healthy                                                  | 20  |
 | /v1/spec                                                       | 20  |
 | /v1/tables/\{table\_handle}/item                               | 20  |
-| /v1/tables/\{table\_handle}/raw\_item                           | 20  |
+| /v1/tables/\{table\_handle}/raw\_item                          | 20  |
 | /v1/transactions                                               | 20  |
 | /v1/transactions/batch                                         | 20  |
-| /v1/transactions/by\_hash/\{txn\_hash}                          | 20  |
-| /v1/transactions/by\_version/\{txn\_version}                    | 20  |
-| /v1/transactions/encode\_submission                             | 20  |
+| /v1/transactions/by\_hash/\{txn\_hash}                         | 20  |
+| /v1/transactions/by\_version/\{txn\_version}                   | 20  |
+| /v1/transactions/encode\_submission                            | 20  |
 | /v1/transactions/simulate                                      | 20  |
 | /v1/view                                                       | 20  |
 


### PR DESCRIPTION
## Description

Update compute unit cost page with new networks and methods for a better coverage. Used sources:

- topconfig: https://github.com/OMGWINNING/chain-config/blob/master/src/main/resources/configs/chainconfig/topconfig/topconfig.yml
- https://www.notion.so/alchemotion/Node-API-Methods-Support-Audit-Tracker-229069f20066806493cdf9e61138dabc

## Related Issues

## Changes Made

- Added the methods mentioned on the Node-API-Methods-Support-Audit-Tracker doc
- Added CUs for: Eth Beacon, Aptos, Bitcoin, Celestia and Tron

## Testing

<!-- Describe the tests that you ran to verify your changes -->

* \[x] I have tested these changes locally
* \[x] I have run the validation scripts (`pnpm run validate`)
* \[x] I have checked that the documentation builds correctly
