### PR TITLE
ci: batch markdown revalidation requests

### DIFF
--- a/.github/workflows/revalidate-content.yml
+++ b/.github/workflows/revalidate-content.yml
@@ -53,40 +53,66 @@ jobs:
       - name: Call revalidation API
         if: steps.changed-files.outputs.filePaths != '[]'
         run: |
-          # Create JSON payload using jq for safety
-          PAYLOAD=$(jq -n --argjson paths '${{ steps.changed-files.outputs.filePaths }}' \
-            '{filePaths: $paths}')
+          ALL_PATHS='${{ steps.changed-files.outputs.filePaths }}'
+          TOTAL=$(echo "$ALL_PATHS" | jq 'length')
+          BATCH_SIZE=50
+          SUCCEEDED=0
+          FAILED=0
+          BATCH_NUM=0
 
-          echo "Revalidating files:"
-          echo "$PAYLOAD" | jq -r '.filePaths[]'
+          echo "Revalidating $TOTAL files in batches of $BATCH_SIZE"
 
-          # Call API with 60s timeout
-          HTTP_CODE=$(curl -X POST "${{ secrets.DOCS_SITE_URL }}/api/revalidate/markdown" \
-            -H "Authorization: Bearer ${{ secrets.DOCS_SITE_API_KEY }}" \
-            -H "Content-Type: application/json" \
-            -d "$PAYLOAD" \
-            --max-time 60 \
-            --fail-with-body \
-            -o response.json \
-            -w "%{http_code}" \
-            -s)
+          for ((i = 0; i < TOTAL; i += BATCH_SIZE)); do
+            BATCH_NUM=$((BATCH_NUM + 1))
+            BATCH=$(echo "$ALL_PATHS" | jq -c ".[$i:$((i + BATCH_SIZE))]")
+            CHUNK_SIZE=$(echo "$BATCH" | jq 'length')
+
+            echo ""
+            echo "=== Batch $BATCH_NUM ($CHUNK_SIZE paths, $((i + CHUNK_SIZE))/$TOTAL) ==="
+            echo "$BATCH" | jq -r '.[]'
+
+            PAYLOAD=$(jq -n --argjson paths "$BATCH" '{filePaths: $paths}')
+
+            HTTP_CODE=$(curl -X POST "${{ secrets.DOCS_SITE_URL }}/api/revalidate/markdown" \
+              -H "Authorization: Bearer ${{ secrets.DOCS_SITE_API_KEY }}" \
+              -H "Content-Type: application/json" \
+              -d "$PAYLOAD" \
+              --max-time 120 \
+              -o response.json \
+              -w "%{http_code}" \
+              -s) || true
+
+            if [ "$HTTP_CODE" = "200" ]; then
+              SUCCESS=$(jq -r '.success' response.json)
+              if [ "$SUCCESS" = "true" ]; then
+                COUNT=$(jq -r '.revalidated | length' response.json)
+                echo "✅ Batch $BATCH_NUM: $COUNT paths revalidated"
+                SUCCEEDED=$((SUCCEEDED + COUNT))
+              else
+                echo "::warning::Batch $BATCH_NUM: HTTP 200 but success=false"
+                jq -r '.errors[]?' response.json
+                ERRORS=$(jq -r '[.revalidated[] | select(.error)] | length' response.json)
+                SUCCEEDED=$((SUCCEEDED + CHUNK_SIZE - ERRORS))
+                FAILED=$((FAILED + ERRORS))
+              fi
+            else
+              echo "::error::Batch $BATCH_NUM: HTTP $HTTP_CODE"
+              jq '.' response.json 2>/dev/null || cat response.json 2>/dev/null || true
+              FAILED=$((FAILED + CHUNK_SIZE))
+            fi
+
+            if [ $((i + BATCH_SIZE)) -lt "$TOTAL" ]; then
+              sleep 2
+            fi
+          done
 
           echo ""
-          echo "Response (HTTP $HTTP_CODE):"
-          jq '.' response.json || cat response.json
+          echo "=== Revalidation complete ==="
+          echo "Total: $TOTAL | Succeeded: $SUCCEEDED | Failed: $FAILED"
 
-          # Check HTTP status
-          if [ "$HTTP_CODE" != "200" ]; then
-            echo "::error::Revalidation API returned status $HTTP_CODE"
+          if [ "$FAILED" -gt 0 ]; then
+            echo "::error::$FAILED paths failed to revalidate"
             exit 1
           fi
 
