### PR TITLE
Document supported account types for requestAccount

### DIFF
--- a/content/wallets/pages/transactions/using-eip-7702/index.mdx
+++ b/content/wallets/pages/transactions/using-eip-7702/index.mdx
@@ -36,6 +36,21 @@ If you've already used an owner address in 7702 mode (e.g. by calling `wallet_pr
 * Using an owner that doesn't support signing EIP-7702 authorizations
 * Specific requirements for smart wallet architecture
 
+### Supported account types
+
+Pass the `accountType` value inside `creationHint` when calling `wallet_requestAccount` to select the account type. If omitted, the default is `"sma-b"` (Modular Account v2).
+
+| `accountType` value | Account | Notes |
+|---|---|---|
+| `"sma-b"` | Modular Account v2 (MAv2) | Default. Single owner. |
+| `"la-v2"` | Light Account v2 | Single owner. |
+| `"la-v2-multi-owner"` | Light Account v2 (Multi-Owner) | Requires `initialOwners` array in `creationHint`. |
+| `"ma-v1-multi-owner"` | Modular Account v1 (Multi-Owner) | Deprecated — backwards compatibility only. |
+| `"la-v1.1.0"` | Light Account v1.1.0 | Deprecated — backwards compatibility only. |
+| `"la-v1.0.2"` | Light Account v1.0.2 | Deprecated — backwards compatibility only. |
+| `"la-v1.0.1"` | Light Account v1.0.1 | Deprecated — backwards compatibility only. |
+| `"7702"` | Smart EOA (EIP-7702) | Explicitly request a 7702-delegated account. |
+
 <Tabs>
   <Tab title="SDK">
     ```ts

--- a/content/wallets/pages/transactions/using-eip-7702/index.mdx
+++ b/content/wallets/pages/transactions/using-eip-7702/index.mdx
@@ -55,6 +55,10 @@ For new integrations, we recommend **Modular Account v2** — either via EIP-770
 | `"la-v1.0.2"` | Light Account v1.0.2 | Backwards compatibility only. |
 | `"la-v1.0.1"` | Light Account v1.0.1 | Backwards compatibility only. |
 
+### Example: request a non-7702 account
+
+Call `requestAccount` with the desired `accountType`, then pass the returned address to subsequent calls like `sendCalls`:
+
 <Tabs>
   <Tab title="SDK">
     ```ts

--- a/content/wallets/pages/transactions/using-eip-7702/index.mdx
+++ b/content/wallets/pages/transactions/using-eip-7702/index.mdx
@@ -40,16 +40,20 @@ If you've already used an owner address in 7702 mode (e.g. by calling `wallet_pr
 
 Pass the `accountType` value inside `creationHint` when calling `wallet_requestAccount` to select the account type. If omitted, the default is `"sma-b"` (Modular Account v2).
 
+<Note>
+For new integrations, we recommend **Modular Account v2** — either via EIP-7702 (the default) or as a smart contract account (`"sma-b"`). The other account types below are supported for backwards compatibility with existing deployments.
+</Note>
+
 | `accountType` value | Account | Notes |
 |---|---|---|
-| `"sma-b"` | Modular Account v2 (MAv2) | Default. Single owner. |
-| `"la-v2"` | Light Account v2 | Single owner. |
-| `"la-v2-multi-owner"` | Light Account v2 (Multi-Owner) | Requires `initialOwners` array in `creationHint`. |
-| `"ma-v1-multi-owner"` | Modular Account v1 (Multi-Owner) | Deprecated — backwards compatibility only. |
-| `"la-v1.1.0"` | Light Account v1.1.0 | Deprecated — backwards compatibility only. |
-| `"la-v1.0.2"` | Light Account v1.0.2 | Deprecated — backwards compatibility only. |
-| `"la-v1.0.1"` | Light Account v1.0.1 | Deprecated — backwards compatibility only. |
-| `"7702"` | Smart EOA (EIP-7702) | Explicitly request a 7702-delegated account. |
+| `"sma-b"` | Modular Account v2 (MAv2) | **Recommended.** Default. Single owner. |
+| `"7702"` | Smart EOA (EIP-7702) | **Recommended.** Explicitly request a 7702-delegated MAv2 account. |
+| `"la-v2"` | Light Account v2 | Backwards compatibility only. Single owner. |
+| `"la-v2-multi-owner"` | Light Account v2 (Multi-Owner) | Backwards compatibility only. Requires `initialOwners` array in `creationHint`. |
+| `"ma-v1-multi-owner"` | Modular Account v1 (Multi-Owner) | Backwards compatibility only. |
+| `"la-v1.1.0"` | Light Account v1.1.0 | Backwards compatibility only. |
+| `"la-v1.0.2"` | Light Account v1.0.2 | Backwards compatibility only. |
+| `"la-v1.0.1"` | Light Account v1.0.1 | Backwards compatibility only. |
 
 <Tabs>
   <Tab title="SDK">

