### PR TITLE
refactor: standardize redis keys

### DIFF
--- a/.github/workflows/revalidate-content.yml
+++ b/.github/workflows/revalidate-content.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
     paths:
+      - "fern/**/*.md"
       - "fern/**/*.mdx"
 
 jobs:
@@ -26,7 +27,7 @@ jobs:
           set +e
           CHANGED_FILES=$(git diff --name-only \
             "${{ github.event.before }}" "${{ github.event.after }}" \
-            -- 'fern/**/*.mdx')
+            -- 'fern/**/*.md' 'fern/**/*.mdx')
           EXIT_CODE=$?
           set -e
 

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -1180,8 +1180,6 @@ navigation:
                     path: wallets/pages/authorization/smart-account-types/modular-account-v2/overview.mdx
                   - page: Getting started
                     path: wallets/pages/smart-contracts/modular-account-v2/getting-started.mdx
-                  - page: Upgrading to MAv2
-                    path: wallets/pages/smart-contracts/modular-account-v2/upgrading-to-mav2.mdx
               - section: Light Account
                 contents:
                   - page: Overview
@@ -4399,8 +4397,4 @@ redirects:
   # Session keys
   - source: /docs/reference/wallet-apis-session-keys/:path*
     destination: /docs/wallets/reference/wallet-apis-session-keys/:path*
-    permanent: true
-
-  - source: /docs/wallets/smart-contracts/modular-account-v2/upgrading-to-MAv2
-    destination: /docs/wallets/smart-contracts/modular-account-v2/upgrading-to-mav2
     permanent: true

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
     "lint:broken-links": "lychee .",
     "add-evm-chain": "tsx ./scripts/add-evm-chain.ts",
     "prepare": "husky",
-    "index:main": "tsx src/content-indexer/index.ts --indexer=main --branch=main",
-    "index:main:preview": "tsx src/content-indexer/index.ts --indexer=main --mode=preview --branch=$(git rev-parse --abbrev-ref HEAD)",
+    "index:main": "tsx src/content-indexer/index.ts --indexer=docs --branch=main",
+    "index:main:preview": "tsx src/content-indexer/index.ts --indexer=docs --mode=preview --branch=$(git rev-parse --abbrev-ref HEAD)",
     "index:sdk": "tsx src/content-indexer/index.ts --indexer=sdk --branch=main",
     "index:changelog": "tsx src/content-indexer/index.ts --indexer=changelog --branch=main"
   },

--- a/src/content-indexer/index.ts
+++ b/src/content-indexer/index.ts
@@ -4,7 +4,10 @@ import path from "path";
 
 import { buildChangelogIndex } from "@/content-indexer/indexers/changelog.ts";
 import { buildDocsContentIndex } from "@/content-indexer/indexers/main.ts";
-import type { IndexerResult } from "@/content-indexer/types/indexer.ts";
+import type {
+  IndexerResult,
+  IndexerType,
+} from "@/content-indexer/types/indexer.ts";
 import { uploadToAlgolia } from "@/content-indexer/uploaders/algolia.ts";
 import { storeToRedis } from "@/content-indexer/uploaders/redis.ts";
 
