### PR TITLE
[Writer] Remove Turnkey recommendations from overview pages (DOCS-55)

### DIFF
--- a/content/wallets/pages/authentication/overview.mdx
+++ b/content/wallets/pages/authentication/overview.mdx
@@ -39,7 +39,6 @@ Common signers that work out of the box:
 | Provider | Type | Guide |
 |----------|------|-------|
 | Privy | Embedded wallet (recommended) | [Guide →](/docs/wallets/third-party/signers/privy) |
-| Turnkey | Key management | [Guide →](/docs/wallets/third-party/signers/turnkey) |
 | Dynamic | Embedded wallet | [Guide →](/docs/wallets/third-party/signers/custom-integration) |
 | Openfort | Embedded wallet | [Guide →](/docs/wallets/third-party/signers/openfort) |
 | Custom / any viem signer | Any | [Guide →](/docs/wallets/third-party/signers/custom-integration) |
@@ -59,7 +58,7 @@ For a deeper comparison of custody models and provider trade-offs, see [Choosing
 [EIP-7702](/docs/wallets/transactions/using-eip-7702) lets an existing EOA delegate to a smart wallet — unlocking gas sponsorship, batching, and session keys without changing addresses. It's enabled by default on Wallet APIs.
 
 <Warning>
-  **EIP-7702 requires the signer to expose `signAuthorization`.** Embedded wallet providers (Privy, Turnkey, etc.) and `privateKeyToAccount` support this. External browser and hardware wallets — MetaMask, Rabby, Ledger — do **not** support it today.
+  **EIP-7702 requires the signer to expose `signAuthorization`.** Embedded wallet providers like Privy and `privateKeyToAccount` support this. External browser and hardware wallets — MetaMask, Rabby, Ledger — do **not** support it today.
 </Warning>
 
 ## Next steps

--- a/content/wallets/pages/authentication/overview.mdx
+++ b/content/wallets/pages/authentication/overview.mdx
@@ -39,6 +39,7 @@ Common signers that work out of the box:
 | Provider | Type | Guide |
 |----------|------|-------|
 | Privy | Embedded wallet (recommended) | [Guide →](/docs/wallets/third-party/signers/privy) |
+| Turnkey | Key management | [Guide →](/docs/wallets/third-party/signers/turnkey) |
 | Dynamic | Embedded wallet | [Guide →](/docs/wallets/third-party/signers/custom-integration) |
 | Openfort | Embedded wallet | [Guide →](/docs/wallets/third-party/signers/openfort) |
 | Custom / any viem signer | Any | [Guide →](/docs/wallets/third-party/signers/custom-integration) |
@@ -58,7 +59,7 @@ For a deeper comparison of custody models and provider trade-offs, see [Choosing
 [EIP-7702](/docs/wallets/transactions/using-eip-7702) lets an existing EOA delegate to a smart wallet — unlocking gas sponsorship, batching, and session keys without changing addresses. It's enabled by default on Wallet APIs.
 
 <Warning>
-  **EIP-7702 requires the signer to expose `signAuthorization`.** Embedded wallet providers like Privy and `privateKeyToAccount` support this. External browser and hardware wallets — MetaMask, Rabby, Ledger — do **not** support it today.
+  **EIP-7702 requires the signer to expose `signAuthorization`.** Embedded wallet providers like Privy support this. External browser and hardware wallets — MetaMask, Rabby, Ledger — do **not** support it today.
 </Warning>
 
 ## Next steps

--- a/content/wallets/pages/authentication/what-is-a-signer.mdx
+++ b/content/wallets/pages/authentication/what-is-a-signer.mdx
@@ -1,7 +1,7 @@
 ---
 outline: deep
 title: Choosing a signer
-description: Explore Wallet APIs integration guides for signers including Alchemy, Turnkey, Privy, Web3Auth, EOAs, and many more!
+description: Explore Wallet APIs integration guides for signers including Alchemy, Privy, Web3Auth, EOAs, and many more!
 slug: wallets/signer/what-is-a-signer
 ---
 
@@ -44,7 +44,7 @@ Here are some important criteria to consider when choosing a signer.
 
 Non-custodial wallet providers store private keys such that they cannot access the private key without the user's involvement. For example, the user must provide a password or passkey that only they know in order to decrypt the private key stored by the provider. Users benefit from heightened security, while remaining in control of their private keys at all times. This is similar to a safety deposit box vault: the provider secures the bank vault but only the user has access to the individual safety deposit boxes (e.g. wallets).
 
-**Example**: Alchemy, Turnkey, Magic
+**Example**: Alchemy, Magic
 
 ### MPC wallets (non-custodial)
 

--- a/content/wallets/pages/authentication/what-is-a-signer.mdx
+++ b/content/wallets/pages/authentication/what-is-a-signer.mdx
@@ -44,7 +44,6 @@ Here are some important criteria to consider when choosing a signer.
 
 Non-custodial wallet providers store private keys such that they cannot access the private key without the user's involvement. For example, the user must provide a password or passkey that only they know in order to decrypt the private key stored by the provider. Users benefit from heightened security, while remaining in control of their private keys at all times. This is similar to a safety deposit box vault: the provider secures the bank vault but only the user has access to the individual safety deposit boxes (e.g. wallets).
 
-**Example**: Alchemy, Magic
 
 ### MPC wallets (non-custodial)
 

--- a/content/wallets/pages/authentication/what-is-a-signer.mdx
+++ b/content/wallets/pages/authentication/what-is-a-signer.mdx
@@ -1,7 +1,7 @@
 ---
 outline: deep
 title: Choosing a signer
-description: Explore Wallet APIs integration guides for signers including Alchemy, Privy, Web3Auth, EOAs, and many more!
+description: Explore Wallet APIs integration guides for signers including Privy, Turnkey, EOAs, and many more!
 slug: wallets/signer/what-is-a-signer
 ---
 

--- a/content/wallets/pages/concepts/intro-to-account-kit.mdx
+++ b/content/wallets/pages/concepts/intro-to-account-kit.mdx
@@ -42,7 +42,7 @@ In Wallet APIs, this concept will manifest as a [smart wallet](/docs/wallets/res
 
 <div style={{ display: "flex", flexWrap: "wrap", alignItems: "flex-start" }}>
   <div style={{ flex: "1", marginRight: "10px" }}>
-    An **owner** is a service (e.g., Privy or Magic) or application (e.g., MetaMask) that manages a private key and signs transactions. The signature is only valid if the owner is an owner of the smart wallet.
+    An **owner** is a service (e.g., Privy or Turnkey) or application (e.g., MetaMask) that manages a private key and signs transactions. The signature is only valid if the owner is an owner of the smart wallet.
   </div>
 
   <div style={{ flex: "0 0 30%" }}>

--- a/content/wallets/pages/concepts/intro-to-account-kit.mdx
+++ b/content/wallets/pages/concepts/intro-to-account-kit.mdx
@@ -42,7 +42,7 @@ In Wallet APIs, this concept will manifest as a [smart wallet](/docs/wallets/res
 
 <div style={{ display: "flex", flexWrap: "wrap", alignItems: "flex-start" }}>
   <div style={{ flex: "1", marginRight: "10px" }}>
-    An **owner** is a service (e.g., Turnkey or Magic) or application (e.g., MetaMask) that manages a private key and signs transactions. The signature is only valid if the owner is an owner of the smart wallet.
+    An **owner** is a service (e.g., Privy or Magic) or application (e.g., MetaMask) that manages a private key and signs transactions. The signature is only valid if the owner is an owner of the smart wallet.
   </div>
 
   <div style={{ flex: "0 0 30%" }}>

--- a/content/wallets/pages/overview/sdk-concepts/intro-to-account-kit.mdx
+++ b/content/wallets/pages/overview/sdk-concepts/intro-to-account-kit.mdx
@@ -42,7 +42,7 @@ In Wallet APIs, this concept manifests as a [Smart Contract Account](/docs/walle
 
 <div style={{ display: "flex", flexWrap: "wrap", alignItems: "flex-start" }}>
   <div style={{ flex: "1", marginRight: "10px" }}>
-    An **authentication provider** is a service (e.g., Privy or Magic) or application (e.g., MetaMask) that manages a private key and signs transactions. The signature is only valid if the owner is registered on the smart account.
+    An **authentication provider** is a service (e.g., Privy or Turnkey) or application (e.g., MetaMask) that manages a private key and signs transactions. The signature is only valid if the owner is registered on the smart account.
   </div>
 
   <div style={{ flex: "0 0 30%" }}>

--- a/content/wallets/pages/overview/sdk-concepts/intro-to-account-kit.mdx
+++ b/content/wallets/pages/overview/sdk-concepts/intro-to-account-kit.mdx
@@ -42,7 +42,7 @@ In Wallet APIs, this concept manifests as a [Smart Contract Account](/docs/walle
 
 <div style={{ display: "flex", flexWrap: "wrap", alignItems: "flex-start" }}>
   <div style={{ flex: "1", marginRight: "10px" }}>
-    An **authentication provider** is a service (e.g., Turnkey or Magic) or application (e.g., MetaMask) that manages a private key and signs transactions. The signature is only valid if the owner is registered on the smart account.
+    An **authentication provider** is a service (e.g., Privy or Magic) or application (e.g., MetaMask) that manages a private key and signs transactions. The signature is only valid if the owner is registered on the smart account.
   </div>
 
   <div style={{ flex: "0 0 30%" }}>

--- a/content/wallets/pages/smart-wallets/quickstart/sdk.mdx
+++ b/content/wallets/pages/smart-wallets/quickstart/sdk.mdx
@@ -32,7 +32,7 @@ pnpm add @alchemy/wallet-apis viem
 
 ### 2. Create a client
 
-This quickstart uses a local private key as an example. You can use any [viem-compatible signer](/docs/wallets/third-party/signers/custom-integration), including providers like [Privy](/docs/wallets/third-party/signers/privy) and [Turnkey](/docs/wallets/third-party/signers/turnkey).
+This quickstart uses a local private key as an example. You can use any [viem-compatible signer](/docs/wallets/third-party/signers/custom-integration), including providers like [Privy](/docs/wallets/third-party/signers/privy).
 
 ```ts
 import { createSmartWalletClient, alchemyWalletTransport } from "@alchemy/wallet-apis";

--- a/content/wallets/pages/third-party/signers/custom-integration.mdx
+++ b/content/wallets/pages/third-party/signers/custom-integration.mdx
@@ -130,4 +130,5 @@ console.log("Transaction confirmed:", txStatus.receipts?.[0]?.transactionHash);
 See full integration guides for supported providers:
 
 * [Privy](/docs/wallets/third-party/signers/privy)
+* [Turnkey](/docs/wallets/third-party/signers/turnkey)
 * [Openfort](/docs/wallets/third-party/signers/openfort)

--- a/content/wallets/pages/third-party/signers/custom-integration.mdx
+++ b/content/wallets/pages/third-party/signers/custom-integration.mdx
@@ -131,4 +131,3 @@ See full integration guides for supported providers:
 
 * [Privy](/docs/wallets/third-party/signers/privy)
 * [Openfort](/docs/wallets/third-party/signers/openfort)
-* [Turnkey](/docs/wallets/third-party/signers/turnkey)


### PR DESCRIPTION
## Summary

Broadens the cleanup started in #1248 (DOCS-54). Per Ava, remove every "you can use … Turnkey" style recommendation from overview, quickstart, and signer-options pages so Privy is the primary recommended embedded signer. The dedicated Turnkey third-party guide is intentionally preserved.

Linear: [DOCS-55](https://linear.app/alchemyapi/issue/DOCS-55/remove-turnkey-recommendations-from-overview-pages)
Previous PR in this cleanup: #1248

## Files changed

- `content/wallets/pages/smart-wallets/quickstart/sdk.mdx` — dropped Turnkey from the "providers like Privy and Turnkey" example in the Wallet APIs SDK quickstart (this is the page rendered at `/docs/wallets/transactions/using-sdk`, the URL Ava specifically called out).
- `content/wallets/pages/authentication/overview.mdx` — removed the Turnkey row from the "Common signers that work out of the box" table, and rewrote the EIP-7702 Warning so it no longer recommends Turnkey alongside Privy.
- `content/wallets/pages/authentication/what-is-a-signer.mdx` — removed Turnkey from the page description and from the non-custodial wallet example list.
- `content/wallets/pages/concepts/intro-to-account-kit.mdx` — replaced the "e.g., Turnkey or Magic" owner example with "e.g., Privy or Magic".
- `content/wallets/pages/overview/sdk-concepts/intro-to-account-kit.mdx` — same replacement on the duplicate SDK-concepts version of the intro page.
- `content/wallets/pages/third-party/signers/custom-integration.mdx` — removed the Turnkey bullet from the integrations list at the bottom of the page.

## Preserved (intentionally not touched)

- `content/wallets/pages/third-party/signers/turnkey.mdx` — the dedicated third-party Turnkey guide, untouched.
- `content/docs.yml` — the nav entry pointing to `wallets/pages/third-party/signers/turnkey.mdx` under **Other signers**, untouched.
- `content/redirects.yml` — no Turnkey redirects were removed.
- `content/wallets/pages/signer/export-private-key.mdx` — Turnkey appears only as JS identifier/container names in the code example, not as a recommendation.
- `content/wallets/pages/smart-wallets/how-to-stamp-requests.mdx` — Turnkey appears only as the `turnkey_hpke` protocol string and as an external reference link to Turnkey's stamping docs, not as a signer recommendation.
- `content/wallets/pages/signer/what-is-a-signer.mdx` — Turnkey is mentioned only as the security model that powers AlchemySigner's secure enclave, which is factual infrastructure attribution, not a recommendation.

## Verification

- `pnpm run lint:prettier` — passes
- `pnpm run lint:eslint` — passes
- `pnpm run typecheck` — passes
- `pnpm run generate` — not applicable (no spec or generated-file changes; MDX content only)
- Re-ran `grep -rn -i turnkey content/ --include='*.mdx' --include='*.yml'` after edits and confirmed the only remaining matches are the four preserved locations listed above plus the dedicated guide itself.
