### PR TITLE
[Writer] Replace deprecated Frax Sepolia testnet endpoint with Frax Hoodi

### DIFF
--- a/src/openrpc/alchemy/debug/debug.yaml
+++ b/src/openrpc/alchemy/debug/debug.yaml
@@ -93,8 +93,8 @@ servers:
     name: Flow EVM Testnet
   - url: https://frax-mainnet.g.alchemy.com/v2
     name: Frax Mainnet
-  - url: https://frax-sepolia.g.alchemy.com/v2
-    name: Frax Sepolia
+  - url: https://frax-hoodi.g.alchemy.com/v2
+    name: Frax Hoodi
   - url: https://gensyn-testnet.g.alchemy.com/v2
     name: Gensyn Testnet
   - url: https://gnosis-mainnet.g.alchemy.com/v2

--- a/src/openrpc/chains/frax/frax.yaml
+++ b/src/openrpc/chains/frax/frax.yaml
@@ -9,8 +9,8 @@ info:
 servers:
   - url: https://frax-mainnet.g.alchemy.com/v2
     name: Frax Mainnet
-  - url: https://frax-sepolia.g.alchemy.com/v2
-    name: Frax Sepolia
+  - url: https://frax-hoodi.g.alchemy.com/v2
+    name: Frax Hoodi
 methods:
   - $ref: ../_components/evm/methods.yaml#/components/methods/eth_blockNumber
   - $ref: ../_components/evm/methods.yaml#/components/methods/eth_call


### PR DESCRIPTION
## Summary

Replaces all instances of the deprecated Frax Sepolia testnet endpoint with the new Frax Hoodi endpoint.

### Changes
- `src/openrpc/chains/frax/frax.yaml`: Updated URL from `frax-sepolia.g.alchemy.com` → `frax-hoodi.g.alchemy.com` and name from "Frax Sepolia" → "Frax Hoodi"
- `src/openrpc/alchemy/debug/debug.yaml`: Same URL and name replacement

### Endpoint Testing
- `https://frax-hoodi.g.alchemy.com/v2/demo` — DNS resolves, SSL valid (\*.g.alchemy.com cert), returns HTTP 429 with demo key (expected rate limiting, confirms endpoint is live)

Closes DOCS-43