@@ -18,7 +21,7 @@ const parseArgs = () => {
   const args = process.argv.slice(2);
 
   const indexer =
-    args.find((arg) => arg.startsWith("--indexer="))?.split("=")[1] || "main";
+    args.find((arg) => arg.startsWith("--indexer="))?.split("=")[1] || "docs";
   const mode =
     args.find((arg) => arg.startsWith("--mode="))?.split("=")[1] ||
     "production";
@@ -26,9 +29,9 @@ const parseArgs = () => {
     args.find((arg) => arg.startsWith("--branch="))?.split("=")[1] || "main";
 
   // Validate arguments
-  if (!["main", "sdk", "changelog"].includes(indexer)) {
+  if (!["docs", "sdk", "changelog"].includes(indexer)) {
     throw new Error(
-      `Invalid indexer: ${indexer}. Must be 'main', 'sdk', or 'changelog'`,
+      `Invalid indexer: ${indexer}. Must be 'docs', 'sdk', or 'changelog'`,
     );
   }
 
@@ -37,7 +40,7 @@ const parseArgs = () => {
   }
 
   return {
-    indexer: indexer as "main" | "sdk" | "changelog",
+    indexer: indexer as IndexerType,
     mode: mode as "preview" | "production",
     branchId: branch,
   };
@@ -48,7 +51,7 @@ const parseArgs = () => {
 // ============================================================================
 
 const buildIndexResults = async (
-  indexerType: "main" | "sdk" | "changelog",
+  indexerType: IndexerType,
   branchId: string,
   mode: "preview" | "production" = "production",
 ): Promise<IndexerResult> => {
@@ -58,7 +61,7 @@ const buildIndexResults = async (
         localBasePath: path.join(process.cwd(), "fern/changelog"),
         branchId,
       });
-    case "main":
+    case "docs":
       return buildDocsContentIndex({
         source: {
           type: "filesystem",
@@ -88,12 +91,12 @@ const buildIndexResults = async (
 };
 
 const runIndexer = async (
-  indexerType: "main" | "sdk" | "changelog",
+  indexerType: IndexerType,
   branchId: string,
   mode?: "preview" | "production",
 ) => {
   console.info(
-    `\n🔍 Running ${indexerType.toUpperCase()} indexer${indexerType === "main" && mode ? ` (${mode} mode)` : ""} (branch: ${branchId})\n`,
+    `\n🔍 Running ${indexerType.toUpperCase()} indexer${indexerType === "docs" && mode ? ` (${mode} mode)` : ""} (branch: ${branchId})\n`,
   );
 
   const { pathIndex, algoliaRecords, navigationTrees } =

--- a/src/content-indexer/types/indexer.ts
+++ b/src/content-indexer/types/indexer.ts
@@ -3,6 +3,14 @@ import type { NavigationTreesByTab } from "@/content-indexer/types/navigation.ts
 import type { PathIndex } from "@/content-indexer/types/pathIndex.ts";
 
 /**
+ * Content indexer types.
+ * - docs: Main documentation content
+ * - sdk: SDK reference documentation
+ * - changelog: Changelog entries
+ */
+export type IndexerType = "docs" | "sdk" | "changelog";
+
+/**
  * Standard result structure returned by all indexers.
  */
 export interface IndexerResult {

--- a/src/content-indexer/uploaders/__tests__/algolia.test.ts
+++ b/src/content-indexer/uploaders/__tests__/algolia.test.ts
@@ -15,7 +15,7 @@ describe("uploadToAlgolia", () => {
     const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const records: AlgoliaRecord[] = [];
 
-    await uploadToAlgolia(records, { indexerType: "main", branchId: "main" });
+    await uploadToAlgolia(records, { indexerType: "docs", branchId: "main" });
 
     expect(consoleSpy).toHaveBeenCalledWith(
       expect.stringContaining("Algolia credentials not found"),
@@ -36,7 +36,7 @@ describe("uploadToAlgolia", () => {
     const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const records: AlgoliaRecord[] = [];
 
-    await uploadToAlgolia(records, { indexerType: "main", branchId: "main" });
+    await uploadToAlgolia(records, { indexerType: "docs", branchId: "main" });
 
     expect(consoleSpy).toHaveBeenCalledWith(
       expect.stringContaining("Algolia credentials not found"),

--- a/src/content-indexer/uploaders/__tests__/redis.test.ts
+++ b/src/content-indexer/uploaders/__tests__/redis.test.ts
@@ -33,11 +33,11 @@ describe("storeToRedis", () => {
 
     await storeToRedis(pathIndex, undefined, {
       branchId: "main",
-      indexerType: "main",
+      indexerType: "docs",
     });
 
     expect(mockSet).toHaveBeenCalledWith(
-      "main/path-index:main",
+      "main:index:docs.json",
       JSON.stringify(pathIndex, null, 2),
       {}, // No TTL for main branch
     );
@@ -55,11 +55,11 @@ describe("storeToRedis", () => {
 
     await storeToRedis(pathIndex, undefined, {
       branchId: "feature-abc",
-      indexerType: "main",
+      indexerType: "docs",
     });
 
     expect(mockSet).toHaveBeenCalledWith(
-      "feature-abc/path-index:main",
+      "feature-abc:index:docs.json",
       JSON.stringify(pathIndex, null, 2),
       { ex: 2592000 }, // 30 days in seconds
     );
@@ -78,11 +78,11 @@ describe("storeToRedis", () => {
 
     await storeToRedis({}, navigationTrees, {
       branchId: "main",
-      indexerType: "main",
+      indexerType: "docs",
     });
 
     expect(mockSet).toHaveBeenCalledWith(
-      "main/nav-tree:guides",
+      "main:nav:guides.json",
       JSON.stringify(navigationTrees.guides, null, 2),
       {}, // No TTL for main branch
     );
@@ -108,16 +108,16 @@ describe("storeToRedis", () => {
 
     await storeToRedis({}, navigationTrees, {
       branchId: "main",
-      indexerType: "main",
+      indexerType: "docs",
     });
 
     expect(mockSet).toHaveBeenCalledWith(
-      "main/nav-tree:guides",
+      "main:nav:guides.json",
       JSON.stringify(navigationTrees.guides, null, 2),
       {}, // No TTL for main branch
     );
     expect(mockSet).toHaveBeenCalledWith(
-      "main/nav-tree:reference",
+      "main:nav:reference.json",
       JSON.stringify(navigationTrees.reference, null, 2),
       {}, // No TTL for main branch
     );
@@ -139,7 +139,7 @@ describe("storeToRedis", () => {
     });
 
     expect(mockSet).toHaveBeenCalledWith(
-      "main/path-index:sdk",
+      "main:index:sdk.json",
       JSON.stringify(pathIndex, null, 2),
       {}, // No TTL for main branch
     );
@@ -162,7 +162,7 @@ describe("storeToRedis", () => {
 
     await storeToRedis(pathIndex, navigationTrees, {
       branchId: "main",
-      indexerType: "main",
+      indexerType: "docs",
     });
 
     // Should have called set 3 times (1 pathIndex + 2 nav trees)

--- a/src/content-indexer/uploaders/algolia.ts
+++ b/src/content-indexer/uploaders/algolia.ts
@@ -1,6 +1,7 @@
 import { algoliasearch } from "algoliasearch";
 
 import type { AlgoliaRecord } from "@/content-indexer/types/algolia.ts";
+import type { IndexerType } from "@/content-indexer/types/indexer.ts";
 import { truncateRecord } from "@/content-indexer/utils/truncate-record.ts";
 
 const ALGOLIA_INDEX_NAME_BASE = "alchemy_docs";
@@ -10,20 +11,20 @@ const ALGOLIA_INDEX_NAME_BASE = "alchemy_docs";
  * Pattern: {branchId}_{baseName}[_{indexerType}]
  *
  * Examples:
- * - main_alchemy_docs (main branch, main content)
+ * - main_alchemy_docs (main branch, docs content)
  * - main_alchemy_docs_sdk (main branch, SDK content)
- * - abc_alchemy_docs (branch-abc, main content)
+ * - abc_alchemy_docs (branch-abc, docs content)
  * - abc_alchemy_docs_sdk (branch-abc, SDK content)
  */
 const buildIndexName = (
   base: string,
-  indexerType: "main" | "sdk" | "changelog",
+  indexerType: IndexerType,
   branchId: string,
 ): string => {
   const parts = [branchId, base];
 
-  // Add type suffix (except for main content)
-  if (indexerType !== "main") {
+  // Add type suffix (except for docs content)
+  if (indexerType !== "docs") {
     parts.push(indexerType);
   }
 
@@ -42,13 +43,13 @@ const buildIndexName = (
  *
  * @param records - Algolia records to upload
  * @param options - Configuration options
- * @param options.indexerType - Type of indexer ("main", "sdk", or "changelog")
+ * @param options.indexerType - Type of indexer ("docs", "sdk", or "changelog")
  * @param options.branchId - Branch identifier for index naming (e.g., "main", "branch-abc")
  */
 export const uploadToAlgolia = async (
   records: AlgoliaRecord[],
   options: {
-    indexerType: "main" | "sdk" | "changelog";
+    indexerType: IndexerType;
     branchId: string;
   },
 ): Promise<void> => {

--- a/src/content-indexer/uploaders/redis.ts
+++ b/src/content-indexer/uploaders/redis.ts
@@ -1,5 +1,6 @@
 import type { SetCommandOptions } from "@upstash/redis";
 
+import type { IndexerType } from "@/content-indexer/types/indexer.ts";
 import type {
   NavigationTree,
   NavigationTreesByTab,
@@ -30,14 +31,14 @@ const PREVIEW_TTL_SECONDS = 30 * 24 * 60 * 60; // 30 days
  * @param navigationTrees - Navigation trees (optional for SDK/changelog indexers)
  * @param options - Configuration options
  * @param options.branchId - Branch identifier for Redis keys (e.g., "main", "branch-abc123")
- * @param options.indexerType - Type of indexer ("main", "sdk", or "changelog")
+ * @param options.indexerType - Type of indexer ("docs", "sdk", or "changelog")
  */
 export const storeToRedis = async (
   pathIndex: PathIndex,
   navigationTrees: NavigationTreesByTab | undefined,
   options: {
     branchId: string;
-    indexerType: "main" | "sdk" | "changelog";
+    indexerType: IndexerType;
   },
 ): Promise<void> => {
   const redis = getRedis();
@@ -50,7 +51,7 @@ export const storeToRedis = async (
   const ttlInfo = isMainBranch ? "" : " (30-day TTL)";
 
   // Store path index with branch scope
-  const pathIndexKey = `${options.branchId}/path-index:${options.indexerType}`;
+  const pathIndexKey = `${options.branchId}:index:${options.indexerType}.json`;
   const pathIndexPromise = redis
     .set(pathIndexKey, stringify(pathIndex), setOptions)
     .then(() => {
@@ -64,7 +65,7 @@ export const storeToRedis = async (
 
   if (options.indexerType === "sdk" && navigationTrees?.wallets) {
     // SDK indexer: merge SDK section into existing wallets nav tree
-    const navTreeKey = `${options.branchId}/nav-tree:wallets`;
+    const navTreeKey = `${options.branchId}:nav:wallets.json`;
     const existingTree = await redis.get<NavigationTree>(navTreeKey);
 
     const mergedTree = mergeWalletsNavTree(
@@ -84,13 +85,13 @@ export const storeToRedis = async (
     // Main indexer: store all navigation trees
     navTreePromises = Object.entries(navigationTrees).map(
       async ([tab, navTree]) => {
-        const redisKey = `${options.branchId}/nav-tree:${tab}`;
+        const redisKey = `${options.branchId}:nav:${tab}.json`;
         let finalTree = navTree;
 
-        // Main indexer: preserve SDK references in wallets tab
-        if (tab === "wallets" && options.indexerType === "main") {
+        // Docs indexer: preserve SDK references in wallets tab
+        if (tab === "wallets" && options.indexerType === "docs") {
           const existingTree = await redis.get<NavigationTree>(redisKey);
-          finalTree = mergeWalletsNavTree(navTree, existingTree, "main");
+          finalTree = mergeWalletsNavTree(navTree, existingTree, "docs");
         }
 
         const itemCount = countItems(finalTree);

--- a/src/content-indexer/utils/nav-tree-merge.ts
+++ b/src/content-indexer/utils/nav-tree-merge.ts
@@ -44,13 +44,13 @@ export const separateSDKAndManualSections = (
  *
  * @param newTree - New sections from current indexer run
  * @param existingTree - Existing wallets navigation tree from Redis (or null if none)
- * @param indexerType - Type of indexer: "sdk" means newTree is SDK refs, "main" means newTree is manual content
+ * @param indexerType - Type of indexer: "sdk" means newTree is SDK refs, "docs" means newTree is manual content
  * @returns Merged tree with manual sections + SDK sections at second-to-last position
  */
 export const mergeWalletsNavTree = (
   newTree: NavigationTree,
   existingTree: NavigationTree | null,
-  indexerType: "main" | "sdk",
+  indexerType: "docs" | "sdk",
 ): NavigationTree => {
   if (!existingTree) {
     if (indexerType === "sdk") {
@@ -66,11 +66,11 @@ export const mergeWalletsNavTree = (
     separateSDKAndManualSections(existingTree);
 
   // Determine which sections are new and which to preserve
-  const manualSections = indexerType === "main" ? newTree : existingManual;
+  const manualSections = indexerType === "docs" ? newTree : existingManual;
   const sdkSections = indexerType === "sdk" ? newTree : existingSDK;
 
   // Log preservation info
-  if (indexerType === "main" && sdkSections.length > 0) {
+  if (indexerType === "docs" && sdkSections.length > 0) {
     console.info(
       `📖 Preserved ${sdkSections.length} SDK reference section(s) in wallets nav tree`,
     );


### PR DESCRIPTION
## Description

Initially we didn't have a clear strategy for the redis cache keys, and so the formats ended up being all over the place. This makes them much more consistent and easy to search for/understand.

## Changes
- Refactors redis cache keys to use standard colon delimiter in content-indexer
- Fix bug in revalidation trigger that missed changelog changes
- Removed empty aa-sdk page

## Key Format Changes

### 1. Path Indices (.json)
```
Before: main/path-index:main, main/path-index:sdk, main/path-index:changelog
After:  main:index:docs.json, main:index:sdk.json, main:index:changelog.json

Note: Renamed "main" indexer to "docs" for clarity and consistency
```

### 2. Navigation Trees (.json)
```
Before: main/nav-wallets.json, main/nav-apis.json
After:  main:nav:wallets.json, main:nav:apis.json
```

### 3. MDX Content (.mdx)
```
Before: main/pages/wallets/overview.mdx
After:  main:mdx:pages/wallets/overview.mdx
```

### 4. Changelog (.md)
```
Before: main/changelog/2025-11-20.md
After:  main:changelog:2025-11-20.md
```

### 5. API Specifications
```
Before: openrpc-spec:https://example.com/spec.json
After:  main:openrpc-spec:https://example.com/spec.json

Before: openapi-spec:https://example.com/spec.json
After:  main:openapi-spec:https://example.com/spec.json
```

## Testing

<!-- Describe the tests that you ran to verify your changes -->

* \[ ] I have tested these changes locally
* \[ ] I have run the validation scripts (`pnpm run validate`)
* \[ ] I have checked that the documentation builds correctly
