### PR TITLE
Update PAYG webhooks limit to 100

### DIFF
--- a/content/api-reference/pricing-resources/pricing/pricing-plans.mdx
+++ b/content/api-reference/pricing-resources/pricing/pricing-plans.mdx
@@ -16,7 +16,7 @@ slug: reference/pricing-plans
 | 300M+ CU rate                    | -           | $0.40/M CU | Custom          |
 | Base Throughput (CUs/second)     | 500         | 10,000     | Custom          |
 | # of apps                        | 5           | 30         | Unlimited       |
-| webhooks                         | 5           | 50         | 500             |
+| webhooks                         | 5           | 100        | 500             |
 | Full Archive Data                | ✓           | ✓          | ✓               |
 | Node API                         | ✓           | ✓          | ✓               |
 | Debug API                        | ✗           | ✓          | ✓               |


### PR DESCRIPTION
Updates the PAYG webhooks limit from 50 to 100 on the pricing plans page.

Resolves DOCS-37.