### PR TITLE
[docs-agent] fix: prepend /docs/ prefix to /wallets/* internal links

### DIFF
--- a/content/wallets/pages/third-party/signers/openfort.mdx
+++ b/content/wallets/pages/third-party/signers/openfort.mdx
@@ -139,7 +139,7 @@ Upgrade existing Openfort embedded wallets to Wallet APIs to enable gasless tran
 
     ### 4. Request an account and send a transaction
 
-    Openfort provides a `WalletClient` signer, which does not support EIP-7702 authorization signing. Use [`requestAccount`](/wallets/transactions/using-eip-7702#how-to-use-non-7702-mode) to create a smart wallet, then pass the account address to `sendCalls`. The returned address is stable for a given signer and can be stored — you don't need to call `requestAccount` before every transaction:
+    Openfort provides a `WalletClient` signer, which does not support EIP-7702 authorization signing. Use [`requestAccount`](/docs/wallets/transactions/using-eip-7702#how-to-use-non-7702-mode) to create a smart wallet, then pass the account address to `sendCalls`. The returned address is stable for a given signer and can be stored — you don't need to call `requestAccount` before every transaction:
 
     ```tsx
     import { useMemo, useCallback } from "react";
@@ -187,7 +187,7 @@ Upgrade existing Openfort embedded wallets to Wallet APIs to enable gasless tran
 
     ### Notes
 
-    * See the [Sponsor gas](/wallets/transactions/sponsor-gas) guide for more on gas sponsorship configuration.
+    * See the [Sponsor gas](/docs/wallets/transactions/sponsor-gas) guide for more on gas sponsorship configuration.
     * Learn more about Openfort's React SDK in the [Openfort documentation](https://www.openfort.io/docs/products/embedded-wallet/react/quickstart).
   </Tab>
 
@@ -299,7 +299,7 @@ Upgrade existing Openfort embedded wallets to Wallet APIs to enable gasless tran
 
     ### Notes
 
-    * See the [Sponsor gas](/wallets/transactions/sponsor-gas) guide for more on gas sponsorship configuration.
+    * See the [Sponsor gas](/docs/wallets/transactions/sponsor-gas) guide for more on gas sponsorship configuration.
     * This example uses Openfort's `@openfort/openfort-js` client-side package. `@alchemy/wallet-apis` can be used in any JavaScript environment.
     * Learn more about Openfort's embedded wallets in the [Openfort documentation](https://www.openfort.io/docs).
   </Tab>

--- a/content/wallets/pages/third-party/signers/privy.mdx
+++ b/content/wallets/pages/third-party/signers/privy.mdx
@@ -174,8 +174,8 @@ Upgrade existing Privy wallets to Wallet APIs to enable gasless transactions, ba
 
     ### Notes
 
-    * The client defaults to [EIP-7702](/wallets/transactions/using-eip-7702), which delegates the Privy wallet to a smart wallet at send time. No deployment or wallet migration needed. See the [EIP-7702 guide](/wallets/transactions/using-eip-7702) for non-7702 mode.
-    * See the [Sponsor gas](/wallets/transactions/sponsor-gas) guide for more on gas sponsorship configuration.
+    * The client defaults to [EIP-7702](/docs/wallets/transactions/using-eip-7702), which delegates the Privy wallet to a smart wallet at send time. No deployment or wallet migration needed. See the [EIP-7702 guide](/docs/wallets/transactions/using-eip-7702) for non-7702 mode.
+    * See the [Sponsor gas](/docs/wallets/transactions/sponsor-gas) guide for more on gas sponsorship configuration.
   </Tab>
 
   <Tab title="JavaScript" language="typescript">
@@ -270,8 +270,8 @@ Upgrade existing Privy wallets to Wallet APIs to enable gasless transactions, ba
 
     ### Notes
 
-    * The client defaults to [EIP-7702](/wallets/transactions/using-eip-7702), which upgrades the wallet to a smart wallet at transaction time without migration or separate deployment. See the [EIP-7702 guide](/wallets/transactions/using-eip-7702) for non-7702 mode.
-    * See the [Sponsor gas](/wallets/transactions/sponsor-gas) guide for more on gas sponsorship configuration.
+    * The client defaults to [EIP-7702](/docs/wallets/transactions/using-eip-7702), which upgrades the wallet to a smart wallet at transaction time without migration or separate deployment. See the [EIP-7702 guide](/docs/wallets/transactions/using-eip-7702) for non-7702 mode.
+    * See the [Sponsor gas](/docs/wallets/transactions/sponsor-gas) guide for more on gas sponsorship configuration.
     * This example uses Privy's `@privy-io/node` package which is designed for server environments. `@alchemy/wallet-apis` can be used in any JavaScript environment.
   </Tab>
 </Tabs>

--- a/content/wallets/pages/third-party/signers/turnkey.mdx
+++ b/content/wallets/pages/third-party/signers/turnkey.mdx
@@ -196,8 +196,8 @@ Upgrade existing Turnkey wallets to Wallet APIs to enable gasless transactions, 
 
     ### Notes
 
-    * The client defaults to [EIP-7702](/wallets/transactions/using-eip-7702), which delegates the Turnkey wallet to a smart wallet at send time. No deployment or wallet migration needed. See the [EIP-7702 guide](/wallets/transactions/using-eip-7702) for non-7702 mode.
-    * See the [Sponsor gas](/wallets/transactions/sponsor-gas) guide for more on gas sponsorship configuration.
+    * The client defaults to [EIP-7702](/docs/wallets/transactions/using-eip-7702), which delegates the Turnkey wallet to a smart wallet at send time. No deployment or wallet migration needed. See the [EIP-7702 guide](/docs/wallets/transactions/using-eip-7702) for non-7702 mode.
+    * See the [Sponsor gas](/docs/wallets/transactions/sponsor-gas) guide for more on gas sponsorship configuration.
   </Tab>
 
   <Tab title="JavaScript" language="typescript">
@@ -317,8 +317,8 @@ Upgrade existing Turnkey wallets to Wallet APIs to enable gasless transactions, 
 
     ### Notes
 
-    * The client defaults to [EIP-7702](/wallets/transactions/using-eip-7702), which upgrades the Turnkey wallet to a smart wallet at transaction time without migration or separate deployment. See the [EIP-7702 guide](/wallets/transactions/using-eip-7702) for non-7702 mode.
-    * See the [Sponsor gas](/wallets/transactions/sponsor-gas) guide for more on gas sponsorship configuration.
+    * The client defaults to [EIP-7702](/docs/wallets/transactions/using-eip-7702), which upgrades the Turnkey wallet to a smart wallet at transaction time without migration or separate deployment. See the [EIP-7702 guide](/docs/wallets/transactions/using-eip-7702) for non-7702 mode.
+    * See the [Sponsor gas](/docs/wallets/transactions/sponsor-gas) guide for more on gas sponsorship configuration.
     * This example uses Turnkey's `@turnkey/sdk-server` package which is designed for server environments. `@alchemy/wallet-apis` can be used in any JavaScript environment.
   </Tab>
 </Tabs>

--- a/content/wallets/wallet-integrations/privy/jwt-auth-migration.mdx
+++ b/content/wallets/wallet-integrations/privy/jwt-auth-migration.mdx
@@ -6,9 +6,9 @@ slug: wallets/wallet-integrations/privy/jwt-auth-migration
 
 This guide is for developers who authenticate users with Alchemy Signer using **JWT (JSON Web Token) authentication** and need to migrate to Privy.
 
-<Info>If you use standard auth methods (email, Google, passkeys) with the React SDK, use the [React migration guide](/wallets/wallet-integrations/privy/react-migration) instead.</Info>
+<Info>If you use standard auth methods (email, Google, passkeys) with the React SDK, use the [React migration guide](/docs/wallets/wallet-integrations/privy/react-migration) instead.</Info>
 
-<Note>Before starting, read the [signer migration overview](/wallets/wallet-integrations/privy/signer-migration-overview) to confirm your account type (Modular Account v2 vs. another implementation) and connection type (EIP-7702 vs. ERC-4337). Apps not on MAv2, or using pure 4337, need to adjust a step in this guide — the overview's [Edge cases](/wallets/wallet-integrations/privy/signer-migration-overview#edge-cases) section walks through each.</Note>
+<Note>Before starting, read the [signer migration overview](/docs/wallets/wallet-integrations/privy/signer-migration-overview) to confirm your account type (Modular Account v2 vs. another implementation) and connection type (EIP-7702 vs. ERC-4337). Apps not on MAv2, or using pure 4337, need to adjust a step in this guide — the overview's [Edge cases](/docs/wallets/wallet-integrations/privy/signer-migration-overview#edge-cases) section walks through each.</Note>
 
 ## How JWT migration differs from standard migration
 
@@ -75,7 +75,7 @@ While existing users still need migrating, you don't want Privy to auto-create a
 
 ## Step 3: Reconnect sending and gas sponsorship
 
-Install `@alchemy/wallet-apis` and wire up `createSmartWalletClient`. See the [Privy signer integration guide](/wallets/third-party/signers/privy) for full setup details, or follow the [React migration guide Step 2](/wallets/wallet-integrations/privy/react-migration#step-2-reconnect-sending-and-gas-sponsorship) for a walkthrough.
+Install `@alchemy/wallet-apis` and wire up `createSmartWalletClient`. See the [Privy signer integration guide](/docs/wallets/third-party/signers/privy) for full setup details, or follow the [React migration guide Step 2](/docs/wallets/wallet-integrations/privy/react-migration#step-2-reconnect-sending-and-gas-sponsorship) for a walkthrough.
 
 ***
 
@@ -415,7 +415,7 @@ Unlike the React migration, JWT migration does **not require a user export/impor
 
 **If you also use other auth methods:**
 
-* You still need to export users from Alchemy and import into Privy (see [React migration guide Step 4](/wallets/wallet-integrations/privy/react-migration#step-4-deploy-your-updated-app-export-users-and-import-into-privy))
+* You still need to export users from Alchemy and import into Privy (see [React migration guide Step 4](/docs/wallets/wallet-integrations/privy/react-migration#step-4-deploy-your-updated-app-export-users-and-import-into-privy))
 * Follow the same Deploy → Export → Import sequence
 
 ### Next steps
@@ -424,7 +424,7 @@ After migration, follow the Privy guides for using embedded wallets:
 
 * [Send a transaction](https://docs.privy.io/wallets/using-wallets/ethereum/send-a-transaction) (generic wallet usage)
 * [Create authorization keys](https://docs.privy.io/controls/authorization-keys/keys/create/user/request) (for server-side usage of wallets)
-* [Prepare smart wallet operations](/wallets/api-reference/smart-wallets/wallet-api-endpoints/wallet-api-endpoints/wallet-prepare-calls)
+* [Prepare smart wallet operations](/docs/wallets/api-reference/smart-wallets/wallet-api-endpoints/wallet-api-endpoints/wallet-prepare-calls)
 * [Sign smart wallet operations](https://docs.privy.io/api-reference/wallets/ethereum/eth-sign-user-operation)
 
 ## Important notes
@@ -440,7 +440,7 @@ Because JWT authentication is controlled by your server, both Alchemy and Privy 
 
 ### Migration tracking is on you
 
-The [React migration SDK](/wallets/wallet-integrations/privy/react-migration) detects migration need automatically via Privy metadata. In the JWT path, you own this logic entirely via your user database.
+The [React migration SDK](/docs/wallets/wallet-integrations/privy/react-migration) detects migration need automatically via Privy metadata. In the JWT path, you own this logic entirely via your user database.
 
 ## FAQ
 

--- a/content/wallets/wallet-integrations/privy/react-migration.mdx
+++ b/content/wallets/wallet-integrations/privy/react-migration.mdx
@@ -8,9 +8,9 @@ This guide walks you through migrating the **signer** for your app and users' em
 
 After completing this migration, users will log in with Privy (wallet addresses are preserved, assets are maintained) and transactions will continue to be sent and sponsored by Alchemy.
 
-<Info>This guide is for **React** apps. For non-React frameworks, [reach out](mailto:support@alchemy.com) for support. If you authenticate users with JWT (JSON Web Token) authentication instead of standard auth methods, use the [JWT auth migration guide](/wallets/wallet-integrations/privy/jwt-auth-migration) instead.</Info>
+<Info>This guide is for **React** apps. For non-React frameworks, [reach out](mailto:support@alchemy.com) for support. If you authenticate users with JWT (JSON Web Token) authentication instead of standard auth methods, use the [JWT auth migration guide](/docs/wallets/wallet-integrations/privy/jwt-auth-migration) instead.</Info>
 
-<Note>Before starting, read the [signer migration overview](/wallets/wallet-integrations/privy/signer-migration-overview) to confirm your account type (Modular Account v2 vs. another implementation) and connection type (EIP-7702 vs. ERC-4337). Apps not on MAv2, or using pure 4337, need to adjust a step in this guide — the overview's [Edge cases](/wallets/wallet-integrations/privy/signer-migration-overview#edge-cases) section walks through each.</Note>
+<Note>Before starting, read the [signer migration overview](/docs/wallets/wallet-integrations/privy/signer-migration-overview) to confirm your account type (Modular Account v2 vs. another implementation) and connection type (EIP-7702 vs. ERC-4337). Apps not on MAv2, or using pure 4337, need to adjust a step in this guide — the overview's [Edge cases](/docs/wallets/wallet-integrations/privy/signer-migration-overview#edge-cases) section walks through each.</Note>
 
 ## Prerequisites
 
@@ -93,11 +93,11 @@ At this point: Your app should compile, users can log in with Privy, but sending
 Wire Privy wallets to Alchemy's transaction infrastructure so gasless transactions, batching, and all your existing flows work again. This uses Alchemy SDK v5 with Wallet APIs.
 
 * The client defaults to EIP-7702, which delegates the Privy wallet to a smart wallet at send time.
-* If you were previously using ERC-4337 (with assets directly in smart accounts), see the [non-7702 mode guide](/wallets/transactions/using-eip-7702#how-to-use-non-7702-mode). You'll need to add an additional call to `wallet_requestAccount` before sending.
-* If your existing app uses a smart account other than Modular Account v2 (Light Account, Modular Account v1, Simple Account, or a custom implementation), stop here and stay on the lower-level SDK for those users. Wallet APIs only support MAv2 — see the overview's [Account type edge case](/wallets/wallet-integrations/privy/signer-migration-overview#account-type--non-mav2-users) and the [choosing a smart account](/wallets/smart-contracts/choosing-a-smart-account) reference.
+* If you were previously using ERC-4337 (with assets directly in smart accounts), see the [non-7702 mode guide](/docs/wallets/transactions/using-eip-7702#how-to-use-non-7702-mode). You'll need to add an additional call to `wallet_requestAccount` before sending.
+* If your existing app uses a smart account other than Modular Account v2 (Light Account, Modular Account v1, Simple Account, or a custom implementation), stop here and stay on the lower-level SDK for those users. Wallet APIs only support MAv2 — see the overview's [Account type edge case](/docs/wallets/wallet-integrations/privy/signer-migration-overview#account-type--non-mav2-users) and the [choosing a smart account](/docs/wallets/smart-contracts/choosing-a-smart-account) reference.
 
 <Info>
-For advanced setups, see the full [Privy signer integration guide](/wallets/third-party/signers/privy) or the [Alchemy Wallet APIs overview](/wallets).
+For advanced setups, see the full [Privy signer integration guide](/docs/wallets/third-party/signers/privy) or the [Alchemy Wallet APIs overview](/docs/wallets).
 </Info>
 
 ### 2a. Install

--- a/content/wallets/wallet-integrations/privy/signer-migration-overview.mdx
+++ b/content/wallets/wallet-integrations/privy/signer-migration-overview.mdx
@@ -8,8 +8,8 @@ This page is the landing guide for moving the **signer** (auth + key custody) fo
 
 <Info>
 Pick the detailed guide that matches your app:
-* **[React migration](/wallets/wallet-integrations/privy/react-migration)** — the default path. React apps using standard auth methods (email, Google, passkeys, etc.).
-* **[JWT auth migration](/wallets/wallet-integrations/privy/jwt-auth-migration)** — special case for apps authenticating users with JWT (JSON Web Token).
+* **[React migration](/docs/wallets/wallet-integrations/privy/react-migration)** — the default path. React apps using standard auth methods (email, Google, passkeys, etc.).
+* **[JWT auth migration](/docs/wallets/wallet-integrations/privy/jwt-auth-migration)** — special case for apps authenticating users with JWT (JSON Web Token).
 </Info>
 
 <Note>
@@ -31,7 +31,7 @@ At a high level, the React migration is two steps:
   </Step>
 </Steps>
 
-For the full, runnable walkthrough — including user export/import and cleanup — follow the [React migration guide](/wallets/wallet-integrations/privy/react-migration). If you authenticate users with JWT, follow the [JWT auth migration guide](/wallets/wallet-integrations/privy/jwt-auth-migration) instead.
+For the full, runnable walkthrough — including user export/import and cleanup — follow the [React migration guide](/docs/wallets/wallet-integrations/privy/react-migration). If you authenticate users with JWT, follow the [JWT auth migration guide](/docs/wallets/wallet-integrations/privy/jwt-auth-migration) instead.
 
 ## Prerequisites
 
@@ -56,7 +56,7 @@ The `@account-kit/react` package (SDK v4) defaulted to **ERC-4337** with a smart
 * **EIP-7702 delegation (Wallet APIs default).** The signer (EOA) address *is* the account address. Assets live at the signer address, and the EOA is delegated to MAv2.
 * **ERC-4337 (SDK v4 default).** The signer is the *owner* of a separate smart contract account. Assets live at the smart contract account address, not at the signer address.
 
-If you want to keep using pure ERC-4337 accounts after migration, you need to request the existing smart contract account type explicitly instead of using the Wallet APIs default. See [How to use non-7702 mode](/wallets/transactions/using-eip-7702#how-to-use-non-7702-mode) for the full flow.
+If you want to keep using pure ERC-4337 accounts after migration, you need to request the existing smart contract account type explicitly instead of using the Wallet APIs default. See [How to use non-7702 mode](/docs/wallets/transactions/using-eip-7702#how-to-use-non-7702-mode) for the full flow.
 
 ### Account type — non-MAv2 users
 
@@ -64,7 +64,7 @@ Wallet APIs default to Modular Account v2, but Light Account and MAv1 are also s
 
 ### Session keys
 
-If your users have legacy session keys installed onchain through the v4 `@account-kit/wallet-client` integration, they're still supported on Wallet APIs. See the [Use existing session keys](/wallets/reference/wallet-apis-session-keys/legacy-session-keys) reference for the guide.
+If your users have legacy session keys installed onchain through the v4 `@account-kit/wallet-client` integration, they're still supported on Wallet APIs. See the [Use existing session keys](/docs/wallets/reference/wallet-apis-session-keys/legacy-session-keys) reference for the guide.
 
 ## Get help
 


### PR DESCRIPTION
## Summary

Lychee link checker (base_url = `https://www.alchemy.com`) has been failing on every PR because several internal links in `content/wallets/` start with `/wallets/...` instead of `/docs/wallets/...`. The live site has a routing fallback that masks the issue for users, but the checker tries to fetch `https://www.alchemy.com/wallets/...` and 404s.

This PR replaces 27 occurrences of `](/wallets` with `](/docs/wallets` across 6 files:

- `content/wallets/wallet-integrations/privy/react-migration.mdx` (5)
- `content/wallets/wallet-integrations/privy/jwt-auth-migration.mdx` (6)
- `content/wallets/wallet-integrations/privy/signer-migration-overview.mdx` (5)
- `content/wallets/pages/third-party/signers/privy.mdx` (4)
- `content/wallets/pages/third-party/signers/turnkey.mdx` (4)
- `content/wallets/pages/third-party/signers/openfort.mdx` (3)

The first three were introduced in #1230 (Privy signer migration guides); the rest predate that PR. The canonical pattern in the rest of `content/` already uses `/docs/wallets/...` (455 occurrences), so this aligns the new pages with the existing convention.

No anchor changes, no link-target rewrites, no nav changes. Pure prefix fix. Verified `grep -rE '\]\(/wallets[^)]*\)' content/` returns zero results post-change.

## Linear

DOCS-67 — https://linear.app/alchemyapi/issue/DOCS-67/fix-wallets-links-in-content-to-use-docswallets-prefix-lychee-link

## Requested by

@dslovinsky (via Slack thread)