### PR TITLE
refactor: unify algolia records into a single index

### DIFF
--- a/src/content-indexer/README.md
+++ b/src/content-indexer/README.md
@@ -22,7 +22,7 @@ Indexes manual documentation content from the local `docs` repository.
 * **Updates**:
   * `{branch}/path-index:main` (Redis, 30-day TTL for preview branches)
   * `{branch}/nav-tree:{tab}` for all tabs (Redis, 30-day TTL for preview branches)
-  * `{branch}_alchemy_docs` (Algolia, production mode only)
+  * `{branch}_alchemy_docs` (Algolia, production mode only - updates records where `indexerType:docs`)
 
 ### 2. SDK Indexer (`pnpm index:sdk`)
 
@@ -33,7 +33,7 @@ Indexes SDK reference documentation from the `aa-sdk` repository.
 * **Updates**:
   * `{branch}/path-index:sdk` (Redis)
   * `{branch}/nav-tree:wallets` (Redis, merged with existing manual content)
-  * `{branch}_alchemy_docs_sdk` (Algolia)
+  * `{branch}_alchemy_docs` (Algolia - updates records where `indexerType:sdk`)
 
 ### 3. Changelog Indexer (`pnpm index:changelog`)
 
@@ -44,7 +44,7 @@ Indexes changelog entries from date-based markdown files.
 * **Updates**:
   * `{branch}/path-index:changelog` (Redis)
   * No navigation tree (changelogs don't have a sidebar)
-  * `{branch}_alchemy_docs_changelog` (Algolia)
+  * `{branch}_alchemy_docs` (Algolia - updates records where `indexerType:changelog`)
 
 ## Key Outputs
 
@@ -156,13 +156,11 @@ Redis (with TTL for preview branches):
 - feature-abc/path-index:main (30-day TTL)
 - feature-abc/nav-tree:wallets (30-day TTL)
 
-Algolia (production mode only):
-- main_alchemy_docs
-- main_alchemy_docs_sdk
-- main_alchemy_docs_changelog
+Algolia (production mode only, unified index per branch):
+- main_alchemy_docs (contains all content types with indexerType field)
 
-Note: Preview branches do NOT create Algolia indices.
-Preview environments use production search indices.
+Note: Each indexer updates only its own records (filtered by indexerType) in the unified index.
+Preview branches use production Algolia indices for search.
 ```
 
 ### Wallets Navigation Tree Merging
@@ -213,18 +211,21 @@ All Algolia records automatically have markdown syntax stripped using the `remov
 ### Stable ObjectIDs for Algolia
 
 Algolia requires unique `objectID` for each record. We generate deterministic
-hashes (SHA-256, first 16 chars) from URL paths:
+hashes from URL paths:
 
-* **All pages (MDX and API methods)**: Hash of the URL path (e.g., hash of
-  `"reference/eth-getbalance"`)
+* **All pages (MDX and API methods)**: SHA-256 hash of the URL path (first 16 chars)
+  * Example: `a3f2c8e1b9d4f6a7`
   * Uniqueness: URLs are guaranteed unique by the routing system
-  * Stability: Paths are designed to be stable. Changes happen but infrequently
-  * Enables incremental index updates in the future
-  * Generates clean IDs like `"a3f2c8e1b9d4f6a7"`
+  * Stability: Paths are designed to be stable (SEO, bookmarks, external links)
+  * Enables partial index updates via `indexerType` field filtering
 
-**Why path-based?** Paths are the web's natural unique identifier and are specifically
-designed to be stable. Unlike titles or breadcrumbs, URL changes are typically
-rare and intentional (considered breaking changes for SEO and bookmarks).
+**IndexerType Field:** Each record includes an `indexerType` field (e.g., "docs", "sdk",
+"changelog") to enable targeted deletion and updates. This allows multiple indexers to
+write to a single unified index without conflicts.
+
+**Why path-based hashes?** Paths are the web's natural unique identifier and are
+specifically designed to be stable. Unlike titles or breadcrumbs, URL changes are
+typically rare and intentional (considered breaking changes for SEO and bookmarks).
 
 **Why hashes?** Provides compact, opaque identifiers that don't expose internal
 structure while maintaining the URL's uniqueness guarantee.
@@ -261,27 +262,35 @@ feature-xyz/path-index:main → Preview branch
 
 This allows preview deployments to have independent data without interfering with production.
 
-### 4. Separate Algolia Indices
+### 4. Unified Algolia Index with IndexerType Field
 
-Main, SDK, and changelog content use separate Algolia indices:
+All content types (docs, SDK, changelog) write to a single Algolia index per branch:
 
 ```text
-- main_alchemy_docs
-- main_alchemy_docs_sdk
-- main_alchemy_docs_changelog
+- main_alchemy_docs (contains all content types)
 ```
 
-**Why?** Each indexer runs independently, so separate indices allow atomic updates without affecting other content. The frontend searches all indices simultaneously using Algolia's multi-index feature.
+**IndexerType Field:** Each record has an `indexerType` field for targeted updates:
 
-### 5. Atomic Index Swap for Algolia
+* `indexerType: "docs"` for main documentation
+* `indexerType: "sdk"` for SDK references
+* `indexerType: "changelog"` for changelog entries
 
-Each indexer fully replaces its Algolia index on every run using atomic swap:
+**ObjectID Format:** Simple hash of URL path (e.g., `a3f2c8e1b9d4f6a7`)
 
-1. Upload to temporary index
-2. Copy settings from production
-3. Atomic move (replace production with temp)
+**Why?** Allows multiple independent indexers to write to the same index without conflicts. Each indexer can update only its own records by filtering on `indexerType:docs`, etc.
 
-**Why?** Our objectIDs are content-based. When files move or are renamed, we generate new IDs, leaving old records orphaned. Full replacement ensures the index is always clean and up-to-date with zero search downtime.
+### 5. Delete-Then-Upload Strategy for Algolia
+
+Each indexer updates only its own records in the unified index:
+
+1. Delete all records matching the indexer type (e.g., `indexerType:docs`)
+2. Upload new records with the same indexerType
+3. Measure and log downtime (gap when records are unavailable)
+
+**Why?** Enables partial index updates without affecting other content types. Simpler than atomic swap and uses similar API operations. Brief downtime is measured and logged to monitor performance.
+
+**Downtime Monitoring:** Each upload logs the gap between delete completion and upload start (when records are unavailable to users). Warning shown if downtime exceeds 5 seconds.
 
 ### 6. Markdown Stripping for Search
 

--- a/src/content-indexer/__tests__/index.test.ts
+++ b/src/content-indexer/__tests__/index.test.ts
@@ -81,6 +81,7 @@ describe("buildDocsContentIndex", () => {
     const result = await buildDocsContentIndex({
       source: { type: "filesystem", basePath: "/test/fern" },
       branchId: "test-branch",
+      indexerType: "docs",
       mode: "preview",
     });
 
@@ -93,6 +94,7 @@ describe("buildDocsContentIndex", () => {
     expect(buildAllOutputs).toHaveBeenCalledWith(
       expect.any(Object),
       mockCache,
+      "docs",
       undefined,
     );
 
@@ -131,13 +133,15 @@ describe("buildDocsContentIndex", () => {
       },
       stripPathPrefix: "wallets/",
       branchId: "main",
+      indexerType: "sdk",
       mode: "production",
     });
 
-    // Verify stripPathPrefix was passed to buildAllOutputs
+    // Verify indexerType and stripPathPrefix were passed to buildAllOutputs
     expect(buildAllOutputs).toHaveBeenCalledWith(
       expect.any(Object),
       expect.any(ContentCache),
+      "sdk",
       "wallets/",
     );
   });

--- a/src/content-indexer/collectors/__tests__/algolia.test.ts
+++ b/src/content-indexer/collectors/__tests__/algolia.test.ts
@@ -78,7 +78,7 @@ describe("AlgoliaCollector", () => {
 
     const records = collector.getRecords();
     expect(records[0].objectID).toBeDefined();
-    expect(records[0].objectID).toMatch(/^[a-f0-9]{16}$/); // Format: hash of 16 chars
+    expect(records[0].objectID).toMatch(/^[a-f0-9]{16}$/); // SHA-256 hash (first 16 chars)
     expect(typeof records[0].objectID).toBe("string");
     expect(records[0].indexerType).toBe("docs");
   });

--- a/src/content-indexer/collectors/__tests__/algolia.test.ts
+++ b/src/content-indexer/collectors/__tests__/algolia.test.ts
@@ -4,12 +4,12 @@ import { AlgoliaCollector } from "../algolia.ts";
 
 describe("AlgoliaCollector", () => {
   test("should initialize with empty records", () => {
-    const collector = new AlgoliaCollector();
+    const collector = new AlgoliaCollector("docs");
     expect(collector.getRecords()).toEqual([]);
   });
 
   test("should add Guide record without httpMethod", () => {
-    const collector = new AlgoliaCollector();
+    const collector = new AlgoliaCollector("docs");
     collector.addRecord({
       pageType: "Guide",
       path: "guides/quickstart",
@@ -32,10 +32,11 @@ describe("AlgoliaCollector", () => {
     expect(records[0].title).toBe("Quickstart Guide");
     expect(records[0].breadcrumbs).toEqual(["Guides", "Getting Started"]);
     expect(records[0].httpMethod).toBeUndefined();
+    expect(records[0].indexerType).toBe("docs");
   });
 
   test("should add API Method record with httpMethod", () => {
-    const collector = new AlgoliaCollector();
+    const collector = new AlgoliaCollector("sdk");
     collector.addRecord({
       pageType: "API Method",
       path: "reference/eth-getbalance",
@@ -58,10 +59,11 @@ describe("AlgoliaCollector", () => {
     expect(records[0].pageType).toBe("API Method");
     expect(records[0].httpMethod).toBe("POST");
     expect(records[0].breadcrumbs).toEqual(["NFT API", "NFT API Endpoints"]);
+    expect(records[0].indexerType).toBe("sdk");
   });
 
   test("should generate stable objectID from path", () => {
-    const collector = new AlgoliaCollector();
+    const collector = new AlgoliaCollector("docs");
     collector.addRecord({
       pageType: "API Method",
       path: "reference/eth-getbalance",
@@ -76,12 +78,13 @@ describe("AlgoliaCollector", () => {
 
     const records = collector.getRecords();
     expect(records[0].objectID).toBeDefined();
-    expect(records[0].objectID).toHaveLength(16); // SHA-256 hash first 16 chars
+    expect(records[0].objectID).toMatch(/^[a-f0-9]{16}$/); // Format: hash of 16 chars
     expect(typeof records[0].objectID).toBe("string");
+    expect(records[0].indexerType).toBe("docs");
   });
 
   test("should filter out link breadcrumbs", () => {
-    const collector = new AlgoliaCollector();
+    const collector = new AlgoliaCollector("docs");
     collector.addRecord({
       pageType: "Guide",
       path: "guides/quickstart",
@@ -105,7 +108,7 @@ describe("AlgoliaCollector", () => {
   });
 
   test("should handle multiple records", () => {
-    const collector = new AlgoliaCollector();
+    const collector = new AlgoliaCollector("changelog");
     collector.addRecord({
       pageType: "Guide",
       path: "guides/quickstart",
@@ -124,10 +127,12 @@ describe("AlgoliaCollector", () => {
 
     const records = collector.getRecords();
     expect(records).toHaveLength(2);
+    expect(records[0].indexerType).toBe("changelog");
+    expect(records[1].indexerType).toBe("changelog");
   });
 
   test("should handle empty breadcrumbs", () => {
-    const collector = new AlgoliaCollector();
+    const collector = new AlgoliaCollector("docs");
     collector.addRecord({
       pageType: "Guide",
       path: "guides/quickstart",
@@ -138,12 +143,13 @@ describe("AlgoliaCollector", () => {
 
     const records = collector.getRecords();
     expect(records[0].breadcrumbs).toEqual([]);
-    // ObjectID should still be generated (using path)
+    // ObjectID should still be generated (using path hash)
     expect(records[0].objectID).toBeDefined();
+    expect(records[0].objectID).toMatch(/^[a-f0-9]{16}$/);
   });
 
-  test("should generate consistent objectID for same path", () => {
-    const collector1 = new AlgoliaCollector();
+  test("should generate consistent objectID for same path and indexer type", () => {
+    const collector1 = new AlgoliaCollector("docs");
     collector1.addRecord({
       pageType: "API Method",
       path: "reference/eth-getbalance",
@@ -156,7 +162,7 @@ describe("AlgoliaCollector", () => {
       ],
     });
 
-    const collector2 = new AlgoliaCollector();
+    const collector2 = new AlgoliaCollector("docs");
     collector2.addRecord({
       pageType: "API Method",
       path: "reference/eth-getbalance", // Same path
@@ -170,12 +176,12 @@ describe("AlgoliaCollector", () => {
 
     const records1 = collector1.getRecords();
     const records2 = collector2.getRecords();
-    // Same path should generate same objectID, regardless of other metadata
+    // Same path and indexer type should generate same objectID, regardless of other metadata
     expect(records1[0].objectID).toBe(records2[0].objectID);
   });
 
   test("should generate different objectIDs for different paths", () => {
-    const collector = new AlgoliaCollector();
+    const collector = new AlgoliaCollector("docs");
     collector.addRecord({
       pageType: "API Method",
       path: "reference/eth-getbalance",
@@ -202,5 +208,36 @@ describe("AlgoliaCollector", () => {
     const records = collector.getRecords();
     // Different paths should generate different objectIDs, even with same title/breadcrumbs
     expect(records[0].objectID).not.toBe(records[1].objectID);
+  });
+
+  test("should generate same objectID for same path across different indexer types", () => {
+    const docsCollector = new AlgoliaCollector("docs");
+    docsCollector.addRecord({
+      pageType: "Guide",
+      path: "guides/quickstart",
+      title: "Quickstart",
+      content: "Content",
+      breadcrumbs: [],
+    });
+
+    const sdkCollector = new AlgoliaCollector("sdk");
+    sdkCollector.addRecord({
+      pageType: "Guide",
+      path: "guides/quickstart", // Same path
+      title: "Quickstart",
+      content: "Content",
+      breadcrumbs: [],
+    });
+
+    const docsRecords = docsCollector.getRecords();
+    const sdkRecords = sdkCollector.getRecords();
+
+    // Same path generates same objectID, but indexerType differentiates them
+    expect(docsRecords[0].objectID).toBe(sdkRecords[0].objectID);
+    expect(docsRecords[0].indexerType).toBe("docs");
+    expect(sdkRecords[0].indexerType).toBe("sdk");
+
+    // indexerType field is what allows filtering/targeted updates
+    expect(docsRecords[0].indexerType).not.toBe(sdkRecords[0].indexerType);
   });
 });

--- a/src/content-indexer/collectors/__tests__/processing-context.test.ts
+++ b/src/content-indexer/collectors/__tests__/processing-context.test.ts
@@ -6,7 +6,7 @@ import { ProcessingContext } from "../processing-context.ts";
 
 describe("ProcessingContext", () => {
   test("should initialize with empty state", () => {
-    const context = new ProcessingContext();
+    const context = new ProcessingContext("docs");
     const results = context.getResults();
 
     expect(results.pathIndex).toEqual({});
@@ -15,7 +15,7 @@ describe("ProcessingContext", () => {
   });
 
   test("should add path index entry", () => {
-    const context = new ProcessingContext();
+    const context = new ProcessingContext("docs");
     context.addPathIndexEntry("guides/quickstart", {
       type: "mdx",
       filePath: "fern/guides/quickstart.mdx",
@@ -29,7 +29,7 @@ describe("ProcessingContext", () => {
   });
 
   test("should add navigation item", () => {
-    const context = new ProcessingContext();
+    const context = new ProcessingContext("docs");
     context.addNavigationItem("guides", {
       title: "Quickstart",
       path: "/guides/quickstart",
@@ -42,7 +42,7 @@ describe("ProcessingContext", () => {
   });
 
   test("should add Guide Algolia record", () => {
-    const context = new ProcessingContext();
+    const context = new ProcessingContext("docs");
     const breadcrumbs: NavItem[] = [
       { title: "Guides", path: "/guides", type: "section", children: [] },
     ];
@@ -59,10 +59,11 @@ describe("ProcessingContext", () => {
     expect(results.algoliaRecords).toHaveLength(1);
     expect(results.algoliaRecords[0].pageType).toBe("Guide");
     expect(results.algoliaRecords[0].httpMethod).toBeUndefined();
+    expect(results.algoliaRecords[0].indexerType).toBe("docs");
   });
 
   test("should add API Method Algolia record with httpMethod", () => {
-    const context = new ProcessingContext();
+    const context = new ProcessingContext("sdk");
     const breadcrumbs: NavItem[] = [
       { title: "API", path: "/api", type: "section", children: [] },
     ];
@@ -80,10 +81,11 @@ describe("ProcessingContext", () => {
     expect(results.algoliaRecords).toHaveLength(1);
     expect(results.algoliaRecords[0].pageType).toBe("API Method");
     expect(results.algoliaRecords[0].httpMethod).toBe("POST");
+    expect(results.algoliaRecords[0].indexerType).toBe("sdk");
   });
 
   test("should accumulate multiple outputs simultaneously", () => {
-    const context = new ProcessingContext();
+    const context = new ProcessingContext("docs");
 
     // Add path index
     context.addPathIndexEntry("guides/quickstart", {
@@ -116,7 +118,7 @@ describe("ProcessingContext", () => {
   });
 
   test("should return correct stats", () => {
-    const context = new ProcessingContext();
+    const context = new ProcessingContext("changelog");
 
     context.addPathIndexEntry("path1", {
       type: "mdx",
@@ -144,7 +146,7 @@ describe("ProcessingContext", () => {
   });
 
   test("should handle multiple tabs in navigation", () => {
-    const context = new ProcessingContext();
+    const context = new ProcessingContext("docs");
 
     context.addNavigationItem("guides", {
       title: "Guide1",

--- a/src/content-indexer/collectors/algolia.ts
+++ b/src/content-indexer/collectors/algolia.ts
@@ -1,7 +1,6 @@
-import { createHash } from "crypto";
-
 import type { AlgoliaRecord } from "@/content-indexer/types/algolia.ts";
 import type { NavItem } from "@/content-indexer/types/navigation.ts";
+import { generateHash } from "@/content-indexer/utils/generate-hash.ts";
 
 /**
  * Extracts breadcrumb titles from NavItems for Algolia.
@@ -56,7 +55,7 @@ export class AlgoliaCollector {
    */
   addRecord(params: AddRecordParams): void {
     const breadcrumbTitles = extractBreadcrumbTitles(params.breadcrumbs);
-    const objectID = this.generateHash(params.path);
+    const objectID = generateHash(params.path);
 
     this.records.push({
       objectID,
@@ -76,13 +75,5 @@ export class AlgoliaCollector {
    */
   getRecords(): AlgoliaRecord[] {
     return this.records;
-  }
-
-  /**
-   * Generate a stable hash-based objectID from a source string.
-   * Returns first 16 characters of SHA-256 hash for a clean ID format.
-   */
-  private generateHash(source: string): string {
-    return createHash("sha256").update(source).digest("hex").substring(0, 16);
   }
 }

--- a/src/content-indexer/collectors/algolia.ts
+++ b/src/content-indexer/collectors/algolia.ts
@@ -40,13 +40,19 @@ export class AlgoliaCollector {
   private records: AlgoliaRecord[] = [];
 
   /**
+   * @param indexerType - The indexer type to namespace objectIDs (e.g., "docs", "sdk", "changelog")
+   */
+  constructor(private indexerType: string) {}
+
+  /**
    * Add a search record for either MDX pages or API methods.
    *
    * ObjectID strategy:
    * Uses hash of the URL path for stable, unique identification.
    * - Uniqueness: URLs are guaranteed unique by the routing system
    * - Stability: Paths are designed to be stable (SEO, bookmarks, external links)
-   * - Enables incremental index updates in the future
+   * - indexerType field enables targeted deletion by indexer type
+   * - Enables partial index updates without affecting other indexer types
    */
   addRecord(params: AddRecordParams): void {
     const breadcrumbTitles = extractBreadcrumbTitles(params.breadcrumbs);
@@ -54,6 +60,7 @@ export class AlgoliaCollector {
 
     this.records.push({
       objectID,
+      indexerType: this.indexerType,
       path: params.path,
       pageType: params.pageType,
       title: params.title,

--- a/src/content-indexer/collectors/processing-context.ts
+++ b/src/content-indexer/collectors/processing-context.ts
@@ -27,9 +27,10 @@ export interface BuildAllOutputsResult {
  */
 export class ProcessingContext {
   constructor(
+    indexerType: string,
     private pathIndexCollector = new PathIndexCollector(),
     private navigationTreesCollector = new NavigationTreesCollector(),
-    private algoliaCollector = new AlgoliaCollector(),
+    private algoliaCollector = new AlgoliaCollector(indexerType),
   ) {}
 
   /**

--- a/src/content-indexer/core/__tests__/build-all-outputs.test.ts
+++ b/src/content-indexer/core/__tests__/build-all-outputs.test.ts
@@ -49,7 +49,7 @@ describe("buildAllOutputs", () => {
       },
     });
 
-    const result = buildAllOutputs(docsYml, cache);
+    const result = buildAllOutputs(docsYml, cache, "docs");
 
     // Verify visitor was called
     expect(visitNavigationItem).toHaveBeenCalled();
@@ -105,7 +105,7 @@ describe("buildAllOutputs", () => {
         },
       });
 
-    const result = buildAllOutputs(docsYml, cache);
+    const result = buildAllOutputs(docsYml, cache, "docs");
 
     // Verify both tabs were processed
     expect(visitNavigationItem).toHaveBeenCalledTimes(2);
@@ -137,7 +137,7 @@ describe("buildAllOutputs", () => {
       navItem: { type: "page", title: "Test", path: "/test" },
     });
 
-    buildAllOutputs(docsYml, cache);
+    buildAllOutputs(docsYml, cache, "docs");
 
     // Only the valid item should be processed
     expect(visitNavigationItem).toHaveBeenCalledTimes(1);
@@ -166,7 +166,7 @@ describe("buildAllOutputs", () => {
       indexEntries: {},
     });
 
-    buildAllOutputs(docsYml, cache);
+    buildAllOutputs(docsYml, cache, "sdk");
 
     // Verify visitor was called with correct path builder
     expect(visitNavigationItem).toHaveBeenCalledWith(
@@ -199,7 +199,7 @@ describe("buildAllOutputs", () => {
       indexEntries: {},
     });
 
-    buildAllOutputs(docsYml, cache);
+    buildAllOutputs(docsYml, cache, "docs");
 
     expect(visitNavigationItem).toHaveBeenCalled();
   });
@@ -225,7 +225,7 @@ describe("buildAllOutputs", () => {
       ],
     });
 
-    const result = buildAllOutputs(docsYml, cache);
+    const result = buildAllOutputs(docsYml, cache, "docs");
 
     // Both items should be added
     expect(result.navigationTrees.guides).toHaveLength(2);
@@ -263,9 +263,10 @@ describe("buildAllOutputs", () => {
       };
     });
 
-    const result = buildAllOutputs(docsYml, cache);
+    const result = buildAllOutputs(docsYml, cache, "docs");
 
     expect(result.algoliaRecords).toHaveLength(1);
     expect(result.algoliaRecords[0].title).toBe("Test");
+    expect(result.algoliaRecords[0].indexerType).toBe("docs");
   });
 });

--- a/src/content-indexer/core/build-all-outputs.ts
+++ b/src/content-indexer/core/build-all-outputs.ts
@@ -21,9 +21,10 @@ import { PathBuilder } from "./path-builder.ts";
 export const buildAllOutputs = (
   docsYml: DocsYml,
   contentCache: ContentCache,
+  indexerType: string,
   stripPathPrefix?: string,
 ): BuildAllOutputsResult => {
-  const context = new ProcessingContext();
+  const context = new ProcessingContext(indexerType);
 
   // Process each tab in docs.yml
   docsYml.navigation.forEach((navItem) => {

--- a/src/content-indexer/index.ts
+++ b/src/content-indexer/index.ts
@@ -68,6 +68,7 @@ const buildIndexResults = async (
           basePath: path.join(process.cwd(), "fern"),
         },
         branchId,
+        indexerType: "docs",
         mode,
       });
     case "sdk": {
@@ -79,6 +80,7 @@ const buildIndexResults = async (
         },
         stripPathPrefix: "wallets/",
         branchId,
+        indexerType: "sdk",
       });
       return {
         ...result,

--- a/src/content-indexer/indexers/changelog.ts
+++ b/src/content-indexer/indexers/changelog.ts
@@ -1,3 +1,4 @@
+import { createHash } from "crypto";
 import { promises as fs } from "fs";
 import path from "path";
 
@@ -86,6 +87,7 @@ export const buildChangelogIndex = async (
 
       // Build route: e.g., "2025/11/20"
       const route = `${year}/${Number(month)}/${Number(day)}`;
+      const fullPath = `changelog/${route}`;
 
       // Create path index entry
       const pathIndexEntry: ChangelogPathIndexEntry = {
@@ -94,13 +96,19 @@ export const buildChangelogIndex = async (
         filePath: filename, // Filename like "2025-12-11.md"
       };
 
+      // Generate hash-based objectID from path (consistent with docs/SDK)
+      const objectID = createHash("sha256")
+        .update(fullPath)
+        .digest("hex")
+        .substring(0, 16);
+
       // Create Algolia record
       const algoliaRecord = truncateRecord({
-        objectID: date, // Use date as objectID (e.g., "2025-01-20")
+        objectID,
         indexerType: "changelog",
         title: `Changelog - ${date}`,
         content, // Raw markdown - truncateRecord will clean it
-        path: `changelog/${route}`,
+        path: fullPath,
         pageType: "Changelog" as const,
         breadcrumbs: ["Changelog", date],
       });

--- a/src/content-indexer/indexers/changelog.ts
+++ b/src/content-indexer/indexers/changelog.ts
@@ -89,13 +89,15 @@ export const buildChangelogIndex = async (
 
       // Create path index entry
       const pathIndexEntry: ChangelogPathIndexEntry = {
+        type: "changelog",
         date, // ISO date string like "2025-12-11"
         filePath: filename, // Filename like "2025-12-11.md"
       };
 
       // Create Algolia record
       const algoliaRecord = truncateRecord({
-        objectID: `changelog-${date}`,
+        objectID: date, // Use date as objectID (e.g., "2025-01-20")
+        indexerType: "changelog",
         title: `Changelog - ${date}`,
         content, // Raw markdown - truncateRecord will clean it
         path: `changelog/${route}`,

--- a/src/content-indexer/indexers/main.ts
+++ b/src/content-indexer/indexers/main.ts
@@ -11,6 +11,7 @@ export interface DocsIndexerConfig {
   source: ContentSource;
   stripPathPrefix?: string;
   branchId: string;
+  indexerType: "docs" | "sdk";
   mode?: "preview" | "production"; // Only relevant for logging
 }
 
@@ -48,6 +49,7 @@ export const buildDocsContentIndex = async (
   const outputs = buildAllOutputs(
     docsYml,
     contentCache,
+    config.indexerType,
     config.stripPathPrefix,
   );
 

--- a/src/content-indexer/types/algolia.ts
+++ b/src/content-indexer/types/algolia.ts
@@ -3,7 +3,8 @@
  * Each record represents a searchable page (Guide or API method).
  */
 export interface AlgoliaRecord {
-  objectID: string; // Hash-based unique identifier - REQUIRED by Algolia
+  objectID: string; // Hash-based unique identifier (e.g., "a3f2c8e1b9d4f6a7") - REQUIRED by Algolia
+  indexerType: string; // Indexer type for filtering/targeted deletion (e.g., "docs", "sdk", "changelog")
   path: string; // Full pathname without leading slash (e.g., "reference/ethereum/eth-getbalance").
   pageType: "API Method" | "Guide" | "Changelog";
   title: string;

--- a/src/content-indexer/types/pathIndex.ts
+++ b/src/content-indexer/types/pathIndex.ts
@@ -22,6 +22,7 @@ export interface OpenApiPathIndexEntry {
 }
 
 export interface ChangelogPathIndexEntry {
+  type: "changelog";
   date: string; // ISO date string like "2025-12-11"
   filePath: string; // Filename like "2025-12-11.md"
 }

--- a/src/content-indexer/uploaders/algolia.ts
+++ b/src/content-indexer/uploaders/algolia.ts
@@ -76,14 +76,14 @@ export const uploadToAlgolia = async (
     const deleteEnd = performance.now();
 
     // 2. Upload new records
-    const uploadStart = performance.now();
     await client.saveObjects({
       indexName,
       objects: truncatedRecords as unknown as Array<Record<string, unknown>>,
     });
+    const uploadEnd = performance.now();
 
-    // 3. Calculate downtime (gap when records were unavailable)
-    const downtime = uploadStart - deleteEnd;
+    // 3. Calculate downtime (time records were unavailable)
+    const downtime = uploadEnd - deleteEnd;
 
     console.info(
       `   ✓ Complete (downtime: ${downtime.toFixed(0)}ms - records unavailable during delete→upload gap)`,

--- a/src/content-indexer/uploaders/algolia.ts
+++ b/src/content-indexer/uploaders/algolia.ts
@@ -7,41 +7,32 @@ import { truncateRecord } from "@/content-indexer/utils/truncate-record.ts";
 const ALGOLIA_INDEX_NAME_BASE = "alchemy_docs";
 
 /**
- * Builds an Algolia index name with branch and type scoping.
- * Pattern: {branchId}_{baseName}[_{indexerType}]
+ * Builds a unified Algolia index name with branch scoping.
+ * Pattern: {branchId}_{baseName}
+ *
+ * All indexer types (docs, sdk, changelog) write to the same index,
+ * differentiated by namespace-prefixed objectIDs (e.g., "docs:abc123").
  *
  * Examples:
- * - main_alchemy_docs (main branch, docs content)
- * - main_alchemy_docs_sdk (main branch, SDK content)
- * - abc_alchemy_docs (branch-abc, docs content)
- * - abc_alchemy_docs_sdk (branch-abc, SDK content)
+ * - main_alchemy_docs (main branch, all content types)
+ * - feature-xyz_alchemy_docs (feature branch, all content types)
  */
-const buildIndexName = (
-  base: string,
-  indexerType: IndexerType,
-  branchId: string,
-): string => {
-  const parts = [branchId, base];
-
-  // Add type suffix (except for docs content)
-  if (indexerType !== "docs") {
-    parts.push(indexerType);
-  }
-
-  return parts.join("_");
+const buildIndexName = (base: string, branchId: string): string => {
+  return `${branchId}_${base}`;
 };
 
 /**
- * Uploads records to Algolia using atomic index swap for zero-downtime updates.
+ * Uploads records to Algolia using delete-then-upload strategy with indexerType filtering.
  *
  * Process:
- * 1. Upload all records to a temporary index
- * 2. Copy settings/synonyms from production index (if exists)
- * 3. Atomically swap temp index to production
+ * 1. Delete all records matching the indexer type (e.g., indexerType:docs)
+ * 2. Upload new records with the same indexerType
+ * 3. Measure and log downtime (gap when records are unavailable)
  *
- * This ensures users never see empty search results during updates.
+ * This approach allows multiple indexers to write to a single unified index,
+ * with each indexer managing its own records via the indexerType field.
  *
- * @param records - Algolia records to upload
+ * @param records - Algolia records to upload (must have indexerType field)
  * @param options - Configuration options
  * @param options.indexerType - Type of indexer ("docs", "sdk", or "changelog")
  * @param options.branchId - Branch identifier for index naming (e.g., "main", "branch-abc")
@@ -64,59 +55,46 @@ export const uploadToAlgolia = async (
     return;
   }
 
-  const targetIndexName = buildIndexName(
-    ALGOLIA_INDEX_NAME_BASE,
-    options.indexerType,
-    options.branchId,
-  );
-
+  const indexName = buildIndexName(ALGOLIA_INDEX_NAME_BASE, options.branchId);
   const client = algoliasearch(appId, adminKey);
-  const tempIndexName = `${targetIndexName}_temp`;
 
   console.info(
-    `📤 Uploading ${records.length} records to Algolia (${targetIndexName})...`,
+    `📤 Uploading ${records.length} records to Algolia (${indexName}, indexerType:${options.indexerType})...`,
   );
 
   // Truncate records to fit Algolia's 100KB limit
   const truncatedRecords = records.map(truncateRecord);
 
   try {
-    // 1. Upload all records to temporary index
+    // 1. Delete all records with matching indexerType to ensure no orphaned records
+    await client.deleteBy({
+      indexName,
+      deleteByParams: {
+        filters: `indexerType:${options.indexerType}`,
+      },
+    });
+    const deleteEnd = performance.now();
+
+    // 2. Upload new records
+    const uploadStart = performance.now();
     await client.saveObjects({
-      indexName: tempIndexName,
+      indexName,
       objects: truncatedRecords as unknown as Array<Record<string, unknown>>,
     });
 
-    console.info(`   ✓ Uploaded ${records.length} records to ${tempIndexName}`);
+    // 3. Calculate downtime (gap when records were unavailable)
+    const downtime = uploadStart - deleteEnd;
 
-    // 2. Copy settings/synonyms from production index (if it exists)
-    try {
-      await client.operationIndex({
-        indexName: targetIndexName,
-        operationIndexParams: {
-          operation: "copy",
-          destination: tempIndexName,
-          scope: ["settings", "synonyms", "rules"],
-        },
-      });
-      console.info("   ✓ Copied settings from production index");
-    } catch (_error) {
-      console.info(
-        "   ℹ️  No existing production index found (might be first run)",
+    console.info(
+      `   ✓ Complete (downtime: ${downtime.toFixed(0)}ms - records unavailable during delete→upload gap)`,
+    );
+
+    // Warn if downtime is significant
+    if (downtime > 5000) {
+      console.warn(
+        `   ⚠️  High downtime (${(downtime / 1000).toFixed(1)}s). Consider atomic index swap for zero-downtime updates.`,
       );
     }
-
-    // 3. Atomic swap: move temp index to production
-    console.info(`   🔄 Swapping ${tempIndexName} → ${targetIndexName}...`);
-    await client.operationIndex({
-      indexName: tempIndexName,
-      operationIndexParams: {
-        operation: "move",
-        destination: targetIndexName,
-      },
-    });
-
-    console.info(`✅ Successfully updated Algolia index: ${targetIndexName}`);
   } catch (error) {
     console.error("❌ Failed to upload to Algolia:", error);
     throw error;

--- a/src/content-indexer/utils/__tests__/truncate-record.test.ts
+++ b/src/content-indexer/utils/__tests__/truncate-record.test.ts
@@ -8,6 +8,7 @@ describe("truncateRecord", () => {
   test("should return record unchanged if under size limit", () => {
     const record: AlgoliaRecord = {
       objectID: "abc123",
+      indexerType: "docs",
       path: "guides/quickstart",
       pageType: "Guide",
       title: "Quickstart",
@@ -25,6 +26,7 @@ describe("truncateRecord", () => {
     const largeContent = "x".repeat(150_000);
     const record: AlgoliaRecord = {
       objectID: "abc123",
+      indexerType: "docs",
       path: "guides/large",
       pageType: "Guide",
       title: "Large Page",
@@ -45,6 +47,7 @@ describe("truncateRecord", () => {
     const largeContent = "x".repeat(150_000);
     const record: AlgoliaRecord = {
       objectID: "abc123",
+      indexerType: "sdk",
       path: "reference/method",
       pageType: "API Method",
       title: "eth_getBalance",
@@ -65,6 +68,7 @@ describe("truncateRecord", () => {
   test("should throw error if overhead is too large", () => {
     const record: AlgoliaRecord = {
       objectID: "abc123",
+      indexerType: "docs",
       path: "guides/test",
       pageType: "Guide",
       title: "Test",
@@ -83,6 +87,7 @@ describe("truncateRecord", () => {
     const largeContent = "x".repeat(150_000);
     const record: AlgoliaRecord = {
       objectID: "abc123",
+      indexerType: "changelog",
       path: "guides/large",
       pageType: "Guide",
       title: "Large Page",
@@ -107,6 +112,7 @@ describe("truncateRecord", () => {
 
     const record: AlgoliaRecord = {
       objectID: "abc",
+      indexerType: "docs",
       path: "path",
       pageType: "Guide",
       title: "Title",

--- a/src/content-indexer/utils/generate-hash.ts
+++ b/src/content-indexer/utils/generate-hash.ts
@@ -1,0 +1,16 @@
+import { createHash } from "crypto";
+
+/**
+ * Generate a deterministic SHA-256 hash from a source string.
+ * Returns first 16 characters of the hash for compact, unique identifiers.
+ *
+ * @param source - Source string to hash
+ * @returns First 16 characters of SHA-256 hash (e.g., "a3f2c8e1b9d4f6a7")
+ *
+ * @example
+ * generateHash("guides/quickstart") // "3f9f805081534e21"
+ * generateHash("changelog/2025/1/20") // "c5f4e0d3b6a9f8c7"
+ */
+export function generateHash(source: string): string {
+  return createHash("sha256").update(source).digest("hex").substring(0, 16);
+}

--- a/src/content-indexer/visitors/__tests__/index.test.ts
+++ b/src/content-indexer/visitors/__tests__/index.test.ts
@@ -9,7 +9,7 @@ import { visitNavigationItem } from "../index.ts";
 
 describe("visitNavigationItem dispatcher", () => {
   test("should route page config to visitPage", () => {
-    const context = new ProcessingContext();
+    const context = new ProcessingContext("docs");
     const result = visitNavigationItem({
       item: {
         page: "Quickstart",
@@ -28,7 +28,7 @@ describe("visitNavigationItem dispatcher", () => {
   });
 
   test("should route link config to visitLink", () => {
-    const context = new ProcessingContext();
+    const context = new ProcessingContext("docs");
     const result = visitNavigationItem({
       item: {
         link: "External",
@@ -47,7 +47,7 @@ describe("visitNavigationItem dispatcher", () => {
   });
 
   test("should route section config to visitSection", () => {
-    const context = new ProcessingContext();
+    const context = new ProcessingContext("docs");
     const result = visitNavigationItem({
       item: {
         section: "Getting Started",
@@ -71,7 +71,7 @@ describe("visitNavigationItem dispatcher", () => {
   });
 
   test("should skip changelog config", () => {
-    const context = new ProcessingContext();
+    const context = new ProcessingContext("docs");
     const result = visitNavigationItem({
       item: {
         changelog: "CHANGELOG.md",
@@ -89,7 +89,7 @@ describe("visitNavigationItem dispatcher", () => {
   });
 
   test("should handle API config routing", () => {
-    const context = new ProcessingContext();
+    const context = new ProcessingContext("docs");
     const cache = new ContentCache();
 
     // Add a mock spec to cache

--- a/src/content-indexer/visitors/__tests__/visit-api-reference.test.ts
+++ b/src/content-indexer/visitors/__tests__/visit-api-reference.test.ts
@@ -12,7 +12,7 @@ import { visitApiReference } from "../visit-api-reference.ts";
 
 describe("visitApiReference", () => {
   test("should return empty result if spec not in cache", () => {
-    const context = new ProcessingContext();
+    const context = new ProcessingContext("docs");
     const cache = new ContentCache();
 
     const result = visitApiReference({
@@ -33,7 +33,7 @@ describe("visitApiReference", () => {
   });
 
   test("should process OpenAPI spec", () => {
-    const context = new ProcessingContext();
+    const context = new ProcessingContext("docs");
     const cache = new ContentCache();
 
     cache.setSpec("ethereum-api", {
@@ -71,7 +71,7 @@ describe("visitApiReference", () => {
   });
 
   test("should process OpenRPC spec", () => {
-    const context = new ProcessingContext();
+    const context = new ProcessingContext("docs");
     const cache = new ContentCache();
 
     cache.setSpec("solana-api", {
@@ -108,7 +108,7 @@ describe("visitApiReference", () => {
   });
 
   test("should use custom slug for API", () => {
-    const context = new ProcessingContext();
+    const context = new ProcessingContext("docs");
     const cache = new ContentCache();
 
     cache.setSpec("ethereum-api", {
@@ -145,7 +145,7 @@ describe("visitApiReference", () => {
   });
 
   test("should skip slug if skip-slug is true", () => {
-    const context = new ProcessingContext();
+    const context = new ProcessingContext("docs");
     const cache = new ContentCache();
 
     cache.setSpec("ethereum-api", {
@@ -183,7 +183,7 @@ describe("visitApiReference", () => {
   });
 
   test("should return no nav for hidden API", () => {
-    const context = new ProcessingContext();
+    const context = new ProcessingContext("docs");
     const cache = new ContentCache();
 
     cache.setSpec("ethereum-api", {
@@ -220,7 +220,7 @@ describe("visitApiReference", () => {
   });
 
   test("should flatten API structure if flattened is true", () => {
-    const context = new ProcessingContext();
+    const context = new ProcessingContext("docs");
     const cache = new ContentCache();
 
     cache.setSpec("ethereum-api", {

--- a/src/content-indexer/visitors/__tests__/visit-link.test.ts
+++ b/src/content-indexer/visitors/__tests__/visit-link.test.ts
@@ -8,7 +8,7 @@ import { visitLink } from "../visit-link.ts";
 
 describe("visitLink", () => {
   test("should create link nav item", () => {
-    const context = new ProcessingContext();
+    const context = new ProcessingContext("docs");
     const result = visitLink({
       item: {
         link: "External Resource",
@@ -31,7 +31,7 @@ describe("visitLink", () => {
   });
 
   test("should not add path index entries for links", () => {
-    const context = new ProcessingContext();
+    const context = new ProcessingContext("docs");
     const result = visitLink({
       item: {
         link: "GitHub",
@@ -50,7 +50,7 @@ describe("visitLink", () => {
   });
 
   test("should preserve exact link title and href", () => {
-    const context = new ProcessingContext();
+    const context = new ProcessingContext("docs");
     const result = visitLink({
       item: {
         link: "API Reference (External)",

--- a/src/content-indexer/visitors/__tests__/visit-page.test.ts
+++ b/src/content-indexer/visitors/__tests__/visit-page.test.ts
@@ -8,7 +8,7 @@ import { visitPage } from "../visit-page.ts";
 
 describe("visitPage", () => {
   test("should create path index entry for page", () => {
-    const context = new ProcessingContext();
+    const context = new ProcessingContext("docs");
     const cache = new ContentCache();
 
     const result = visitPage({
@@ -33,7 +33,7 @@ describe("visitPage", () => {
   });
 
   test("should create nav item for visible page", () => {
-    const context = new ProcessingContext();
+    const context = new ProcessingContext("docs");
     const cache = new ContentCache();
 
     const result = visitPage({
@@ -57,7 +57,7 @@ describe("visitPage", () => {
   });
 
   test("should skip nav item for hidden page", () => {
-    const context = new ProcessingContext();
+    const context = new ProcessingContext("docs");
     const cache = new ContentCache();
 
     const result = visitPage({
@@ -79,7 +79,7 @@ describe("visitPage", () => {
   });
 
   test("should use custom slug if provided", () => {
-    const context = new ProcessingContext();
+    const context = new ProcessingContext("docs");
     const cache = new ContentCache();
 
     const result = visitPage({
@@ -108,7 +108,7 @@ describe("visitPage", () => {
   });
 
   test("should use frontmatter slug if available", () => {
-    const context = new ProcessingContext();
+    const context = new ProcessingContext("docs");
     const cache = new ContentCache();
 
     cache.setMdxContent("fern/guides/quickstart.mdx", {
@@ -132,14 +132,16 @@ describe("visitPage", () => {
       navigationAncestors: [],
     });
 
-    expect(result.indexEntries["custom/frontmatter/path"]).toBeDefined();
-    expect(result.indexEntries["custom/frontmatter/path"].source).toBe(
-      "frontmatter",
-    );
+    const entry = result.indexEntries["custom/frontmatter/path"];
+    expect(entry).toBeDefined();
+    expect(entry.type).toBe("mdx");
+    if (entry.type === "mdx") {
+      expect(entry.source).toBe("frontmatter");
+    }
   });
 
   test("should add Algolia record if content cached and not hidden", () => {
-    const context = new ProcessingContext();
+    const context = new ProcessingContext("docs");
     const cache = new ContentCache();
 
     cache.setMdxContent("fern/guides/quickstart.mdx", {
@@ -177,7 +179,7 @@ describe("visitPage", () => {
   });
 
   test("should fallback to page name for Algolia title if no frontmatter title", () => {
-    const context = new ProcessingContext();
+    const context = new ProcessingContext("docs");
     const cache = new ContentCache();
 
     cache.setMdxContent("fern/guides/quickstart.mdx", {
@@ -203,7 +205,7 @@ describe("visitPage", () => {
   });
 
   test("should not add Algolia record if content not cached", () => {
-    const context = new ProcessingContext();
+    const context = new ProcessingContext("docs");
     const cache = new ContentCache();
 
     visitPage({
@@ -224,7 +226,7 @@ describe("visitPage", () => {
   });
 
   test("should not add Algolia record if page is hidden", () => {
-    const context = new ProcessingContext();
+    const context = new ProcessingContext("docs");
     const cache = new ContentCache();
 
     cache.setMdxContent("fern/guides/hidden.mdx", {

--- a/src/content-indexer/visitors/__tests__/visit-section.test.ts
+++ b/src/content-indexer/visitors/__tests__/visit-section.test.ts
@@ -9,7 +9,7 @@ import { visitSection } from "../visit-section.ts";
 
 describe("visitSection", () => {
   test("should create section nav item with children", () => {
-    const context = new ProcessingContext();
+    const context = new ProcessingContext("docs");
     const cache = new ContentCache();
 
     const result = visitSection(
@@ -47,7 +47,7 @@ describe("visitSection", () => {
   });
 
   test("should process all child items", () => {
-    const context = new ProcessingContext();
+    const context = new ProcessingContext("docs");
     const cache = new ContentCache();
 
     const result = visitSection(
@@ -87,7 +87,7 @@ describe("visitSection", () => {
   });
 
   test("should handle section with overview page", () => {
-    const context = new ProcessingContext();
+    const context = new ProcessingContext("docs");
     const cache = new ContentCache();
 
     cache.setMdxContent("fern/guides/overview.mdx", {
@@ -123,7 +123,7 @@ describe("visitSection", () => {
   });
 
   test("should use custom slug if provided", () => {
-    const context = new ProcessingContext();
+    const context = new ProcessingContext("docs");
     const cache = new ContentCache();
 
     const result = visitSection(
@@ -152,7 +152,7 @@ describe("visitSection", () => {
   });
 
   test("should skip slug if skip-slug is true", () => {
-    const context = new ProcessingContext();
+    const context = new ProcessingContext("docs");
     const cache = new ContentCache();
 
     const result = visitSection(
@@ -182,7 +182,7 @@ describe("visitSection", () => {
   });
 
   test("should handle hidden section", () => {
-    const context = new ProcessingContext();
+    const context = new ProcessingContext("docs");
     const cache = new ContentCache();
 
     const result = visitSection(
@@ -213,7 +213,7 @@ describe("visitSection", () => {
   });
 
   test("should recursively process nested sections", () => {
-    const context = new ProcessingContext();
+    const context = new ProcessingContext("docs");
     const cache = new ContentCache();
 
     const result = visitSection(
@@ -249,7 +249,7 @@ describe("visitSection", () => {
   });
 
   test("should add section to breadcrumbs for children", () => {
-    const context = new ProcessingContext();
+    const context = new ProcessingContext("docs");
     const cache = new ContentCache();
 
     cache.setMdxContent("fern/guides/quickstart.mdx", {
@@ -284,7 +284,7 @@ describe("visitSection", () => {
   });
 
   test("should handle section with mix of pages and subsections", () => {
-    const context = new ProcessingContext();
+    const context = new ProcessingContext("docs");
     const cache = new ContentCache();
 
     const result = visitSection(

--- a/src/content-indexer/visitors/processors/__tests__/process-openapi.test.ts
+++ b/src/content-indexer/visitors/processors/__tests__/process-openapi.test.ts
@@ -9,7 +9,7 @@ import { processOpenApiSpec } from "../process-openapi.ts";
 
 describe("processOpenApiSpec", () => {
   test("should process operations and create index entries", () => {
-    const context = new ProcessingContext();
+    const context = new ProcessingContext("docs");
 
     const result = processOpenApiSpec({
       spec: openApiSpecFactory({
@@ -53,7 +53,7 @@ describe("processOpenApiSpec", () => {
   });
 
   test("should group operations by tag", () => {
-    const context = new ProcessingContext();
+    const context = new ProcessingContext("docs");
 
     const result = processOpenApiSpec({
       spec: openApiSpecFactory({
@@ -106,7 +106,7 @@ describe("processOpenApiSpec", () => {
   });
 
   test("should use summary as operation title", () => {
-    const context = new ProcessingContext();
+    const context = new ProcessingContext("docs");
 
     processOpenApiSpec({
       spec: openApiSpecFactory({
@@ -141,7 +141,7 @@ describe("processOpenApiSpec", () => {
   });
 
   test("should fallback to operationId for title if no summary", () => {
-    const context = new ProcessingContext();
+    const context = new ProcessingContext("docs");
 
     processOpenApiSpec({
       spec: openApiSpecFactory({
@@ -175,7 +175,7 @@ describe("processOpenApiSpec", () => {
   });
 
   test("should include tag in path if tag exists", () => {
-    const context = new ProcessingContext();
+    const context = new ProcessingContext("docs");
 
     const result = processOpenApiSpec({
       spec: openApiSpecFactory({
@@ -209,7 +209,7 @@ describe("processOpenApiSpec", () => {
   });
 
   test("should add Algolia records with breadcrumbs", () => {
-    const context = new ProcessingContext();
+    const context = new ProcessingContext("docs");
 
     processOpenApiSpec({
       spec: openApiSpecFactory({
@@ -252,7 +252,7 @@ describe("processOpenApiSpec", () => {
   });
 
   test("should not add Algolia records if hidden", () => {
-    const context = new ProcessingContext();
+    const context = new ProcessingContext("docs");
 
     processOpenApiSpec({
       spec: openApiSpecFactory({
@@ -286,7 +286,7 @@ describe("processOpenApiSpec", () => {
   });
 
   test("should handle operations without tags", () => {
-    const context = new ProcessingContext();
+    const context = new ProcessingContext("docs");
 
     const result = processOpenApiSpec({
       spec: openApiSpecFactory({

--- a/src/content-indexer/visitors/processors/__tests__/process-openrpc.test.ts
+++ b/src/content-indexer/visitors/processors/__tests__/process-openrpc.test.ts
@@ -10,7 +10,7 @@ import { processOpenRpcSpec } from "../process-openrpc.ts";
 
 describe("processOpenRpcSpec", () => {
   test("should return empty result for invalid spec", () => {
-    const context = new ProcessingContext();
+    const context = new ProcessingContext("docs");
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
     const result = processOpenRpcSpec({
@@ -40,7 +40,7 @@ describe("processOpenRpcSpec", () => {
   });
 
   test("should process methods and create index entries", () => {
-    const context = new ProcessingContext();
+    const context = new ProcessingContext("docs");
 
     const result = processOpenRpcSpec({
       spec: openRpcSpecFactory({
@@ -85,7 +85,7 @@ describe("processOpenRpcSpec", () => {
   });
 
   test("should create navigation with API section wrapper", () => {
-    const context = new ProcessingContext();
+    const context = new ProcessingContext("docs");
 
     const result = processOpenRpcSpec({
       spec: openRpcSpecFactory({
@@ -127,7 +127,7 @@ describe("processOpenRpcSpec", () => {
   });
 
   test("should flatten navigation if flattened is true", () => {
-    const context = new ProcessingContext();
+    const context = new ProcessingContext("docs");
 
     const result = processOpenRpcSpec({
       spec: openRpcSpecFactory({
@@ -159,7 +159,7 @@ describe("processOpenRpcSpec", () => {
   });
 
   test("should not create nav if hidden", () => {
-    const context = new ProcessingContext();
+    const context = new ProcessingContext("docs");
 
     const result = processOpenRpcSpec({
       spec: openRpcSpecFactory({
@@ -192,7 +192,7 @@ describe("processOpenRpcSpec", () => {
   });
 
   test("should add Algolia records for methods", () => {
-    const context = new ProcessingContext();
+    const context = new ProcessingContext("docs");
 
     processOpenRpcSpec({
       spec: openRpcSpecFactory({
@@ -236,7 +236,7 @@ describe("processOpenRpcSpec", () => {
   });
 
   test("should use method name as title", () => {
-    const context = new ProcessingContext();
+    const context = new ProcessingContext("docs");
 
     processOpenRpcSpec({
       spec: openRpcSpecFactory({
@@ -269,7 +269,7 @@ describe("processOpenRpcSpec", () => {
   });
 
   test("should use description over summary for Algolia content", () => {
-    const context = new ProcessingContext();
+    const context = new ProcessingContext("docs");
 
     processOpenRpcSpec({
       spec: openRpcSpecFactory({


### PR DESCRIPTION
## Description

This is the content-indexer solution for a problem we faced in the frontend:
Having content split across 3 indices was really convenient for managing content that changes at different times. Combining them and searching them at once in the frontend works, but Algolia doesn't combine search relevance, causing search results to be prioritize low relevance content from one index above high relevance content from another (leading to weird stuff like changelogs being top result for API queries).

The only practical option is to search a single index. This makes content-indexer a bit more complicated in that it has to manage content from multiple indexer triggers in the same index. We can't just replace records in-place using objectIDs because those aren't 100% stable - they change when URL paths change. That means we'd end up with outdated "orphan" records stuck in the index.

This solution labels records with an `indexerType`, then when that indexer is run we use batch queries to delete all records of that type and reupload them with new content. The consequence is we no longer use atomic swap, so there will be momentary downtime between the delete and upload steps in which case records will be missing from index. Measured downtime is around 300-500ms. Eliminating this is possible, but only with a more complex flow that I didn't feel was warranted given the low chance of someone actually searching during this downtime. We can re-evaluate if we get reports to the contrary.

## Changes Made

- Add `indexerType` field to Algolia records
- Write all Algolia records across indexer types to a single index.

## Testing

<!-- Describe the tests that you ran to verify your changes -->

* \[ ] I have tested these changes locally
* \[ ] I have run the validation scripts (`pnpm run validate`)
* \[ ] I have checked that the documentation builds correctly
