### PR TITLE
[Writer] Add FAQ #8: Usage Limit spending control to PAYG pricing FAQ

### DIFF
--- a/content/api-reference/pricing-resources/pricing-faq/pay-as-you-go-pricing-faq.mdx
+++ b/content/api-reference/pricing-resources/pricing-faq/pay-as-you-go-pricing-faq.mdx
@@ -41,9 +41,11 @@ This FAQ answers what you need to know about our Pay As You Go plan.
 
 7. **How does this impact Enterprise plans?** Enterprise plans remain unchanged.
 
-8. What do I need to know if I'm an existing Scale or Growth Customer? All Growth and Scale plans transitioned to Pay As You Go on February 1st, 2025.
+8. **How do I make sure I don't spend more than I'm willing to?** Once on the Pay As You Go plan, head to [**Billing Settings**](https://dashboard.alchemy.com/settings/billing/manage-plan) in your dashboard and set a **Usage Limit** — either as a Compute Unit amount or its dollar equivalent. Your usage will be capped at that limit and you won't be charged beyond it.
 
-9. I'm a free plan user! What happens after I hit 30M Compute Units?
+9. What do I need to know if I'm an existing Scale or Growth Customer? All Growth and Scale plans transitioned to Pay As You Go on February 1st, 2025.
+
+10. I'm a free plan user! What happens after I hit 30M Compute Units?
 
    We offer **the most generous free plan** in the industry. Our free plan gives you **3x the capacity** to build for free compared to competitors, giving you massive computing power and throughput to start building right away.
 


### PR DESCRIPTION
Adds a new FAQ entry (#8) to the Pay As You Go Pricing FAQ page explaining how users can set a Usage Limit in Billing Settings to cap their spending.

- New Q8: 'How do I make sure I don't spend more than I'm willing to?'
- Renumbered previous #8 → #9, #9 → #10

Resolves DOCS-40.