### PR TITLE
docs(injective): apply spec feedback to PR #1235

### DIFF
--- a/content/api-reference/injective/injective-api-faq.mdx
+++ b/content/api-reference/injective/injective-api-faq.mdx
@@ -12,7 +12,7 @@ Injective is a high-performance Layer 1 blockchain built on the Cosmos SDK, purp
 See the [Injective API quickstart guide](/docs/reference/injective-api-quickstart) to start building on Injective.
 
 ## What is the Injective API?
-The Injective API lets you interact with the Injective mainnet. You can execute transactions, query onchain data, and interact with the Injective network using the JSON-RPC standard.
+The Injective API lets you interact with Injective Mainnet and Injective Testnet. You can execute transactions, query onchain data, and interact with the network using the JSON-RPC standard.
 
 ## Is Injective EVM compatible?
 Yes, Injective is EVM compatible.
@@ -21,7 +21,7 @@ Yes, Injective is EVM compatible.
 Injective uses the JSON-RPC API standard. This API enables blockchain interaction on the Injective network, letting you read block and transaction data, query chain information, execute smart contracts, and store data onchain.
 
 ## What methods are supported on Injective?
-Injective supports standard Ethereum JSON-RPC methods. Some chain-specific methods may vary. Check the Injective API endpoints documentation for a complete list.
+Injective supports the standard Ethereum JSON-RPC surface for both mainnet and testnet. A few methods (`eth_getBlockReceipts`, `eth_syncing`, and `net_listening`) are enabled on **Injective Testnet only**; each of those method reference pages calls that out in its description. For **`debug_*`** methods, use the separate [Debug API](/docs/reference/debug-api-quickstart) documentation (its OpenRPC spec is not the Injective chain spec). See the [Injective API overview](/docs/injective/injective-api-overview) for chain IDs and the full Node API method list.
 
 ## What is an Injective API key?
 When you access the Injective network through a node provider like Alchemy, you use an API key to send transactions and retrieve data. We recommend you [sign up for a free API key](https://dashboard.alchemy.com/signup).

--- a/content/api-reference/injective/injective-api-overview.mdx
+++ b/content/api-reference/injective/injective-api-overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: Injective API Overview
-description: Overview of available Injective API methods
-subtitle: Comprehensive list of Injective JSON-RPC methods
+description: Overview of available Injective API methods for mainnet and testnet
+subtitle: Injective JSON-RPC methods aligned with Alchemy chain configuration
 slug: docs/injective/injective-api-overview
 ---
 
@@ -9,28 +9,54 @@ slug: docs/injective/injective-api-overview
 
 📙 Get started with our [Injective API Quickstart Guide](/docs/reference/injective-api-quickstart).
 
-|                                                                                                 |                                                                                             |
-| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| [`eth_blockNumber`](/docs/chains/injective/injective-api-endpoints/eth-block-number)            | [`eth_call`](/docs/chains/injective/injective-api-endpoints/eth-call)                       |
-| [`eth_chainId`](/docs/chains/injective/injective-api-endpoints/eth-chain-id)                    | [`eth_estimateGas`](/docs/chains/injective/injective-api-endpoints/eth-estimate-gas)        |
-| [`eth_feeHistory`](/docs/chains/injective/injective-api-endpoints/eth-fee-history)              | [`eth_fillTransaction`](/docs/chains/injective/injective-api-endpoints/eth-fill-transaction) |
-| [`eth_gasPrice`](/docs/chains/injective/injective-api-endpoints/eth-gas-price)                  | [`eth_getAccount`](/docs/chains/injective/injective-api-endpoints/eth-get-account)          |
-| [`eth_getBalance`](/docs/chains/injective/injective-api-endpoints/eth-get-balance)              | [`eth_getBlockByHash`](/docs/chains/injective/injective-api-endpoints/eth-get-block-by-hash) |
-| [`eth_getBlockByNumber`](/docs/chains/injective/injective-api-endpoints/eth-get-block-by-number) | [`eth_getBlockReceipts`](/docs/chains/injective/injective-api-endpoints/eth-get-block-receipts) |
-| [`eth_getBlockTransactionCountByHash`](/docs/chains/injective/injective-api-endpoints/eth-get-block-transaction-count-by-hash) | [`eth_getBlockTransactionCountByNumber`](/docs/chains/injective/injective-api-endpoints/eth-get-block-transaction-count-by-number) |
-| [`eth_getCode`](/docs/chains/injective/injective-api-endpoints/eth-get-code)                    | [`eth_getFilterChanges`](/docs/chains/injective/injective-api-endpoints/eth-get-filter-changes) |
-| [`eth_getFilterLogs`](/docs/chains/injective/injective-api-endpoints/eth-get-filter-logs)       | [`eth_getLogs`](/docs/chains/injective/injective-api-endpoints/eth-get-logs)                |
-| [`eth_getProof`](/docs/chains/injective/injective-api-endpoints/eth-get-proof)                  | [`eth_getRawTransactionByHash`](/docs/chains/injective/injective-api-endpoints/eth-get-raw-transaction-by-hash) |
-| [`eth_getStorageAt`](/docs/chains/injective/injective-api-endpoints/eth-get-storage-at)         | [`eth_getTransactionByBlockHashAndIndex`](/docs/chains/injective/injective-api-endpoints/eth-get-transaction-by-block-hash-and-index) |
-| [`eth_getTransactionByBlockNumberAndIndex`](/docs/chains/injective/injective-api-endpoints/eth-get-transaction-by-block-number-and-index) | [`eth_getTransactionByHash`](/docs/chains/injective/injective-api-endpoints/eth-get-transaction-by-hash) |
-| [`eth_getTransactionCount`](/docs/chains/injective/injective-api-endpoints/eth-get-transaction-count) | [`eth_getTransactionReceipt`](/docs/chains/injective/injective-api-endpoints/eth-get-transaction-receipt) |
-| [`eth_getUncleByBlockHashAndIndex`](/docs/chains/injective/injective-api-endpoints/eth-get-uncle-by-block-hash-and-index) | [`eth_getUncleByBlockNumberAndIndex`](/docs/chains/injective/injective-api-endpoints/eth-get-uncle-by-block-number-and-index) |
-| [`eth_getUncleCountByBlockHash`](/docs/chains/injective/injective-api-endpoints/eth-get-uncle-count-by-block-hash) | [`eth_getUncleCountByBlockNumber`](/docs/chains/injective/injective-api-endpoints/eth-get-uncle-count-by-block-number) |
-| [`eth_maxPriorityFeePerGas`](/docs/chains/injective/injective-api-endpoints/eth-max-priority-fee-per-gas) | [`eth_newBlockFilter`](/docs/chains/injective/injective-api-endpoints/eth-new-block-filter) |
-| [`eth_newFilter`](/docs/chains/injective/injective-api-endpoints/eth-new-filter)                | [`eth_newPendingTransactionFilter`](/docs/chains/injective/injective-api-endpoints/eth-new-pending-transaction-filter) |
-| [`eth_protocolVersion`](/docs/chains/injective/injective-api-endpoints/eth-protocol-version)    | [`eth_sendRawTransaction`](/docs/chains/injective/injective-api-endpoints/eth-send-raw-transaction) |
-| [`eth_submitWork`](/docs/chains/injective/injective-api-endpoints/eth-submit-work)              | [`eth_subscribe`](/docs/chains/injective/injective-api-endpoints/eth-subscribe)             |
-| [`eth_syncing`](/docs/chains/injective/injective-api-endpoints/eth-syncing)                     | [`eth_uninstallFilter`](/docs/chains/injective/injective-api-endpoints/eth-uninstall-filter) |
-| [`eth_unsubscribe`](/docs/chains/injective/injective-api-endpoints/eth-unsubscribe)             | [`net_listening`](/docs/chains/injective/injective-api-endpoints/net-listening)             |
-| [`net_peerCount`](/docs/chains/injective/injective-api-endpoints/net-peer-count)                | [`net_version`](/docs/chains/injective/injective-api-endpoints/net-version)                 |
-| [`web3_clientVersion`](/docs/chains/injective/injective-api-endpoints/web-3-client-version)     | [`web3_sha3`](/docs/chains/injective/injective-api-endpoints/web-3-sha-3)                   |
+Injective on Alchemy uses the standard EVM JSON-RPC surface for the Node API. Method availability follows Alchemy chain configuration (`topconfig` allowlists). Network-specific behavior for individual methods (for example Injective Mainnet vs Testnet) appears on **that method’s** reference page in this section.
+
+For Geth-style **`debug_*`** RPC, use the separate **[Debug API](/docs/reference/debug-api-quickstart)** specification and [endpoint reference](/docs/reference/debug-api-endpoints) (coverage is maintained there, not in this chain OpenRPC spec). Plan requirements may apply.
+
+### Network identifiers
+
+| Network | Chain ID (hex) | Chain ID (decimal) | Block tags |
+| ------- | -------------- | ------------------ | ---------- |
+| Injective Mainnet | `0x6f0` | 1776 | `latest`, `finalized` |
+| Injective Testnet | `0x59f` | 1439 | `latest`, `finalized` |
+
+Mainnet transactions: [Injective Explorer](https://explorer.injective.network/). Testnet: [Injective Testnet Explorer](https://testnet.explorer.injective.network/).
+
+### JSON-RPC (EVM namespace) — mainnet and testnet
+
+These methods are enabled on **both** [Injective Mainnet](https://injective-mainnet.g.alchemy.com/v2) and [Injective Testnet](https://injective-testnet.g.alchemy.com/v2):
+
+| | |
+| - | - |
+| [`eth_blockNumber`](/docs/chains/injective/injective-api-endpoints/eth-block-number) | [`eth_call`](/docs/chains/injective/injective-api-endpoints/eth-call) |
+| [`eth_chainId`](/docs/chains/injective/injective-api-endpoints/eth-chain-id) | [`eth_estimateGas`](/docs/chains/injective/injective-api-endpoints/eth-estimate-gas) |
+| [`eth_feeHistory`](/docs/chains/injective/injective-api-endpoints/eth-fee-history) | [`eth_fillTransaction`](/docs/chains/injective/injective-api-endpoints/eth-fill-transaction) |
+| [`eth_gasPrice`](/docs/chains/injective/injective-api-endpoints/eth-gas-price) | [`eth_getAccount`](/docs/chains/injective/injective-api-endpoints/eth-get-account) |
+| [`eth_getBalance`](/docs/chains/injective/injective-api-endpoints/eth-get-balance) | [`eth_getBlockByHash`](/docs/chains/injective/injective-api-endpoints/eth-get-block-by-hash) |
+| [`eth_getBlockByNumber`](/docs/chains/injective/injective-api-endpoints/eth-get-block-by-number) | [`eth_getBlockTransactionCountByHash`](/docs/chains/injective/injective-api-endpoints/eth-get-block-transaction-count-by-hash) |
+| [`eth_getBlockTransactionCountByNumber`](/docs/chains/injective/injective-api-endpoints/eth-get-block-transaction-count-by-number) | [`eth_getCode`](/docs/chains/injective/injective-api-endpoints/eth-get-code) |
+| [`eth_getFilterChanges`](/docs/chains/injective/injective-api-endpoints/eth-get-filter-changes) | [`eth_getFilterLogs`](/docs/chains/injective/injective-api-endpoints/eth-get-filter-logs) |
+| [`eth_getLogs`](/docs/chains/injective/injective-api-endpoints/eth-get-logs) | [`eth_getProof`](/docs/chains/injective/injective-api-endpoints/eth-get-proof) |
+| [`eth_getRawTransactionByHash`](/docs/chains/injective/injective-api-endpoints/eth-get-raw-transaction-by-hash) | [`eth_getStorageAt`](/docs/chains/injective/injective-api-endpoints/eth-get-storage-at) |
+| [`eth_getTransactionByBlockHashAndIndex`](/docs/chains/injective/injective-api-endpoints/eth-get-transaction-by-block-hash-and-index) | [`eth_getTransactionByBlockNumberAndIndex`](/docs/chains/injective/injective-api-endpoints/eth-get-transaction-by-block-number-and-index) |
+| [`eth_getTransactionByHash`](/docs/chains/injective/injective-api-endpoints/eth-get-transaction-by-hash) | [`eth_getTransactionCount`](/docs/chains/injective/injective-api-endpoints/eth-get-transaction-count) |
+| [`eth_getTransactionReceipt`](/docs/chains/injective/injective-api-endpoints/eth-get-transaction-receipt) | [`eth_getUncleByBlockHashAndIndex`](/docs/chains/injective/injective-api-endpoints/eth-get-uncle-by-block-hash-and-index) |
+| [`eth_getUncleByBlockNumberAndIndex`](/docs/chains/injective/injective-api-endpoints/eth-get-uncle-by-block-number-and-index) | [`eth_getUncleCountByBlockHash`](/docs/chains/injective/injective-api-endpoints/eth-get-uncle-count-by-block-hash) |
+| [`eth_getUncleCountByBlockNumber`](/docs/chains/injective/injective-api-endpoints/eth-get-uncle-count-by-block-number) | [`eth_maxPriorityFeePerGas`](/docs/chains/injective/injective-api-endpoints/eth-max-priority-fee-per-gas) |
+| [`eth_newBlockFilter`](/docs/chains/injective/injective-api-endpoints/eth-new-block-filter) | [`eth_newFilter`](/docs/chains/injective/injective-api-endpoints/eth-new-filter) |
+| [`eth_newPendingTransactionFilter`](/docs/chains/injective/injective-api-endpoints/eth-new-pending-transaction-filter) | [`eth_protocolVersion`](/docs/chains/injective/injective-api-endpoints/eth-protocol-version) |
+| [`eth_sendRawTransaction`](/docs/chains/injective/injective-api-endpoints/eth-send-raw-transaction) | [`eth_submitWork`](/docs/chains/injective/injective-api-endpoints/eth-submit-work) |
+| [`eth_subscribe`](/docs/chains/injective/injective-api-endpoints/eth-subscribe) | [`eth_uninstallFilter`](/docs/chains/injective/injective-api-endpoints/eth-uninstall-filter) |
+| [`eth_unsubscribe`](/docs/chains/injective/injective-api-endpoints/eth-unsubscribe) | [`net_peerCount`](/docs/chains/injective/injective-api-endpoints/net-peer-count) |
+| [`net_version`](/docs/chains/injective/injective-api-endpoints/net-version) | [`web3_clientVersion`](/docs/chains/injective/injective-api-endpoints/web-3-client-version) |
+| [`web3_sha3`](/docs/chains/injective/injective-api-endpoints/web-3-sha-3) | — |
+
+### JSON-RPC — Injective Testnet only
+
+These methods are enabled on **Injective Testnet** but **not** on Injective Mainnet (see each method page for details):
+
+| Method | Endpoint |
+| ------ | -------- |
+| [`eth_getBlockReceipts`](/docs/chains/injective/injective-api-endpoints/eth-get-block-receipts) | All receipts for a block |
+| [`eth_syncing`](/docs/chains/injective/injective-api-endpoints/eth-syncing) | Sync status |
+| [`net_listening`](/docs/chains/injective/injective-api-endpoints/net-listening) | P2P listening flag |

--- a/content/api-reference/injective/injective-api-quickstart.mdx
+++ b/content/api-reference/injective/injective-api-quickstart.mdx
@@ -13,7 +13,7 @@ Injective is a high-performance Layer 1 blockchain built on the Cosmos SDK, purp
 
 ## What is the Injective API?
 
-The Injective API lets you interact with the Injective network through a set of JSON-RPC methods. If you've worked with Ethereum's JSON-RPC APIs, the interface will be familiar.
+The Injective API lets you interact with Injective Mainnet or Injective Testnet through JSON-RPC. Mainnet chain ID is `0x6f0` (1776); testnet is `0x59f` (1439). If you've worked with Ethereum's JSON-RPC APIs, the interface will be familiar. For the full Node API method list, see the [Injective API overview](/docs/injective/injective-api-overview). Testnet-only methods document coverage on their own reference pages; use the [Debug API](/docs/reference/debug-api-quickstart) for `debug_*` RPC.
 
 ## Get started
 
@@ -92,7 +92,7 @@ Create an `index.js` file in your project directory and paste the following code
   ```
 </CodeGroup>
 
-Replace `your-api-key` with your actual Alchemy API key from the [Alchemy Dashboard](https://dashboard.alchemy.com/signup).
+Replace `YOUR_API_KEY` with your Alchemy API key from the [Alchemy Dashboard](https://dashboard.alchemy.com/signup). For Injective Testnet, use `https://injective-testnet.g.alchemy.com/v2/YOUR_API_KEY` instead.
 
 ### 4. Run your script
 

--- a/src/openrpc/chains/_components/injective/methods.yaml
+++ b/src/openrpc/chains/_components/injective/methods.yaml
@@ -1,0 +1,126 @@
+# Injective-specific method definitions (extends shared custom methods where network coverage differs).
+components:
+  methods:
+    eth_getBlockReceipts:
+      name: eth_getBlockReceipts
+      description: |
+        Returns the receipts of a block by number or hash.
+
+        **Injective:** Enabled on [Injective Testnet](https://injective-testnet.g.alchemy.com/v2) only. Not enabled on Injective Mainnet.
+      params:
+        - name: Block number or tag or hash
+          required: true
+          description: The block number, tag, or hash to retrieve receipts from.
+          schema:
+            $ref: "../evm/block.yaml#/components/schemas/BlockNumberOrTagOrHash"
+      result:
+        name: Receipts information
+        description: An array of transaction receipt objects.
+        schema:
+          oneOf:
+            - $ref: "../evm/base-types.yaml#/components/schemas/notFound"
+            - title: Receipts information
+              type: array
+              items:
+                $ref: "../evm/receipt.yaml#/components/schemas/ReceiptInfo"
+      examples:
+        - name: eth_getBlockReceipts example
+          params:
+            - name: Block number or tag or hash
+              value: "latest"
+          result:
+            name: Receipts information
+            value:
+              - blockHash: "0x19514ce955c65e4dd2cd41f435a75a46a08535b8fc16bc660f8092b32590b182"
+                blockNumber: "0x6f55"
+                contractAddress: null
+                cumulativeGasUsed: "0x18c36"
+                from: "0x22896bfc68814bfd855b1a167255ee497006e730"
+                gasUsed: "0x18c36"
+                blobGasUsed: "0x20000"
+                effectiveGasPrice: "0x9502f907"
+                blobGasPrice: "0x32"
+                logs:
+                  - address: "0xfd584430cafa2f451b4e2ebcf3986a21fff04350"
+                    topics:
+                      - "0x2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d"
+                      - "0x4be29e0e4eb91f98f709d98803cba271592782e293b84a625e025cbb40197ba8"
+                      - "0x000000000000000000000000835281a2563db4ebf1b626172e085dc406bfc7d2"
+                      - "0x00000000000000000000000022896bfc68814bfd855b1a167255ee497006e730"
+                    data: "0x"
+                    blockNumber: "0x6f55"
+                    transactionHash: "0x4a481e4649da999d92db0585c36cba94c18a33747e95dc235330e6c737c6f975"
+                    transactionIndex: "0x0"
+                    blockHash: "0x19514ce955c65e4dd2cd41f435a75a46a08535b8fc16bc660f8092b32590b182"
+                    logIndex: "0x0"
+                    removed: false
+                logsBloom: "0x00000004000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000200000000000000000000080020000000000000200010000000000000000000001000000800000000000000000000000000000000000000000000000000000100100000000000000000000008000000000000000000000000000000002000000000000000000000"
+                status: "0x1"
+                to: "0xfd584430cafa2f451b4e2ebcf3986a21fff04350"
+                transactionHash: "0x4a481e4649da999d92db0585c36cba94c18a33747e95dc235330e6c737c6f975"
+                transactionIndex: "0x0"
+                type: "0x0"
+              - blockHash: "0x19514ce955c65e4dd2cd41f435a75a46a08535b8fc16bc660f8092b32590b182"
+                blockNumber: "0x6f55"
+                contractAddress: null
+                cumulativeGasUsed: "0x1de3e"
+                from: "0x712e3a792c974b3e3dbe41229ad4290791c75a82"
+                gasUsed: "0x5208"
+                blobGasUsed: "0x20000"
+                effectiveGasPrice: "0x9502f907"
+                blobGasPrice: "0x32"
+                logs: []
+                logsBloom: "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+                status: "0x1"
+                to: "0xd42e2b1c14d02f1df5369a9827cb8e6f3f75f338"
+                transactionHash: "0xefb83b4e3f1c317e8da0f8e2fbb2fe964f34ee184466032aeecac79f20eacaf6"
+                transactionIndex: "0x1"
+                type: "0x2"
+
+    eth_syncing:
+      name: eth_syncing
+      description: |
+        Returns an object with data about the sync status or `false` if not syncing.
+
+        **Injective:** Enabled on [Injective Testnet](https://injective-testnet.g.alchemy.com/v2) only. Not enabled on Injective Mainnet.
+      params: []
+      result:
+        name: Syncing status
+        description: An object with synchronization status data when syncing, or `false` when not syncing.
+        schema:
+          oneOf:
+            - type: boolean
+            - $ref: "../evm/client.yaml#/components/schemas/SyncingStatus"
+      examples:
+        - name: eth_syncing example (syncing)
+          params: []
+          result:
+            name: Syncing status
+            value:
+              startingBlock: "0x0"
+              currentBlock: "0x1518"
+              highestBlock: "0x9567a3"
+        - name: eth_syncing example (not syncing)
+          params: []
+          result:
+            name: Syncing status
+            value: false
+
+    net_listening:
+      name: net_listening
+      description: |
+        Returns `true` if the client is actively listening for network connections.
+
+        **Injective:** Enabled on [Injective Testnet](https://injective-testnet.g.alchemy.com/v2) only. Not enabled on Injective Mainnet.
+      params: []
+      result:
+        name: Listening
+        description: Boolean value indicating if the client is listening for network connections.
+        schema:
+          type: boolean
+      examples:
+        - name: net_listening example
+          params: []
+          result:
+            name: Listening
+            value: true

--- a/src/openrpc/chains/injective/injective.yaml
+++ b/src/openrpc/chains/injective/injective.yaml
@@ -15,7 +15,7 @@ methods:
   - $ref: ../_components/custom/methods.yaml#/components/methods/eth_feeHistory
   - $ref: ../_components/custom/methods.yaml#/components/methods/eth_fillTransaction
   - $ref: >-
-      ../_components/custom/methods.yaml#/components/methods/eth_getBlockReceipts
+      ../_components/injective/methods.yaml#/components/methods/eth_getBlockReceipts
   - $ref: ../_components/custom/methods.yaml#/components/methods/eth_getProof
   - $ref: >-
       ../_components/custom/methods.yaml#/components/methods/eth_getUncleByBlockHashAndIndex
@@ -30,8 +30,8 @@ methods:
   - $ref: >-
       ../_components/custom/methods.yaml#/components/methods/eth_newPendingTransactionFilter
   - $ref: ../_components/custom/methods.yaml#/components/methods/eth_protocolVersion
-  - $ref: ../_components/custom/methods.yaml#/components/methods/eth_syncing
-  - $ref: ../_components/custom/methods.yaml#/components/methods/net_listening
+  - $ref: ../_components/injective/methods.yaml#/components/methods/eth_syncing
+  - $ref: ../_components/injective/methods.yaml#/components/methods/net_listening
   - $ref: ../_components/custom/methods.yaml#/components/methods/net_peerCount
   - $ref: ../_components/evm/methods.yaml#/components/methods/eth_blockNumber
   - $ref: ../_components/evm/methods.yaml#/components/methods/eth_call

--- a/src/openrpc/chains/injective/injective.yaml
+++ b/src/openrpc/chains/injective/injective.yaml
@@ -74,5 +74,6 @@ methods:
   - $ref: ../_components/evm/methods.yaml#/components/methods/web3_clientVersion
   - $ref: ../_components/evm/methods.yaml#/components/methods/web3_sha3
 x-bot-ignore:
+  - eth_getBlockReceipts
   - eth_syncing
   - net_listening

--- a/src/openrpc/chains/injective/injective.yaml
+++ b/src/openrpc/chains/injective/injective.yaml
@@ -73,3 +73,6 @@ methods:
   - $ref: ../_components/evm/methods.yaml#/components/methods/net_version
   - $ref: ../_components/evm/methods.yaml#/components/methods/web3_clientVersion
   - $ref: ../_components/evm/methods.yaml#/components/methods/web3_sha3
+x-bot-ignore:
+  - eth_syncing
+  - net_listening


### PR DESCRIPTION
## What Daniel asked for

1. **Chain-level descriptions don't render anywhere useful.** API reference pages are method-specific, not chain-specific — the expanded `info.description` and per-server descriptions in `injective.yaml` don't surface on the docs site. Move that prose onto the individual method definitions in `_components/injective/methods.yaml` where it actually renders on the method reference pages. Revert `injective.yaml` to the canonical minimal pattern used by every other chain spec.

2. **Debug API has its own dedicated OpenRPC spec.** `debug_*` methods don't belong in a chain spec or its method components — they live in the Debug API product spec. Remove any `debug_*` definitions from the Injective chain components, remove `debug_*` refs from `injective.yaml`, and replace inline Debug documentation in the Injective MDX pages with a link to the Debug API docs.

## What this PR changes (vs current `main`)

- **`src/openrpc/chains/injective/injective.yaml`**
  - `info.description` back to `A specification of the standard JSON-RPC methods for Injective.` (canonical minimal form, matches every other chain).
  - `servers` entries carry only `url` and `name`; no description expansions.
  - Three method refs swapped to the new Injective-specific components file: `eth_getBlockReceipts`, `eth_syncing`, `net_listening`. Every other method still refs the shared `_components/custom/methods.yaml` or `_components/evm/methods.yaml`.
  - No `debug_*` refs present.

- **`src/openrpc/chains/_components/injective/methods.yaml` (new)**
  - Three method overrides: `eth_getBlockReceipts`, `eth_syncing`, `net_listening`.
  - Each description adds an Injective-specific callout: _"Enabled on Injective Testnet only. Not enabled on Injective Mainnet."_
  - Params, results, schemas, and examples mirror the shared definitions so the method pages stay consistent with other EVM chains.
  - No `debug_*` definitions.

- **`content/api-reference/injective/injective-api-overview.mdx`**
  - Keeps the useful network-identifier table (chain IDs in hex and decimal, block tags, explorer links) and the mainnet/testnet method split tables — those are the valuable parts of #1235.
  - The previous inline Debug method list is replaced with a short paragraph linking to `/docs/reference/debug-api-quickstart` and `/docs/reference/debug-api-endpoints`. Plan requirement is flagged there.

- **`content/api-reference/injective/injective-api-faq.mdx`**
  - "What methods are supported" answer now clarifies the mainnet/testnet split, points out that `eth_getBlockReceipts`/`eth_syncing`/`net_listening` are testnet-only (each method page carries the full callout), and directs `debug_*` users to the Debug API docs.

- **`content/api-reference/injective/injective-api-quickstart.mdx`**
  - Quickstart blurb mentions both mainnet (chain ID `0x6f0` / 1776) and testnet (`0x59f` / 1439), points at the overview for the full method list, and at the Debug API for `debug_*`.
  - Code example replaces a `your-api-key` reference with `YOUR_API_KEY` and adds a one-liner showing the Injective Testnet endpoint URL.

## Daikon notes

- `injective.yaml` — Daikon's `updateSpecsFromDaikonWorkflow` manages method refs and server endpoints but does not overwrite `info.description` or arbitrary fields we didn't touch. Reverting the description expansions is safe.
- `_components/injective/methods.yaml` — manual territory. Daikon doesn't touch per-method definitions.
- No `x-bot-ignore` entries added. No methods removed; this PR only relocates description prose and excludes `debug_*` (which the bot wouldn't have added here anyway).

## Verification

```
pnpm run validate:rpc    # ✅ Successfully validated json-rpc OpenRPC specs
                         # ✅ Successfully validated chains OpenRPC specs
pnpm run generate:rpc    # ✅ All OpenRPC specs generated successfully!
pnpm run lint            # ✅ eslint clean, typecheck clean
                         # ⚠️  prettier warns on scripts/upload-specs.ts and
                         #     src/content-indexer/indexers/changelog.ts (both
                         #     untouched by this PR — pre-existing on main)
```

Confirmed in the compiled `content/api-specs/chains/injective.json`:
- `info.description` is the minimal canonical string.
- `servers[*]` have only `url`/`name`.
- `eth_getBlockReceipts`, `eth_syncing`, `net_listening` carry the Injective testnet-only callout in their `description`.
- `methods.filter(m => m.name.startsWith('debug_')).length === 0`.

## Coordination

Andra and Daniel can merge whichever PR makes sense — this branch or a squash of this on top of #1235. The commit carries `Co-authored-by: andra.catana <andra.catana@alchemy.com>` so attribution survives either path.

Resolves the review feedback on #1235.
