### PR TITLE
[Writer] Sort Injective alphabetically in chains nav

### DIFF
--- a/content/docs.yml
+++ b/content/docs.yml
@@ -1649,6 +1649,17 @@ navigation:
           - api: Ink API Endpoints
             api-name: ink
         slug: ink
+      - section: Injective
+        contents:
+          - page: Quickstart
+            path: api-reference/injective/injective-api-quickstart.mdx
+          - page: FAQ
+            path: api-reference/injective/injective-api-faq.mdx
+          - page: Injective API Overview
+            path: api-reference/injective/injective-api-overview.mdx
+          - api: Injective API Endpoints
+            api-name: injective
+        slug: injective
       - section: Jovay
         contents:
           - page: Quickstart
@@ -2152,17 +2163,5 @@ navigation:
           - api: Zora API Endpoints
             api-name: zora
         slug: zora
-
-      - section: Injective
-        contents:
-          - page: Quickstart
-            path: api-reference/injective/injective-api-quickstart.mdx
-          - page: FAQ
-            path: api-reference/injective/injective-api-faq.mdx
-          - page: Injective API Overview
-            path: api-reference/injective/injective-api-overview.mdx
-          - api: Injective API Endpoints
-            api-name: injective
-        slug: injective
 
   - tab: changelog


### PR DESCRIPTION
Moves the Injective section in content/docs.yml from its incorrect position (after Zora, at the bottom of the chains tab) to its correct alphabetical position between Ink and Jovay.

The chains tab sort order is: Ethereum, Solana, then all other chains A-Z.