### PR TITLE
chore(icons): migrate Card icon props from fa-* strings to bare sprite ids

### DIFF
--- a/content/api-reference/data/data-overview.mdx
+++ b/content/api-reference/data/data-overview.mdx
@@ -12,35 +12,35 @@ The Data APIs give you fast, reliable access to blockchain data without running 
 ## Components of the Data APIs
 
 <CardGroup cols={3}>
-  <Card title="Portfolio API" icon="fa-solid fa-chart-pie" href="/docs/reference/portfolio-apis">
+  <Card title="Portfolio API" icon="chart-pie" href="/docs/reference/portfolio-apis">
     Build a complete portfolio view of a user’s wallet, across tokens and NFTs.
   </Card>
 
-  <Card title="Token API" icon="fa-solid fa-coins" href="/docs/reference/token-api-quickstart">
+  <Card title="Token API" icon="coins" href="/docs/reference/token-api-quickstart">
     Request information about specific tokens like metadata or wallet balances.
   </Card>
 
-  <Card title="Transfers API" icon="fa-solid fa-arrow-right-arrow-left" href="/docs/reference/transfers-api-quickstart">
+  <Card title="Transfers API" icon="arrow-right-arrow-left" href="/docs/reference/transfers-api-quickstart">
     Fetch historical transactions for any address in one request.
   </Card>
 
-  <Card title="Prices API" icon="fa-solid fa-chart-line" href="/docs/reference/prices-api-quickstart">
+  <Card title="Prices API" icon="chart-line" href="/docs/reference/prices-api-quickstart">
     Access real-time and historical prices for tokens.
   </Card>
 
-  <Card title="NFT API" icon="fa-solid fa-image" href="/docs/reference/nft-api-quickstart">
+  <Card title="NFT API" icon="image" href="/docs/reference/nft-api-quickstart">
     Instantly find, verify, and display any NFT, across all major blockchains.
   </Card>
 
-  <Card title="Webhooks" icon="fa-solid fa-bell" href="/docs/reference/notify-api-quickstart">
+  <Card title="Webhooks" icon="bell" href="/docs/reference/notify-api-quickstart">
     Subscribe to onchain events like transfers, transactions, and balance changes.
   </Card>
 
-  <Card title="Simulation API" icon="fa-solid fa-flask" href="/docs/reference/simulation">
+  <Card title="Simulation API" icon="flask" href="/docs/reference/simulation">
     Simulate a transaction and see its potential effects before you send it.
   </Card>
 
-  <Card title="Utility API" icon="fa-solid fa-screwdriver-wrench" href="/docs/reference/utility-api-overview">
+  <Card title="Utility API" icon="screwdriver-wrench" href="/docs/reference/utility-api-overview">
     Enhanced APIs to get blocks by timestamp and transaction receipts.
   </Card>
 </CardGroup>
@@ -121,19 +121,19 @@ We're not just a data provider -- we're the infra layer behind the biggest names
 ### Token, NFT, and Prices APIs
 
 <CardGroup cols={3}>
-  <Card title="Token API" icon="fa-solid fa-coins" href="/docs/reference/token-api-quickstart">
+  <Card title="Token API" icon="coins" href="/docs/reference/token-api-quickstart">
     **Ideal for:** Multi-chain token experiences, balance indexing
     
     **How it works:** Call an API to return multi-chain and complete token data
   </Card>
 
-  <Card title="NFT API" icon="fa-solid fa-image" href="/docs/reference/nft-api-quickstart">
+  <Card title="NFT API" icon="image" href="/docs/reference/nft-api-quickstart">
     **Ideal for:** NFT drops, token gating, analytics, wallets, marketplaces
 
     **How it works:** Call an API to return multi-chain and complete NFT data
   </Card>
 
-  <Card title="Prices API" icon="fa-solid fa-chart-line" href="/docs/reference/prices-api-quickstart">
+  <Card title="Prices API" icon="chart-line" href="/docs/reference/prices-api-quickstart">
     **Ideal for:** Multi-chain token experiences, trading apps, wallets
 
     **How it works:** Call an API to return multi-chain and complete token prices data
@@ -143,13 +143,13 @@ We're not just a data provider -- we're the infra layer behind the biggest names
 ### Webhooks
 
 <CardGroup cols={2}>
-  <Card title="Webhooks" icon="fa-solid fa-bell" href="/docs/reference/notify-api-quickstart">
+  <Card title="Webhooks" icon="bell" href="/docs/reference/notify-api-quickstart">
     **Ideal for:** Push notifications, wallets, consumer facing apps
     
     **How it works:** Define your webhook and start receiving relevant events
   </Card>
 
-  <Card title="Custom Webhooks" icon="fa-solid fa-code" href="/docs/reference/custom-webhooks-quickstart">
+  <Card title="Custom Webhooks" icon="code" href="/docs/reference/custom-webhooks-quickstart">
     **Ideal for:** Infinite customization, specific data needs, multi-chain apps
     
     **How it works:** Customize your event to your exact needs and immediately receive them

--- a/content/api-reference/introduction/api-overview.mdx
+++ b/content/api-reference/introduction/api-overview.mdx
@@ -8,19 +8,19 @@ hide-toc: true
 ---
 
 <CardGroup cols={4}>
-  <Card title="Node API" icon="fa-solid fa-diagram-project" href="/docs/reference/node-api-overview">
+  <Card title="Node API" icon="diagram-project" href="/docs/reference/node-api-overview">
     Low-level JSON-RPC for reading & writing blockchain data.
   </Card>
 
-  <Card title="Data APIs" icon="fa-solid fa-database" href="/docs/reference/data-overview">
+  <Card title="Data APIs" icon="database" href="/docs/reference/data-overview">
     Structured, indexed data for balances, NFTs, prices, and more.
   </Card>
 
-  <Card title="Wallet APIs" icon="fa-solid fa-wallet" href="/docs/wallets">
+  <Card title="Wallet APIs" icon="wallet" href="/docs/wallets">
     Account abstraction infrastructure for smart wallets.
   </Card>
 
-  <Card title="Rollups" icon="fa-solid fa-layer-group" href="/docs/reference/rollups-quickstart">
+  <Card title="Rollups" icon="layer-group" href="/docs/reference/rollups-quickstart">
     Launch dedicated rollups with full control over your L2.
   </Card>
 </CardGroup>
@@ -39,23 +39,23 @@ The [Node API](/docs/reference/node-api-overview) gives you low-level access to 
 Use it for sending transactions, querying blocks and logs, and accessing state. It supports multiple chains; see the [Chain APIs Overview](/docs/reference/chain-apis-overview) page for the full list.
 
 <CardGroup cols={3}>
