### PR TITLE
[Writer] Fix read_mask format in Sui gRPC quickstart

### DIFF
--- a/content/api-reference/sui-grpc/quickstart.mdx
+++ b/content/api-reference/sui-grpc/quickstart.mdx
@@ -66,7 +66,7 @@ grpcurl \
   -proto sui/rpc/v2/ledger_service.proto \
   -d '{
     "object_id": "0x5",
-    "read_mask": "object_id,version,digest,owner"
+    "read_mask": {"paths": ["object_id", "version", "digest", "owner"]}
   }' \
   sui-mainnet.g.alchemy.com:443 \
   sui.rpc.v2.LedgerService/GetObject


### PR DESCRIPTION
Fixes the `read_mask` field in the GetObject example (section '2. Fetch an object') to use proper FieldMask JSON object format instead of a comma-separated string.

**Before:**
```json
"read_mask": "object_id,version,digest,owner"
```

**After:**
```json
"read_mask": {"paths": ["object_id", "version", "digest", "owner"]}
```

The old format caused grpcurl to throw: `bad input: expecting start of JSON object`.

Resolves DOCS-41.