### PR TITLE
docs: hide Sui documentation until chain becomes public

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -1476,13 +1476,17 @@ navigation:
             api-name: bitcoin
         slug: bitcoin
       - section: Sui
+        hidden: true
         contents:
           - page: Sui API Quickstart
             path: api-reference/sui/sui-api-quickstart.mdx
+            hidden: true
           - page: Sui API FAQ
             path: api-reference/sui/sui-api-faq.mdx
+            hidden: true
           - api: Sui API Endpoints
             api-name: sui
+            hidden: true
         slug: sui
       - section: Superseed
         contents:


### PR DESCRIPTION
## Description

Hide the Sui chain from the public documentation.

Sui documentation (API Reference) was previously visible publicly when the chain was part of Alchemy Blast, but it is currently private and not part of the public Alchemy offering. This change hides all Sui-related docs until the chain becomes public again.

## Related Issues

## Changes Made

- Marked the entire Sui section and its pages as hidden
- Left the content intact for easy reactivation once Sui becomes public

## Testing

<!-- Describe the tests that you ran to verify your changes -->

* \[x] I have tested these changes locally
* \[x] I have run the validation scripts (`pnpm run validate`)
* \[x] I have checked that the documentation builds correctly
