### PR TITLE
[Styler] Weekly style audit (2026-04-22)

### DIFF
--- a/content/tutorials/build-with-ai/alchemy-cli.mdx
+++ b/content/tutorials/build-with-ai/alchemy-cli.mdx
@@ -5,7 +5,7 @@ subtitle: Query blockchain data and manage your Alchemy account from the termina
 slug: docs/alchemy-cli
 ---
 
-The Alchemy CLI wraps every Alchemy product including nodes, Data APIs, Smart Wallets, webhooks, and more. Use it to:
+The Alchemy CLI wraps every Alchemy product including nodes, Data APIs, Wallet APIs, webhooks, and more. Use it to:
 
 * Live query onchain data without writing a script
 * Run admin tasks like creating apps, rotating allowlists, and managing webhooks
@@ -160,7 +160,7 @@ Preview a transaction's outcome before broadcasting.
 
 All four accept an optional `--block-tag` (defaults to `latest`).
 
-### Smart Wallets (Bundler and Gas Manager)
+### Wallet APIs (Bundler and Gas Manager)
 
 | Command | Description |
 |---|---|

--- a/content/tutorials/build-with-ai/overview.mdx
+++ b/content/tutorials/build-with-ai/overview.mdx
@@ -30,7 +30,7 @@ The [Alchemy CLI](docs/alchemy-cli) is a single binary that wraps every Alchemy 
 npm i -g @alchemy/cli@latest
 ```
 
-* Covers JSON-RPC nodes, Data APIs, Smart Wallets, Notify webhooks, and the Admin API across [100+ networks](docs/reference/node-supported-chains)
+* Covers JSON-RPC nodes, Data APIs, Wallet APIs, Notify webhooks, and the Admin API across [100+ networks](docs/reference/node-supported-chains)
 * `--json --no-interactive` flags make every command machine-readable
 * Built-in `agent-prompt` command emits a complete usage spec for AI agents
 * Supports API key, access key, and x402 wallet authentication

--- a/content/wallets/pages/index.mdx
+++ b/content/wallets/pages/index.mdx
@@ -59,7 +59,7 @@ Simple APIs to send transactions with advanced capabilities. Gas sponsorship, ba
 
   <Card title="Automatic retries" icon="arrow-rotate-right" href="/docs/wallets/transactions/retry-transactions">
     Stuck transactions are automatically re-priced and resubmitted so they
-    land on-chain.
+    land onchain.
   </Card>
 
   <Card title="Session keys" icon="fa-solid fa-clock" href="/docs/wallets/reference/wallet-apis-session-keys">

--- a/content/wallets/pages/resources/types.mdx
+++ b/content/wallets/pages/resources/types.mdx
@@ -201,7 +201,7 @@ export type ClientMiddlewareConfig<
 
 ## `ClientMiddlewareFn`
 
-Each middleware is a function that takes in a user operation object, `UserOperationStruct`, performs its job to retrieve or compute the data, and populate different fields of the user operation to pass onto the next middleware in the pipeline before being signed and sent to the network. `ClientMiddlewareFn` is the function type that represents each middleware. In optional [`UserOperationOverrides`](#useroperationoverrides), and [`UserOperationFeeOptions`](https://github.com/alchemyplatform/aa-sdk/blob/v4.x.x/aa-sdk/core/src/types.ts#L55), and returns a promise that resolves to a modified `UserOperationStruct`. This function is what you specify as your overridden middleware value for applying custom logic during the `UserOperationStruct` object to be sent to the bundler for on-chain execution.
+Each middleware is a function that takes in a user operation object, `UserOperationStruct`, performs its job to retrieve or compute the data, and populate different fields of the user operation to pass onto the next middleware in the pipeline before being signed and sent to the network. `ClientMiddlewareFn` is the function type that represents each middleware. In optional [`UserOperationOverrides`](#useroperationoverrides), and [`UserOperationFeeOptions`](https://github.com/alchemyplatform/aa-sdk/blob/v4.x.x/aa-sdk/core/src/types.ts#L55), and returns a promise that resolves to a modified `UserOperationStruct`. This function is what you specify as your overridden middleware value for applying custom logic during the `UserOperationStruct` object to be sent to the bundler for onchain execution.
 
 <Accordion title="ClientMiddlewareFn">
 
@@ -353,7 +353,7 @@ export type SmartAccountClientActions<
 
 ## `SmartAccountSigner`
 
-An interface representing a signer capable of signing messages and typed data. It provides methods to retrieve the signer's address (`getAddress`), sign a message (`signMessage`), and sign typed data (`signTypedData`). `SmartAccountSigner` refers to the [`Signer`](/docs/wallets/resources/terms#signer) instance responsible for the signing activities using its private key for smart wallet activities. Often, the `Signer` is referred to as the `Owner` of the account as it has the authority to use the smart wallet on-chain with its signatures.
+An interface representing a signer capable of signing messages and typed data. It provides methods to retrieve the signer's address (`getAddress`), sign a message (`signMessage`), and sign typed data (`signTypedData`). `SmartAccountSigner` refers to the [`Signer`](/docs/wallets/resources/terms#signer) instance responsible for the signing activities using its private key for smart wallet activities. Often, the `Signer` is referred to as the `Owner` of the account as it has the authority to use the smart wallet onchain with its signatures.
 
 <Accordion title="SmartAccountSigner">
 


### PR DESCRIPTION
Weekly style audit of content files changed in PRs merged during the last 7 days, against `STYLE_RULES.md`.

## Fixes

### Rebrand leftovers: `Smart Wallets` (product) → `Wallet APIs`
PR #1223 renamed the product surface from **Smart Wallets** to **Wallet APIs** on 2026-04-16. PR #1233 (merged later the same week) introduced two new pages that still referenced the old product name.

- `content/tutorials/build-with-ai/alchemy-cli.mdx`
  - Line 8 (intro prose): `nodes, Data APIs, Smart Wallets, webhooks` → `nodes, Data APIs, Wallet APIs, webhooks`
  - Line 163 (section heading): `### Smart Wallets (Bundler and Gas Manager)` → `### Wallet APIs (Bundler and Gas Manager)`
