### PR TITLE
[docs-agent] Rename rollups page title to "Alchemy Rollups"

### DIFF
--- a/content/api-reference/alchemy-rollups/rollups-quickstart.mdx
+++ b/content/api-reference/alchemy-rollups/rollups-quickstart.mdx
@@ -1,5 +1,5 @@
 ---
-title: Alchemy Rollups Overview
+title: Alchemy Rollups
 description: "Introduction to Alchemy Rollups: deploy a rollup in minutes, no code required, using our all-in-one infrastructure."
 subtitle: "Introduction to Alchemy Rollups: deploy a rollup in minutes, no code required, using our all-in-one infrastructure."
 slug: rollups


### PR DESCRIPTION
## Summary

Drops "Overview" from the frontmatter title on the Rollups landing page (https://www.alchemy.com/docs/rollups) so the rendered title is just "Alchemy Rollups", per Sahil's request. The slug, nav entries, description, and content are unchanged.

## Linear

[DOCS-66 — Rename rollups page title](https://linear.app/alchemyapi/issue/DOCS-66/rename-alchemy-rollups-overview-page-title-to-alchemy-rollups)

## Requested by

@SahilAujla (via Slack thread)