-  <Card title="Chain APIs" icon="fa-solid fa-diagram-project" href="/docs/chains">
+  <Card title="Chain APIs" icon="diagram-project" href="/docs/chains">
     Read & write interface for all blockchains supported by us.
   </Card>
 
-  <Card title="WebSockets" icon="fa-solid fa-wave-square" href="/docs/reference/subscription-api">
+  <Card title="WebSockets" icon="wave-square" href="/docs/reference/subscription-api">
     Subscribe to pending transactions, log events, new blocks, and more.
   </Card>
 
-  <Card title="Trace API" icon="fa-solid fa-magnifying-glass-arrow-right" href="/docs/reference/trace-api-quickstart">
+  <Card title="Trace API" icon="magnifying-glass-arrow-right" href="/docs/reference/trace-api-quickstart">
     Get insights into transaction processing and onchain activity.
   </Card>
 
-  <Card title="Debug API" icon="fa-solid fa-bug" href="/docs/reference/debug-api-quickstart">
+  <Card title="Debug API" icon="bug" href="/docs/reference/debug-api-quickstart">
     Non-standard RPC methods for inspecting and debugging transactions.
   </Card>
 
-  <Card title="Yellowstone gRPC" icon="fa-solid fa-bolt" href="/docs/reference/yellowstone-grpc-overview">
+  <Card title="Yellowstone gRPC" icon="bolt" href="/docs/reference/yellowstone-grpc-overview">
     High-performance real-time Solana data streaming interface.
   </Card>
 </CardGroup>
@@ -69,27 +69,27 @@ The [Data APIs](/docs/reference/data-overview) provide structured, indexed data 
 Use it for NFT metadata, token balances, transaction histories, enriched transfers, and analytics. Optimized for high-volume reads, dashboards, and data-heavy applications.
 
 <CardGroup cols={3}>
-  <Card title="Portfolio API" icon="fa-solid fa-chart-pie" href="/docs/reference/portfolio-apis">
+  <Card title="Portfolio API" icon="chart-pie" href="/docs/reference/portfolio-apis">
     Build a complete portfolio view of a user's wallet across tokens and NFTs.
   </Card>
 
-  <Card title="Transfers API" icon="fa-solid fa-arrow-right-arrow-left" href="/docs/reference/transfers-api-quickstart">
+  <Card title="Transfers API" icon="arrow-right-arrow-left" href="/docs/reference/transfers-api-quickstart">
     Get historical transactions for any address in a single request.
   </Card>
 
-  <Card title="Prices API" icon="fa-solid fa-chart-line" href="/docs/reference/prices-api-quickstart">
+  <Card title="Prices API" icon="chart-line" href="/docs/reference/prices-api-quickstart">
     Access real-time and historical token prices.
   </Card>
 
-  <Card title="NFT API" icon="fa-solid fa-image" href="/docs/reference/nft-api-quickstart">
+  <Card title="NFT API" icon="image" href="/docs/reference/nft-api-quickstart">
     Find, verify, and display NFTs across major blockchains.
   </Card>
 
-  <Card title="Webhooks" icon="fa-solid fa-bell" href="/docs/reference/notify-api-quickstart">
+  <Card title="Webhooks" icon="bell" href="/docs/reference/notify-api-quickstart">
     Subscribe to onchain events like transfers, transactions, and balance changes.
   </Card>
 
-  <Card title="Simulation API" icon="fa-solid fa-flask" href="/docs/reference/simulation">
+  <Card title="Simulation API" icon="flask" href="/docs/reference/simulation">
     Simulate transactions and see their effects before you send them.
   </Card>
 </CardGroup>
@@ -103,15 +103,15 @@ Our [Smart Wallets](/docs/wallets) product gives you everything you need to buil
 Use these APIs to handle user operations, sponsor gas, and implement smart accounts with account abstraction.
 
 <CardGroup cols={3}>
-  <Card title="Bundler" icon="fa-solid fa-layer-group" href="/docs/reference/bundler-api-quickstart">
+  <Card title="Bundler" icon="layer-group" href="/docs/reference/bundler-api-quickstart">
     Bundler API Quickstart for handling user operations.
   </Card>
 
-  <Card title="Gas Manager" icon="fa-solid fa-gas-pump" href="https://www.alchemy.com/docs/reference/how-to-sponsor-gas-on-evm">
+  <Card title="Gas Manager" icon="gas-pump" href="https://www.alchemy.com/docs/reference/how-to-sponsor-gas-on-evm">
     Gas Manager API Quickstart for sponsoring gas fees.
   </Card>
 
-  <Card title="Transaction APIs" icon="fa-solid fa-toolbox" href="/docs/wallets/transactions/send-transactions">
+  <Card title="Transaction APIs" icon="toolbox" href="/docs/wallets/transactions/send-transactions">
     Send transactions with smart accounts.
   </Card>
 </CardGroup>

--- a/content/api-reference/node-api/node-api-overview.mdx
+++ b/content/api-reference/node-api/node-api-overview.mdx
@@ -41,19 +41,19 @@ Chain APIs are the per-chain RPC surfaces exposed through the Node API.
 Use these alongside the Node API for streaming, performance, and deeper inspection. Chain coverage varies: check each page for supported networks.
 
 <CardGroup>
-  <Card title="WebSockets" icon="fa-solid fa-wave-square" href="/docs/reference/subscription-api">
+  <Card title="WebSockets" icon="wave-square" href="/docs/reference/subscription-api">
     Subscribe to pending transactions, log events, new blocks, and more.
   </Card>
 
-  <Card title="Trace API" icon="fa-solid fa-magnifying-glass-arrow-right" href="/docs/reference/transfers-api-quickstart">
+  <Card title="Trace API" icon="magnifying-glass-arrow-right" href="/docs/reference/transfers-api-quickstart">
     Get insights into transaction processing and onchain activity.
   </Card>
 
-  <Card title="Debug API" icon="fa-solid fa-bug" href="/docs/reference/debug-api-quickstart">
+  <Card title="Debug API" icon="bug" href="/docs/reference/debug-api-quickstart">
     Non-standard RPC methods for inspecting and debugging transactions.
   </Card>
 
-  <Card title="Yellowstone gRPC" icon="fa-solid fa-bolt" href="/docs/reference/yellowstone-grpc-overview">
+  <Card title="Yellowstone gRPC" icon="bolt" href="/docs/reference/yellowstone-grpc-overview">
     High-performance real-time Solana data streaming interface.
   </Card>
 </CardGroup>

--- a/content/api-reference/solana/solana-api-faq.mdx
+++ b/content/api-reference/solana/solana-api-faq.mdx
@@ -26,19 +26,19 @@ You can find the list of all the methods Alchemy supports for the Solana API on 
 Yes! Check out the section below:
 
 <CardGroup>
