### PR TITLE
[docs-agent] Update wallets CONTRIBUTING.md to require /docs/ prefix on relative links

### DIFF
--- a/content/wallets/CONTRIBUTING.md
+++ b/content/wallets/CONTRIBUTING.md
@@ -201,7 +201,7 @@ Content under `content/wallets/pages/low-level-infra/` targets developers workin
 **Link Strategy**:
 
 * **Link to existing docs** instead of repeating content
-* **Use relative links**: All relative links should begin with `/wallets/...` instead of full URLs (`https://www.alchemy.com/docs/wallets/...`)
+* **Use relative links**: All relative links should begin with `/docs/wallets/...` instead of full URLs (`https://www.alchemy.com/docs/wallets/...`). The `/docs/` prefix is required, links missing it work on the live site via fallback formatting, but the lychee link checker (run on every PR) fails on them.
 * **Ensure no broken or circular references**
 
 ***
@@ -283,7 +283,7 @@ Ensure you are using aa-sdk version 3.x or later...
 
 **Links and References**:
 
-* ✅ **Use relative links**: `[/wallets/authentication]`
+* ✅ **Use relative links**: `[/docs/wallets/authentication]`
 * ❌ **Avoid full URLs**: `[https://www.alchemy.com/docs/...]`
 * ✅ **Include alt text** for all images
 * ✅ **Verify no broken links**


### PR DESCRIPTION
## Summary

The wallets contributor guide previously instructed writers to begin relative links with `/wallets/...`, which was the source of repeated lychee CI failures. Links missing the `/docs/` prefix render fine on the live site thanks to URL-handling fallback, but the lychee link checker (run on every PR) treats them as broken and fails CI.

This PR updates `content/wallets/CONTRIBUTING.md` in two places:

- **Section 4 (Content Organization → Link Strategy)**: change the relative-link example from `/wallets/...` to `/docs/wallets/...` and add a one-line note explaining why the `/docs/` prefix is required.
- **Section 6 (Markdown Formatting Standards → Links and References)**: change the example `[/wallets/authentication]` to `[/docs/wallets/authentication]` so the bullet matches the new rule.

This is purely a guideline correction. No other content changes. The link instances themselves were already fixed across MDX files in #1267.

## Linear

DOCS-68 — https://linear.app/alchemyapi/issue/DOCS-68/prepend-docs-to-wallet-links-breaking-lychee-link-checker

## Requested by

@SahilAujla (via Slack thread)
