### PR TITLE
feat: trigger revalidate tags endpoint on mdx content changes

### DIFF
--- a/.github/workflows/revalidate-content.yml
+++ b/.github/workflows/revalidate-content.yml
@@ -23,10 +23,20 @@ jobs:
         id: changed-files
         run: |
           # Get all MDX files changed in this push (handles multiple commits)
+          set +e
           CHANGED_FILES=$(git diff --name-only \
             "${{ github.event.before }}" "${{ github.event.after }}" \
-            -- 'fern/**/*.mdx' || true)
+            -- 'fern/**/*.mdx')
+          EXIT_CODE=$?
+          set -e
 
+          # Check for git errors
+          if [ $EXIT_CODE -ne 0 ]; then
+            echo "::error::git diff failed with exit code $EXIT_CODE"
+            exit 1
+          fi
+
+          # Handle empty result (no files changed)
           if [ -z "$CHANGED_FILES" ]; then
             echo "No MDX files changed in /fern/ directory"
             echo "filePaths=[]" >> $GITHUB_OUTPUT

--- a/.github/workflows/revalidate-content.yml
+++ b/.github/workflows/revalidate-content.yml
@@ -72,7 +72,7 @@ jobs:
 
           echo ""
           echo "Response (HTTP $HTTP_CODE):"
-          cat response.json | jq '.' || cat response.json
+          jq '.' response.json || cat response.json
 
           # Check HTTP status
           if [ "$HTTP_CODE" != "200" ]; then

--- a/.github/workflows/revalidate-content.yml
+++ b/.github/workflows/revalidate-content.yml
@@ -34,8 +34,8 @@ jobs:
             exit 0
           fi
 
-          # Convert to JSON array using jq
-          FILE_PATHS_JSON=$(echo "$CHANGED_FILES" | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          # Strip 'fern/' prefix and convert to JSON array
+          FILE_PATHS_JSON=$(echo "$CHANGED_FILES" | sed 's|^fern/||' | jq -R -s -c 'split("\n") | map(select(length > 0))')
 
           echo "File paths JSON: $FILE_PATHS_JSON"
           echo "filePaths=$FILE_PATHS_JSON" >> $GITHUB_OUTPUT

--- a/.github/workflows/revalidate-content.yml
+++ b/.github/workflows/revalidate-content.yml
@@ -1,0 +1,82 @@
+name: Revalidate Content
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "fern/**/*.mdx"
+
+jobs:
+  revalidate-content:
+    name: Revalidate Changed Pages
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Fetch full history to compare all commits in push
+
+      - name: Get changed MDX files
+        id: changed-files
+        run: |
+          # Get all MDX files changed in this push (handles multiple commits)
+          # Only consider Added or Modified files (not Deleted) in /fern/ directory
+          CHANGED_FILES=$(git diff --name-only --diff-filter=AM \
+            "${{ github.event.before }}" "${{ github.event.after }}" \
+            -- 'fern/**/*.mdx' || true)
+
+          if [ -z "$CHANGED_FILES" ]; then
+            echo "No MDX files changed in /fern/ directory"
+            echo "filePaths=[]" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Convert to JSON array using jq
+          FILE_PATHS_JSON=$(echo "$CHANGED_FILES" | jq -R -s -c 'split("\n") | map(select(length > 0))')
+
+          echo "File paths JSON: $FILE_PATHS_JSON"
+          echo "filePaths=$FILE_PATHS_JSON" >> $GITHUB_OUTPUT
+
+      - name: Call revalidation API
+        if: steps.changed-files.outputs.filePaths != '[]'
+        run: |
+          # Create JSON payload using jq for safety
+          PAYLOAD=$(jq -n --argjson paths '${{ steps.changed-files.outputs.filePaths }}' \
+            '{filePaths: $paths}')
+
+          echo "Revalidating files:"
+          echo "$PAYLOAD" | jq -r '.filePaths[]'
+
+          # Call API with 60s timeout
+          HTTP_CODE=$(curl -X POST "${{ secrets.DOCS_SITE_URL }}/api/revalidate/tags" \
+            -H "Authorization: Bearer ${{ secrets.DOCS_SITE_API_KEY }}" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD" \
+            --max-time 60 \
+            --fail-with-body \
+            -o response.json \
+            -w "%{http_code}" \
+            -s)
+
+          echo ""
+          echo "Response (HTTP $HTTP_CODE):"
+          cat response.json | jq '.' || cat response.json
+
+          # Check HTTP status
+          if [ "$HTTP_CODE" != "200" ]; then
+            echo "::error::Revalidation API returned status $HTTP_CODE"
+            exit 1
+          fi
+
+          # Check success field in response
+          SUCCESS=$(jq -r '.success' response.json)
+          if [ "$SUCCESS" != "true" ]; then
+            echo "::warning::Revalidation completed with errors"
+            jq -r '.errors[]?' response.json
+          else
+            FILE_COUNT=$(jq -r '.revalidated | length' response.json)
+            echo "::notice::✅ Successfully revalidated $FILE_COUNT files"
+          fi

--- a/.github/workflows/revalidate-content.yml
+++ b/.github/workflows/revalidate-content.yml
@@ -23,8 +23,7 @@ jobs:
         id: changed-files
         run: |
           # Get all MDX files changed in this push (handles multiple commits)
-          # Only consider Added or Modified files (not Deleted) in /fern/ directory
-          CHANGED_FILES=$(git diff --name-only --diff-filter=AM \
+          CHANGED_FILES=$(git diff --name-only \
             "${{ github.event.before }}" "${{ github.event.after }}" \
             -- 'fern/**/*.mdx' || true)
 


### PR DESCRIPTION
## Description

Now that we have a revalidation endpoint, this GHA checks for changes in MDX files that were just merged to main. Then it fires one call to the revalidate endpoint in the docs site and echoes the response.

## Related Issues

https://app.asana.com/1/1129441638109975/project/1211825853436056/task/1212833101586117?focus=true

## Changes Made

<!-- List the specific changes made in this PR -->

## Testing

<!-- Describe the tests that you ran to verify your changes -->

* \[ ] I have tested these changes locally
* \[ ] I have run the validation scripts (`pnpm run validate`)
* \[ ] I have checked that the documentation builds correctly