--- a/content/wallets/wallet-integrations/privy/react-migration.mdx
+++ b/content/wallets/wallet-integrations/privy/react-migration.mdx
@@ -94,7 +94,7 @@ Wire Privy wallets to Alchemy's transaction infrastructure so gasless transactio
 
 * The client defaults to EIP-7702, which delegates the Privy wallet to a smart wallet at send time.
 * If you were previously using ERC-4337 (with assets directly in smart accounts), see the [non-7702 mode guide](/docs/wallets/transactions/using-eip-7702#how-to-use-non-7702-mode). You'll need to add an additional call to `wallet_requestAccount` before sending.
-* If your existing app uses a smart account other than Modular Account v2 (Light Account, Modular Account v1, Simple Account, or a custom implementation), stop here and stay on the lower-level SDK for those users. Wallet APIs only support MAv2 — see the overview's [Account type edge case](/docs/wallets/wallet-integrations/privy/signer-migration-overview#account-type--non-mav2-users) and the [choosing a smart account](/docs/wallets/smart-contracts/choosing-a-smart-account) reference.
+* If your existing app uses a smart account other than Modular Account v2 (Light Account, Modular Account v1, etc.), pass the matching `accountType` value when calling `requestAccount`. See the [supported account types](/docs/wallets/transactions/using-eip-7702#supported-account-types) table for the full list of values.
 
 <Info>
 For advanced setups, see the full [Privy signer integration guide](/docs/wallets/third-party/signers/privy) or the [Alchemy Wallet APIs overview](/docs/wallets).

--- a/content/wallets/wallet-integrations/privy/signer-migration-overview.mdx
+++ b/content/wallets/wallet-integrations/privy/signer-migration-overview.mdx
@@ -39,7 +39,7 @@ Before starting, confirm your setup and have the following ready:
 
 * **Confirm your migration path.** Review the [Edge cases](#edge-cases) below to self-identify which guide applies:
   * Confirm whether you want to use **EIP-7702 or ERC-4337** after migration — the default changed between SDK versions. See [EIP-7702 vs. ERC-4337](#eip-7702-vs-erc-4337) below.
-  * Confirm your **account type**. Modular Account v2 (MAv2) is the default; Light Account and MAv1 are also supported on Wallet APIs — reach out to [support@alchemy.com](mailto:support@alchemy.com) to enable these legacy account types.
+  * Confirm your **account type**. Modular Account v2 (MAv2) is the default; Light Account and MAv1 are also supported. Pass the matching `accountType` value when calling `requestAccount` — see the [supported account types](/docs/wallets/transactions/using-eip-7702#supported-account-types) table for the full list.
   * Pick the **migration guide** that matches — React by default, JWT if you authenticate with JSON Web Tokens.
 * **Alchemy API key** — From the [Alchemy Dashboard](https://dashboard.alchemy.com/). Use the same app that has your Smart Wallets configuration and Gas Manager policy linked.
 * **Gas Manager policy ID** — From the [Gas Manager dashboard](https://dashboard.alchemy.com/services/gas-manager/configuration). Must be linked to the app above.
@@ -60,7 +60,7 @@ If you want to keep using pure ERC-4337 accounts after migration, you need to re
 
 ### Account type — non-MAv2 users
 
-Wallet APIs default to Modular Account v2, but Light Account and MAv1 are also supported. If your current app uses one of those account types, reach out to [support@alchemy.com](mailto:support@alchemy.com) to enable it.
+Wallet APIs default to Modular Account v2, but Light Account and MAv1 are also supported. If your current app uses one of those account types, pass the matching `accountType` value when calling `requestAccount`. See the [supported account types](/docs/wallets/transactions/using-eip-7702#supported-account-types) table for the full list of values.
 
 ### Session keys
 


### PR DESCRIPTION
## Summary
- Added a "Supported account types" table to the [non-7702 mode docs](https://docs.alchemy.com/docs/wallets/transactions/using-eip-7702#how-to-use-non-7702-mode) listing all `accountType` values for `wallet_requestAccount`
- Removed incorrect "reach out to support@alchemy.com to enable" language from both migration guide pages — legacy account types are already enabled for everyone
- Fixed the react-migration guide's incorrect claim that "Wallet APIs only support MAv2" — replaced with actionable guidance linking to the account types table

## Test plan
- [ ] Verify the account types table renders correctly on the EIP-7702 page
- [ ] Confirm the anchor link `#supported-account-types` works from both migration pages
- [ ] Review that all 7 SCA account types + `7702` are listed accurately

🤖 Generated with [Claude Code](https://claude.com/claude-code)