### PR TITLE
Add warning about empty topics in Custom Webhook filters

### DIFF
--- a/fern/api-reference/data/webhooks/webhook-types/custom-webhook.mdx
+++ b/fern/api-reference/data/webhooks/webhook-types/custom-webhook.mdx
@@ -2409,6 +2409,15 @@ Below you can find descriptions for select response fields. Note that this is no
 
 If you're new to GraphQL, this editor has autocomplete enabled and will magically suggest fields as you start typing. If you get lost, you can always search for available queries in the docs tab on the right!
 
+<Warning>
+**Important Note About Empty Topics**
+
+Leaving topics empty makes your filter match **all events** (for the selected address, or for **all addresses** if none is provided).  
+This can generate very high webhook volume and **significant usage costs**.  
+If you only want specific event types, be sure to include topic filters.  
+Learn more: [Event Log Filters](https://www.alchemy.com/docs/reference/custom-webhook-filters#eventlog-filters)
+</Warning>
+
 6. Test and validate your GraphQL query by clicking the **Test Webhook** button. Confirm that your GraphQL query is valid does not contain any syntactical errors. **NOTE:** If you want to test your GraphQL query on a historical block, you can simply define your target block hash within the top-level block filter.
 
 <CodeGroup>


### PR DESCRIPTION
Add warning about empty topics in webhook filters

## Description

Adds a <Warning> block to the “How to Set Up Custom Webhooks” section to clearly explain the behavior of empty topic filters.  
This is a common point of confusion for users and often results in unexpectedly high webhook volume and usage charges.  
The warning links to the Event Log Filters guide for more details.

## Related Issues

<!-- Link to any related issues or Asana tasks this PR addresses (e.g., "Fixes #123") -->

## Changes Made

- Added a new <Warning> block directly under the "How to Set Up Custom Webhooks" instructions
- Explained the behavior of empty topics (wildcard matching)
- Included documentation link for proper topic filtering
- No other content modified

## Testing

<!-- Describe the tests that you ran to verify your changes -->

* \[ ] I have tested these changes locally
* \[ ] I have run the validation scripts (`pnpm run validate`)
* \[ ] I have checked that the documentation builds correctly
