### PR TITLE
docs: add guide for using existing session keys with Wallet APIs

### DIFF
--- a/content/docs.yml
+++ b/content/docs.yml
@@ -890,6 +890,8 @@ navigation:
                 path: wallets/pages/smart-wallets/session-keys/sdk.mdx
               - page: Using API
                 path: wallets/pages/smart-wallets/session-keys/api.mdx
+              - page: Use existing session keys
+                path: wallets/pages/smart-wallets/session-keys/legacy-session-keys.mdx
           - page: Retry transactions
             path: wallets/pages/transactions/retry-transactions/index.mdx
           - section: Sign

--- a/content/docs.yml
+++ b/content/docs.yml
@@ -890,7 +890,7 @@ navigation:
                 path: wallets/pages/smart-wallets/session-keys/sdk.mdx
               - page: Using API
                 path: wallets/pages/smart-wallets/session-keys/api.mdx
-              - page: Use existing session keys
+              - page: Legacy session keys
                 path: wallets/pages/smart-wallets/session-keys/legacy-session-keys.mdx
           - page: Retry transactions
             path: wallets/pages/transactions/retry-transactions/index.mdx

--- a/content/wallets/pages/resources/migration-v5.mdx
+++ b/content/wallets/pages/resources/migration-v5.mdx
@@ -112,3 +112,9 @@ const client = createSmartWalletClient({
 | `import { WalletClientSigner } from "@aa-sdk/core"` | *(remove — pass `WalletClient` directly as signer)* |
 | `import { swapActions } from "@account-kit/wallet-client/experimental"` | `import { swapActions } from "@alchemy/wallet-apis/experimental"` |
 | `import { type SmartWalletClientParams } from "@account-kit/wallet-client"` | `import { type CreateSmartWalletClientParams } from "@alchemy/wallet-apis"` |
+
+## Session keys installed via `installValidation`
+
+If you have session keys that were manually installed onchain using `installValidation` (e.g., through the `@account-kit/smart-contracts` v4 SDK), you can use them with Wallet APIs without reinstalling. Build a permissions context hex string and pass it in `capabilities.permissions.context` when sending transactions.
+
+See [Use existing session keys](/docs/reference/wallet-apis-session-keys/legacy-session-keys) for the full guide.

--- a/content/wallets/pages/smart-wallets/session-keys/legacy-session-keys.mdx
+++ b/content/wallets/pages/smart-wallets/session-keys/legacy-session-keys.mdx
@@ -169,5 +169,3 @@ Pass the permissions context in `capabilities.permissions.context` when sending 
     See [Send transactions (API)](/docs/wallets/transactions/send-transactions) for the full prepare-sign-send flow.
   </Tab>
 </Tabs>
-
-<Markdown src="../../../shared/v4-accordion.mdx" />

--- a/content/wallets/pages/smart-wallets/session-keys/legacy-session-keys.mdx
+++ b/content/wallets/pages/smart-wallets/session-keys/legacy-session-keys.mdx
@@ -1,0 +1,173 @@
+---
+title: Use existing session keys
+subtitle: Use session keys installed via installValidation with Wallet APIs
+url: https://alchemy.com/docs/wallets/reference/wallet-apis-session-keys/legacy-session-keys
+slug: wallets/reference/wallet-apis-session-keys/legacy-session-keys
+---
+
+<Warning>
+  This guide is for session keys that were **manually installed** onchain via [`installValidation`](/docs/wallets/smart-contracts/modular-account-v2/session-keys/adding-session-keys). For new session keys, use [`wallet_createSession`](/docs/reference/wallet-apis-session-keys/api) or [`grantPermissions`](/docs/reference/wallet-apis-session-keys/sdk) instead — they handle installation, permissions, and context automatically.
+</Warning>
+
+If you have session keys installed directly on a Modular Account V2 (for example, from a v4 `@account-kit/wallet-client` integration) and are migrating to Wallet APIs (`@alchemy/wallet-apis` v5), you can use those existing keys without reinstalling them. Build a permissions context hex string and pass it when sending transactions.
+
+## Requirements
+
+- The smart wallet must be a **Modular Account V2** (`sma-b`) or an **EIP-7702 account** delegated to Modular Account V2.
+- The session key must already be **installed onchain** with a known `entityId` via `installValidation`.
+- You must know whether the session key was installed as a **global** validation (`isGlobal: true`) or scoped to specific selectors.
+
+## Build the permissions context
+
+The permissions context tells Wallet APIs how to locate and validate the session key onchain. Construct it by concatenating three values:
+
+| Byte(s) | Value | Meaning |
+|---|---|---|
+| `0x02` | Fixed prefix | Indicates a session key installed outside of Wallet APIs |
+| `0x01` or `0x00` | `isGlobal` flag | `0x01` if the key was installed with `isGlobal: true`, `0x00` otherwise |
+| 4 bytes | `entityId` | The `entityId` used in the `installValidation` call, as a `uint32` hex value |
+
+<Tabs>
+  <Tab title="JavaScript">
+    ```ts
+    import { concatHex, toHex } from "viem";
+
+    const isGlobal = true; // match the value used in installValidation
+    const entityId = 1; // match the entityId used in installValidation
+
+    const permissionsContext = concatHex([
+      "0x02",
+      isGlobal ? "0x01" : "0x00",
+      toHex(entityId, { size: 4 }),
+    ]);
+    ```
+  </Tab>
+
+  <Tab title="Manual">
+    For an `entityId` of `1` with `isGlobal: true`:
+
+    ```
+    0x02 01 00000001
+    ```
+
+    This produces: `0x020100000001`
+  </Tab>
+</Tabs>
+
+## Send transactions with the context
+
+Pass the permissions context in `capabilities.permissions.context` when sending transactions.
+
+<Tabs>
+  <Tab title="SDK">
+    ```ts
+    import { privateKeyToAccount } from "viem/accounts";
+    import { arbitrumSepolia } from "viem/chains";
+    import { concatHex, toHex } from "viem";
+    import { createSmartWalletClient, alchemyWalletTransport } from "@alchemy/wallet-apis";
+
+    const sessionKey = privateKeyToAccount("0xSESSION_PRIVATE_KEY" as const);
+
+    // The address of the account that the session key is installed on
+    const accountAddress = "0xACCOUNT_ADDRESS";
+
+    const isGlobal = true;
+    const entityId = 1;
+
+    const permissionsContext = concatHex([
+      "0x02",
+      isGlobal ? "0x01" : "0x00",
+      toHex(entityId, { size: 4 }),
+    ]);
+
+    const client = createSmartWalletClient({
+      transport: alchemyWalletTransport({
+        apiKey: "YOUR_API_KEY",
+      }),
+      chain: arbitrumSepolia,
+      signer: sessionKey,
+      account: accountAddress,
+    });
+
+    const { id } = await client.sendCalls({
+      calls: [{ to: "0x...", value: BigInt(0) }],
+      capabilities: {
+        permissions: {
+          context: permissionsContext,
+        },
+      },
+    });
+
+    await client.waitForCallsStatus({ id });
+    ```
+  </Tab>
+
+  <Tab title="API">
+    Use the context in both `wallet_prepareCalls` and `wallet_sendPreparedCalls`:
+
+    ```bash
+    # Step 1: Prepare calls
+    curl --request POST \
+        --url https://api.g.alchemy.com/v2/$ALCHEMY_API_KEY \
+        --header 'content-type: application/json' \
+        --data '
+    {
+        "id": 1,
+        "jsonrpc": "2.0",
+        "method": "wallet_prepareCalls",
+        "params": [
+            {
+                "from": "'$ACCOUNT_ADDRESS'",
+                "chainId": "'$CHAIN_ID'",
+                "calls": [
+                    {
+                        "to": "0x0000000000000000000000000000000000000000",
+                        "value": "0x0"
+                    }
+                ],
+                "capabilities": {
+                    "permissions": {
+                        "context": "'$PERMISSIONS_CONTEXT'"
+                    }
+                }
+            }
+        ]
+    }'
+    ```
+
+    Then sign the returned `signatureRequest` with the **session key** and send via `wallet_sendPreparedCalls`:
+
+    ```bash
+    # Step 2: Send prepared calls
+    curl --request POST \
+        --url https://api.g.alchemy.com/v2/$ALCHEMY_API_KEY \
+        --header 'content-type: application/json' \
+        --data '
+    {
+        "id": 1,
+        "jsonrpc": "2.0",
+        "method": "wallet_sendPreparedCalls",
+        "params": [
+            {
+                "type": "user-operation-v070",
+                "data": { ...prepareCallsResult },
+                "chainId": "'$CHAIN_ID'",
+                "capabilities": {
+                    "permissions": {
+                        "context": "'$PERMISSIONS_CONTEXT'"
+                    }
+                },
+                "signature": {
+                    "type": "secp256k1",
+                    "data": "'$SESSION_KEY_SIGNATURE'"
+                }
+            }
+        ]
+    }'
+    ```
+
+    See [Send transactions (API)](/docs/wallets/transactions/send-transactions) for the full prepare-sign-send flow.
+  </Tab>
+</Tabs>
+
+<Markdown src="../../../shared/v4-accordion.mdx" />

--- a/content/wallets/pages/smart-wallets/session-keys/legacy-session-keys.mdx
+++ b/content/wallets/pages/smart-wallets/session-keys/legacy-session-keys.mdx
@@ -1,6 +1,6 @@
 ---
 title: Use existing session keys
-subtitle: Use session keys installed via installValidation with Wallet APIs
+subtitle: Use session keys installed via `installValidation` with Wallet APIs
 url: https://alchemy.com/docs/wallets/reference/wallet-apis-session-keys/legacy-session-keys
 slug: wallets/reference/wallet-apis-session-keys/legacy-session-keys
 ---


### PR DESCRIPTION
For customers migrating from v4 (installValidation-based session keys) to v5 Wallet APIs, documents how to build a permissions context hex string and pass it via capabilities.permissions.context. Also adds a cross-reference from the v5 migration guide.

## Description

<!-- Provide a brief summary of the changes in this PR -->

## Related Issues

<!-- Link to any related issues or Asana tasks this PR addresses (e.g., "Fixes #123") -->

## Changes Made

<!-- List the specific changes made in this PR -->

## Testing

<!-- Describe the tests that you ran to verify your changes -->

* \[ ] I have tested these changes locally
* \[ ] I have run the validation scripts (`pnpm run validate`)
* \[ ] I have checked that the documentation builds correctly
