### PR TITLE
fix: remove buggy if check in changelog index gha

### DIFF
--- a/.github/workflows/index-changelog.yml
+++ b/.github/workflows/index-changelog.yml
@@ -11,17 +11,6 @@ jobs:
   index-changelog:
     name: Index Changelog
     runs-on: ubuntu-latest
-    # Only run when files are added or removed, not modified
-    if: |
-      github.event.head_commit &&
-      (
-        github.event.head_commit.added[0] != null ||
-        github.event.head_commit.removed[0] != null
-      ) &&
-      (
-        contains(join(github.event.head_commit.added, ','), 'fern/changelog/') ||
-        contains(join(github.event.head_commit.removed, ','), 'fern/changelog/')
-      )
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
## Description

Ideally we still only need to run the changelog indexer when a file is added/removed, not modified. But this if check doesn't work, plus its hard to read and annoying to test. Existing changelog files are rarely edited after the fact anyway so we're not losing much by letting the indexer run on every change anyway.

This is not the case for other docs content, but luckily those triggers are much easier since we can just watch docs.yml changes.

## Changes Made

- remove buggy if check in changelog index gha

## Testing

<!-- Describe the tests that you ran to verify your changes -->

* \[ ] I have tested these changes locally
* \[ ] I have run the validation scripts (`pnpm run validate`)
* \[ ] I have checked that the documentation builds correctly
