### PR TITLE
Remove outdated webhook repository link from Notify quickstart docs

### DIFF
--- a/fern/api-reference/data/webhooks/notify-api-quickstart.mdx
+++ b/fern/api-reference/data/webhooks/notify-api-quickstart.mdx
@@ -41,7 +41,7 @@ Webhook listeners receive requests and process event data.
 
 The listener responds to the Alchemy server with a `200` status code once you've successfully received the webhook event. Your webhook listener can be a simple server or Slack integration to receive the webhook listener data.
 
-After setting up the webhooks in your Alchemy dashboard (or programmatically) use the starter code in JavaScript, Python, Go, and Rust below. Here's the [GitHub repository](https://github.com/alchemyplatform/webhook-examples) for the entire code.
+After setting up the webhooks in your Alchemy dashboard (or programmatically) use the starter code in JavaScript, Python, Go, and Rust below.
 
 <CodeGroup>
   ```ts typescript

--- a/fern/api-reference/data/webhooks/webhooks-quickstart/notify-api-quickstart.mdx
+++ b/fern/api-reference/data/webhooks/webhooks-quickstart/notify-api-quickstart.mdx
@@ -25,7 +25,7 @@ Webhook listeners receive requests and process event data.
 
 The listener responds to the Alchemy server with a `200` status code once it successfully receives the webhook event. Your webhook listener can be a simple server or Slack integration to receive the webhook listener data.
 
-After setting up the webhooks in your Alchemy dashboard (or programmatically) use the starter code in JavaScript, Python, Go, and Rust below. Here's the [GitHub repository](https://github.com/alchemyplatform/webhook-examples) for the entire code.
+After setting up the webhooks in your Alchemy dashboard (or programmatically) use the starter code in JavaScript, Python, Go, and Rust below.
 
 <CodeGroup>
   ```ts typescript


### PR DESCRIPTION
## Summary
- remove the outdated webhook GitHub repository link from both Notify quickstart pages

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691e27bee354832c95a3d19dc4b7fd9b)