### PR TITLE
[Writer] Remove Turnkey callout from Wallets Quickstart (DOCS-54)

### DIFF
--- a/content/wallets/pages/smart-wallets/quickstart/sdk.mdx
+++ b/content/wallets/pages/smart-wallets/quickstart/sdk.mdx
@@ -32,7 +32,7 @@ pnpm add @alchemy/wallet-apis viem
 
 ### 2. Create a client
 
-This quickstart uses a local private key as an example. You can use any [viem-compatible signer](/docs/wallets/third-party/signers/custom-integration), including providers like [Privy](/docs/wallets/third-party/signers/privy).
+This quickstart uses a local private key as an example. You can use any [viem-compatible signer](/docs/wallets/third-party/signers/custom-integration), including embedded wallet providers like [Privy](/docs/wallets/third-party/signers/privy).
 
 ```ts
 import { createSmartWalletClient, alchemyWalletTransport } from "@alchemy/wallet-apis";

--- a/content/wallets/pages/smart-wallets/quickstart/sdk.mdx
+++ b/content/wallets/pages/smart-wallets/quickstart/sdk.mdx
@@ -32,7 +32,7 @@ pnpm add @alchemy/wallet-apis viem
 
 ### 2. Create a client
 
-This quickstart uses a local private key as an example. You can use any [viem-compatible signer](/docs/wallets/third-party/signers/custom-integration), including providers like [Privy](/docs/wallets/third-party/signers/privy) and [Turnkey](/docs/wallets/third-party/signers/turnkey).
+This quickstart uses a local private key as an example. You can use any [viem-compatible signer](/docs/wallets/third-party/signers/custom-integration), including providers like [Privy](/docs/wallets/third-party/signers/privy).
 
 ```ts
 import { createSmartWalletClient, alchemyWalletTransport } from "@alchemy/wallet-apis";


### PR DESCRIPTION
## Summary

Removes the Turnkey mention from the Smart Wallets SDK Quickstart callout. Privy is our recommended embedded wallet provider, so we're no longer calling out Turnkey alongside it in the Quickstart prose.

Turnkey remains a supported signer — the Turnkey signer page (`content/wallets/pages/third-party/signers/turnkey.mdx`) and its nav entry in `docs.yml` are untouched.

## Change

File: `content/wallets/pages/smart-wallets/quickstart/sdk.mdx` (line 35)

Before:
> This quickstart uses a local private key as an example. You can use any [viem-compatible signer](/docs/wallets/third-party/signers/custom-integration), including providers like [Privy](/docs/wallets/third-party/signers/privy) and [Turnkey](/docs/wallets/third-party/signers/turnkey).

After:
> This quickstart uses a local private key as an example. You can use any [viem-compatible signer](/docs/wallets/third-party/signers/custom-integration), including providers like [Privy](/docs/wallets/third-party/signers/privy).

## Scope check

Grepped `content/wallets/pages/smart-wallets/quickstart/` for other Turnkey mentions — only this one callout existed.

## Linear

Closes [DOCS-54](https://linear.app/alchemyapi/issue/DOCS-54/remove-turnkey-callout-from-wallets-quickstart)

Requested by Ava via Slack.