-  <Card title="Current State Methods" icon="fa-solid fa-clock" href="#current-state-methods">
+  <Card title="Current State Methods" icon="clock" href="#current-state-methods">
     Query live blockchain data and network status
   </Card>
 
-  <Card title="Historical Data (Archival)" icon="fa-solid fa-box-archive" href="#historical-data-archival">
+  <Card title="Historical Data (Archival)" icon="box-archive" href="#historical-data-archival">
     Access complete transaction and block history
   </Card>
 
-  <Card title="Transaction Submission" icon="fa-solid fa-paper-plane" href="#transaction-submission">
+  <Card title="Transaction Submission" icon="paper-plane" href="#transaction-submission">
     Send and simulate transactions with fee estimation
   </Card>
 
-  <Card title="Network & Cluster Info" icon="fa-solid fa-network-wired" href="#network-performance-economics">
+  <Card title="Network & Cluster Info" icon="network-wired" href="#network-performance-economics">
     Monitor validators, epochs and network performance
   </Card>
 </CardGroup>
@@ -50,27 +50,27 @@ Query live blockchain data including accounts, balances, current slots, and real
 ### Account & Balance Queries
 
 <CardGroup>
-  <Card title="getAccountInfo" icon="fa-solid fa-info" href="/docs/chains/solana/solana-api-endpoints/get-account-info">
+  <Card title="getAccountInfo" icon="info" href="/docs/chains/solana/solana-api-endpoints/get-account-info">
     Returns all information associated with the account of provided Pubkey.
   </Card>
 
-  <Card title="getBalance" icon="fa-solid fa-money-bill" href="/docs/chains/solana/solana-api-endpoints/get-balance">
+  <Card title="getBalance" icon="money-bill" href="/docs/chains/solana/solana-api-endpoints/get-balance">
     Returns the lamport balance of the account of the provided Pubkey.
   </Card>
 
-  <Card title="getMultipleAccounts" icon="fa-solid fa-group-arrows-rotate" href="/docs/chains/solana/solana-api-endpoints/get-multiple-accounts">
+  <Card title="getMultipleAccounts" icon="group-arrows-rotate" href="/docs/chains/solana/solana-api-endpoints/get-multiple-accounts">
     Returns the account information for a list of Pubkeys.
   </Card>
 
-  <Card title="getProgramAccounts" icon="fa-solid fa-network-wired" href="/docs/chains/solana/solana-api-endpoints/get-program-accounts">
+  <Card title="getProgramAccounts" icon="network-wired" href="/docs/chains/solana/solana-api-endpoints/get-program-accounts">
     Returns all accounts owned by the provided program Pubkey.
   </Card>
 
-  <Card title="getLargestAccounts" icon="fa-solid fa-list-ol" href="/docs/chains/solana/solana-api-endpoints/get-largest-accounts">
+  <Card title="getLargestAccounts" icon="list-ol" href="/docs/chains/solana/solana-api-endpoints/get-largest-accounts">
     Returns the addresses of the largest accounts, by lamport balance.
   </Card>
 
-  <Card title="getSupply" icon="fa-solid fa-coins" href="/docs/chains/solana/solana-api-endpoints/get-supply">
+  <Card title="getSupply" icon="coins" href="/docs/chains/solana/solana-api-endpoints/get-supply">
     Returns information about the current supply of SOL.
   </Card>
 </CardGroup>
@@ -80,23 +80,23 @@ Query live blockchain data including accounts, balances, current slots, and real
 ### Token Account Methods
 
 <CardGroup>
-  <Card title="getTokenAccountsByOwner" icon="fa-solid fa-wallet" href="/docs/chains/solana/solana-api-endpoints/get-token-accounts-by-owner">
+  <Card title="getTokenAccountsByOwner" icon="wallet" href="/docs/chains/solana/solana-api-endpoints/get-token-accounts-by-owner">
     Get all token accounts for a wallet.
   </Card>
 
-  <Card title="getTokenAccountsByDelegate" icon="fa-solid fa-user-shield" href="/docs/chains/solana/solana-api-endpoints/get-token-accounts-by-delegate">
+  <Card title="getTokenAccountsByDelegate" icon="user-shield" href="/docs/chains/solana/solana-api-endpoints/get-token-accounts-by-delegate">
     Query token accounts by delegate.
   </Card>
 
-  <Card title="getTokenAccountBalance" icon="fa-solid fa-scale-balanced" href="/docs/chains/solana/solana-api-endpoints/get-token-account-balance">
+  <Card title="getTokenAccountBalance" icon="scale-balanced" href="/docs/chains/solana/solana-api-endpoints/get-token-account-balance">
     Get balance of a specific token account.
   </Card>
 
-  <Card title="getTokenSupply" icon="fa-solid fa-coins" href="/docs/chains/solana/solana-api-endpoints/get-token-supply">
+  <Card title="getTokenSupply" icon="coins" href="/docs/chains/solana/solana-api-endpoints/get-token-supply">
     Query total supply of an SPL token.
   </Card>
 
-  <Card title="getTokenLargestAccounts" icon="fa-solid fa-list-ol" href="/docs/chains/solana/solana-api-endpoints/get-token-largest-accounts">
+  <Card title="getTokenLargestAccounts" icon="list-ol" href="/docs/chains/solana/solana-api-endpoints/get-token-largest-accounts">
     Find accounts with largest token holdings.
   </Card>
 </CardGroup>
@@ -106,27 +106,27 @@ Query live blockchain data including accounts, balances, current slots, and real
 ### Current Slot & Blockhash
 
 <CardGroup>
-  <Card title="getSlot" icon="fa-solid fa-clone" href="/docs/chains/solana/solana-api-endpoints/get-slot">
+  <Card title="getSlot" icon="clone" href="/docs/chains/solana/solana-api-endpoints/get-slot">
     Get current slot number.
   </Card>
 
-  <Card title="getBlockHeight" icon="fa-solid fa-layer-group" href="/docs/chains/solana/solana-api-endpoints/get-block-height">
+  <Card title="getBlockHeight" icon="layer-group" href="/docs/chains/solana/solana-api-endpoints/get-block-height">
     Get current block height of the network.
   </Card>
 
-  <Card title="getLatestBlockhash" icon="fa-solid fa-hashtag" href="/docs/chains/solana/solana-api-endpoints/get-latest-blockhash">
+  <Card title="getLatestBlockhash" icon="hashtag" href="/docs/chains/solana/solana-api-endpoints/get-latest-blockhash">
     Get most recent blockhash for transactions.
   </Card>
 
-  <Card title="isBlockhashValid" icon="fa-solid fa-circle-check" href="/docs/chains/solana/solana-api-endpoints/is-blockhash-valid">
+  <Card title="isBlockhashValid" icon="circle-check" href="/docs/chains/solana/solana-api-endpoints/is-blockhash-valid">
     Validate if a blockhash is still valid.
   </Card>
 
