### PR TITLE
Remove Portfolio API card from Data APIs overview

### DIFF
--- a/fern/api-reference/data/data-overview.mdx
+++ b/fern/api-reference/data/data-overview.mdx
@@ -20,10 +20,6 @@ The Data APIs give you fast, reliable access to blockchain data without running 
 ## Components of the Data APIs
 
 <CardGroup cols={3}>
-  <Card title="Portfolio API" icon="fa-solid fa-chart-pie" href="/docs/reference/portfolio-apis">
-    Build a complete portfolio view of a user’s wallet, across tokens and NFTs.
-  </Card>
-
   <Card title="Token API" icon="fa-solid fa-coins" href="/docs/reference/token-api-quickstart">
     Easily request information about specific tokens like metadata or wallet balances.
   </Card>


### PR DESCRIPTION
## Summary
- remove the Portfolio API card from the Data APIs components section

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691f4e160590832db629fb87e2a3acb7)