### PR TITLE
chore: add summary field to eth_getLogs definition

### DIFF
--- a/src/openrpc/chains/_components/evm/methods.yaml
+++ b/src/openrpc/chains/_components/evm/methods.yaml
@@ -796,6 +796,7 @@ components:
 
     eth_getLogs:
       name: eth_getLogs
+      summary: Returns an array of all logs matching the specified filter.
       description: |
         Returns an array of all logs matching the specified filter.
         ### Supported Block Ranges


### PR DESCRIPTION
## Description

This method had no summary and a long description. The new site uses description as a fallback for summary for things like search modal and metadata. In most cases this is fine since both summary and description are short, but in this specific case it causes an enormous block of text with a table to appear in places that weren't designed for this. Adding summary fixes this.

<img width="1229" height="627" alt="image" src="https://github.com/user-attachments/assets/e6f9e344-ef10-487e-88c7-1789e74223cf" />


## Related Issues

<!-- Link to any related issues or Asana tasks this PR addresses (e.g., "Fixes #123") -->

## Changes Made

<!-- List the specific changes made in this PR -->

## Testing

<!-- Describe the tests that you ran to verify your changes -->

* \[x] I have tested these changes locally
* \[x] I have run the validation scripts (`pnpm run validate`)
* \[x] I have checked that the documentation builds correctly