-  <Card title="getSlotLeader" icon="fa-solid fa-chess-king" href="/docs/chains/solana/solana-api-endpoints/get-slot-leader">
+  <Card title="getSlotLeader" icon="chess-king" href="/docs/chains/solana/solana-api-endpoints/get-slot-leader">
     Get current slot leader.
   </Card>
 
-  <Card title="getSlotLeaders" icon="fa-solid fa-chess-board" href="/docs/chains/solana/solana-api-endpoints/get-slot-leaders">
+  <Card title="getSlotLeaders" icon="chess-board" href="/docs/chains/solana/solana-api-endpoints/get-slot-leaders">
     Get slot leaders for a range of slots.
   </Card>
 </CardGroup>
@@ -136,11 +136,11 @@ Query live blockchain data including accounts, balances, current slots, and real
 ### Transaction Status & Confirmation
 
 <CardGroup>
-  <Card title="getSignatureStatuses" icon="fa-solid fa-question-circle" href="/docs/chains/solana/solana-api-endpoints/get-signature-statuses">
+  <Card title="getSignatureStatuses" icon="question-circle" href="/docs/chains/solana/solana-api-endpoints/get-signature-statuses">
     Check confirmation status of transactions.
   </Card>
 
-  <Card title="getTransactionCount" icon="fa-solid fa-list-numeric" href="/docs/chains/solana/solana-api-endpoints/get-transaction-count">
+  <Card title="getTransactionCount" icon="list-numeric" href="/docs/chains/solana/solana-api-endpoints/get-transaction-count">
     Get total number of transactions processed.
   </Card>
 </CardGroup>
@@ -154,15 +154,15 @@ Access complete transaction and block history from Solana genesis.
 ### Transaction History
 
 <CardGroup>
-  <Card title="getTransaction" icon="fa-solid fa-file-alt" href="/docs/chains/solana/solana-api-endpoints/get-transaction">
+  <Card title="getTransaction" icon="file-alt" href="/docs/chains/solana/solana-api-endpoints/get-transaction">
     Get detailed information about a specific transaction.
   </Card>
 
-  <Card title="getSignaturesForAddress" icon="fa-solid fa-signature" href="/docs/chains/solana/solana-api-endpoints/get-signatures-for-address">
+  <Card title="getSignaturesForAddress" icon="signature" href="/docs/chains/solana/solana-api-endpoints/get-signatures-for-address">
     Get transaction signatures for an account.
   </Card>
 
-  <Card title="getInflationReward" icon="fa-solid fa-medal" href="/docs/chains/solana/solana-api-endpoints/get-inflation-reward">
+  <Card title="getInflationReward" icon="medal" href="/docs/chains/solana/solana-api-endpoints/get-inflation-reward">
     Calculate inflation rewards for accounts.
   </Card>
 </CardGroup>
@@ -174,23 +174,23 @@ Access complete transaction and block history from Solana genesis.
 Access blockchain structure, timing, and historical data.
 
 <CardGroup>
-  <Card title="getBlock" icon="fa-solid fa-cube" href="/docs/chains/solana/solana-api-endpoints/get-block">
+  <Card title="getBlock" icon="cube" href="/docs/chains/solana/solana-api-endpoints/get-block">
     Get complete block information including all transactions.
   </Card>
 
-  <Card title="getBlocks" icon="fa-solid fa-cubes" href="/docs/chains/solana/solana-api-endpoints/get-blocks">
+  <Card title="getBlocks" icon="cubes" href="/docs/chains/solana/solana-api-endpoints/get-blocks">
     Get list of confirmed blocks in a range.
   </Card>
 
-  <Card title="getBlocksWithLimit" icon="fa-solid fa-arrow-down-1-9" href="/docs/chains/solana/solana-api-endpoints/get-blocks-with-limit">
+  <Card title="getBlocksWithLimit" icon="arrow-down-1-9" href="/docs/chains/solana/solana-api-endpoints/get-blocks-with-limit">
     Get limited number of confirmed blocks.
   </Card>
 
-  <Card title="getBlockTime" icon="fa-solid fa-stopwatch" href="/docs/chains/solana/solana-api-endpoints/get-block-time">
+  <Card title="getBlockTime" icon="stopwatch" href="/docs/chains/solana/solana-api-endpoints/get-block-time">
     Get estimated production time of a block.
   </Card>
 
-  <Card title="getBlockCommitment" icon="fa-solid fa-check-double" href="/docs/chains/solana/solana-api-endpoints/get-block-commitment">
+  <Card title="getBlockCommitment" icon="check-double" href="/docs/chains/solana/solana-api-endpoints/get-block-commitment">
     Get commitment for a particular block.
   </Card>
 </CardGroup>
@@ -204,23 +204,23 @@ Send and simulate transactions with fee estimation and optimization.
 ### Transaction Methods
 
 <CardGroup>
-  <Card title="sendTransaction" icon="fa-solid fa-paper-plane" href="/docs/solana/solana-api-overview">
+  <Card title="sendTransaction" icon="paper-plane" href="/docs/solana/solana-api-overview">
     Send a transaction to the network.
   </Card>
 
-  <Card title="simulateTransaction" icon="fa-solid fa-flask" href="/docs/solana/solana-api-overview">
+  <Card title="simulateTransaction" icon="flask" href="/docs/solana/solana-api-overview">
     Simulate a transaction to preview effects.
   </Card>
 
-  <Card title="requestAirdrop" icon="fa-solid fa-faucet-drip" href="/docs/chains/solana/solana-api-endpoints/request-airdrop">
+  <Card title="requestAirdrop" icon="faucet-drip" href="/docs/chains/solana/solana-api-endpoints/request-airdrop">
     Request SOL airdrop on Devnet.
   </Card>
 
-  <Card title="getRecentPrioritizationFees" icon="fa-solid fa-arrow-trend-up" href="/docs/chains/solana/solana-api-endpoints/get-recent-prioritization-fees">
+  <Card title="getRecentPrioritizationFees" icon="arrow-trend-up" href="/docs/chains/solana/solana-api-endpoints/get-recent-prioritization-fees">
     Get recent priority fees for optimal pricing.
   </Card>
 
-  <Card title="getFeeForMessage" icon="fa-solid fa-coins" href="/docs/chains/solana/solana-api-endpoints/get-fee-for-message">
+  <Card title="getFeeForMessage" icon="coins" href="/docs/chains/solana/solana-api-endpoints/get-fee-for-message">
     Calculate transaction fees before sending.
   </Card>
 </CardGroup>
