### PR TITLE
[docs-agent] Rename Alchemy Rollups overview page title to "Alchemy Rollups"

### DIFF
--- a/content/api-reference/alchemy-rollups/rollups-quickstart.mdx
+++ b/content/api-reference/alchemy-rollups/rollups-quickstart.mdx
@@ -1,5 +1,5 @@
 ---
-title: Alchemy Rollups Overview
+title: Alchemy Rollups
 description: "Introduction to Alchemy Rollups: deploy a rollup in minutes, no code required, using our all-in-one infrastructure."
 subtitle: "Introduction to Alchemy Rollups: deploy a rollup in minutes, no code required, using our all-in-one infrastructure."
 slug: rollups


### PR DESCRIPTION
## Summary

Renames the page title at https://www.alchemy.com/docs/rollups from "Alchemy Rollups Overview" to "Alchemy Rollups".

## Changes

- `content/api-reference/alchemy-rollups/rollups-quickstart.mdx`: frontmatter `title` changed from `Alchemy Rollups Overview` to `Alchemy Rollups`.

## Notes

- Slug (`rollups`) is unchanged, so no redirects are needed.
- Nav sidebar entry (`Rollups Overview`) and H1 headings inside the page (`Intro`, `What is a Rollup?`) are unchanged per the request (title-only rename).

Refs [DOCS-64](https://linear.app/alchemyapi/issue/DOCS-64/rename-alchemy-rollups-overview-page-title-to-alchemy-rollups).

Requested via Slack.