### PR TITLE
[Writer] Add non-React migration callout and Privy contacts to signer migration overview

### DIFF
--- a/content/wallets/wallet-integrations/privy/signer-migration-overview.mdx
+++ b/content/wallets/wallet-integrations/privy/signer-migration-overview.mdx
@@ -12,6 +12,10 @@ Pick the detailed guide that matches your app:
 * **[JWT auth migration](/wallets/wallet-integrations/privy/jwt-auth-migration)** — special case for apps authenticating users with JWT (JSON Web Token).
 </Info>
 
+<Note>
+If your migration path does not make use of React, please [reach out to the team](#get-help) for assistance in the service migration!
+</Note>
+
 ## What to expect
 
 You swap the signer layer and keep everything else. Users keep their wallet addresses, assets, and history — the only visible change is the login screen switching from Alchemy to Privy. The drop-in migration SDK re-authenticates each user on first login and transfers their keys from Alchemy's TEE to Privy's TEE, invisibly.
@@ -61,3 +65,10 @@ Wallet APIs default to Modular Account v2, but Light Account and MAv1 are also s
 ### Session keys
 
 If your users have legacy session keys installed onchain through the v4 `@account-kit/wallet-client` integration, they're still supported on Wallet APIs. See the [Use existing session keys](/wallets/reference/wallet-apis-session-keys/legacy-session-keys) reference for the guide.
+
+## Get help
+
+For direct help with your Privy signer migration, reach out through either of the following:
+
+* **Email:** [alchemy@privy.io](mailto:alchemy@privy.io)
+* **Slack:** [privy.io/slack](https://privy.io/slack)

--- a/content/wallets/wallet-integrations/privy/signer-migration-overview.mdx
+++ b/content/wallets/wallet-integrations/privy/signer-migration-overview.mdx
@@ -13,7 +13,7 @@ Pick the detailed guide that matches your app:
 </Info>
 
 <Note>
-If your migration path does not make use of React, please [reach out to the team](#get-help) for assistance in the service migration!
+If your migration path does not make use of React or JWT authentication, please [reach out to the team](#get-help) for assistance in the service migration!
 </Note>
 
 ## What to expect


### PR DESCRIPTION
Resolves [DOCS-61](https://linear.app/alchemy/issue/DOCS-61).

## What changed

Updates `content/wallets/wallet-integrations/privy/signer-migration-overview.mdx` with two small additions:

1. **Non-React migration callout.** Adds a `<Note>` immediately after the sub-guide list so users whose migration path does not use React are told to reach out for service migration help. The callout links to the new `Get help` section at the bottom of the page.

2. **Get help section.** New section at the end of the page with Privy-specific migration contacts:
   - Email: `alchemy@privy.io`
   - Slack: `https://privy.io/slack`

Existing inline `support@alchemy.com` references (for Alchemy-side asks like enabling legacy account types) are left as-is — those aren't Privy migration support.

## Why

Requested by Ava so customers migrating off Account Kit who aren't on React know they have a dedicated contact path, and so the page surfaces Privy's direct support channels instead of only the generic Alchemy support alias.

## Test plan

- `pnpm run lint` passes locally.
- Page renders with the new `<Note>` between the sub-guide `<Info>` and the `## What to expect` section, and the new `## Get help` heading appears in the right rail TOC after `### Session keys`.