@@ -234,31 +234,31 @@ Monitor validators, epochs, network performance, and cluster health.
 ### Cluster Information
 
 <CardGroup>
-  <Card title="getHealth" icon="fa-solid fa-heart-pulse" href="/docs/solana/solana-api-overview">
+  <Card title="getHealth" icon="heart-pulse" href="/docs/solana/solana-api-overview">
     Check RPC node health status.
   </Card>
 
-  <Card title="getVersion" icon="fa-solid fa-code-branch" href="/docs/chains/solana/solana-api-endpoints/get-version">
+  <Card title="getVersion" icon="code-branch" href="/docs/chains/solana/solana-api-endpoints/get-version">
     Get Solana software version information.
   </Card>
 
-  <Card title="getClusterNodes" icon="fa-solid fa-network-wired" href="/docs/chains/solana/solana-api-endpoints/get-cluster-nodes">
+  <Card title="getClusterNodes" icon="network-wired" href="/docs/chains/solana/solana-api-endpoints/get-cluster-nodes">
     Get information about cluster validators.
   </Card>
 
-  <Card title="getVoteAccounts" icon="fa-solid fa-certificate" href="/docs/chains/solana/solana-api-endpoints/get-vote-accounts">
+  <Card title="getVoteAccounts" icon="certificate" href="/docs/chains/solana/solana-api-endpoints/get-vote-accounts">
     Get current and delinquent vote accounts.
   </Card>
 
-  <Card title="getEpochInfo" icon="fa-solid fa-clock-rotate-left" href="/docs/chains/solana/solana-api-endpoints/get-epoch-info">
+  <Card title="getEpochInfo" icon="clock-rotate-left" href="/docs/chains/solana/solana-api-endpoints/get-epoch-info">
     Get information about the current epoch.
   </Card>
 
-  <Card title="getEpochSchedule" icon="fa-solid fa-calendar-days" href="/docs/chains/solana/solana-api-endpoints/get-epoch-schedule">
+  <Card title="getEpochSchedule" icon="calendar-days" href="/docs/chains/solana/solana-api-endpoints/get-epoch-schedule">
     Get epoch schedule information.
   </Card>
 
-  <Card title="getLeaderSchedule" icon="fa-solid fa-crown" href="/docs/chains/solana/solana-api-endpoints/get-leader-schedule">
+  <Card title="getLeaderSchedule" icon="crown" href="/docs/chains/solana/solana-api-endpoints/get-leader-schedule">
     Get leader schedule for an epoch.
   </Card>
 </CardGroup>
@@ -268,23 +268,23 @@ Monitor validators, epochs, network performance, and cluster health.
 ### Network Performance & Economics
 
 <CardGroup>
-  <Card title="getRecentPerformanceSamples" icon="fa-solid fa-chart-line" href="/docs/chains/solana/solana-api-endpoints/get-recent-performance-samples">
+  <Card title="getRecentPerformanceSamples" icon="chart-line" href="/docs/chains/solana/solana-api-endpoints/get-recent-performance-samples">
     Get recent network performance metrics.
   </Card>
 
-  <Card title="getInflationGovernor" icon="fa-solid fa-gavel" href="/docs/chains/solana/solana-api-endpoints/get-inflation-governor">
+  <Card title="getInflationGovernor" icon="gavel" href="/docs/chains/solana/solana-api-endpoints/get-inflation-governor">
     Get current inflation parameters.
   </Card>
 
-  <Card title="getInflationRate" icon="fa-solid fa-percent" href="/docs/chains/solana/solana-api-endpoints/get-inflation-rate">
+  <Card title="getInflationRate" icon="percent" href="/docs/chains/solana/solana-api-endpoints/get-inflation-rate">
     Get current inflation rate.
   </Card>
 
-  <Card title="getStakeActivation" icon="fa-solid fa-handshake-simple" href="/docs/chains/solana/solana-api-endpoints/get-stake-activation">
+  <Card title="getStakeActivation" icon="handshake-simple" href="/docs/chains/solana/solana-api-endpoints/get-stake-activation">
     Get epoch activation information for a stake account.
   </Card>
 
-  <Card title="getBlockProduction" icon="fa-solid fa-cubes" href="/docs/chains/solana/solana-api-endpoints/get-block-production">
+  <Card title="getBlockProduction" icon="cubes" href="/docs/chains/solana/solana-api-endpoints/get-block-production">
     Get block production information for current/previous epochs.
   </Card>
 </CardGroup>
@@ -298,35 +298,35 @@ Helper methods for system information, validation, and advanced queries.
 ### Basic Utility Methods
 
 <CardGroup>
-  <Card title="getMinimumBalanceForRentExemption" icon="fa-solid fa-circle-dollar-to-slot" href="/docs/chains/solana/solana-api-endpoints/get-minimum-balance-for-rent-exemption">
+  <Card title="getMinimumBalanceForRentExemption" icon="circle-dollar-to-slot" href="/docs/chains/solana/solana-api-endpoints/get-minimum-balance-for-rent-exemption">
     Calculate minimum balance for rent exemption.
   </Card>
 
-  <Card title="getGenesisHash" icon="fa-solid fa-dna" href="/docs/chains/solana/solana-api-endpoints/get-genesis-hash">
+  <Card title="getGenesisHash" icon="dna" href="/docs/chains/solana/solana-api-endpoints/get-genesis-hash">
     Get genesis hash of the cluster.
   </Card>
 
-  <Card title="getIdentity" icon="fa-solid fa-id-card" href="/docs/chains/solana/solana-api-endpoints/get-identity">
+  <Card title="getIdentity" icon="id-card" href="/docs/chains/solana/solana-api-endpoints/get-identity">
     Get identity public key of the RPC node.
   </Card>
 
-  <Card title="getFirstAvailableBlock" icon="fa-solid fa-door-open" href="/docs/chains/solana/solana-api-endpoints/get-first-available-block">
+  <Card title="getFirstAvailableBlock" icon="door-open" href="/docs/chains/solana/solana-api-endpoints/get-first-available-block">
     Get slot of first available block.
   </Card>
 
-  <Card title="getHighestSnapshotSlot" icon="fa-solid fa-angle-double-up" href="/docs/chains/solana/solana-api-endpoints/get-highest-snapshot-slot">
+  <Card title="getHighestSnapshotSlot" icon="angle-double-up" href="/docs/chains/solana/solana-api-endpoints/get-highest-snapshot-slot">
     Get highest slot with a snapshot.
   </Card>
 
-  <Card title="minimumLedgerSlot" icon="fa-solid fa-layer-group" href="/docs/chains/solana/solana-api-endpoints/minimum-ledger-slot">
+  <Card title="minimumLedgerSlot" icon="layer-group" href="/docs/chains/solana/solana-api-endpoints/minimum-ledger-slot">
     Get minimum slot that node has ledger information.
   </Card>
 
