### PR TITLE
Remove AA user op and signature limits from pricing

### DIFF
--- a/fern/api-reference/pricing-resources/pricing/pricing-plans.mdx
+++ b/fern/api-reference/pricing-resources/pricing/pricing-plans.mdx
@@ -40,10 +40,8 @@ slug: reference/pricing-plans
 
 | Feature                    | Free Tier        | PAYG         | Enterprise Tier  |
 | -------------------------- | ---------------- | ------------ | ---------------- |
-| User Ops                   | ~30k/mo          | 100k/mo      | Custom           |
 | Gas Manager                | Free on testnets | 8% admin fee | Custom admin fee |
 | Gas Sponsorship Base Limit | -                | $100/mo      | Custom           |
-| Signature Limit            | 2,000/mo         | Unlimited    | Unlimited        |
 | Account Kit SDK            | ✓                | ✓            | ✓                |
 | Bundler API                | ✓                | ✓            | ✓                |
 | Gas Manager Coverage API   | ✓                | ✓            | ✓                |


### PR DESCRIPTION
## Summary
- remove the user op estimate and signature limit rows from the Account Abstraction pricing table

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69123e03938c8329964089a1cf084f9d)