### PR TITLE
[Writer] Add eth_getWithdrawalProof CU cost for MegaETH

### DIFF
--- a/content/api-reference/pricing-resources/pricing/compute-unit-costs.mdx
+++ b/content/api-reference/pricing-resources/pricing/compute-unit-costs.mdx
@@ -616,6 +616,14 @@ On average, a typical webhook or WebSocket subscription event is about 1000 byte
 | linea\_getProof                               | 20 |
 | linea\_getTransactionExclusionStatusV1        | 20 |
 
+# MegaETH: Specific Methods
+
+Applies to `MEGAETH_TESTNET` and `MEGAETH_MAINNET`.
+
+| Method                    | CU |
+| ------------------------- | -- |
+| eth\_getWithdrawalProof   | 20 |
+
 # Sui: Standard Methods
 
 | Method                                   | CU |

--- a/content/api-reference/pricing-resources/pricing/compute-unit-costs.mdx
+++ b/content/api-reference/pricing-resources/pricing/compute-unit-costs.mdx
@@ -618,8 +618,6 @@ On average, a typical webhook or WebSocket subscription event is about 1000 byte
 
 # MegaETH: Specific Methods
 
-Applies to `MEGAETH_TESTNET` and `MEGAETH_MAINNET`.
-
 | Method                    | CU |
 | ------------------------- | -- |
 | eth\_getWithdrawalProof   | 20 |


### PR DESCRIPTION
Closes [DOCS-44](https://linear.app/alchemyapi/issue/DOCS-44/add-eth-getwithdrawalproof-to-compute-unit-cost-page-for-megaeth).

## Change

Adds a new `# MegaETH: Specific Methods` section to the [Compute Unit Costs](https://www.alchemy.com/docs/reference/compute-unit-costs) page with an entry for `eth_getWithdrawalProof` at **20 CU**, applicable to `MEGAETH_TESTNET` and `MEGAETH_MAINNET`.

## Why this structure

The page already uses a per-chain "Specific Methods" pattern for chains that support non-standard RPC methods or chain-specific variants (Polygon PoS, Polygon zkEVM, Citrea, Linea, zkSync Era, etc.). Even though `eth_getWithdrawalProof` uses the `eth_` namespace, it's only supported on MegaETH, so adding it to the chain-agnostic `EVM: Standard JSON-RPC Methods` table would be misleading. A dedicated `MegaETH: Specific Methods` section (placed next to Linea, another L2) is consistent with the existing convention, and I added a short note clarifying that the section applies to both MegaETH testnet and mainnet.

## Test plan

- Visually verified the rendered table in the diff
- No other pages touched