-  <Card title="getMaxRetransmitSlot" icon="fa-solid fa-arrow-rotate-right" href="/docs/chains/solana/solana-api-endpoints/get-max-retransmit-slot">
+  <Card title="getMaxRetransmitSlot" icon="arrow-rotate-right" href="/docs/chains/solana/solana-api-endpoints/get-max-retransmit-slot">
     Get max slot seen from retransmit stage.
   </Card>
 
-  <Card title="getMaxShredInsertSlot" icon="fa-solid fa-arrow-up-right-dots" href="/docs/chains/solana/solana-api-endpoints/get-max-shred-insert-slot">
+  <Card title="getMaxShredInsertSlot" icon="arrow-up-right-dots" href="/docs/chains/solana/solana-api-endpoints/get-max-shred-insert-slot">
     Get max slot seen from after shred insert.
   </Card>
 </CardGroup>

--- a/content/api-reference/solana/solana-api-quickstart.mdx
+++ b/content/api-reference/solana/solana-api-quickstart.mdx
@@ -74,19 +74,19 @@ Now that you've set up a connection to Alchemy, you can continue with some basic
 ## Find Solana methods by category
 
 <CardGroup>
-  <Card title="Current State Methods" icon="fa-solid fa-clock" href="/docs/solana-api-faq#current-state-methods">
+  <Card title="Current State Methods" icon="clock" href="/docs/solana-api-faq#current-state-methods">
     Query live blockchain data and network status
   </Card>
 
-  <Card title="Historical Data (Archival)" icon="fa-solid fa-box-archive" href="/docs/solana-api-faq#historical-data-archival">
+  <Card title="Historical Data (Archival)" icon="box-archive" href="/docs/solana-api-faq#historical-data-archival">
     Access complete transaction and block history
   </Card>
 
-  <Card title="Transaction Submission" icon="fa-solid fa-paper-plane" href="/docs/solana-api-faq#transaction-submission">
+  <Card title="Transaction Submission" icon="paper-plane" href="/docs/solana-api-faq#transaction-submission">
     Send and simulate transactions with fee estimation
   </Card>
 
-  <Card title="Network & Cluster Info" icon="fa-solid fa-network-wired" href="/docs/solana-api-faq#network-performance-economics">
+  <Card title="Network & Cluster Info" icon="network-wired" href="/docs/solana-api-faq#network-performance-economics">
     Monitor validators, epochs and network performance
   </Card>
 </CardGroup>

--- a/content/wallets/pages/authentication/overview.mdx
+++ b/content/wallets/pages/authentication/overview.mdx
@@ -14,7 +14,7 @@ A **signer** is the service or key that controls a wallet — it authenticates u
 
 For most teams, we recommend **[Privy](/docs/wallets/third-party/signers/privy)** as the embedded wallet provider. Privy handles key creation, social/email login, and recovery, and exposes a viem `LocalAccount` that drops straight into `createSmartWalletClient`.
 
-<Card title="Privy integration guide" icon="fa-solid fa-bolt" href="/docs/wallets/third-party/signers/privy">
+<Card title="Privy integration guide" icon="bolt" href="/docs/wallets/third-party/signers/privy">
   Step-by-step setup for Privy with Wallet APIs.
 </Card>
 
