### PR TITLE
[Writer] Add CU cost bullet for alchemy_requestFeePayer with prefundRent

### DIFF
--- a/content/api-reference/pricing-resources/pricing/compute-unit-costs.mdx
+++ b/content/api-reference/pricing-resources/pricing/compute-unit-costs.mdx
@@ -215,6 +215,7 @@ Similar to the [NFT API](/docs/reference/compute-unit-costs#nft-api), the Gas Ma
 | alchemy\_requestFeePayer                   | 1000 | 100           |
 
 * When `eth_sendUserOperation` is called with a valid bundler sponsorship header (`x-alchemy-policy-id`), the CU cost is 3000 instead of the standard 1000.
+* When `alchemy_requestFeePayer` is called with `prefundRent = true`, the CU cost is 1250 instead of the standard 1000.
 
 # NFT API
 


### PR DESCRIPTION
Closes DOCS-58.

Adds a single bullet below the Gas Manager & Bundler APIs table documenting the special-case CU cost for `alchemy_requestFeePayer` requests with `prefundRent = true` (**1250** CU instead of the standard 1000).

Mirrors the formatting of the existing bullet for `eth_sendUserOperation` with a bundler sponsorship header. No table or other section modified.

Linear: https://linear.app/alchemyapi/issue/DOCS-58/add-cu-cost-bullet-for-alchemy-requestfeepayer-with-prefundrent-on