### PR TITLE
Sort Injective alphabetically in chains nav

### DIFF
--- a/content/docs.yml
+++ b/content/docs.yml
@@ -1649,6 +1649,17 @@ navigation:
           - api: Ink API Endpoints
             api-name: ink
         slug: ink
+      - section: Injective
+        contents:
+          - page: Quickstart
+            path: api-reference/injective/injective-api-quickstart.mdx
+          - page: FAQ
+            path: api-reference/injective/injective-api-faq.mdx
+          - page: Injective API Overview
+            path: api-reference/injective/injective-api-overview.mdx
+          - api: Injective API Endpoints
+            api-name: injective
+        slug: injective
       - section: Jovay
         contents:
           - page: Quickstart
@@ -2152,17 +2163,5 @@ navigation:
           - api: Zora API Endpoints
             api-name: zora
         slug: zora
-
-      - section: Injective
-        contents:
-          - page: Quickstart
-            path: api-reference/injective/injective-api-quickstart.mdx
-          - page: FAQ
-            path: api-reference/injective/injective-api-faq.mdx
-          - page: Injective API Overview
-            path: api-reference/injective/injective-api-overview.mdx
-          - api: Injective API Endpoints
-            api-name: injective
-        slug: injective
 
   - tab: changelog

--- a/content/docs.yml
+++ b/content/docs.yml
@@ -1638,17 +1638,6 @@ navigation:
           - page: Hyperliquid Info Endpoint
             path: api-reference/hyperliquid/hyperliquid-info-endpoint.mdx
         slug: hyperliquid
-      - section: Ink
-        contents:
-          - page: Quickstart
-            path: api-reference/ink/ink-api-quickstart.mdx
-          - page: FAQ
-            path: api-reference/ink/ink-api-faq.mdx
-          - page: Ink API Overview
-            path: api-reference/ink/ink-api-overview.mdx
-          - api: Ink API Endpoints
-            api-name: ink
-        slug: ink
       - section: Injective
         contents:
           - page: Quickstart
@@ -1660,6 +1649,17 @@ navigation:
           - api: Injective API Endpoints
             api-name: injective
         slug: injective
+      - section: Ink
+        contents:
+          - page: Quickstart
+            path: api-reference/ink/ink-api-quickstart.mdx
+          - page: FAQ
+            path: api-reference/ink/ink-api-faq.mdx
+          - page: Ink API Overview
+            path: api-reference/ink/ink-api-overview.mdx
+          - api: Ink API Endpoints
+            api-name: ink
+        slug: ink
       - section: Jovay
         contents:
           - page: Quickstart


### PR DESCRIPTION
Moves the Injective section from the bottom of the chains tab to its correct alphabetical position between Ink and Jovay in docs.yml.