### PR TITLE
[docs-agent] document Rise Mainnet support in Node API pages

### DIFF
--- a/content/api-reference/node-api/node-supported-chains.mdx
+++ b/content/api-reference/node-api/node-supported-chains.mdx
@@ -302,6 +302,7 @@ Alchemy supports both EVM and non-EVM chains, view API references below:
 | Syndicate | Syndicate Mainnet | https://synd-mainnet.g.alchemy.com/v2/API_KEY |
 | Superseed | Superseed Mainnet | https://superseed-mainnet.g.alchemy.com/v2/API_KEY |
 | Superseed | Superseed Sepolia | https://superseed-sepolia.g.alchemy.com/v2/API_KEY |
+| Rise | Rise Mainnet | https://rise-mainnet.g.alchemy.com/v2/API_KEY |
 | Rise | Rise Testnet | https://rise-testnet.g.alchemy.com/v2/API_KEY |
 | Monad | Monad Testnet | https://monad-testnet.g.alchemy.com/v2/API_KEY |
 | Monad | Monad Mainnet | https://monad-mainnet.g.alchemy.com/v2/API_KEY |

--- a/content/api-reference/rise/rise-api-quickstart.mdx
+++ b/content/api-reference/rise/rise-api-quickstart.mdx
@@ -14,6 +14,13 @@ RISE is an Ethereum Layer-2 with a parallel EVM and a "based" hybrid rollup desi
 
 The Rise API lets you interact with the Rise network through a set of JSON-RPC methods. If you've worked with Ethereum's JSON-RPC APIs, the design will feel familiar.
 
+Alchemy supports both Rise networks. Use the endpoint that matches the network you want to connect to:
+
+| Network | RPC URL |
+| ------- | ------- |
+| Rise Mainnet | `https://rise-mainnet.g.alchemy.com/v2/YOUR_ALCHEMY_API_KEY` |
+| Rise Testnet | `https://rise-testnet.g.alchemy.com/v2/YOUR_ALCHEMY_API_KEY` |
+
 ## Send your first request on Alchemy
 
 Let's use the [`viem`](https://www.npmjs.com/package/viem) package to create a Rise client connected to Alchemy and fetch the latest block number!


### PR DESCRIPTION
## Summary

Daikon PR #1273 adds a `Rise Mainnet` server entry (`https://rise-mainnet.g.alchemy.com/v2`) to the Rise OpenRPC spec, but the rest of the Node API content still describes Rise as testnet-only. Codex flagged the inconsistency on #1273. This PR catches the companion content pages up so the docs match the spec change.

Changes:

- `content/api-reference/node-api/node-supported-chains.mdx` — add a `Rise Mainnet` row alongside the existing `Rise Testnet` row in the supported-chains table.
- `content/api-reference/rise/rise-api-quickstart.mdx` — add a short RPC-URL table near the top showing both Rise Mainnet and Rise Testnet endpoints, so readers know mainnet is supported before they hit the testnet code sample.

Out of scope: Smart Wallets / Bundler integrations on Rise (`content/wallets/pages/overview/supported-chains.mdx`, `bundler-faqs.mdx`). Those depend on bundler/wallet infra availability on Rise mainnet, which is a separate signal not covered by #1273. Open a follow-up if/when those products go live on Rise mainnet.

## Linear

DOCS-70 — https://linear.app/alchemyapi/issue/DOCS-70/document-rise-mainnet-support-in-node-api-pages

## Related

- Daikon spec change: #1273

## Requested by

@SahilAujla (via Slack thread)
