### PR TITLE
fix: remove support-email.mdx snippet

### DIFF
--- a/fern/api-reference/abstract/abstract-api-faq.mdx
+++ b/fern/api-reference/abstract/abstract-api-faq.mdx
@@ -35,4 +35,4 @@ Built on top of the ZK Stack, Abstract is a zero-knowledge (ZK) rollup built to 
 
 ## My question isn't here, where can I get help?
 
-Don't worry, we got you. If you have any questions or feedback, please contact us at <Markdown src="../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+Don't worry, we got you. If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.

--- a/fern/api-reference/anime/anime-api-faq.mdx
+++ b/fern/api-reference/anime/anime-api-faq.mdx
@@ -52,4 +52,4 @@ You can find the list of all the methods Alchemy supports for the Anime API on t
 
 ## My question isn't here, where can I get help?
 
-If you have any questions or feedback, please contact us at <Markdown src="../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.

--- a/fern/api-reference/apechain/apechain-api-faq.mdx
+++ b/fern/api-reference/apechain/apechain-api-faq.mdx
@@ -56,4 +56,4 @@ ApeChain inherits security features from Arbitrum's technology and ultimately de
 
 ## My question isn't here, where can I get help?
 
-If you have any questions or feedback, please contact us at <Markdown src="../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.

--- a/fern/api-reference/aptos/aptos-api-faq.mdx
+++ b/fern/api-reference/aptos/aptos-api-faq.mdx
@@ -47,4 +47,4 @@ Aptos uses its native token, APT, to pay transaction fees. The API provides endp
 
 ## My question isn't listed here — where can I get help?
 
-If you have any questions or feedback, please contact us at <Markdown src="../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.

--- a/fern/api-reference/arbitrum-nova/arbitrum-nova-chain-api-faq.mdx
+++ b/fern/api-reference/arbitrum-nova/arbitrum-nova-chain-api-faq.mdx
@@ -49,4 +49,4 @@ You can find the list of all the methods Alchemy supports for the Arbitrum Nova 
 
 ## My question isn't here, where can I get help?
 
-If you have any questions or feedback, please contact us at <Markdown src="../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.

--- a/fern/api-reference/arbitrum/arbitrum-api-faq/arbitrum-api-faq.mdx
+++ b/fern/api-reference/arbitrum/arbitrum-api-faq/arbitrum-api-faq.mdx
@@ -94,4 +94,4 @@ You can find the list of all the methods Alchemy supports for the Arbitrum API o
 
 ## My question isn't here, where can I get help?
 
-If you have any questions or feedback, please contact us at <Markdown src="../../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.

--- a/fern/api-reference/astar/astar-api-faq.mdx
+++ b/fern/api-reference/astar/astar-api-faq.mdx
@@ -117,4 +117,4 @@ You can find the list of all the methods Alchemy supports for the Astar API on t
 
 ## My question isn't here, where can I get help?
 
-If you have any questions or feedback, please contact us at <Markdown src="../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.

--- a/fern/api-reference/avalanche/avalanche-api-faq.mdx
+++ b/fern/api-reference/avalanche/avalanche-api-faq.mdx
@@ -49,4 +49,4 @@ You can find the list of all the methods Alchemy supports for the Avalanche API 
 
 ## My question isn't here, where can I get help?
 
-If you have any questions or feedback, please contact us at <Markdown src="../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.

--- a/fern/api-reference/base/base-api-faq.mdx
+++ b/fern/api-reference/base/base-api-faq.mdx
@@ -61,4 +61,4 @@ The Base Bridge facilitates the bridging of ETH between Ethereum and Base. To br
 
 ## My question isn't here, where can I get help?
 
-If you have any questions or feedback, please contact us at <Markdown src="../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.

--- a/fern/api-reference/berachain/berachain-api-faq.mdx
+++ b/fern/api-reference/berachain/berachain-api-faq.mdx
@@ -49,4 +49,4 @@ You can find the list of all the methods Alchemy supports for the Berachain API 
 
 ## My question isn't here, where can I get help?
 
