### PR TITLE
[Styler] Weekly style audit 2026-04-30

### DIFF
--- a/content/api-reference/websockets/solana-subscription-api-endpoints/solana-subscription-api-endpoints.mdx
+++ b/content/api-reference/websockets/solana-subscription-api-endpoints/solana-subscription-api-endpoints.mdx
@@ -7,7 +7,7 @@ slug: reference/solana-subscription-api-endpoints
 
 # Overview
 
-Solana exposes a PubSub WebSocket API alongside its standard HTTP JSON-RPC. Each subscription opens a long-lived stream that pushes notifications when on-chain state changes (account data, program-owned accounts, transaction logs, signature status, slots, blocks, votes, and roots).
+Solana exposes a PubSub WebSocket API alongside its standard HTTP JSON-RPC. Each subscription opens a long-lived stream that pushes notifications when onchain state changes (account data, program-owned accounts, transaction logs, signature status, slots, blocks, votes, and roots).
 
 Connect to the PubSub endpoint using your Alchemy WebSocket URL:
 

--- a/content/wallets/wallet-integrations/privy/react-migration.mdx
+++ b/content/wallets/wallet-integrations/privy/react-migration.mdx
@@ -14,7 +14,7 @@ After completing this migration, users will log in with Privy (wallet addresses 
 
 ## Prerequisites
 
-* **Alchemy API Key** — From the [Alchemy Dashboard](https://dashboard.alchemy.com/). Must be the same app that has your Smart Wallets configuration and gas policy linked.
+* **Alchemy API key** — From the [Alchemy Dashboard](https://dashboard.alchemy.com/). Must be the same app that has your Smart Wallets configuration and gas policy linked.
 * **Gas Sponsorship Policy ID** — From the [Gas Manager dashboard](https://dashboard.alchemy.com/services/gas-manager/configuration).
 * A React app currently using Alchemy Account Kit (`@account-kit/react`).
 


### PR DESCRIPTION
## Summary

Weekly style audit covering PRs merged in the last 7 days (2026-04-23 → 2026-04-30). Audited 35 unique \`.md\`/\`.mdx\` files in \`content/\` against [STYLE_RULES.md](../blob/main/STYLE_RULES.md).

## Fixes

Two ERROR-level terminology violations:

### 1. \`content/wallets/wallet-integrations/privy/react-migration.mdx\` (line 17)
- **Rule:** Preferred form \`API key\` (not \`API Key\`)
- **Found:** \`**Alchemy API Key** — From the [Alchemy Dashboard]...\`
- **Fix:** \`**Alchemy API key** — From the [Alchemy Dashboard]...\`
- Source PR: #1230

### 2. \`content/api-reference/websockets/solana-subscription-api-endpoints/solana-subscription-api-endpoints.mdx\` (line 10)
- **Rule:** Preferred form \`onchain\` (not \`on-chain\`)
- **Found:** \`...pushes notifications when on-chain state changes...\`
- **Fix:** \`...pushes notifications when onchain state changes...\`
- Source PR: #1234

## Audit notes (no PR action)

- \`websocket\` casing appears in code-block comments (\`// initiate websocket stream first\`) across the new Solana subscription endpoint pages. Per Styler policy, code samples are flagged only, not modified — leaving these as a soft suggestion for the Writer.
- \`compute-unit-costs.mdx\` line 384 uses \`WebSocket Subscriptions\` in title-case as a feature label; arguably correct in context.
- \`subscription-api.mdx\` references a \`websockets\` anchor ID — not changed (anchors are stable).
- \`content/wallets/CONTRIBUTING.md\` mentions of \`on-chain\` and \`ERC20\` are inside a table that explicitly lists those as forms to avoid — intentional, not a violation.
- Bot-generated and CI-only PRs (#1271, #1265, #1257, #1272, #1273, #1275, #1253) had no \`content/\` style impact.

## Verification

\`pnpm run lint\` was attempted but the local sandbox killed the process (OOM) before it completed; the changes are pure prose terminology swaps with no syntax impact. CI lint will run on this PR.