### PR TITLE
wallets: minor copy polish in authentication overview

### DIFF
--- a/content/wallets/pages/authentication/overview.mdx
+++ b/content/wallets/pages/authentication/overview.mdx
@@ -4,7 +4,7 @@ description: Connect any embedded wallet or key management solution to Wallet AP
 slug: wallets/authentication/overview
 ---
 
-A **signer** is the service or key that controls a wallet — it authenticates users and signs transactions on their behalf. Wallet APIs are signer-agnostic: anything that produces a valid viem signature works.
+A **signer** is the service or key that controls a wallet — it authenticates users and signs transactions on their behalf. Wallet APIs are signer-agnostic: anything that produces a valid signature works.
 
 <Note>
   Wallet APIs work with embedded wallets and server-managed keys. External browser wallets (MetaMask, Rabby, Ledger) are not yet supported.
@@ -12,7 +12,7 @@ A **signer** is the service or key that controls a wallet — it authenticates u
 
 ## Recommended: Privy
 
-For most teams, we recommend **[Privy](/docs/wallets/third-party/signers/privy)** as the embedded wallet provider. Privy handles key creation, social/email login, and recovery — and exposes a viem `LocalAccount` that drops straight into `createSmartWalletClient`.
+For most teams, we recommend **[Privy](/docs/wallets/third-party/signers/privy)** as the embedded wallet provider. Privy handles key creation, social/email login, and recovery, and exposes a viem `LocalAccount` that drops straight into `createSmartWalletClient`.
 
 <Card title="Privy integration guide" icon="fa-solid fa-bolt" href="/docs/wallets/third-party/signers/privy">
   Step-by-step setup for Privy with Wallet APIs.


### PR DESCRIPTION
## Summary
- Drop redundant "viem" qualifier from signer-agnostic description (any valid signature works)
- Replace em dash with comma in Privy recommendation for readability

## Test plan
- [ ] Verify rendered page at /docs/wallets/authentication/overview reads cleanly