### PR TITLE
Update eth_getLogs block range for Berachain (DOCS-39)

### DIFF
--- a/src/openrpc/chains/_components/evm/methods.yaml
+++ b/src/openrpc/chains/_components/evm/methods.yaml
@@ -809,7 +809,8 @@ components:
         | Ethereum, Base, Optimism, Arbitrum, Worldchain, zkSync | 10 | unlimited | unlimited |
         | Polygon | 10 | 2000 | unlimited |
         | BSC, Unichain | 10 | 10,000 | 10,000 |
-        | Berachain, Plasma | 10 | 10,000 | 100,000 |
+        | Berachain | 10 | 1,000 | 100,000 |
+        | Plasma | 10 | 10,000 | 100,000 |
         | Monad | 10 | 1000 | 1000 |
         | Polygon zkEVM | 10 | 10,000 | 20,000 |
         | Sei | 10 | 2000 | 2000 |


### PR DESCRIPTION
Split the Berachain/Plasma row in the eth_getLogs Supported Block Ranges table into two separate rows:

- **Berachain**: Pay As You Go changed from 10,000 → 1,000, Enterprise stays at 100,000
- **Plasma**: Keeps existing values (10,000 / 100,000)

Closes DOCS-39