### PR TITLE
[Styler] Fix Lumia deprecation page style violations

### DIFF
--- a/fern/api-reference/lumia/lumia-deprecation-notice.mdx
+++ b/fern/api-reference/lumia/lumia-deprecation-notice.mdx
@@ -1,12 +1,14 @@
 ---
-title: Lumia Network Deprecation Notice
+title: Lumia network deprecation notice
 description: Important notice regarding the deprecation of Lumia network support on Alchemy
 slug: reference/lumia-deprecation-notice
 ---
 
-## ⚠️ Deprecation Notice
+## Deprecation notice
 
-As part of our annual process to evaluate the networks supported on Alchemy, we've decided to spin down support of Lumia.
+**Date:** February 10, 2026
+
+As part of our annual process to evaluate the networks we support, we've decided to spin down support of Lumia.
 
 Please migrate to an alternate provider.
 


### PR DESCRIPTION
Fixes style violations in the Lumia deprecation notice page (merged via PR #1011):

1. **Emoji in heading** — Removed ⚠️ from heading (FORMATTING rule: no emojis in headings)
2. **Title case** — Changed title and heading to sentence case
3. **Missing deprecation date** — Added date per DEPRECATION rule
4. **Third-person Alchemy** — Changed 'supported on Alchemy' to 'we support' in body text