### PR TITLE
Update redirects

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -5469,7 +5469,7 @@ redirects:
   - source: /discuss/63b471e44ee8d5003f5ea0d0
     destination: https://www.alchemy.com/support/where-are-alchemys-servers-located
     permanent: true
-  - source: /discuss/(\w)
+  - source: /discuss/:path*
     destination: https://www.alchemy.com/support
     permanent: true
   - source: /docs/setup-a-gas-manager-policy
@@ -6285,10 +6285,10 @@ redirects:
   # and we want static redirects to take precedence over dynamic redirects.
   # ======================================= Dynamic Redirects ========================================
   # Remove the duplicate /docs from the url
-  - source: "/docs/docs/:path"
-    destination: "/docs/:path"
+  - source: "/docs/docs/:path*"
+    destination: "/docs/:path*"
     permanent: true
-  - source: "/docs/node/smart-wallets/:path"
+  - source: "/docs/node/smart-wallets/:path*"
     destination: "/docs/wallets/api/smart-wallets/:path*"
     permanent: true
   - source: "/docs/node/gas-manager-admin-api/:path*"


### PR DESCRIPTION
`*` alone is not valid redirect syntax. This PR updates redirects to convert to the `/:path*` syntax, which matches with zero or more arbitrary paths.
