### PR TITLE
fix: silence pnpm output of detect-spec-changes

### DIFF
--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Detect changed specs
         id: detect-changes
         run: |
-          CHANGED=$(pnpm detect-spec-changes)
+          CHANGED=$(pnpm -s detect-spec-changes)
           echo "specUrls=$CHANGED" >> $GITHUB_OUTPUT
 
       - name: Upload static files as artifact


### PR DESCRIPTION
## Description

The first run of this failed. Looks like there was a bug in the GHA workflow itself caused by pnpm output overwriting the output of the detect-spec-changes script. Adding -s flag should fix it by suppressing that.

This time I tested the build step in the feature branch. You can see output [here](https://github.com/alchemyplatform/docs/actions/runs/21272437763). The deploy to GH pages fails because of env protections but that's fine.

## Changes Made

Call `detect-spec-changes` with `-s` flag

## Testing

<!-- Describe the tests that you ran to verify your changes -->

* \[ ] I have tested these changes locally
* \[ ] I have run the validation scripts (`pnpm run validate`)
* \[ ] I have checked that the documentation builds correctly
