### PR TITLE
[docs-agent] Rename Alchemy Rollups overview page title to "Alchemy Rollups"

### DIFF
--- a/content/api-reference/alchemy-rollups/rollups-quickstart.mdx
+++ b/content/api-reference/alchemy-rollups/rollups-quickstart.mdx
@@ -1,5 +1,5 @@
 ---
-title: Alchemy Rollups Overview
+title: Alchemy Rollups
 description: "Introduction to Alchemy Rollups: deploy a rollup in minutes, no code required, using our all-in-one infrastructure."
 subtitle: "Introduction to Alchemy Rollups: deploy a rollup in minutes, no code required, using our all-in-one infrastructure."
 slug: rollups


### PR DESCRIPTION
## Summary

Renames the rollups landing page title from `Alchemy Rollups Overview` to `Alchemy Rollups`.

- File: `content/api-reference/alchemy-rollups/rollups-quickstart.mdx`
- Page URL: https://www.alchemy.com/docs/rollups
- Slug, description, subtitle, body, and nav are unchanged.

## Requested by

@SahilAujla (via Slack thread)

## Linear

DOCS-65 — https://linear.app/alchemyapi/issue/DOCS-65/rename-alchemy-rollups-overview-page-title-to-alchemy-rollups
