### PR TITLE
docs(pricing): switch Base Flashblocks subscriptions to event-based pricing

### DIFF
--- a/content/api-reference/pricing-resources/pricing/compute-unit-costs.mdx
+++ b/content/api-reference/pricing-resources/pricing/compute-unit-costs.mdx
@@ -373,15 +373,15 @@ Similar to the [NFT API](/docs/reference/compute-unit-costs#nft-api), the Wallet
 
 # Webhooks and Subscription APIs
 
-[Webhooks](/docs/reference/notify-api-quickstart) and [WebSocket Subscriptions](/docs/websocket-subscriptions) on Alchemy are priced based on **bandwidth:** the amount of data delivered as part of the subscription.
+[Webhooks](/docs/reference/notify-api-quickstart) and [WebSocket Subscriptions](/docs/websocket-subscriptions) on Alchemy are priced based on **bandwidth** (the amount of data delivered) by default, except for Base Flashblocks subscriptions, which are priced **per event**.
 
-Each subscription type is priced identically per byte:
+| Subscription                | Pricing       |
+| --------------------------- | ------------- |
+| `newFlashblockTransactions` | 40 CU / event |
+| `newFlashblocks`            | 60 CU / event |
+| All other subscriptions     | 0.04 CU / byte |
 
-| Bandwidth | CU  |
-| --------- | --- |
-| 1 byte    | .04 |
-
-On average, a typical webhook or WebSocket subscription event is about 1000 bytes, so it would consume 40 compute units. Note that this can vary significantly based on the specific event delivered [Subscription API Quickstart](/docs/reference/subscription-api)
+On average, a typical byte-priced webhook or WebSocket subscription event is about 1000 bytes, so it would consume 40 compute units. Note that this can vary significantly based on the specific event delivered. See the [Subscription API Quickstart](/docs/reference/subscription-api) for details.
 
 # Polygon PoS: Specific Methods
 

--- a/content/api-reference/pricing-resources/pricing/compute-unit-costs.mdx
+++ b/content/api-reference/pricing-resources/pricing/compute-unit-costs.mdx
@@ -375,11 +375,11 @@ Similar to the [NFT API](/docs/reference/compute-unit-costs#nft-api), the Wallet
 
 [Webhooks](/docs/reference/notify-api-quickstart) and [WebSocket Subscriptions](/docs/websocket-subscriptions) on Alchemy are priced based on **bandwidth** (the amount of data delivered) by default, except for Base Flashblocks subscriptions, which are priced **per event**.
 
-| Subscription                | Pricing       |
-| --------------------------- | ------------- |
-| `newFlashblockTransactions` | 40 CU / event |
-| `newFlashblocks`            | 60 CU / event |
-| All other subscriptions     | 0.04 CU / byte |
+| Subscription              | Pricing        |
+| ------------------------- | -------------- |
+| newFlashblockTransactions | 40 CU / event  |
+| newFlashblocks            | 60 CU / event  |
+| All other subscriptions   | 0.04 CU / byte |
 
 On average, a typical byte-priced webhook or WebSocket subscription event is about 1000 bytes, so it would consume 40 compute units. Note that this can vary significantly based on the specific event delivered. See the [Subscription API Quickstart](/docs/reference/subscription-api) for details.
 


### PR DESCRIPTION
## Summary
- Updates the **Webhooks and Subscription APIs** section of [compute-unit-costs](/docs/reference/compute-unit-costs#webhooks-and-subscription-apis) to reflect the [Pricing Revamp Proposal](https://www.notion.so/alchemotion/Pricing-Revamp-Proposal-32f069f200668111a6f0dd04e641525f) section 3.5 decision
- `newFlashblockTransactions` → **40 CU / event** (was 0.04 CU/byte)
- `newFlashblocks` → **60 CU / event** (was 0.04 CU/byte)
- All other subscriptions remain at **0.04 CU/byte**

## Test plan
- [ ] Preview the rendered docs page and confirm the table shows the two Flashblocks rows + the catch-all row
- [ ] Confirm the `#webhooks-and-subscription-apis` anchor still resolves
- [ ] Confirm copy is consistent with the pricing rollout timeline (do not merge before the pricing change is live)

🤖 Generated with [Claude Code](https://claude.com/claude-code)