-If you have any questions or feedback, please contact us at <Markdown src="../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.

--- a/fern/api-reference/bitcoin/bitcoin-api-faq.mdx
+++ b/fern/api-reference/bitcoin/bitcoin-api-faq.mdx
@@ -46,4 +46,4 @@ You can find a full list of supported JSON-RPC methods on the [Bitcoin API Endpo
 
 ## My question isn't listed here — where can I get help?
 
-If you have any questions or feedback, please contact us at <Markdown src="../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.

--- a/fern/api-reference/blast/blast-api-faq.mdx
+++ b/fern/api-reference/blast/blast-api-faq.mdx
@@ -49,4 +49,4 @@ You can find the list of all the methods Alchemy supports for the Blast Chain AP
 
 ## My question isn't here, where can I get help?
 
-If you have any questions or feedback, please contact us at <Markdown src="../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.

--- a/fern/api-reference/bnb-smart-chain/bnb-smart-chain-faq.mdx
+++ b/fern/api-reference/bnb-smart-chain/bnb-smart-chain-faq.mdx
@@ -49,4 +49,4 @@ You can find the list of all the methods Alchemy support for the BSC API on [BSC
 
 ## My question isn't here, where can I get help?
 
-If you have any questions or feedback, please contact us at <Markdown src="../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.

--- a/fern/api-reference/botanix/botanix-api-faq.mdx
+++ b/fern/api-reference/botanix/botanix-api-faq.mdx
@@ -49,4 +49,4 @@ You can find the list of all the methods Alchemy supports for the Botanix API on
 
 ## My question isn't here, where can I get help?
 
-If you have any questions or feedback, please contact us at <Markdown src="../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.

--- a/fern/api-reference/celo/celo-chain-api-faq.mdx
+++ b/fern/api-reference/celo/celo-chain-api-faq.mdx
@@ -52,4 +52,4 @@ You can find the list of all the methods Alchemy supports for the Celo Chain API
 
 ## My question isn't here, where can I get help?
 
-If you have any questions or feedback, please contact us at <Markdown src="../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.

--- a/fern/api-reference/crossfi/crossfi-api-faq.mdx
+++ b/fern/api-reference/crossfi/crossfi-api-faq.mdx
@@ -49,4 +49,4 @@ You can find the full list of methods supported by Alchemy for the CrossFi API o
 
 ## My question isn't here, where can I get help?
 
-If you have any questions or feedback, please contact us at <Markdown src="../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.

--- a/fern/api-reference/data/nft-api/nft-api-faq.mdx
+++ b/fern/api-reference/data/nft-api/nft-api-faq.mdx
@@ -23,7 +23,7 @@ You can check out the rest of our docs for more in-depth documentation about our
 
 All NFTs made with the ERC721 and ERC1155 standards are supported by the NFT API. At the moment, we support a select number of tokens like CryptoPunks and CryptoKitties that pre-date the existence of standardized NFT contracts.
 
-Alchemy is actively working on adding support for as many blockchains / NFT standards as we can. If you find that NFTs are missing in wallets you are calling, please provide details about the missing NFT over email: <Markdown src="../../../snippets/support-email.mdx" />
+Alchemy is actively working on adding support for as many blockchains / NFT standards as we can. If you find that NFTs are missing in wallets you are calling, please provide details about the missing NFT over email: support@alchemy.com
 
 ## How does Alchemy determine NFT Standard i.e. if a collection is `ERC721` or `ERC1155` ?
 
@@ -129,7 +129,7 @@ Here's an example of a BAYC NFT asset cached by Alchemy: [https://nft-cdn.alchem
 
 ## Why did my request not return a cached media url?
 
-We're actively working on expanding coverage of Alchemy-hosted NFT endpoints. Feel free to reach out to us over email for specific questions: <Markdown src="../../../snippets/support-email.mdx" />
+We're actively working on expanding coverage of Alchemy-hosted NFT endpoints. Feel free to reach out to us over email for specific questions: support@alchemy.com
 
 ## Which media URL should I use to get the NFT image?
 

--- a/fern/api-reference/data/prices-api/prices-api-faq.mdx
+++ b/fern/api-reference/data/prices-api/prices-api-faq.mdx
@@ -59,4 +59,4 @@ Enterprise: No limits (except for [account throughput](/reference/throughput))
 
 ### Something else
 
-If you have any questions or feedback, please contact us at <Markdown src="../../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.

--- a/fern/api-reference/ethereum/ethereum-api-faq/ethereum-api-faq.mdx
+++ b/fern/api-reference/ethereum/ethereum-api-faq/ethereum-api-faq.mdx
@@ -114,4 +114,4 @@ You can find the list of all the methods Alchemy support for the Ethereum API on
 
 ## My question isn't here, where can I get help?
 
-If you have any questions or feedback, please contact us at <Markdown src="../../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.

--- a/fern/api-reference/flow/flow-api-faq.mdx
+++ b/fern/api-reference/flow/flow-api-faq.mdx
@@ -49,4 +49,4 @@ Refer to the [Flow API Endpoints](/docs/chains#flow-apis) for a complete list of
 
 ## Where can I get additional help?
 
-If you have any questions or feedback, please contact us at <Markdown src="../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.

--- a/fern/api-reference/gnosis/gnosis-chain-faq.mdx
+++ b/fern/api-reference/gnosis/gnosis-chain-faq.mdx
@@ -49,4 +49,4 @@ You can find the list of all the methods Alchemy supports for the Gnosis Chain A
 
 ## My question isn't here, where can I get help?
 
-If you have any questions or feedback, please contact us at <Markdown src="../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.

--- a/fern/api-reference/hyperliquid/hyperliquid-api-faq.mdx
+++ b/fern/api-reference/hyperliquid/hyperliquid-api-faq.mdx
@@ -49,4 +49,4 @@ You can find the list of all the methods Alchemy supports for the HyperEVM API o
 
 ## My question isn't here, where can I get help?
 
-If you have any questions or feedback, please contact us at <Markdown src="../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.

--- a/fern/api-reference/ink/ink-api-faq.mdx
+++ b/fern/api-reference/ink/ink-api-faq.mdx
@@ -49,4 +49,4 @@ You can find the list of all the methods Alchemy supports for the Ink API on the
 
 ## My question isn't here, where can I get help?
 
-If you have any questions or feedback, please contact us at <Markdown src="../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.

--- a/fern/api-reference/lens/lens-api-faq.mdx
+++ b/fern/api-reference/lens/lens-api-faq.mdx
@@ -64,4 +64,4 @@ Developers are encouraged to build new experiences on the Lens Network architect
 
 ## My question isn't here, where can I get help?
 
-If you have any questions or feedback, please contact us at <Markdown src="../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.

--- a/fern/api-reference/linea/linea-chain-api-faq.mdx
+++ b/fern/api-reference/linea/linea-chain-api-faq.mdx
@@ -49,4 +49,4 @@ You can find the list of all the methods Alchemy supports for the Linea Chain AP
 
 ## My question isn't here, where can I get help?
 
-If you have any questions or feedback, please contact us at <Markdown src="../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.

--- a/fern/api-reference/mantle/mantle-chain-api-faq.mdx
+++ b/fern/api-reference/mantle/mantle-chain-api-faq.mdx
@@ -49,4 +49,4 @@ You can find the list of all the methods Alchemy supports for the Mantle Chain A
 
 ## My question isn't here, where can I get help?
 
-If you have any questions or feedback, please contact us at <Markdown src="../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.

--- a/fern/api-reference/metis/metis-chain-api-faq.mdx
+++ b/fern/api-reference/metis/metis-chain-api-faq.mdx
@@ -53,4 +53,4 @@ You can find the list of all the methods Alchemy supports for the Metis Chain AP
 
 ## My question isn't here, where can I get help?
 
-If you have any questions or feedback, please contact us at <Markdown src="../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.

--- a/fern/api-reference/monad/monad-api-faq.mdx
+++ b/fern/api-reference/monad/monad-api-faq.mdx
@@ -49,4 +49,4 @@ You can find the list of all the methods Alchemy supports for the Monad Chain AP
 
 ## My question isn't here, where can I get help?
 
-If you have any questions or feedback, please contact us at <Markdown src="../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.

--- a/fern/api-reference/op-mainnet/op-mainnet-api-faq/op-mainnet-api-faq.mdx
+++ b/fern/api-reference/op-mainnet/op-mainnet-api-faq/op-mainnet-api-faq.mdx
@@ -110,7 +110,7 @@ The Optimism sequencer has an additional limit on write requests or sending tran
 
 ## My question isn't here, where can I get help?
 
-If you have any questions or feedback, please contact us at <Markdown src="../../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.
 
 ***
 

--- a/fern/api-reference/opbnb-paid-tier/opbnb-chain-api-faq.mdx
+++ b/fern/api-reference/opbnb-paid-tier/opbnb-chain-api-faq.mdx
@@ -53,4 +53,4 @@ You can find the list of all the methods Alchemy supports for the opBNB API on t
 
 ## My question isn't here, where can I get help?
 
-If you have any questions or feedback, please contact us at <Markdown src="../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.

--- a/fern/api-reference/polygon-pos/polygon-api-faq.mdx
+++ b/fern/api-reference/polygon-pos/polygon-api-faq.mdx
@@ -91,4 +91,4 @@ You can find the list of all the methods Alchemy supports for the Polygon API on
 
 ## My question isn't here, where can I get help?
 
-If you have any questions or feedback, please contact us at <Markdown src="../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.

--- a/fern/api-reference/polygon-zkevm/polygon-zkevm-api-faq/polygon-zkevm-api-faq.mdx
+++ b/fern/api-reference/polygon-zkevm/polygon-zkevm-api-faq/polygon-zkevm-api-faq.mdx
@@ -55,4 +55,4 @@ You can find the list of all the methods Alchemy supports for the Polygon zkEVM 
 
 ## My question isn't here, where can I get help?
 
-If you have any questions or feedback, please contact us at <Markdown src="../../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.

--- a/fern/api-reference/pricing-resources/pricing-faq/new-pricing-for-existing-scale-and-growth-customers.mdx
+++ b/fern/api-reference/pricing-resources/pricing-faq/new-pricing-for-existing-scale-and-growth-customers.mdx
@@ -67,4 +67,4 @@ With Pay As You Go plan, you'll get:
 1. **How do unused compute units work for Scale Annual plan customers?** If you're on a Scale Annual plan, all remaining Compute Units will be credited to you and will expire at the end of your annual contract. **Note:** For the month of February, these credits will be transferred as a dollar value directly to your account. Starting March 1st, credits will be issued in Compute Units (CUs), available for you to use any time before your contract ends.
 2. **What happens to my current features?** You'll maintain access to all your current features and services.
 3. **Will my costs increase?** With similar usage patterns, most Growth plan, Scale Monthly, and Scale Annually users will see their costs decrease under Pay As You Go plan.
-If you have any questions or feedback, please contact us at <Markdown src="../../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.

--- a/fern/api-reference/pricing-resources/resources/error-reference.mdx
+++ b/fern/api-reference/pricing-resources/resources/error-reference.mdx
@@ -131,7 +131,7 @@ Here are some guidelines to limit client side issues:
 
 5. Ensure systems outside of your production environment are are also not creating too many requests!
 
-If you have any questions or feedback, please contact us at <Markdown src="../../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.
 
 # How we define “successful” vs. “failed” requests in the dashboard
 

--- a/fern/api-reference/pricing-resources/resources/gas-limits-for-eth-call-and-eth-estimategas.mdx
+++ b/fern/api-reference/pricing-resources/resources/gas-limits-for-eth-call-and-eth-estimategas.mdx
@@ -16,4 +16,4 @@ A breakdown of the gas cap limits for `eth_call` and `eth_estimateGas` on Ethere
 | Optimism | 550 million |
 | Arbitrum | 550 million |
 
-*Alchemy has the highest gas limits for any provider, if you're interested in increasing these limits even further, reach out to us at <Markdown src="../../../snippets/support-email.mdx" />!
+*Alchemy has the highest gas limits for any provider, if you're interested in increasing these limits even further, reach out to us at support@alchemy.com!

--- a/fern/api-reference/rootstock/rootstock-api-faq.mdx
+++ b/fern/api-reference/rootstock/rootstock-api-faq.mdx
@@ -51,4 +51,4 @@ The Powpeg is Rootstock's security mechanism based on a layered "defence-in-dept
 
 ## My question isn't here, where can I get help?
 
-If you have any questions or feedback, please contact us at <Markdown src="../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.

--- a/fern/api-reference/scroll/scroll-chain-api-faq.mdx
+++ b/fern/api-reference/scroll/scroll-chain-api-faq.mdx
@@ -49,4 +49,4 @@ You can find the list of all the methods Alchemy supports for the Scroll Chain A
 
 ## My question isn't here, where can I get help?
 
-If you have any questions or feedback, please contact us at <Markdown src="../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.

--- a/fern/api-reference/sei/sei-api-faq.mdx
+++ b/fern/api-reference/sei/sei-api-faq.mdx
@@ -49,4 +49,4 @@ You can find the list of all the methods Alchemy supports for the Sei API on the
 
 ## My question isn't here, where can I get help?
 
-If you have any questions or feedback, please contact us at <Markdown src="../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.

--- a/fern/api-reference/shape/shape-api-faq.mdx
+++ b/fern/api-reference/shape/shape-api-faq.mdx
@@ -39,4 +39,4 @@ Shape inherits its security directly from Ethereum, ensuring a high level of sec
 
 ## My question isn't here, where can I get help?
 
-If you have any questions or feedback, please contact us at <Markdown src="../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.

--- a/fern/api-reference/soneium/soneium-api-faq.mdx
+++ b/fern/api-reference/soneium/soneium-api-faq.mdx
@@ -49,4 +49,4 @@ For a comprehensive list of methods supported by Alchemy for the Soneium API, pl
 
 ## My question isn't here, where can I get help?
 
-If you have any questions or feedback, please refer to the official Soneium documentation, contact us at <Markdown src="../../snippets/support-email.mdx" />, or open a ticket in the dashboard.
+If you have any questions or feedback, please refer to the official Soneium documentation, contact us at support@alchemy.com, or open a ticket in the dashboard.

--- a/fern/api-reference/sonic/sonic-api-faq.mdx
+++ b/fern/api-reference/sonic/sonic-api-faq.mdx
@@ -49,4 +49,4 @@ You can find the list of all the methods Alchemy supports for the Sonic Chain AP
 
 ## My question isn't here, where can I get help?
 
-If you have any questions or feedback, please contact us at <Markdown src="../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.

--- a/fern/api-reference/starknet/starknet-api-faq.mdx
+++ b/fern/api-reference/starknet/starknet-api-faq.mdx
@@ -89,4 +89,4 @@ You can find the list of all the methods Alchemy support for the Starknet API on
 
 ## My question isn't here, where can I get help?
 
-If you have any questions or feedback, please contact us at <Markdown src="../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.

--- a/fern/api-reference/story/story-api-faq.mdx
+++ b/fern/api-reference/story/story-api-faq.mdx
@@ -48,4 +48,4 @@ You can find the list of all the methods Alchemy supports for the Story API on t
 
 ## My question isn't here, where can I get help?
 
-If you have any questions or feedback, please contact us at <Markdown src="../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.

--- a/fern/api-reference/sui/sui-api-faq.mdx
+++ b/fern/api-reference/sui/sui-api-faq.mdx
@@ -46,4 +46,4 @@ You can find a full list of supported JSON-RPC methods on the [Sui API Endpoints
 
 ## My question isn't listed here — where can I get help?
 
-If you have any questions or feedback, please contact us at <Markdown src="../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.

--- a/fern/api-reference/superseed/superseed-api-faq.mdx
+++ b/fern/api-reference/superseed/superseed-api-faq.mdx
@@ -46,4 +46,4 @@ You can find a full list of supported JSON-RPC methods on the [Superseed API End
 
 ## My question isn't listed here — where can I get help?
 
-If you have any questions or feedback, please contact us at <Markdown src="../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.

--- a/fern/api-reference/tron/tron-api-faq.mdx
+++ b/fern/api-reference/tron/tron-api-faq.mdx
@@ -46,4 +46,4 @@ You can find a full list of supported JSON-RPC methods on the [Tron API Endpoint
 
 ## My question isn't listed here — where can I get help?
 
-If you have any questions or feedback, please contact us at <Markdown src="../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.

--- a/fern/api-reference/unichain/unichain-api-faq.mdx
+++ b/fern/api-reference/unichain/unichain-api-faq.mdx
@@ -53,4 +53,4 @@ Check out the [Unichain API Endpoints](/docs/chains#unichain-apis)
 
 ## My question isn't here, where can I get help?
 
-If you have any questions or feedback, please contact us at <Markdown src="../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.

--- a/fern/api-reference/world-chain/world-chain-api-faq.mdx
+++ b/fern/api-reference/world-chain/world-chain-api-faq.mdx
@@ -39,4 +39,4 @@ World Chain uses World ID's Proof of Personhood system to verify human users. Ve
 
 ## My question isn't here, where can I get help?
 
-If you have any questions or feedback, please contact us at <Markdown src="../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.

--- a/fern/api-reference/zetachain/zetachain-api-faq.mdx
+++ b/fern/api-reference/zetachain/zetachain-api-faq.mdx
@@ -49,4 +49,4 @@ You can find the list of all the methods Alchemy supports for the ZetaChain API 
 
 ## My question isn't here, where can I get help?
 
-If you have any questions or feedback, please contact us at <Markdown src="../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.

--- a/fern/api-reference/zksync/zksync-api-faq.mdx
+++ b/fern/api-reference/zksync/zksync-api-faq.mdx
@@ -89,4 +89,4 @@ For Windows users, it's recommended to use WSL 2 and ensure that projects are lo
 
 ## My question isn't here, where can I get help?
 
-If you have any questions or feedback, please contact us at <Markdown src="../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.

--- a/fern/snippets/support-email.mdx
+++ b/fern/snippets/support-email.mdx
@@ -1,1 +1,0 @@
-support@alchemy.com

--- a/fern/tutorials/creating-smart-contracts/hello-world-smart-contract/how-to-code-and-deploy-a-polygon-smart-contract.mdx
+++ b/fern/tutorials/creating-smart-contracts/hello-world-smart-contract/how-to-code-and-deploy-a-polygon-smart-contract.mdx
@@ -17,7 +17,7 @@ And don’t worry if you don’t understand what any of these words mean yet, I'
 
 2. Tweet at us [@Alchemy](https://twitter.com/Alchemy).
 
-If you have any questions or feedback, please contact us at <Markdown src="../../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.
 
 **Our tools today for creating a smart contract on Polygon**:
 
@@ -641,4 +641,4 @@ You're well on your way to becoming a blockchain developer :)
 
 If you enjoyed this tutorial for how to deploy your first Polygon smart contract, give us a tweet [@Alchemy](https://twitter.com/Alchemy)! And tell us if you tried to deploy this to Polygon mainnet!
 
-If you have any questions or feedback, please contact us at <Markdown src="../../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.

--- a/fern/tutorials/getting-started/api-security-and-authentication/how-to-use-api-keys-in-http-headers.mdx
+++ b/fern/tutorials/getting-started/api-security-and-authentication/how-to-use-api-keys-in-http-headers.mdx
@@ -247,4 +247,4 @@ In this guide you learned how to make HTTP header-based API requests.
 
 We recommend moving your Alchemy API keys from the URL to HTTP headers as it enhances the security of your projects. With our support for header-based requests, this transition is seamless and easy.
 
-If you have any questions or feedback, please contact us at <Markdown src="../../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.

--- a/fern/tutorials/getting-started/developer-best-practices/debugging-cors-problems-for-end-users.mdx
+++ b/fern/tutorials/getting-started/developer-best-practices/debugging-cors-problems-for-end-users.mdx
@@ -47,7 +47,7 @@ Google Chrome released [an update](https://www.chromium.org/Home/chromium-securi
 
 ## Submitting a persistent problem
 
-If none of the causes and fixes above are helping, then please contact us at <Markdown src="../../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+If none of the causes and fixes above are helping, then please contact us at support@alchemy.com or open a ticket in the dashboard.
 
 * User's computer manufacturer.
 

--- a/fern/tutorials/getting-started/developer-best-practices/how-to-enable-compression-to-speed-up-json-rpc-blockchain-requests.mdx
+++ b/fern/tutorials/getting-started/developer-best-practices/how-to-enable-compression-to-speed-up-json-rpc-blockchain-requests.mdx
@@ -179,4 +179,4 @@ JSON-RPC response latency improvements are dependent on many factors, including 
 
 Though this number will vary dramatically based on these factors, you’ll typically see a non-trivial decrease in latency using gzip compression for speeding up large response packages.
 
-If you have any questions or feedback, please contact us at <Markdown src="../../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.

--- a/fern/tutorials/learning-solidity/how-to-interact-with-erc-721-tokens-in-solidity.mdx
+++ b/fern/tutorials/learning-solidity/how-to-interact-with-erc-721-tokens-in-solidity.mdx
@@ -405,7 +405,7 @@ Congratulations! You now know how to interact with ERC-721 tokens and smart cont
 
 If you enjoyed this tutorial about creating on-chain allowlists, tweet us at [@Alchemy](https://twitter.com/Alchemy) and give us a shoutout!
 
-If you have any questions or feedback, please contact us at <Markdown src="../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.
 
 Ready to start building your NFT collection?
 

--- a/fern/tutorials/streaming-data/websocket-subscriptions/how-to-subscribe-to-pending-transactions-via-websocket-endpoints.mdx
+++ b/fern/tutorials/streaming-data/websocket-subscriptions/how-to-subscribe-to-pending-transactions-via-websocket-endpoints.mdx
@@ -401,4 +401,4 @@ For more advanced filtering capabilities, consider using Alchemy's enhanced `alc
 
 If you enjoyed this tutorial, tweet us at **@Alchemy**.
 
-If you have any questions or feedback, please contact us at <Markdown src="../../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.

--- a/fern/tutorials/streaming-data/websocket-subscriptions/how-to-subscribe-to-transactions-via-websocket-endpoints.mdx
+++ b/fern/tutorials/streaming-data/websocket-subscriptions/how-to-subscribe-to-transactions-via-websocket-endpoints.mdx
@@ -323,4 +323,4 @@ For more advanced filtering capabilities, consider using Alchemy's enhanced `alc
 
 If you enjoyed this tutorial, tweet us at **@Alchemy**.
 
-If you have any questions or feedback, please contact us at <Markdown src="../../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.

--- a/fern/tutorials/transactions/sending-transactions/how-to-send-transactions-on-ethereum.mdx
+++ b/fern/tutorials/transactions/sending-transactions/how-to-send-transactions-on-ethereum.mdx
@@ -40,7 +40,7 @@ Like most blockchain developers when they first start, you might have done some 
 * Modern Web3 libraries like Viem and Ethers.js are wrapper libraries around the standard JSON-RPC calls that are quite common to use in Ethereum development.
 * There are many different web3 libraries for different languages. In this tutorial, we'll use Viem and Ethers.js which are written in JavaScript.
 
-Okay, now that we have a few of these questions out of the way, let's move onto the tutorial. Feel free to contact us at <Markdown src="../../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+Okay, now that we have a few of these questions out of the way, let's move onto the tutorial. Feel free to contact us at support@alchemy.com or open a ticket in the dashboard.
 
 <Info>
   This guide assumes you have an Alchemy account, an Ethereum address or Metamask wallet, Node.js, and npm installed. If not, follow these steps:
@@ -233,6 +233,6 @@ From there you can view your transaction on Etherscan by clicking on the icon ci
 
 Once you complete this tutorial, let us know how your experience was or if you have any feedback by tagging us on Twitter [@Alchemy](https://twitter.com/Alchemy)!
 
-If you have any questions or feedback, please contact us at <Markdown src="../../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.
 
 \_Not sure what to do next? As a final test of your skills, get your hands dirty with some solidity programming by implementing our [Hello World Smart Contract](/docs/hello-world-smart-contract) tutorial.

--- a/fern/tutorials/transactions/transaction-history/how-to-get-all-the-contracts-deployed-by-a-wallet.mdx
+++ b/fern/tutorials/transactions/transaction-history/how-to-get-all-the-contracts-deployed-by-a-wallet.mdx
@@ -261,4 +261,4 @@ In this tutorial, we learned how to programmatically retrieve all the contracts 
 
 By following the code and explanations provided, you should now be able to adapt this script to suit your specific needs or integrate it into a larger project.
 
-If you have any questions or feedback, please contact us at <Markdown src="../../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.

--- a/fern/tutorials/transactions/transaction-history/how-to-get-contract-deployment-transactions-in-a-block.mdx
+++ b/fern/tutorials/transactions/transaction-history/how-to-get-contract-deployment-transactions-in-a-block.mdx
@@ -348,4 +348,4 @@ Therefore, generally, you would prefer the first approach but there might be cas
 
 Congratulations! You now know how to get contract deployment transactions in a block 🎉
 
-If you have any questions or feedback, please contact us at <Markdown src="../../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.

--- a/fern/tutorials/understanding-the-evm/how-to-deploy-a-contract-to-the-same-address-on-multiple-networks/create2-an-alternative-to-deriving-contract-addresses.mdx
+++ b/fern/tutorials/understanding-the-evm/how-to-deploy-a-contract-to-the-same-address-on-multiple-networks/create2-an-alternative-to-deriving-contract-addresses.mdx
@@ -553,4 +553,4 @@ In this tutorial, you learned:
 
 * How to deploy a contract to the same precomputed address on multiple networks with create2.
 
-If you have any questions or feedback, please contact us at <Markdown src="../../../snippets/support-email.mdx" /> or open a ticket in the dashboard.
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the dashboard.


### PR DESCRIPTION
## Description

This snippet is causing hydration issues in the new app. The problem is that plain markdown text are rendered as an HTML paragraph if nothing else is present to indicate otherwise. Referencing this snippet inline means that a p tag is rendered within a p tag which is invalid HTML. The browser fixes this for us client-side but can't server-side of course causing a mismatch which forces the full page to render client-side. This creates a flash and the support email appears on its own line.
<img width="948" height="428" alt="image" src="https://github.com/user-attachments/assets/cbd8c619-f31f-42c2-b53b-fc7cbaee2bf8" />

There are code solutions for this but not pretty ones - would most likely require a rehype plugin. Given this is a very niche case it doesn't seem worth it. IMO we gain little benefit by storing this email in a snippet. Markdown isn't really meant to be used to hold inline variables - it's meant to page content. If we want to change the email in the future we can easily do find/replace.

## Related Issues

hotfix

## Changes Made

- Replace all instances of support-email.mdx snippet with the email itself
- Delete the snippet

## Testing

<!-- Describe the tests that you ran to verify your changes -->

* \[ ] I have tested these changes locally
* \[ ] I have run the validation scripts (`pnpm run validate`)
* \[ ] I have checked that the documentation builds correctly
