### PR TITLE
feat: call revalidate index endpoint after content-indexer

### DIFF
--- a/.github/workflows/index-changelog.yml
+++ b/.github/workflows/index-changelog.yml
@@ -27,3 +27,40 @@ jobs:
           KV_REST_API_URL: ${{ secrets.KV_REST_API_URL }}
           ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
           ALGOLIA_ADMIN_API_KEY: ${{ secrets.ALGOLIA_ADMIN_API_KEY }}
+
+      - name: Revalidate changelog index cache
+        run: |
+          echo "Revalidating changelog index cache..."
+
+          # Create JSON payload
+          PAYLOAD='{"pathIndices": ["changelog"]}'
+
+          # Call revalidation API
+          HTTP_CODE=$(curl -X POST "${{ secrets.DOCS_SITE_URL }}/api/revalidate/indices" \
+            -H "Authorization: Bearer ${{ secrets.DOCS_SITE_API_KEY }}" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD" \
+            --max-time 30 \
+            --fail-with-body \
+            -o response.json \
+            -w "%{http_code}" \
+            -s)
+
+          echo ""
+          echo "Response (HTTP $HTTP_CODE):"
+          jq '.' response.json || cat response.json
+
+          # Check HTTP status
+          if [ "$HTTP_CODE" != "200" ]; then
+            echo "::error::Indices revalidation API returned status $HTTP_CODE"
+            exit 1
+          fi
+
+          # Check success field in response
+          SUCCESS=$(jq -r '.success' response.json)
+          if [ "$SUCCESS" != "true" ]; then
+            echo "::warning::Revalidation completed with errors"
+            jq -r '.errors[]?' response.json
+          else
+            echo "::notice::✅ Successfully revalidated changelog index"
+          fi

--- a/.github/workflows/index-main-content.yml
+++ b/.github/workflows/index-main-content.yml
@@ -28,3 +28,48 @@ jobs:
           ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
           ALGOLIA_ADMIN_API_KEY: ${{ secrets.ALGOLIA_ADMIN_API_KEY }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
+
+      - name: Revalidate docs index and nav caches
+        run: |
+          echo "Revalidating docs index and navigation caches..."
+
+          # Extract tab IDs from docs.yml (these are the nav tree keys)
+          NAV_TREES=$(yq -o=json '.tabs | keys' fern/docs.yml)
+          echo "Nav trees to revalidate: $NAV_TREES"
+
+          # Create JSON payload using jq
+          PAYLOAD=$(jq -n \
+            --argjson navTrees "$NAV_TREES" \
+            '{pathIndices: ["docs"], navTrees: $navTrees}')
+
+          echo "Payload: $PAYLOAD"
+
+          # Call revalidation API
+          HTTP_CODE=$(curl -X POST "${{ secrets.DOCS_SITE_URL }}/api/revalidate/indices" \
+            -H "Authorization: Bearer ${{ secrets.DOCS_SITE_API_KEY }}" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD" \
+            --max-time 30 \
+            --fail-with-body \
+            -o response.json \
+            -w "%{http_code}" \
+            -s)
+
+          echo ""
+          echo "Response (HTTP $HTTP_CODE):"
+          jq '.' response.json || cat response.json
+
+          # Check HTTP status
+          if [ "$HTTP_CODE" != "200" ]; then
+            echo "::error::Indices revalidation API returned status $HTTP_CODE"
+            exit 1
+          fi
+
+          # Check success field in response
+          SUCCESS=$(jq -r '.success' response.json)
+          if [ "$SUCCESS" != "true" ]; then
+            echo "::warning::Revalidation completed with errors"
+            jq -r '.errors[]?' response.json
+          else
+            echo "::notice::✅ Successfully revalidated docs index and nav trees"
+          fi

--- a/.github/workflows/index-sdk-references.yml
+++ b/.github/workflows/index-sdk-references.yml
@@ -34,3 +34,42 @@ jobs:
           KV_REST_API_URL: ${{ secrets.KV_REST_API_URL }}
           ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
           ALGOLIA_ADMIN_API_KEY: ${{ secrets.ALGOLIA_ADMIN_API_KEY }}
+
+      - name: Revalidate SDK index and wallets nav cache
+        run: |
+          echo "Revalidating SDK index and wallets nav cache..."
+
+          # SDK indexer only updates the wallets nav tree (hardcoded in indexer)
+          PAYLOAD='{"pathIndices": ["sdk"], "navTrees": ["wallets"]}'
+
+          echo "Payload: $PAYLOAD"
+
+          # Call revalidation API
+          HTTP_CODE=$(curl -X POST "${{ secrets.DOCS_SITE_URL }}/api/revalidate/indices" \
+            -H "Authorization: Bearer ${{ secrets.DOCS_SITE_API_KEY }}" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD" \
+            --max-time 30 \
+            --fail-with-body \
+            -o response.json \
+            -w "%{http_code}" \
+            -s)
+
+          echo ""
+          echo "Response (HTTP $HTTP_CODE):"
+          jq '.' response.json || cat response.json
+
+          # Check HTTP status
+          if [ "$HTTP_CODE" != "200" ]; then
+            echo "::error::Indices revalidation API returned status $HTTP_CODE"
+            exit 1
+          fi
+
+          # Check success field in response
+          SUCCESS=$(jq -r '.success' response.json)
+          if [ "$SUCCESS" != "true" ]; then
+            echo "::warning::Revalidation completed with errors"
+            jq -r '.errors[]?' response.json
+          else
+            echo "::notice::✅ Successfully revalidated SDK index and wallets nav"
+          fi


### PR DESCRIPTION
## Description

After content-indexer runs in main, this will call the new revalidate index endpoint to ensure the newly indexed content is now fetched by the frontend. This ensures that sidebar navs for example update in tandem: so its not possible for different pages in the same tab to have different sidebar navs (because one is out of date).

## Related Issues

[<!-- Link to any related issues or Asana tasks this PR addresses (e.g., "Fixes #123") -->](https://app.asana.com/1/1129441638109975/project/1211825853436056/task/1212917242381419?focus=true)

## Changes Made

- Trigger new revalidate index endpoint after all indexer runs

## Testing

<!-- Describe the tests that you ran to verify your changes -->

* \[ ] I have tested these changes locally
* \[ ] I have run the validation scripts (`pnpm run validate`)
* \[ ] I have checked that the documentation builds correctly
