### PR TITLE
[docs-agent] Deprecate Aptos and Avalanche Snapshots tutorial pages

### DIFF
--- a/content/tutorials/snapshots/aptos.mdx
+++ b/content/tutorials/snapshots/aptos.mdx
@@ -1,70 +1,11 @@
 ---
 title: Aptos
 slug: docs/snapshots/aptos
-description: View current network statistics and performance data for Aptos on Alchemy.
+description: Notice regarding the deprecation of the Aptos snapshot service on Alchemy.
 ---
 
-* [Official Docs](https://aptos.dev/)
-* [Github Repository](https://github.com/aptos-labs/aptos-core)
+## ⚠️ Deprecation Notice
 
-The snapshot service for Aptos is available [here](https://alchemy.com/snapshots/aptos).
+Alchemy's snapshot service for Aptos has been deprecated and is no longer available.
 
-Whether you need to bootstrap your full node or you are in need of a snapshot to ease the migration or kick-start of your validator, you can use our daily snapshot service to speed up the process.
-
-Note: the nodes used for snapshotting are using the default pruning values of Aptos and are hosted as Docker containers on machines using Ubuntu 22.04.
-
-### How to use
-
-Go to our [Aptos snapshot service](https://alchemy.com/snapshots/aptos) and download the latest available snapshot. Decompress the archive as per the following instructions and start your node.
-
-**1. Download the snapshot**
-
-```bash
-wget <APTOS_SNAPSHOT_URL>
-```
-
-**2. Stop your Aptos service**
-
-If Aptos was already running on your machine, stop your services:
-
-```bash
-sudo systemctl stop aptos.service
-```
-
-OR if you are using a container:
-
-```bash
-docker stop <APTOS_CONTAINER_NAME>
-```
-
-Make sure there is no process running that might try to write to the database:
-
-```bash
-ps -ef | grep aptos-node
-```
-
-**3. Clean the data directory**
-
-Make sure your Aptos data directory is clean (let us assume `<APTOS_HOME>` is your root Aptos directory):
-
-```bash
-rm -rf <APTOS_HOME>/data/*
-```
-
-**4. Install lz4 and decompress the archive**
-
-```bash
-sudo apt-get install lz4
-```
-
-```bash
-lz4 -c -d <APTOS_SNAPSHOT_NAME>.tar.lz4  | tar -x -C <APTOS_HOME>/data
-```
-
-**5. Start the Aptos service or container**
-
-You should be in-sync with the network in minutes after starting the node.
-
-<Info>
-  Also check the official documentation and the GitHub repository posted above to correctly deploy the node of your choice.
-</Info>
+If you have questions or need help bootstrapping an Aptos node, please reach out to [Alchemy Support](https://www.alchemy.com/support) or refer to the official [Aptos documentation](https://aptos.dev/).

--- a/content/tutorials/snapshots/avalanche.mdx
+++ b/content/tutorials/snapshots/avalanche.mdx
@@ -1,66 +1,11 @@
 ---
 title: Avalanche
 slug: docs/snapshots/avalanche
-description: View current network statistics and performance data for Avalanche on Alchemy.
+description: Notice regarding the deprecation of the Avalanche snapshot service on Alchemy.
 ---
 
-* [Official Docs](https://build.avax.network/docs)
-* [Github Repository](https://github.com/ava-labs)
+## ⚠️ Deprecation Notice
 
-The snapshot service for Avalanche is available [here](https://alchemy.com/snapshots/avalanche).
+Alchemy's snapshot service for Avalanche has been deprecated and is no longer available.
 
-Whether you need to bootstrap your full node or you are in need of a snapshot to ease the migration or kick-start of your validator, you can use our daily snapshot service to speed up the process.
-
-Note: the nodes used for snapshotting are using the default pruning values of Avalanche and are hosted as Docker containers on machines using Ubuntu 22.04.
-
-### How to use
-
-Go to our [Avalanche snapshot service](https://alchemy.com/snapshots/avalanche) and download the latest available snapshot. Decompress the archive as per the following instructions and start your node.
-
-**1. Download the snapshot**
-
-```bash
-wget <AVALANCHE_SNAPSHOT_URL>
-```
-
-**2. Stop your Avalanche service**
-
-If Avalanche was already running on your machine, stop your services:
-
-```bash
-sudo systemctl stop avalanche.service
-```
-
-OR if you are using a container:
-
-```bash
-docker stop <AVALANCHE_CONTAINER_NAME>
-```
-
-Make sure there is no process running that might try to write to the database.
-
-**3. Clean the data directory**
-
-Make sure your Avalanche data directory is clean (let us assume `<AVALANCHE_HOME>` is your root Avalanche directory):
-
-```bash
-rm -rf <AVALANCHE_HOME>/db/mainnet/*
-```
-
-**4. Install lz4 and decompress the archive**
-
-```bash
-sudo apt-get install lz4
-```
-
-```bash
-lz4 -c -d <AVALANCHE_SNAPSHOT_NAME>.tar.lz4  | tar -x -C <AVALANCHE_HOME>/db/mainnet/
-```
-
-**5. Start the Avalanche service or container**
-
-You should be in-sync with the network in minutes after starting the node.
-
-<Info>
-  Also check the official documentation and the GitHub repository posted above to correctly deploy the node of your choice.
-</Info>
+If you have questions or need help bootstrapping an Avalanche node, please reach out to [Alchemy Support](https://www.alchemy.com/support) or refer to the official [Avalanche documentation](https://build.avax.network/docs).


### PR DESCRIPTION
## Summary

The Aptos and Avalanche Snapshots features have been deprecated. This PR rewrites both tutorial pages as short deprecation notices and drops the now-dead links to `alchemy.com/snapshots/aptos` and `alchemy.com/snapshots/avalanche`.

Slugs (`docs/snapshots/aptos`, `docs/snapshots/avalanche`) are unchanged, so any inbound links from blog posts, indexers, or external sites land on the deprecation notice rather than 404. Nav (`content/docs.yml`) and `redirects.yml` therefore need no changes. The other 5 chains in `content/tutorials/snapshots/` (Ink, Shape, Soneium, Unichain, Worldchain) still have an active snapshot service and are untouched.

## Linear

DOCS-69 — https://linear.app/alchemyapi/issue/DOCS-69/deprecate-aptos-and-avalanche-snapshots-tutorial-pages

## Requested by

@dslovinsky (via Slack thread)