- `content/tutorials/build-with-ai/overview.mdx`
  - Line 33: `Data APIs, Smart Wallets, Notify webhooks` → `Data APIs, Wallet APIs, Notify webhooks`

Note: lowercase `smart wallet` (the smart-contract-account concept) is preserved — only the product name was rebranded.

### Terminology: `on-chain` → `onchain` (prose)
Per the preferred-forms table in `STYLE_RULES.md`.

- `content/wallets/pages/index.mdx` line 62 — `land on-chain` → `land onchain`
- `content/wallets/pages/resources/types.mdx` line 204 — `sent to the bundler for on-chain execution` → `...onchain execution`
- `content/wallets/pages/resources/types.mdx` line 356 — `use the smart wallet on-chain` → `...smart wallet onchain`

Both files were touched by recent PRs (#1251, #1223, #1243), so they fall within this week's audit scope.

## Not fixed (intentional)

- `content/wallets/pages/third-party/smart-contracts.mdx` line 309 — `"could not get on-chain owner"` lives inside a code block error string; Styler does not modify code without verification.
- `content/wallets/shared/react-native/signer-setup.mdx` line 82 — `alt="how to copy the api key"` is an image alt attribute; cosmetic only.
- `content/tutorials/getting-started/developer-best-practices/best-practices-when-using-alchemy.mdx` has pre-existing `API Key` casing and duplicated `## 8.` headings, but PR #1218 only added callouts — the violations were not introduced this week.
- `content/wallets/pages/core/quickstart.mdx` line 34 — `copy the **API Key**` reads as a UI label reference; left as-is.

## Audit scope
`gh pr list --state merged --search "merged:>=2026-04-15" --limit 50` returned 24 PRs; 147 unique `.mdx`/`.md` content files changed. All were scanned for terminology, casing, and tone violations.