### PR TITLE
Add eth_getLogs to Base Flashblocks endpoint list

### DIFF
--- a/fern/api-reference/base/base-flashblocks-api-quickstart.mdx
+++ b/fern/api-reference/base/base-flashblocks-api-quickstart.mdx
@@ -27,5 +27,6 @@ Flashblocks is currently supported on both Base testnet and mainnet and can be 
 * [eth\_getBalance](https://www.alchemy.com/docs/node/base/base-api-endpoints/eth-get-balance)
 * [eth\_getTransactionCount](https://www.alchemy.com/docs/node/base/base-api-endpoints/eth-get-transaction-count)
 * [eth\_getTransactionByHash](https://www.alchemy.com/docs/node/base/base-api-endpoints/eth-get-transaction-by-hash)
+* [eth\_getLogs](https://www.alchemy.com/docs/node/base/base-api-endpoints/eth-get-logs)
 
 Also check out the [Official Base Flashblocks Docs](https://docs.base.org/base-chain/flashblocks/apps)!


### PR DESCRIPTION
## Summary
- document eth_getLogs as a Flashblocks-enabled method for Base

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69149a327d94832eb6816b90599a3843)