### PR TITLE
fix: restore format for changelog pathIndex entries

### DIFF
--- a/src/content-indexer/indexers/changelog.ts
+++ b/src/content-indexer/indexers/changelog.ts
@@ -3,7 +3,10 @@ import path from "path";
 
 import type { AlgoliaRecord } from "@/content-indexer/types/algolia.ts";
 import type { IndexerResult } from "@/content-indexer/types/indexer.ts";
-import type { PathIndex } from "@/content-indexer/types/pathIndex.ts";
+import type {
+  ChangelogPathIndexEntry,
+  PathIndex,
+} from "@/content-indexer/types/pathIndex.ts";
 import { readLocalFile } from "@/content-indexer/utils/filesystem.ts";
 import { truncateRecord } from "@/content-indexer/utils/truncate-record.ts";
 
@@ -85,11 +88,9 @@ export const buildChangelogIndex = async (
       const route = `${year}/${Number(month)}/${Number(day)}`;
 
       // Create path index entry
-      const pathIndexEntry = {
-        type: "mdx" as const,
-        filePath: `fern/changelog/${filename}`,
-        source: "changelog" as const,
-        tab: "changelog",
+      const pathIndexEntry: ChangelogPathIndexEntry = {
+        date, // ISO date string like "2025-12-11"
+        filePath: filename, // Filename like "2025-12-11.md"
       };
 
       // Create Algolia record

--- a/src/content-indexer/types/pathIndex.ts
+++ b/src/content-indexer/types/pathIndex.ts
@@ -21,9 +21,15 @@ export interface OpenApiPathIndexEntry {
   tab: string;
 }
 
+export interface ChangelogPathIndexEntry {
+  date: string; // ISO date string like "2025-12-11"
+  filePath: string; // Filename like "2025-12-11.md"
+}
+
 export type PathIndexEntry =
   | MdxPathIndexEntry
   | OpenRpcPathIndexEntry
-  | OpenApiPathIndexEntry;
+  | OpenApiPathIndexEntry
+  | ChangelogPathIndexEntry;
 
 export type PathIndex = Record<string, PathIndexEntry>;


### PR DESCRIPTION
## Description

Looks like when I moved content-indexer to this repo, Claude created the changelog pathIndex entry format to use the same fields as other formats, which isn't really correct. This broke the site when I switched the index key over.

## Changes Made

- Create new changelog type for path index entries and implement it

## Testing

<!-- Describe the tests that you ran to verify your changes -->

* \[ ] I have tested these changes locally
* \[ ] I have run the validation scripts (`pnpm run validate`)
* \[ ] I have checked that the documentation builds correctly
