### PR TITLE
[docs-agent] Weekly style audit fixes 2026-04-29

### DIFF
--- a/content/api-reference/data/nft-api/alchemy-photon-apis-for-solana.mdx
+++ b/content/api-reference/data/nft-api/alchemy-photon-apis-for-solana.mdx
@@ -8,7 +8,7 @@ subtitle: Alchemy Photon APIs for Solana ZK Compression
 
 Alchemy supports the [Photon](https://github.com/helius-labs/photon) indexer, an open-source ZK Compression indexer maintained by Helius. These endpoints let you read [ZK Compressed](https://www.zkcompression.com/) Solana state — accounts, token balances, and transaction signatures — through the same familiar JSON-RPC surface used for standard Solana calls.
 
-ZK Compression stores most of an account's data off-chain in a merkle tree while keeping a small commitment on-chain, letting applications mint and manage thousands of accounts or tokens at a fraction of the normal rent cost. Photon indexes those compressed accounts and exposes them through the methods below, following the [Photon API specification](https://github.com/helius-labs/photon).
+ZK Compression stores most of an account's data offchain in a merkle tree while keeping a small commitment onchain, letting applications mint and manage thousands of accounts or tokens at a fraction of the normal rent cost. Photon indexes those compressed accounts and exposes them through the methods below, following the [Photon API specification](https://github.com/helius-labs/photon).
 
 These endpoints are served through the standard Solana Alchemy endpoints (`https://solana-mainnet.g.alchemy.com/v2/<API_KEY>` and `https://solana-devnet.g.alchemy.com/v2/<API_KEY>`), so you can call them with the same client you already use for Solana Core RPC.
 


### PR DESCRIPTION
Weekly audit fixes for ERROR-level style violations found in PRs merged in the last 7 days (2026-04-22 → 2026-04-29).

## Files fixed

- `content/api-reference/data/nft-api/alchemy-photon-apis-for-solana.mdx` — Background paragraph contained two `STYLE_RULES.md` preferred-forms violations in the same sentence: `off-chain` → `offchain` and `on-chain` → `onchain`. The page was newly added in #1240, so this catches up the new copy to the house style table.

## Audit scope

`gh pr list --state merged --search "merged:>=2026-04-22"` returned 28 PRs. After filtering to `.mdx`/`.md` files under `content/`, **65 unique files** were touched this week. Each was scanned against `STYLE_RULES.md` (preferred-forms table, voice, structure, link patterns).

## ERROR-level (PR'd here)

1 finding, listed above. Per the playbook: "wrong terminology repeated in multiple places within the same file" → ERROR. The Photon page introduced two preferred-forms misses in one paragraph in a brand-new page.

## WARNING-level (noted, not PR'd)

Per the playbook, single-instance / style-preference issues do not get a fix PR. For visibility:

- `content/wallets/wallet-integrations/privy/react-migration.mdx` (new in #1230) — line 17 uses `Alchemy API Key` (capitalized); the companion `signer-migration-overview.mdx:44` uses the correct `API key` form, so this is a single bullet that drifted.
- `content/wallets/wallet-integrations/privy/react-migration.mdx` line 21 — `## Overview` heading is on the `STYLE_RULES.md` "vague labels" avoid list; left as-is for the human writer's judgment since rewriting a section heading is more than a mechanical swap.
- `content/wallets/shared/infra/api-endpoints/gas-manager-sponsorship.mdx:12` (touched by #1244) — `ERC20 fee quote` should be `ERC-20 fee quote` (single instance).
- `content/wallets/pages/transactions/solana/sponsor-gas-solana.mdx:85` (touched by #1244) — `fail on-chain` should be `fail onchain` (single instance).
- `content/api-reference/pricing-resources/pricing/compute-unit-costs.mdx:376` — `Webhooks` capitalized mid-sentence; the offending line wasn't actually edited by this week's PRs (#1255 / #1237 only touched other parts of the file).
- `content/tutorials/alchemy-university/smart-contract-basics/multi-sig-contracts.mdx` and `content/wallets/pages/authentication/what-is-a-signer.mdx` carry `in order to` filler; both lines pre-date this week's edits (only links/list-items were touched in #1243 / #1251).

## Out of scope

- Daikon bot PRs (#1275, #1273, #1272, #1257, #1250, #1249, #1246) — automated spec/server updates, not editorial content the audit covers.
- CI workflow PRs (#1271, #1265) — not `content/`.
- Redirect-only PR (#1259) — `redirects.yml`, not auditable prose.

## Verification

- `git diff --stat` → 1 file, 1 insertion, 1 deletion.
- Diff is the two-word swap and nothing else; no surrounding prose touched, no link targets changed.
- `pnpm run lint` produces only pre-existing warnings on files this PR does not touch (`MDX_FEATURES.md`, `scripts/upload-specs.ts`, `src/content-indexer/indexers/changelog.ts`, `content/wallets/pages/authentication/what-is-a-signer.mdx`, `content/wallets/pages/smart-wallets/session-keys/legacy-session-keys.mdx`). The changed MDX file is clean.
