### PR TITLE
[Writer] docs(solana): separate API overview into Core RPC, DAS, and Photon sections

### DIFF
--- a/content/api-reference/solana/solana-api-overview.mdx
+++ b/content/api-reference/solana/solana-api-overview.mdx
@@ -9,6 +9,12 @@ slug: docs/solana/solana-api-overview
 
 📙 Get started with our [Solana API Quickstart Guide](/docs/reference/solana-api-quickstart).
 
+Alchemy's Solana endpoint exposes three distinct API surfaces on the same URL. Use the sections below to find the method you need.
+
+## Core Solana RPC methods
+
+Standard Solana JSON-RPC methods for reading on-chain state, submitting transactions, and inspecting the cluster. These match the official [Solana RPC specification](https://solana.com/docs/rpc) and are supported on every Alchemy Solana endpoint.
+
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
 | [`getAccountInfo`](/docs/chains/solana/solana-api-endpoints/get-account-info)                   | [`getBalance`](/docs/chains/solana/solana-api-endpoints/get-balance)                        |
@@ -16,38 +22,60 @@ slug: docs/solana/solana-api-overview
 | [`getBlockHeight`](/docs/chains/solana/solana-api-endpoints/get-block-height)                   | [`getBlockProduction`](/docs/chains/solana/solana-api-endpoints/get-block-production)       |
 | [`getBlocks`](/docs/chains/solana/solana-api-endpoints/get-blocks)                              | [`getBlocksWithLimit`](/docs/chains/solana/solana-api-endpoints/get-blocks-with-limit)      |
 | [`getBlockTime`](/docs/chains/solana/solana-api-endpoints/get-block-time)                       | [`getClusterNodes`](/docs/chains/solana/solana-api-endpoints/get-cluster-nodes)             |
-| [`getCompressedAccount`](/docs/chains/solana/solana-api-endpoints/get-compressed-account)       | [`getCompressedAccountProof`](/docs/chains/solana/solana-api-endpoints/get-compressed-account-proof) |
-| [`getCompressedAccountsByOwner`](/docs/chains/solana/solana-api-endpoints/get-compressed-accounts-by-owner) | [`getCompressedBalance`](/docs/chains/solana/solana-api-endpoints/get-compressed-balance)   |
-| [`getCompressedBalanceByOwner`](/docs/chains/solana/solana-api-endpoints/get-compressed-balance-by-owner) | [`getCompressedMintTokenHolders`](/docs/chains/solana/solana-api-endpoints/get-compressed-mint-token-holders) |
-| [`getCompressedTokenAccountBalance`](/docs/chains/solana/solana-api-endpoints/get-compressed-token-account-balance) | [`getCompressedTokenAccountsByDelegate`](/docs/chains/solana/solana-api-endpoints/get-compressed-token-accounts-by-delegate) |
-| [`getCompressedTokenAccountsByOwner`](/docs/chains/solana/solana-api-endpoints/get-compressed-token-accounts-by-owner) | [`getCompressedTokenBalancesByOwner`](/docs/chains/solana/solana-api-endpoints/get-compressed-token-balances-by-owner) |
-| [`getCompressedTokenBalancesByOwnerV2`](/docs/chains/solana/solana-api-endpoints/get-compressed-token-balances-by-owner-v-2) | [`getCompressionSignaturesForAccount`](/docs/chains/solana/solana-api-endpoints/get-compression-signatures-for-account) |
-| [`getCompressionSignaturesForAddress`](/docs/chains/solana/solana-api-endpoints/get-compression-signatures-for-address) | [`getCompressionSignaturesForOwner`](/docs/chains/solana/solana-api-endpoints/get-compression-signatures-for-owner) |
-| [`getCompressionSignaturesForTokenOwner`](/docs/chains/solana/solana-api-endpoints/get-compression-signatures-for-token-owner) | [`getEpochInfo`](/docs/chains/solana/solana-api-endpoints/get-epoch-info)                   |
-| [`getEpochSchedule`](/docs/chains/solana/solana-api-endpoints/get-epoch-schedule)               | [`getFeeForMessage`](/docs/chains/solana/solana-api-endpoints/get-fee-for-message)          |
-| [`getFirstAvailableBlock`](/docs/chains/solana/solana-api-endpoints/get-first-available-block)  | [`getGenesisHash`](/docs/chains/solana/solana-api-endpoints/get-genesis-hash)               |
-| [`getHealth`](/docs/chains/solana/solana-api-endpoints/get-health)                              | [`getHighestSnapshotSlot`](/docs/chains/solana/solana-api-endpoints/get-highest-snapshot-slot) |
-| [`getIdentity`](/docs/chains/solana/solana-api-endpoints/get-identity)                          | [`getIndexerHealth`](/docs/chains/solana/solana-api-endpoints/get-indexer-health)           |
-| [`getIndexerSlot`](/docs/chains/solana/solana-api-endpoints/get-indexer-slot)                   | [`getInflationGovernor`](/docs/chains/solana/solana-api-endpoints/get-inflation-governor)   |
-| [`getInflationRate`](/docs/chains/solana/solana-api-endpoints/get-inflation-rate)               | [`getInflationReward`](/docs/chains/solana/solana-api-endpoints/get-inflation-reward)       |
-| [`getLargestAccounts`](/docs/chains/solana/solana-api-endpoints/get-largest-accounts)           | [`getLatestBlockhash`](/docs/chains/solana/solana-api-endpoints/get-latest-blockhash)       |
-| [`getLatestCompressionSignatures`](/docs/chains/solana/solana-api-endpoints/get-latest-compression-signatures) | [`getLatestNonVotingSignatures`](/docs/chains/solana/solana-api-endpoints/get-latest-non-voting-signatures) |
-| [`getLeaderSchedule`](/docs/chains/solana/solana-api-endpoints/get-leader-schedule)             | [`getMaxRetransmitSlot`](/docs/chains/solana/solana-api-endpoints/get-max-retransmit-slot)  |
-| [`getMaxShredInsertSlot`](/docs/chains/solana/solana-api-endpoints/get-max-shred-insert-slot)   | [`getMinimumBalanceForRentExemption`](/docs/chains/solana/solana-api-endpoints/get-minimum-balance-for-rent-exemption) |
-| [`getMultipleAccounts`](/docs/chains/solana/solana-api-endpoints/get-multiple-accounts)         | [`getMultipleCompressedAccountProofs`](/docs/chains/solana/solana-api-endpoints/get-multiple-compressed-account-proofs) |
-| [`getMultipleCompressedAccounts`](/docs/chains/solana/solana-api-endpoints/get-multiple-compressed-accounts) | [`getMultipleNewAddressProofs`](/docs/chains/solana/solana-api-endpoints/get-multiple-new-address-proofs) |
-| [`getMultipleNewAddressProofsV2`](/docs/chains/solana/solana-api-endpoints/get-multiple-new-address-proofs-v-2) | [`getPriorityFeeEstimate`](/docs/chains/solana/solana-api-endpoints/get-priority-fee-estimate) |
-| [`getProgramAccounts`](/docs/chains/solana/solana-api-endpoints/get-program-accounts)           | [`getRecentPerformanceSamples`](/docs/chains/solana/solana-api-endpoints/get-recent-performance-samples) |
-| [`getRecentPrioritizationFees`](/docs/chains/solana/solana-api-endpoints/get-recent-prioritization-fees) | [`getSignaturesForAddress`](/docs/chains/solana/solana-api-endpoints/get-signatures-for-address) |
-| [`getSignatureStatuses`](/docs/chains/solana/solana-api-endpoints/get-signature-statuses)       | [`getSlot`](/docs/chains/solana/solana-api-endpoints/get-slot)                              |
-| [`getSlotLeader`](/docs/chains/solana/solana-api-endpoints/get-slot-leader)                     | [`getSlotLeaders`](/docs/chains/solana/solana-api-endpoints/get-slot-leaders)               |
-| [`getStakeActivation`](/docs/chains/solana/solana-api-endpoints/get-stake-activation)           | [`getSupply`](/docs/chains/solana/solana-api-endpoints/get-supply)                          |
-| [`getTokenAccountBalance`](/docs/chains/solana/solana-api-endpoints/get-token-account-balance)  | [`getTokenAccountsByDelegate`](/docs/chains/solana/solana-api-endpoints/get-token-accounts-by-delegate) |
-| [`getTokenAccountsByOwner`](/docs/chains/solana/solana-api-endpoints/get-token-accounts-by-owner) | [`getTokenLargestAccounts`](/docs/chains/solana/solana-api-endpoints/get-token-largest-accounts) |
-| [`getTokenSupply`](/docs/chains/solana/solana-api-endpoints/get-token-supply)                   | [`getTransaction`](/docs/chains/solana/solana-api-endpoints/get-transaction)                |
-| [`getTransactionCount`](/docs/chains/solana/solana-api-endpoints/get-transaction-count)         | [`getTransactionWithCompressionInfo`](/docs/chains/solana/solana-api-endpoints/get-transaction-with-compression-info) |
-| [`getValidityProof`](/docs/chains/solana/solana-api-endpoints/get-validity-proof)               | [`getValidityProofV2`](/docs/chains/solana/solana-api-endpoints/get-validity-proof-v-2)     |
+| [`getEpochInfo`](/docs/chains/solana/solana-api-endpoints/get-epoch-info)                       | [`getEpochSchedule`](/docs/chains/solana/solana-api-endpoints/get-epoch-schedule)           |
+| [`getFeeForMessage`](/docs/chains/solana/solana-api-endpoints/get-fee-for-message)              | [`getFirstAvailableBlock`](/docs/chains/solana/solana-api-endpoints/get-first-available-block) |
+| [`getGenesisHash`](/docs/chains/solana/solana-api-endpoints/get-genesis-hash)                   | [`getHealth`](/docs/chains/solana/solana-api-endpoints/get-health)                          |
+| [`getHighestSnapshotSlot`](/docs/chains/solana/solana-api-endpoints/get-highest-snapshot-slot)  | [`getIdentity`](/docs/chains/solana/solana-api-endpoints/get-identity)                      |
+| [`getInflationGovernor`](/docs/chains/solana/solana-api-endpoints/get-inflation-governor)       | [`getInflationRate`](/docs/chains/solana/solana-api-endpoints/get-inflation-rate)           |
+| [`getInflationReward`](/docs/chains/solana/solana-api-endpoints/get-inflation-reward)           | [`getLargestAccounts`](/docs/chains/solana/solana-api-endpoints/get-largest-accounts)       |
+| [`getLatestBlockhash`](/docs/chains/solana/solana-api-endpoints/get-latest-blockhash)           | [`getLeaderSchedule`](/docs/chains/solana/solana-api-endpoints/get-leader-schedule)         |
+| [`getMaxRetransmitSlot`](/docs/chains/solana/solana-api-endpoints/get-max-retransmit-slot)      | [`getMaxShredInsertSlot`](/docs/chains/solana/solana-api-endpoints/get-max-shred-insert-slot) |
+| [`getMinimumBalanceForRentExemption`](/docs/chains/solana/solana-api-endpoints/get-minimum-balance-for-rent-exemption) | [`getMultipleAccounts`](/docs/chains/solana/solana-api-endpoints/get-multiple-accounts)     |
+| [`getPriorityFeeEstimate`](/docs/chains/solana/solana-api-endpoints/get-priority-fee-estimate)  | [`getProgramAccounts`](/docs/chains/solana/solana-api-endpoints/get-program-accounts)       |
+| [`getRecentPerformanceSamples`](/docs/chains/solana/solana-api-endpoints/get-recent-performance-samples) | [`getRecentPrioritizationFees`](/docs/chains/solana/solana-api-endpoints/get-recent-prioritization-fees) |
+| [`getSignaturesForAddress`](/docs/chains/solana/solana-api-endpoints/get-signatures-for-address) | [`getSignatureStatuses`](/docs/chains/solana/solana-api-endpoints/get-signature-statuses)   |
+| [`getSlot`](/docs/chains/solana/solana-api-endpoints/get-slot)                                  | [`getSlotLeader`](/docs/chains/solana/solana-api-endpoints/get-slot-leader)                 |
+| [`getSlotLeaders`](/docs/chains/solana/solana-api-endpoints/get-slot-leaders)                   | [`getStakeActivation`](/docs/chains/solana/solana-api-endpoints/get-stake-activation)       |
+| [`getSupply`](/docs/chains/solana/solana-api-endpoints/get-supply)                              | [`getTokenAccountBalance`](/docs/chains/solana/solana-api-endpoints/get-token-account-balance) |
+| [`getTokenAccountsByDelegate`](/docs/chains/solana/solana-api-endpoints/get-token-accounts-by-delegate) | [`getTokenAccountsByOwner`](/docs/chains/solana/solana-api-endpoints/get-token-accounts-by-owner) |
+| [`getTokenLargestAccounts`](/docs/chains/solana/solana-api-endpoints/get-token-largest-accounts) | [`getTokenSupply`](/docs/chains/solana/solana-api-endpoints/get-token-supply)               |
+| [`getTransaction`](/docs/chains/solana/solana-api-endpoints/get-transaction)                    | [`getTransactionCount`](/docs/chains/solana/solana-api-endpoints/get-transaction-count)     |
 | [`getVersion`](/docs/chains/solana/solana-api-endpoints/get-version)                            | [`getVoteAccounts`](/docs/chains/solana/solana-api-endpoints/get-vote-accounts)             |
 | [`isBlockhashValid`](/docs/chains/solana/solana-api-endpoints/is-blockhash-valid)               | [`minimumLedgerSlot`](/docs/chains/solana/solana-api-endpoints/minimum-ledger-slot)         |
 | [`requestAirdrop`](/docs/chains/solana/solana-api-endpoints/request-airdrop)                    | [`sendTransaction`](/docs/chains/solana/solana-api-endpoints/send-transaction)              |
 | [`simulateBundle`](/docs/chains/solana/solana-api-endpoints/simulate-bundle)                    |                                                                                             |
+
+## DAS API (Digital Asset Standard)
+
+The [Digital Asset Standard (DAS)](/docs/reference/alchemy-das-apis-for-solana) is a Metaplex-defined interface for reading NFT and fungible-token data on Solana. Use these methods to look up assets, ownership, and compressed NFT proofs without parsing raw account data.
+
+See the [dedicated DAS API reference](/docs/reference/alchemy-das-apis-for-solana) for full parameter and response details.
+
+|                                                                                                              |                                                                                                              |
+| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
+| [`getAsset`](/docs/reference/alchemy-das-apis-for-solana/solana-das-api-endpoints/get-asset)                 | [`getAssets`](/docs/reference/alchemy-das-apis-for-solana/solana-das-api-endpoints/get-assets)               |
+| [`getAssetProof`](/docs/reference/alchemy-das-apis-for-solana/solana-das-api-endpoints/get-asset-proof)      | [`getAssetProofs`](/docs/reference/alchemy-das-apis-for-solana/solana-das-api-endpoints/get-asset-proofs)    |
+| [`getAssetsByAuthority`](/docs/reference/alchemy-das-apis-for-solana/solana-das-api-endpoints/get-assets-by-authority) | [`getAssetsByCreator`](/docs/reference/alchemy-das-apis-for-solana/solana-das-api-endpoints/get-assets-by-creator) |
+| [`getAssetsByGroup`](/docs/reference/alchemy-das-apis-for-solana/solana-das-api-endpoints/get-assets-by-group) | [`getAssetsByOwner`](/docs/reference/alchemy-das-apis-for-solana/solana-das-api-endpoints/get-assets-by-owner) |
+| [`getAssetSignatures`](/docs/reference/alchemy-das-apis-for-solana/solana-das-api-endpoints/get-asset-signatures) | [`getNftEditions`](/docs/reference/alchemy-das-apis-for-solana/solana-das-api-endpoints/get-nft-editions)    |
+| [`searchAssets`](/docs/reference/alchemy-das-apis-for-solana/solana-das-api-endpoints/search-assets)         |                                                                                                              |
+
+## Photon API (ZK Compression)
+
+The Photon API exposes ZK-compressed accounts, tokens, and transaction data for applications built on Solana's ZK Compression stack. These methods are powered by the [Helius Photon indexer](https://github.com/helius-labs/photon) and follow the Photon JSON-RPC specification.
+
+|                                                                                                              |                                                                                                              |
+| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
+| [`getCompressedAccount`](/docs/chains/solana/solana-api-endpoints/get-compressed-account)                    | [`getCompressedAccountProof`](/docs/chains/solana/solana-api-endpoints/get-compressed-account-proof)         |
+| [`getCompressedAccountsByOwner`](/docs/chains/solana/solana-api-endpoints/get-compressed-accounts-by-owner)  | [`getCompressedBalance`](/docs/chains/solana/solana-api-endpoints/get-compressed-balance)                    |
+| [`getCompressedBalanceByOwner`](/docs/chains/solana/solana-api-endpoints/get-compressed-balance-by-owner)    | [`getCompressedMintTokenHolders`](/docs/chains/solana/solana-api-endpoints/get-compressed-mint-token-holders) |
+| [`getCompressedTokenAccountBalance`](/docs/chains/solana/solana-api-endpoints/get-compressed-token-account-balance) | [`getCompressedTokenAccountsByDelegate`](/docs/chains/solana/solana-api-endpoints/get-compressed-token-accounts-by-delegate) |
+| [`getCompressedTokenAccountsByOwner`](/docs/chains/solana/solana-api-endpoints/get-compressed-token-accounts-by-owner) | [`getCompressedTokenBalancesByOwner`](/docs/chains/solana/solana-api-endpoints/get-compressed-token-balances-by-owner) |
+| [`getCompressedTokenBalancesByOwnerV2`](/docs/chains/solana/solana-api-endpoints/get-compressed-token-balances-by-owner-v-2) | [`getCompressionSignaturesForAccount`](/docs/chains/solana/solana-api-endpoints/get-compression-signatures-for-account) |
+| [`getCompressionSignaturesForAddress`](/docs/chains/solana/solana-api-endpoints/get-compression-signatures-for-address) | [`getCompressionSignaturesForOwner`](/docs/chains/solana/solana-api-endpoints/get-compression-signatures-for-owner) |
+| [`getCompressionSignaturesForTokenOwner`](/docs/chains/solana/solana-api-endpoints/get-compression-signatures-for-token-owner) | [`getIndexerHealth`](/docs/chains/solana/solana-api-endpoints/get-indexer-health)                            |
+| [`getIndexerSlot`](/docs/chains/solana/solana-api-endpoints/get-indexer-slot)                                | [`getLatestCompressionSignatures`](/docs/chains/solana/solana-api-endpoints/get-latest-compression-signatures) |
+| [`getLatestNonVotingSignatures`](/docs/chains/solana/solana-api-endpoints/get-latest-non-voting-signatures)  | [`getMultipleCompressedAccountProofs`](/docs/chains/solana/solana-api-endpoints/get-multiple-compressed-account-proofs) |
+| [`getMultipleCompressedAccounts`](/docs/chains/solana/solana-api-endpoints/get-multiple-compressed-accounts) | [`getMultipleNewAddressProofs`](/docs/chains/solana/solana-api-endpoints/get-multiple-new-address-proofs)    |
+| [`getMultipleNewAddressProofsV2`](/docs/chains/solana/solana-api-endpoints/get-multiple-new-address-proofs-v-2) | [`getTransactionWithCompressionInfo`](/docs/chains/solana/solana-api-endpoints/get-transaction-with-compression-info) |
+| [`getValidityProof`](/docs/chains/solana/solana-api-endpoints/get-validity-proof)                            | [`getValidityProofV2`](/docs/chains/solana/solana-api-endpoints/get-validity-proof-v-2)                      |

--- a/content/api-reference/solana/solana-api-overview.mdx
+++ b/content/api-reference/solana/solana-api-overview.mdx
@@ -13,7 +13,7 @@ Alchemy's Solana endpoint exposes three distinct API surfaces on the same URL. U
 
 ## Core Solana RPC methods
 
-Standard Solana JSON-RPC methods for reading on-chain state, submitting transactions, and inspecting the cluster. These match the official [Solana RPC specification](https://solana.com/docs/rpc) and are supported on every Alchemy Solana endpoint.
+Standard Solana JSON-RPC methods for reading on-chain state, submitting transactions, and inspecting the cluster. Most of these are standard methods from the official [Solana RPC specification](https://solana.com/docs/rpc). A few (like [`getPriorityFeeEstimate`](/docs/chains/solana/solana-api-endpoints/get-priority-fee-estimate) and [`simulateBundle`](/docs/chains/solana/solana-api-endpoints/simulate-bundle)) are provider-specific extensions (Alchemy and Jito, respectively) exposed on the same endpoint for convenience.
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
@@ -58,7 +58,7 @@ See the [dedicated DAS API reference](/docs/reference/alchemy-das-apis-for-solan
 | [`getAssetsByAuthority`](/docs/reference/alchemy-das-apis-for-solana/solana-das-api-endpoints/get-assets-by-authority) | [`getAssetsByCreator`](/docs/reference/alchemy-das-apis-for-solana/solana-das-api-endpoints/get-assets-by-creator) |
 | [`getAssetsByGroup`](/docs/reference/alchemy-das-apis-for-solana/solana-das-api-endpoints/get-assets-by-group) | [`getAssetsByOwner`](/docs/reference/alchemy-das-apis-for-solana/solana-das-api-endpoints/get-assets-by-owner) |
 | [`getAssetSignatures`](/docs/reference/alchemy-das-apis-for-solana/solana-das-api-endpoints/get-asset-signatures) | [`getNftEditions`](/docs/reference/alchemy-das-apis-for-solana/solana-das-api-endpoints/get-nft-editions)    |
-| [`searchAssets`](/docs/reference/alchemy-das-apis-for-solana/solana-das-api-endpoints/search-assets)         |                                                                                                              |
+| [`getTokenAccounts`](/docs/reference/alchemy-das-apis-for-solana/solana-das-api-endpoints/get-token-accounts) | [`searchAssets`](/docs/reference/alchemy-das-apis-for-solana/solana-das-api-endpoints/search-assets)         |
 
 ## Photon API (ZK Compression)
 

--- a/content/api-reference/solana/solana-api-overview.mdx
+++ b/content/api-reference/solana/solana-api-overview.mdx
@@ -13,7 +13,7 @@ Alchemy's Solana endpoint exposes three distinct API surfaces on the same URL. U
 
 ## Core Solana RPC methods
 
-Standard Solana JSON-RPC methods for reading on-chain state, submitting transactions, and inspecting the cluster. Most of these are standard methods from the official [Solana RPC specification](https://solana.com/docs/rpc). A few (like [`getPriorityFeeEstimate`](/docs/chains/solana/solana-api-endpoints/get-priority-fee-estimate) and [`simulateBundle`](/docs/chains/solana/solana-api-endpoints/simulate-bundle)) are provider-specific extensions (Alchemy and Jito, respectively) exposed on the same endpoint for convenience.
+Standard [Solana JSON-RPC](https://solana.com/docs/rpc) methods for reading on-chain state, submitting transactions, and inspecting the cluster. Every method in this table follows the official Solana RPC specification and works against any Solana RPC provider. For Alchemy-only methods (like `getPriorityFeeEstimate` and `simulateBundle`), see [Alchemy-specific extensions](#alchemy-specific-extensions) below.
 
 |                                                                                                 |                                                                                             |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
@@ -31,19 +31,26 @@ Standard Solana JSON-RPC methods for reading on-chain state, submitting transact
 | [`getLatestBlockhash`](/docs/chains/solana/solana-api-endpoints/get-latest-blockhash)           | [`getLeaderSchedule`](/docs/chains/solana/solana-api-endpoints/get-leader-schedule)         |
 | [`getMaxRetransmitSlot`](/docs/chains/solana/solana-api-endpoints/get-max-retransmit-slot)      | [`getMaxShredInsertSlot`](/docs/chains/solana/solana-api-endpoints/get-max-shred-insert-slot) |
 | [`getMinimumBalanceForRentExemption`](/docs/chains/solana/solana-api-endpoints/get-minimum-balance-for-rent-exemption) | [`getMultipleAccounts`](/docs/chains/solana/solana-api-endpoints/get-multiple-accounts)     |
-| [`getPriorityFeeEstimate`](/docs/chains/solana/solana-api-endpoints/get-priority-fee-estimate)  | [`getProgramAccounts`](/docs/chains/solana/solana-api-endpoints/get-program-accounts)       |
-| [`getRecentPerformanceSamples`](/docs/chains/solana/solana-api-endpoints/get-recent-performance-samples) | [`getRecentPrioritizationFees`](/docs/chains/solana/solana-api-endpoints/get-recent-prioritization-fees) |
-| [`getSignaturesForAddress`](/docs/chains/solana/solana-api-endpoints/get-signatures-for-address) | [`getSignatureStatuses`](/docs/chains/solana/solana-api-endpoints/get-signature-statuses)   |
-| [`getSlot`](/docs/chains/solana/solana-api-endpoints/get-slot)                                  | [`getSlotLeader`](/docs/chains/solana/solana-api-endpoints/get-slot-leader)                 |
-| [`getSlotLeaders`](/docs/chains/solana/solana-api-endpoints/get-slot-leaders)                   | [`getStakeActivation`](/docs/chains/solana/solana-api-endpoints/get-stake-activation)       |
-| [`getSupply`](/docs/chains/solana/solana-api-endpoints/get-supply)                              | [`getTokenAccountBalance`](/docs/chains/solana/solana-api-endpoints/get-token-account-balance) |
-| [`getTokenAccountsByDelegate`](/docs/chains/solana/solana-api-endpoints/get-token-accounts-by-delegate) | [`getTokenAccountsByOwner`](/docs/chains/solana/solana-api-endpoints/get-token-accounts-by-owner) |
-| [`getTokenLargestAccounts`](/docs/chains/solana/solana-api-endpoints/get-token-largest-accounts) | [`getTokenSupply`](/docs/chains/solana/solana-api-endpoints/get-token-supply)               |
-| [`getTransaction`](/docs/chains/solana/solana-api-endpoints/get-transaction)                    | [`getTransactionCount`](/docs/chains/solana/solana-api-endpoints/get-transaction-count)     |
-| [`getVersion`](/docs/chains/solana/solana-api-endpoints/get-version)                            | [`getVoteAccounts`](/docs/chains/solana/solana-api-endpoints/get-vote-accounts)             |
-| [`isBlockhashValid`](/docs/chains/solana/solana-api-endpoints/is-blockhash-valid)               | [`minimumLedgerSlot`](/docs/chains/solana/solana-api-endpoints/minimum-ledger-slot)         |
-| [`requestAirdrop`](/docs/chains/solana/solana-api-endpoints/request-airdrop)                    | [`sendTransaction`](/docs/chains/solana/solana-api-endpoints/send-transaction)              |
-| [`simulateBundle`](/docs/chains/solana/solana-api-endpoints/simulate-bundle)                    |                                                                                             |
+| [`getProgramAccounts`](/docs/chains/solana/solana-api-endpoints/get-program-accounts)           | [`getRecentPerformanceSamples`](/docs/chains/solana/solana-api-endpoints/get-recent-performance-samples) |
+| [`getRecentPrioritizationFees`](/docs/chains/solana/solana-api-endpoints/get-recent-prioritization-fees) | [`getSignaturesForAddress`](/docs/chains/solana/solana-api-endpoints/get-signatures-for-address) |
+| [`getSignatureStatuses`](/docs/chains/solana/solana-api-endpoints/get-signature-statuses)       | [`getSlot`](/docs/chains/solana/solana-api-endpoints/get-slot)                              |
+| [`getSlotLeader`](/docs/chains/solana/solana-api-endpoints/get-slot-leader)                     | [`getSlotLeaders`](/docs/chains/solana/solana-api-endpoints/get-slot-leaders)               |
+| [`getStakeActivation`](/docs/chains/solana/solana-api-endpoints/get-stake-activation)           | [`getSupply`](/docs/chains/solana/solana-api-endpoints/get-supply)                          |
+| [`getTokenAccountBalance`](/docs/chains/solana/solana-api-endpoints/get-token-account-balance)  | [`getTokenAccountsByDelegate`](/docs/chains/solana/solana-api-endpoints/get-token-accounts-by-delegate) |
+| [`getTokenAccountsByOwner`](/docs/chains/solana/solana-api-endpoints/get-token-accounts-by-owner) | [`getTokenLargestAccounts`](/docs/chains/solana/solana-api-endpoints/get-token-largest-accounts) |
+| [`getTokenSupply`](/docs/chains/solana/solana-api-endpoints/get-token-supply)                   | [`getTransaction`](/docs/chains/solana/solana-api-endpoints/get-transaction)                |
+| [`getTransactionCount`](/docs/chains/solana/solana-api-endpoints/get-transaction-count)         | [`getVersion`](/docs/chains/solana/solana-api-endpoints/get-version)                        |
+| [`getVoteAccounts`](/docs/chains/solana/solana-api-endpoints/get-vote-accounts)                 | [`isBlockhashValid`](/docs/chains/solana/solana-api-endpoints/is-blockhash-valid)           |
+| [`minimumLedgerSlot`](/docs/chains/solana/solana-api-endpoints/minimum-ledger-slot)             | [`requestAirdrop`](/docs/chains/solana/solana-api-endpoints/request-airdrop)                |
+| [`sendTransaction`](/docs/chains/solana/solana-api-endpoints/send-transaction)                  |                                                                                             |
+
+### Alchemy-specific extensions
+
+These methods are provider-specific extensions exposed on Alchemy's Solana endpoint for convenience. They are not part of the official Solana RPC specification and are not available on other Solana RPC providers.
+
+|                                                                                                 |                                                                                             |
+| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| [`getPriorityFeeEstimate`](/docs/chains/solana/solana-api-endpoints/get-priority-fee-estimate)  | [`simulateBundle`](/docs/chains/solana/solana-api-endpoints/simulate-bundle)                |
 
 ## DAS API (Digital Asset Standard)
 


### PR DESCRIPTION
## Summary

Reorganizes `content/api-reference/solana/solana-api-overview.mdx` into three clearly-labeled H2 sections so developers can quickly find the method they need instead of scanning one long alphabetical table that mixes three different API surfaces.

### New structure

1. **Core Solana RPC methods** — standard `solana-rpc` methods (getAccountInfo, getBalance, getBlock, sendTransaction, etc.)
2. **DAS API (Digital Asset Standard)** — Metaplex-defined NFT/asset methods (getAsset, getAssetsByOwner, searchAssets, getNftEditions, …). Links each method to the existing DAS reference at `/docs/reference/alchemy-das-apis-for-solana`.
3. **Photon API (ZK Compression)** — compressed-account and validity-proof methods (getCompressed*, getValidityProof*, getMultipleCompressedAccounts, getIndexerHealth, …). Includes a note that these methods are powered by the Helius Photon indexer.

### Verification

- Every method currently listed in `src/openrpc/chains/solana/solana.yaml` ends up in exactly one section; all existing endpoint links are preserved.
- No OpenRPC specs were modified — this is a presentation-only change.
- `docs.yml` nav structure is unchanged.

### Context

Linear: [DOCS-45](https://linear.app/alchemyapi/issue/DOCS-45/separate-solana-api-overview-into-core-rpc-das-and-photon-sections)

Requested by @cosmin on Slack.