-          # Check success field in response
-          SUCCESS=$(jq -r '.success' response.json)
-          if [ "$SUCCESS" != "true" ]; then
-            echo "::warning::Revalidation completed with errors"
-            jq -r '.errors[]?' response.json
-          else
-            FILE_COUNT=$(jq -r '.revalidated | length' response.json)
-            echo "::notice::✅ Successfully revalidated $FILE_COUNT files"
-          fi
+          echo "::notice::✅ Successfully revalidated $SUCCEEDED files"

--- a/.github/workflows/revalidate-content.yml
+++ b/.github/workflows/revalidate-content.yml
@@ -92,7 +92,20 @@ jobs:
                 echo "::warning::Batch $BATCH_NUM: HTTP 200 but success=false"
                 jq -r '(.errors // [])[]?' response.json
                 jq -r '[(.revalidated // [])[]? | select(.error) | .error] | .[]?' response.json
-                FAILED=$((FAILED + CHUNK_SIZE))
+                ITEM_COUNT=$(jq -r '(.revalidated // []) | length' response.json)
+
+                if [ "$ITEM_COUNT" -gt 0 ]; then
+                  if [ "$ITEM_COUNT" -gt "$CHUNK_SIZE" ]; then
+                    ITEM_COUNT=$CHUNK_SIZE
+                  fi
+                  ERRORS=$(jq -r '[(.revalidated // [])[]? | select(.error)] | length' response.json)
+                  ITEM_SUCCEEDED=$((ITEM_COUNT - ERRORS))
+                  UNREPORTED=$((CHUNK_SIZE - ITEM_COUNT))
+                  SUCCEEDED=$((SUCCEEDED + ITEM_SUCCEEDED))
+                  FAILED=$((FAILED + ERRORS + UNREPORTED))
+                else
+                  FAILED=$((FAILED + CHUNK_SIZE))
+                fi
               fi
             else
               echo "::error::Batch $BATCH_NUM: HTTP $HTTP_CODE"

--- a/.github/workflows/revalidate-content.yml
+++ b/.github/workflows/revalidate-content.yml
@@ -85,15 +85,14 @@ jobs:
             if [ "$HTTP_CODE" = "200" ]; then
               SUCCESS=$(jq -r '.success' response.json)
               if [ "$SUCCESS" = "true" ]; then
-                COUNT=$(jq -r '.revalidated | length' response.json)
+                COUNT=$(jq -r '(.revalidated // []) | length' response.json)
                 echo "✅ Batch $BATCH_NUM: $COUNT paths revalidated"
                 SUCCEEDED=$((SUCCEEDED + COUNT))
               else
                 echo "::warning::Batch $BATCH_NUM: HTTP 200 but success=false"
-                jq -r '.errors[]?' response.json
-                ERRORS=$(jq -r '[.revalidated[] | select(.error)] | length' response.json)
-                SUCCEEDED=$((SUCCEEDED + CHUNK_SIZE - ERRORS))
-                FAILED=$((FAILED + ERRORS))
+                jq -r '(.errors // [])[]?' response.json
+                jq -r '[(.revalidated // [])[]? | select(.error) | .error] | .[]?' response.json
+                FAILED=$((FAILED + CHUNK_SIZE))
               fi
             else
               echo "::error::Batch $BATCH_NUM: HTTP $HTTP_CODE"


### PR DESCRIPTION
## What changed
This updates the content revalidation workflow to process changed Markdown files in batches instead of sending a single large request.

### Key updates
- Split changed file paths into batches of 50.
- Revalidate each batch with a separate call to /api/revalidate/markdown.
- Track per-batch and total success/failure counts.
- Add a short delay between batches to reduce burst load.
- Fail the workflow if any files fail revalidation.

## Why
Large pushes can include many changed docs pages. Sending everything in one request is more likely to hit timeout, payload-size, or rate-limit issues. Batching makes the workflow more reliable and easier to debug when partial failures happen. This approach mirrors [the one in aa-sdk](https://github.com/alchemyplatform/aa-sdk/blob/2fe5105f3e206ae0a0b387d1e8388054295af61d/.github/workflows/revalidate-sdk-content.yml) which is already confirmed to work well.

## Behavior details
- If no relevant files changed, the job exits early as before.
- Successful batches contribute to the final success total.
- For HTTP 200 responses with success=false, batch errors are surfaced and counted.
- Non-200 responses mark the full batch as failed.

## Testing
- Validated workflow logic and shell script behavior in the updated GitHub Actions file.
- No runtime code-path changes outside CI workflow configuration.