### PR TITLE
Fix broken card links on Node API Overview page

### DIFF
--- a/fern/api-reference/node-api/node-api-overview.mdx
+++ b/fern/api-reference/node-api/node-api-overview.mdx
@@ -41,7 +41,7 @@ Chain APIs are the per-chain RPC surfaces exposed through the Node API.
 Use these alongside the Node API for streaming, performance, and deeper inspection. Chain coverage varies: check each page for supported networks.
 
 <CardGroup>
-  <Card title="WebSockets" icon="fa-solid fa-wave-square" href="subscription-api">
+  <Card title="WebSockets" icon="fa-solid fa-wave-square" href="/reference/subscription-api">
     Subscribe to pending transactions, log events, new blocks, and more.
   </Card>
 
@@ -49,11 +49,11 @@ Use these alongside the Node API for streaming, performance, and deeper inspecti
     Get insights into transaction processing and onchain activity.
   </Card>
 
-  <Card title="Debug API" icon="fa-solid fa-bug" href="debug-api-quickstart">
+  <Card title="Debug API" icon="fa-solid fa-bug" href="/reference/debug-api-quickstart">
     Non-standard RPC methods for inspecting and debugging transactions.
   </Card>
 
-  <Card title="Yellowstone gRPC" icon="fa-solid fa-bolt" href="yellowstone-grpc-overview">
+  <Card title="Yellowstone gRPC" icon="fa-solid fa-bolt" href="/reference/yellowstone-grpc-overview">
     High-performance real-time Solana data streaming interface.
   </Card>
 </CardGroup>


### PR DESCRIPTION
## Summary
- Fixed 3 broken card hrefs on the Node API Overview page (`node-api-overview.mdx`)
- WebSockets, Debug API, and Yellowstone gRPC cards used relative hrefs that didn't resolve; updated to absolute paths (`/reference/...`) matching each target page's frontmatter slug

## Test plan
- [x] Verify the WebSockets, Debug API, and Yellowstone gRPC card links navigate to the correct pages