@@ -65,19 +65,19 @@ For a deeper comparison of custody models and provider trade-offs, see [Choosing
 ## Next steps
 
 <CardGroup cols={2}>
-  <Card title="Quickstart" icon="fa-solid fa-bolt" href="/docs/wallets/quickstart">
+  <Card title="Quickstart" icon="bolt" href="/docs/wallets/quickstart">
     Send your first transaction end-to-end.
   </Card>
 
-  <Card title="Bring your own signer" icon="fa-solid fa-link" href="/docs/wallets/third-party/signers/custom-integration">
+  <Card title="Bring your own signer" icon="link" href="/docs/wallets/third-party/signers/custom-integration">
     Full guide for plugging in any viem-compatible signer.
   </Card>
 
-  <Card title="EIP-7702" icon="fa-solid fa-chevron-up" href="/docs/wallets/transactions/using-eip-7702">
+  <Card title="EIP-7702" icon="chevron-up" href="/docs/wallets/transactions/using-eip-7702">
     Upgrade existing EOAs into smart accounts.
   </Card>
 
-  <Card title="Choosing a signer" icon="fa-solid fa-book" href="/docs/wallets/signer/what-is-a-signer">
+  <Card title="Choosing a signer" icon="book" href="/docs/wallets/signer/what-is-a-signer">
     Deep dive into custody models and provider comparison.
   </Card>
 </CardGroup>

--- a/content/wallets/pages/index.mdx
+++ b/content/wallets/pages/index.mdx
@@ -8,7 +8,7 @@ hide-toc: true
 
 Simple APIs to send transactions with advanced capabilities. Gas sponsorship, batching, retries, and more — all handled for you.
 
-<Card title="Quickstart →" icon="fa-solid fa-bolt" href="/docs/wallets/quickstart">
+<Card title="Quickstart →" icon="bolt" href="/docs/wallets/quickstart">
   Send your first gasless transaction in under 5 minutes.
 </Card>
 
@@ -17,19 +17,19 @@ Simple APIs to send transactions with advanced capabilities. Gas sponsorship, ba
 ## How it works
 
 <CardGroup cols={4}>
-  <Card title="1. Prepare" icon="fa-solid fa-screwdriver-wrench">
+  <Card title="1. Prepare" icon="screwdriver-wrench">
     Build one or more calls - transfer, swap, — anything.
   </Card>
 
-  <Card title="2. Sign" icon="fa-solid fa-signature">
+  <Card title="2. Sign" icon="signature">
     Bring your own embedded wallet or key to sign.
   </Card>
 
-  <Card title="3. Send" icon="fa-solid fa-paper-plane">
+  <Card title="3. Send" icon="paper-plane">
     We submit, optimize gas, sponsor fees, and retry if needed.
   </Card>
 
-  <Card title="4. Track" icon="fa-solid fa-magnifying-glass-arrow-right">
+  <Card title="4. Track" icon="magnifying-glass-arrow-right">
     Get status and transaction data through simple endpoints.
   </Card>
 </CardGroup>
@@ -39,20 +39,20 @@ Simple APIs to send transactions with advanced capabilities. Gas sponsorship, ba
 ## Capabilities
 
 <CardGroup cols={2}>
-  <Card title="Gas sponsorship" icon="fa-solid fa-gas-pump" href="/docs/wallets/transactions/sponsor-gas/overview">
+  <Card title="Gas sponsorship" icon="gas-pump" href="/docs/wallets/transactions/sponsor-gas/overview">
     Cover gas fees so users never need ETH and you never hold crypto on your balance sheet. Set custom spending rules.
   </Card>
 
-  <Card title="ERC-20 gas payments" icon="fa-solid fa-coins" href="/docs/wallets/transactions/pay-gas-with-any-token">
+  <Card title="ERC-20 gas payments" icon="coins" href="/docs/wallets/transactions/pay-gas-with-any-token">
     Let users pay gas with USDC, USDT, or any ERC-20 token instead of the
     native currency.
   </Card>
 
-  <Card title="Solana sponsorship" icon="fa-solid fa-hand-holding-dollar" href="/docs/wallets/transactions/solana/sponsor-gas">
+  <Card title="Solana sponsorship" icon="hand-holding-dollar" href="/docs/wallets/transactions/solana/sponsor-gas">
     Sponsor fees & rent and say goodbye to "insufficient fees".
   </Card>
 
-  <Card title="Batch transactions" icon="fa-solid fa-layer-group" href="/docs/wallets/transactions/send-batch-transactions">
+  <Card title="Batch transactions" icon="layer-group" href="/docs/wallets/transactions/send-batch-transactions">
     Combine multiple calls into a single atomic transaction — approve + swap,
     mint + transfer, and more.
   </Card>
@@ -62,15 +62,15 @@ Simple APIs to send transactions with advanced capabilities. Gas sponsorship, ba
     land onchain.
   </Card>
 
-  <Card title="Session keys" icon="fa-solid fa-clock" href="/docs/wallets/reference/wallet-apis-session-keys">
+  <Card title="Session keys" icon="clock" href="/docs/wallets/reference/wallet-apis-session-keys">
     Grant scoped, time-limited signing permissions for autonomous signing. 
   </Card>
 
-  <Card title="Parallel transactions" icon="fa-solid fa-code" href="/docs/wallets/transactions/send-parallel-transactions">
+  <Card title="Parallel transactions" icon="code" href="/docs/wallets/transactions/send-parallel-transactions">
     Fire multiple transactions simultaneously without nonce collisions.
   </Card>
 
-  <Card title="Token swaps" icon="fa-solid fa-arrow-right-arrow-left" href="/docs/wallets/transactions/swap-tokens">
+  <Card title="Token swaps" icon="arrow-right-arrow-left" href="/docs/wallets/transactions/swap-tokens">
     Same-chain and cross-chain token swaps with built-in routing.
   </Card>
 
@@ -78,11 +78,11 @@ Simple APIs to send transactions with advanced capabilities. Gas sponsorship, ba
     Track the status of the transaction via APIs.
   </Card>
 
-  <Card title="Debug transactions" icon="fa-solid fa-bug" href="/docs/wallets/transactions/debug-transactions">
+  <Card title="Debug transactions" icon="bug" href="/docs/wallets/transactions/debug-transactions">
     Debug failed transactions and reverts.
   </Card>
 
-  <Card title="EIP-7702" icon="fa-solid fa-angle-double-up" href="/docs/wallets/transactions/sponsor-gas/overview">
+  <Card title="EIP-7702" icon="angle-double-up" href="/docs/wallets/transactions/sponsor-gas/overview">
     Upgrade embedded EOA users to smart wallets.
   </Card>
 </CardGroup>
@@ -112,10 +112,10 @@ Use the TypeScript SDK or call the REST APIs directly from any language.
 Compatible with any embedded wallet or key management solution.
 
 <CardGroup cols={2}>
-  <Card title="Privy (recommended)" icon="fa-solid fa-shield-halved" href="/docs/wallets/third-party/signers/privy">
+  <Card title="Privy (recommended)" icon="shield-halved" href="/docs/wallets/third-party/signers/privy">
     Embedded wallets with social login, email OTP, and passkeys.
   </Card>
-  <Card title="Other signers" icon="fa-solid fa-link" href="/docs/wallets/third-party/signers/custom-integration">
+  <Card title="Other signers" icon="link" href="/docs/wallets/third-party/signers/custom-integration">
     Integrate other embedded wallets or any viem compatible provider as a signer.
   </Card>
 </CardGroup>
@@ -125,19 +125,19 @@ Compatible with any embedded wallet or key management solution.
 ## Explore
 
 <CardGroup cols={3}>
-  <Card title="Supported chains" icon="fa-solid fa-link" href="/docs/wallets/supported-chains">
+  <Card title="Supported chains" icon="link" href="/docs/wallets/supported-chains">
     See every EVM and Solana network supported.
   </Card>
 
-  <Card title="Recipes" icon="fa-solid fa-book" href="/docs/wallets/recipes/overview">
+  <Card title="Recipes" icon="book" href="/docs/wallets/recipes/overview">
     End-to-end guides: send USDC, Hyperliquid, Aave, and more.
   </Card>
 
-  <Card title="API reference" icon="fa-solid fa-code" href="/docs/wallets/api-reference/smart-wallets/wallet-api-endpoints/wallet-api-endpoints/wallet-prepare-calls">
+  <Card title="API reference" icon="code" href="/docs/wallets/api-reference/smart-wallets/wallet-api-endpoints/wallet-api-endpoints/wallet-prepare-calls">
     Full REST API reference for server-side wallet management.
   </Card>
 
-  <Card title="Pricing" icon="fa-solid fa-dollar-sign" href="/docs/reference/compute-unit-costs#wallet-apis">
+  <Card title="Pricing" icon="dollar-sign" href="/docs/reference/compute-unit-costs#wallet-apis">
     Estimate costs and compare plans.
   </Card>
 
@@ -145,7 +145,7 @@ Compatible with any embedded wallet or key management solution.
     Common questions and troubleshooting.
   </Card>
 
-  <Card title="Contact us" icon="fa-solid fa-map-pin" href="/docs/wallets/resources/contact-us">
+  <Card title="Contact us" icon="map-pin" href="/docs/wallets/resources/contact-us">
     Get help from the Alchemy team.
   </Card>
 </CardGroup>

--- a/content/wallets/pages/react/getting-started/existing-project.mdx
+++ b/content/wallets/pages/react/getting-started/existing-project.mdx
@@ -141,7 +141,7 @@ Now that you have basic authentication working, you can explore additional featu
 
 <Card
   title="Customize UI components"
-  icon="fa-solid fa-pencil"
+  icon="pencil"
   href="/docs/wallets/react/ui-components"
 >
   Customize and style the UI components to match your application's design.

--- a/content/wallets/pages/recipes/upgrade-to-smart-accounts.mdx
+++ b/content/wallets/pages/recipes/upgrade-to-smart-accounts.mdx
@@ -18,7 +18,7 @@ Either way, you can follow the Wallet APIs quickstart to integrate smart wallets
   <Card
     title="Wallet APIs Quickstart"
     href="/docs/wallets/quickstart"
-    icon="fa-brands fa-js"
+    icon="js"
   >
     Install `@alchemy/wallet-apis`, create a client, and add smart wallets to your React, other JavaScript, or React Native app.
   </Card>

--- a/content/wallets/pages/transactions/debug-transactions/index.mdx
+++ b/content/wallets/pages/transactions/debug-transactions/index.mdx
@@ -25,19 +25,19 @@ A failure at any step can be difficult to diagnose from raw logs alone. The Tran
 ## Key features
 
 <CardGroup cols={2}>
-  <Card title="Transaction lifecycle view" icon="fa-solid fa-layer-group">
+  <Card title="Transaction lifecycle view" icon="layer-group">
     See every step of a Wallet API call grouped by Call ID, with status, duration, and full request/response payloads
   </Card>
 
-  <Card title="AI error explanations" icon="fa-solid fa-bolt">
+  <Card title="AI error explanations" icon="bolt">
     Get plain-language explanations of why a transaction failed, along with specific remediation steps
   </Card>
 
-  <Card title="Filters & search" icon="fa-solid fa-chart-line">
+  <Card title="Filters & search" icon="chart-line">
     Filter by status, app, network, and time range to find the exact transactions you're looking for
   </Card>
 
-  <Card title="Detailed payloads" icon="fa-solid fa-code">
+  <Card title="Detailed payloads" icon="code">
     Inspect full JSON request and response bodies for each step, with copy support
   </Card>
 </CardGroup>

--- a/content/wallets/pages/transactions/sponsor-gas/overview.mdx
+++ b/content/wallets/pages/transactions/sponsor-gas/overview.mdx
@@ -22,28 +22,28 @@ Get started with the [gas sponsorship guide](/docs/wallets/transactions/sponsor-
 <CardGroup cols={2}>
   <Card
     title="Full sponsorship"
-    icon="fa-solid fa-bolt"
+    icon="bolt"
     href="/docs/wallets/transactions/sponsor-gas"
   >
     Cover all gas fees. Best for onboarding and growth
   </Card>
   <Card
     title="Conditional sponsorship"
-    icon="fa-solid fa-shield-halved"
+    icon="shield-halved"
     href="/docs/wallets/transactions/sponsor-gas/conditional-sponsorship-rules"
   >
     Set spending limits and rules to control costs
   </Card>
   <Card
     title="ERC-20 payments"
-    icon="fa-solid fa-coins"
+    icon="coins"
     href="/docs/wallets/transactions/pay-gas-with-any-token"
   >
     Let users pay gas with USDC, USDT, or any token
   </Card>
   <Card
     title="Solana sponsorship"
-    icon="fa-solid fa-layer-group"
+    icon="layer-group"
     href="/docs/wallets/transactions/solana/sponsor-gas"
   >
     Sponsor transaction fees on Solana
@@ -55,19 +55,19 @@ Get started with the [gas sponsorship guide](/docs/wallets/transactions/sponsor-
 Track and optimize your sponsorship spending in real-time through the dashboard and APIs.
 
 <CardGroup cols={2}>
-  <Card title="Zero crypto management" icon="fa-solid fa-hand-holding-dollar">
+  <Card title="Zero crypto management" icon="hand-holding-dollar">
     No need to pre-fund wallets or manage tokens. Gas is fronted and billed
     in USD.
   </Card>
-  <Card title="Real-time analytics" icon="fa-solid fa-chart-line">
+  <Card title="Real-time analytics" icon="chart-line">
     Monitor spending as transactions happen with live dashboards
   </Card>
-  <Card title="Flexible limits & alerts" icon="fa-solid fa-bell">
+  <Card title="Flexible limits & alerts" icon="bell">
     Get notified when approaching limits and pre-deposit to scale up instantly
   </Card>
   <Card
     title="Admin APIs"
-    icon="fa-solid fa-code"
+    icon="code"
     href="/docs/wallets/low-level-infra/gas-manager/policy-management/api-endpoints"
   >
     Programmatically manage policies, retrieve stats, and monitor sponsorships


### PR DESCRIPTION
## Summary

The docs-site renders icons from an SVG sprite sheet (not FontAwesome directly). Valid `icon` values on `<Card>` are bare sprite ids listed in `iconIds` (e.g., `bolt`, `book`, `network-wired`); any `icon="fa-solid fa-X"` / `icon="fa-brands fa-X"` value that has a mapping in `fontAwesomeToSpriteMap` is invalid at render time and must be rewritten to its sprite id. This PR applies the authoritative migration table supplied by @dslovinsky across all affected MDX files in `content/`.

**71 icon strings migrated across 135 occurrences in 11 files.**

## Files changed

- `content/api-reference/data/data-overview.mdx` (13)
- `content/api-reference/introduction/api-overview.mdx` (18)
- `content/api-reference/node-api/node-api-overview.mdx` (4)
- `content/api-reference/solana/solana-api-faq.mdx` (56)
- `content/api-reference/solana/solana-api-quickstart.mdx` (4)
- `content/wallets/pages/authentication/overview.mdx` (5)
- `content/wallets/pages/index.mdx` (21)
- `content/wallets/pages/react/getting-started/existing-project.mdx` (1)
- `content/wallets/pages/recipes/upgrade-to-smart-accounts.mdx` (1)
- `content/wallets/pages/transactions/debug-transactions/index.mdx` (4)
- `content/wallets/pages/transactions/sponsor-gas/overview.mdx` (8)

## How the transform was applied

- Matched only `icon="fa-..."` attributes (regex `icon="(fa-[^"]+)"`) inside `.mdx` files under `content/`.
- Rewrote the attribute value to the mapped bare sprite id. Nothing else was touched (no other `<Card>` props, no whitespace/formatting).
- Separate from #1254 (which was a one-file `fa-book-open` → `book` hotfix); this PR covers the remaining full sweep.

## Verification

- `grep -rE 'icon="fa-' content/` → **0 matches**
- `grep -rhoE 'icon="[a-z0-9 -]+"' content/ | sort -u` → every remaining value is in the `iconIds` whitelist supplied by Daniel
- Only `content/` was modified; `<Card>` props other than `icon` were not touched

Lint: `pnpm run lint:prettier`, `pnpm run lint:eslint`, and `pnpm run typecheck` all get SIGKILLed in the sandbox (OOM), consistent with prior known behavior — none of these targets include `content/**.mdx` (prettier globs `{src,scripts}/**`, eslint targets source JS/TS, tsc is TS-only), so the migration cannot affect them. CI will confirm.

## Reviewer

cc @dslovinsky — thanks for the whitelist + migration table.

Resolves DOCS-59.
