### PR TITLE
[docs-agent] Add docs for 5 new Bitcoin-ecosystem chains and UTXO REST API

### DIFF
--- a/content/api-reference/bitcoincash/bitcoincash-api-faq.mdx
+++ b/content/api-reference/bitcoincash/bitcoincash-api-faq.mdx
@@ -1,0 +1,49 @@
+---
+title: "Bitcoin Cash API FAQ"
+description: "Frequently asked questions about the Bitcoin Cash API"
+slug: "reference/bitcoincash-api-faq"
+---
+
+## What is Bitcoin Cash?
+
+Bitcoin Cash (BCH) is a peer-to-peer electronic cash system that originated as a hard fork of Bitcoin in 2017. It uses a larger block size to support higher on-chain transaction throughput, and is secured by proof-of-work mining.
+
+## What is the Bitcoin Cash API?
+
+The Bitcoin Cash API allows you to interact with the Bitcoin Cash network using JSON-RPC methods. Through the API, you can retrieve data about blocks, transactions, and the mempool, as well as broadcast new transactions to the network.
+
+## How can I get started using the Bitcoin Cash API?
+
+Check out our [Bitcoin Cash API Quickstart](/docs/reference/bitcoincash-api-quickstart) guide for setup instructions, sample code, and your first API call.
+
+## Does Bitcoin Cash support smart contracts?
+
+Bitcoin Cash supports a richer scripting language than Bitcoin via the CashScript ecosystem and CashTokens, but it does not have a full smart contract virtual machine like Ethereum.
+
+## What API standard does Bitcoin Cash use?
+
+Bitcoin Cash Node and BCHN implement a standard JSON-RPC interface for querying blockchain data and submitting transactions, derived from Bitcoin Core.
+
+## What is a Bitcoin Cash API key?
+
+When accessing the Bitcoin Cash network via a node provider like Alchemy, you use an API key to send transactions and retrieve data from the network.
+
+## Which libraries can I use with the Bitcoin Cash API?
+
+You can use any HTTP client that supports JSON payloads, e.g. `axios`, `fetch`, `requests`, or `curl`. There are also Bitcoin-Cash-specific libraries like `bchjs` (Node.js) and `bitcash` (Python) for deeper integration.
+
+## What programming languages are compatible with the API?
+
+The API works with any programming language that can send JSON over HTTP. Common choices include JavaScript/TypeScript, Python, Go, and Java.
+
+## What is used for fees in Bitcoin Cash?
+
+Bitcoin Cash transaction fees are paid in BCH and are calculated per byte of transaction data. Fees are used to incentivize miners to include transactions in blocks.
+
+## What methods does Alchemy support for the Bitcoin Cash API?
+
+You can find a full list of supported JSON-RPC methods on the [Bitcoin Cash API Overview](/docs/bitcoincash/bitcoincash-api-overview) page.
+
+## My question isn't listed here, where can I get help?
+
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the Alchemy Dashboard.

--- a/content/api-reference/bitcoincash/bitcoincash-api-overview.mdx
+++ b/content/api-reference/bitcoincash/bitcoincash-api-overview.mdx
@@ -1,0 +1,31 @@
+---
+title: Bitcoin Cash API Overview
+description: Overview of available Bitcoin Cash API methods
+subtitle: Comprehensive list of Bitcoin Cash JSON-RPC methods
+slug: docs/bitcoincash/bitcoincash-api-overview
+---
+
+## Bitcoin Cash APIs
+
+📙 Get started with our [Bitcoin Cash API Quickstart Guide](/docs/reference/bitcoincash-api-quickstart).
+
+|                                                                                                            |                                                                                                        |
+| ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| [`createrawtransaction`](/docs/chains/bitcoincash/bitcoincash-api-endpoints/createrawtransaction)          | [`decoderawtransaction`](/docs/chains/bitcoincash/bitcoincash-api-endpoints/decoderawtransaction)      |
+| [`decodescript`](/docs/chains/bitcoincash/bitcoincash-api-endpoints/decodescript)                          | [`estimatesmartfee`](/docs/chains/bitcoincash/bitcoincash-api-endpoints/estimatesmartfee)              |
+| [`getbestblockhash`](/docs/chains/bitcoincash/bitcoincash-api-endpoints/getbestblockhash)                  | [`getblock`](/docs/chains/bitcoincash/bitcoincash-api-endpoints/getblock)                              |
+| [`getblockchaininfo`](/docs/chains/bitcoincash/bitcoincash-api-endpoints/getblockchaininfo)                | [`getblockcount`](/docs/chains/bitcoincash/bitcoincash-api-endpoints/getblockcount)                    |
+| [`getblockfilter`](/docs/chains/bitcoincash/bitcoincash-api-endpoints/getblockfilter)                      | [`getblockhash`](/docs/chains/bitcoincash/bitcoincash-api-endpoints/getblockhash)                      |
+| [`getblockheader`](/docs/chains/bitcoincash/bitcoincash-api-endpoints/getblockheader)                      | [`getblockstats`](/docs/chains/bitcoincash/bitcoincash-api-endpoints/getblockstats)                    |
+| [`getblocktemplate`](/docs/chains/bitcoincash/bitcoincash-api-endpoints/getblocktemplate)                  | [`getchaintips`](/docs/chains/bitcoincash/bitcoincash-api-endpoints/getchaintips)                      |
+| [`getchaintxstats`](/docs/chains/bitcoincash/bitcoincash-api-endpoints/getchaintxstats)                    | [`getconnectioncount`](/docs/chains/bitcoincash/bitcoincash-api-endpoints/getconnectioncount)          |
+| [`getdifficulty`](/docs/chains/bitcoincash/bitcoincash-api-endpoints/getdifficulty)                        | [`getindexinfo`](/docs/chains/bitcoincash/bitcoincash-api-endpoints/getindexinfo)                      |
+| [`getmemoryinfo`](/docs/chains/bitcoincash/bitcoincash-api-endpoints/getmemoryinfo)                        | [`getmempoolancestors`](/docs/chains/bitcoincash/bitcoincash-api-endpoints/getmempoolancestors)        |
+| [`getmempooldescendants`](/docs/chains/bitcoincash/bitcoincash-api-endpoints/getmempooldescendants)        | [`getmempoolinfo`](/docs/chains/bitcoincash/bitcoincash-api-endpoints/getmempoolinfo)                  |
+| [`getnetworkhashps`](/docs/chains/bitcoincash/bitcoincash-api-endpoints/getnetworkhashps)                  | [`getnetworkinfo`](/docs/chains/bitcoincash/bitcoincash-api-endpoints/getnetworkinfo)                  |
+| [`getrawmempool`](/docs/chains/bitcoincash/bitcoincash-api-endpoints/getrawmempool)                        | [`getrawtransaction`](/docs/chains/bitcoincash/bitcoincash-api-endpoints/getrawtransaction)            |
+| [`gettxout`](/docs/chains/bitcoincash/bitcoincash-api-endpoints/gettxout)                                  | [`gettxoutproof`](/docs/chains/bitcoincash/bitcoincash-api-endpoints/gettxoutproof)                    |
+| [`gettxoutsetinfo`](/docs/chains/bitcoincash/bitcoincash-api-endpoints/gettxoutsetinfo)                    | [`sendrawtransaction`](/docs/chains/bitcoincash/bitcoincash-api-endpoints/sendrawtransaction)          |
+| [`submitblock`](/docs/chains/bitcoincash/bitcoincash-api-endpoints/submitblock)                            | [`submitheader`](/docs/chains/bitcoincash/bitcoincash-api-endpoints/submitheader)                      |
+| [`submitpackage`](/docs/chains/bitcoincash/bitcoincash-api-endpoints/submitpackage)                        | [`testmempoolaccept`](/docs/chains/bitcoincash/bitcoincash-api-endpoints/testmempoolaccept)            |
+| [`validateaddress`](/docs/chains/bitcoincash/bitcoincash-api-endpoints/validateaddress)                    | [`verifymessage`](/docs/chains/bitcoincash/bitcoincash-api-endpoints/verifymessage)                    |

--- a/content/api-reference/bitcoincash/bitcoincash-api-quickstart.mdx
+++ b/content/api-reference/bitcoincash/bitcoincash-api-quickstart.mdx
@@ -1,0 +1,117 @@
+---
+title: "Bitcoin Cash API Quickstart"
+description: "Get started building on Bitcoin Cash and using the JSON-RPC API"
+slug: "reference/bitcoincash-api-quickstart"
+---
+
+# Introduction
+
+The Bitcoin Cash API gives you access to the Bitcoin Cash blockchain through a standard set of JSON-RPC methods. With this API, you can retrieve block and transaction data, inspect the mempool, broadcast transactions, and more.
+
+Bitcoin Cash uses a UTXO-based model and exposes its functionality via the JSON-RPC protocol. This quickstart will help you make your first request.
+
+***
+
+## What is the Bitcoin Cash Chain API?
+
+The Bitcoin Cash Chain API allows applications to communicate with a Bitcoin Cash node using the JSON-RPC protocol. Like Bitcoin, Bitcoin Cash relies on a UTXO (Unspent Transaction Output) model, which means balances are tracked by outputs that are explicitly spent or unspent.
+
+Alchemy's Bitcoin Cash API gives developers a consistent interface to query blockchain data, submit transactions, and monitor network activity. This includes:
+
+* Retrieving raw or decoded transaction data
+* Querying block headers and full blocks
+* Monitoring mempool entries and states
+* Submitting and testing raw transactions
+
+If you've worked with Bitcoin or other JSON-RPC-compatible chains, the structure will feel familiar.
+
+***
+
+## Getting started
+
+### 1. Choose a package manager (npm or yarn)
+
+Select a package manager to manage your project's dependencies. The choice between `npm` and `yarn` depends on your preference or project requirements.
+
+| npm                                                                                                                       | yarn                                                                                                |
+| ------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| Begin with `npm` by following the [npm documentation](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm). | For `yarn`, refer to [yarn's installation guide](https://classic.yarnpkg.com/lang/en/docs/install). |
+
+### 2. Set up your project
+
+Open your terminal and run the following commands:
+
+<CodeGroup>
+  ```text npm
+  mkdir bitcoincash-api-quickstart
+  cd bitcoincash-api-quickstart
+  npm init --yes
+  ```
+
+  ```text yarn
+  mkdir bitcoincash-api-quickstart
+  cd bitcoincash-api-quickstart
+  yarn init --yes
+  ```
+</CodeGroup>
+
+This creates a new directory named `bitcoincash-api-quickstart` and initializes a Node.js project within it.
+
+### 3. Make your first request
+
+Install Axios, a popular HTTP client, to make API requests:
+
+<CodeGroup>
+  ```bash bash
+  npm install axios
+  # Or with yarn
+  # yarn add axios
+  ```
+</CodeGroup>
+
+Create an `index.js` file in your project directory and paste the following code:
+
+<CodeGroup>
+  ```javascript javascript
+  const axios = require('axios');
+
+  const url = `https://bitcoincash-mainnet.g.alchemy.com/v2/${apiKey}`;
+
+  const payload = {
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'getblockcount',
+    params: []
+  };
+
+  axios.post(url, payload)
+    .then(response => {
+      console.log('Current block height:', response.data.result);
+    })
+    .catch(error => {
+      console.error('Error fetching block count:', error);
+    });
+  ```
+</CodeGroup>
+
+Replace `apiKey` with your actual Alchemy API key that you can get from the [Alchemy Dashboard](https://dashboard.alchemy.com/signup).
+
+### 4. Run your script
+
+To execute your script and make a request to the Bitcoin Cash API, run:
+
+<CodeGroup>
+  ```bash bash
+  node index.js
+  ```
+</CodeGroup>
+
+You should see the current block height on Bitcoin Cash printed to your console:
+
+```shell
+Current block height: 869432
+```
+
+## Next steps
+
+You've made your first request to the Bitcoin Cash API. With this foundation, you can dive deeper into the [JSON-RPC methods available on Bitcoin Cash](/docs/bitcoincash/bitcoincash-api-overview) and start building on it.

--- a/content/api-reference/dogecoin/dogecoin-api-faq.mdx
+++ b/content/api-reference/dogecoin/dogecoin-api-faq.mdx
@@ -1,0 +1,49 @@
+---
+title: "Dogecoin API FAQ"
+description: "Frequently asked questions about the Dogecoin API"
+slug: "reference/dogecoin-api-faq"
+---
+
+## What is Dogecoin?
+
+Dogecoin (DOGE) is a peer-to-peer cryptocurrency launched in 2013. Originally derived from Litecoin (and indirectly Bitcoin), it uses a Scrypt-based proof-of-work consensus and is known for its active community and low transaction fees.
+
+## What is the Dogecoin API?
+
+The Dogecoin API allows you to interact with the Dogecoin network using JSON-RPC methods. Through the API, you can retrieve data about blocks, transactions, and the mempool, as well as broadcast new transactions to the network.
+
+## How can I get started using the Dogecoin API?
+
+Check out our [Dogecoin API Quickstart](/docs/reference/dogecoin-api-quickstart) guide for setup instructions, sample code, and your first API call.
+
+## Does Dogecoin support smart contracts?
+
+Dogecoin supports basic Bitcoin-style scripting but does not have a full smart contract virtual machine like Ethereum.
+
+## What API standard does Dogecoin use?
+
+Dogecoin Core implements a standard JSON-RPC interface for querying blockchain data and submitting transactions, derived from Bitcoin Core.
+
+## What is a Dogecoin API key?
+
+When accessing the Dogecoin network via a node provider like Alchemy, you use an API key to send transactions and retrieve data from the network.
+
+## Which libraries can I use with the Dogecoin API?
+
+You can use any HTTP client that supports JSON payloads, e.g. `axios`, `fetch`, `requests`, or `curl`. Bitcoin-Core-compatible libraries like `bitcoin-core` (Node.js) and `python-bitcoinrpc` also work with Dogecoin's RPC interface.
+
+## What programming languages are compatible with the API?
+
+The API works with any programming language that can send JSON over HTTP. Common choices include JavaScript/TypeScript, Python, Go, and Java.
+
+## What is used for fees in Dogecoin?
+
+Dogecoin transaction fees are paid in DOGE. They are calculated per byte of transaction data and are used to incentivize miners to include transactions in blocks.
+
+## What methods does Alchemy support for the Dogecoin API?
+
+You can find a full list of supported JSON-RPC methods on the [Dogecoin API Overview](/docs/dogecoin/dogecoin-api-overview) page.
+
+## My question isn't listed here, where can I get help?
+
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the Alchemy Dashboard.

--- a/content/api-reference/dogecoin/dogecoin-api-overview.mdx
+++ b/content/api-reference/dogecoin/dogecoin-api-overview.mdx
@@ -1,0 +1,31 @@
+---
+title: Dogecoin API Overview
+description: Overview of available Dogecoin API methods
+subtitle: Comprehensive list of Dogecoin JSON-RPC methods
+slug: docs/dogecoin/dogecoin-api-overview
+---
+
+## Dogecoin APIs
+
+📙 Get started with our [Dogecoin API Quickstart Guide](/docs/reference/dogecoin-api-quickstart).
+
+|                                                                                                  |                                                                                              |
+| ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------- |
+| [`createrawtransaction`](/docs/chains/dogecoin/dogecoin-api-endpoints/createrawtransaction)      | [`decoderawtransaction`](/docs/chains/dogecoin/dogecoin-api-endpoints/decoderawtransaction)  |
+| [`decodescript`](/docs/chains/dogecoin/dogecoin-api-endpoints/decodescript)                      | [`estimatesmartfee`](/docs/chains/dogecoin/dogecoin-api-endpoints/estimatesmartfee)          |
+| [`getbestblockhash`](/docs/chains/dogecoin/dogecoin-api-endpoints/getbestblockhash)              | [`getblock`](/docs/chains/dogecoin/dogecoin-api-endpoints/getblock)                          |
+| [`getblockchaininfo`](/docs/chains/dogecoin/dogecoin-api-endpoints/getblockchaininfo)            | [`getblockcount`](/docs/chains/dogecoin/dogecoin-api-endpoints/getblockcount)                |
+| [`getblockfilter`](/docs/chains/dogecoin/dogecoin-api-endpoints/getblockfilter)                  | [`getblockhash`](/docs/chains/dogecoin/dogecoin-api-endpoints/getblockhash)                  |
+| [`getblockheader`](/docs/chains/dogecoin/dogecoin-api-endpoints/getblockheader)                  | [`getblockstats`](/docs/chains/dogecoin/dogecoin-api-endpoints/getblockstats)                |
+| [`getblocktemplate`](/docs/chains/dogecoin/dogecoin-api-endpoints/getblocktemplate)              | [`getchaintips`](/docs/chains/dogecoin/dogecoin-api-endpoints/getchaintips)                  |
+| [`getchaintxstats`](/docs/chains/dogecoin/dogecoin-api-endpoints/getchaintxstats)                | [`getconnectioncount`](/docs/chains/dogecoin/dogecoin-api-endpoints/getconnectioncount)      |
+| [`getdifficulty`](/docs/chains/dogecoin/dogecoin-api-endpoints/getdifficulty)                    | [`getindexinfo`](/docs/chains/dogecoin/dogecoin-api-endpoints/getindexinfo)                  |
+| [`getmemoryinfo`](/docs/chains/dogecoin/dogecoin-api-endpoints/getmemoryinfo)                    | [`getmempoolancestors`](/docs/chains/dogecoin/dogecoin-api-endpoints/getmempoolancestors)    |
+| [`getmempooldescendants`](/docs/chains/dogecoin/dogecoin-api-endpoints/getmempooldescendants)    | [`getmempoolinfo`](/docs/chains/dogecoin/dogecoin-api-endpoints/getmempoolinfo)              |
+| [`getnetworkhashps`](/docs/chains/dogecoin/dogecoin-api-endpoints/getnetworkhashps)              | [`getnetworkinfo`](/docs/chains/dogecoin/dogecoin-api-endpoints/getnetworkinfo)              |
+| [`getrawmempool`](/docs/chains/dogecoin/dogecoin-api-endpoints/getrawmempool)                    | [`getrawtransaction`](/docs/chains/dogecoin/dogecoin-api-endpoints/getrawtransaction)        |
+| [`gettxout`](/docs/chains/dogecoin/dogecoin-api-endpoints/gettxout)                              | [`gettxoutproof`](/docs/chains/dogecoin/dogecoin-api-endpoints/gettxoutproof)                |
+| [`gettxoutsetinfo`](/docs/chains/dogecoin/dogecoin-api-endpoints/gettxoutsetinfo)                | [`sendrawtransaction`](/docs/chains/dogecoin/dogecoin-api-endpoints/sendrawtransaction)      |
+| [`submitblock`](/docs/chains/dogecoin/dogecoin-api-endpoints/submitblock)                        | [`submitheader`](/docs/chains/dogecoin/dogecoin-api-endpoints/submitheader)                  |
+| [`submitpackage`](/docs/chains/dogecoin/dogecoin-api-endpoints/submitpackage)                    | [`testmempoolaccept`](/docs/chains/dogecoin/dogecoin-api-endpoints/testmempoolaccept)        |
+| [`validateaddress`](/docs/chains/dogecoin/dogecoin-api-endpoints/validateaddress)                | [`verifymessage`](/docs/chains/dogecoin/dogecoin-api-endpoints/verifymessage)                |

--- a/content/api-reference/dogecoin/dogecoin-api-quickstart.mdx
+++ b/content/api-reference/dogecoin/dogecoin-api-quickstart.mdx
@@ -1,0 +1,117 @@
+---
+title: "Dogecoin API Quickstart"
+description: "Get started building on Dogecoin and using the JSON-RPC API"
+slug: "reference/dogecoin-api-quickstart"
+---
+
+# Introduction
+
+The Dogecoin API gives you access to the Dogecoin blockchain through a standard set of JSON-RPC methods. With this API, you can retrieve block and transaction data, inspect the mempool, broadcast transactions, and more.
+
+Dogecoin uses a UTXO-based model and exposes its functionality via the JSON-RPC protocol. This quickstart will help you make your first request.
+
+***
+
+## What is the Dogecoin Chain API?
+
+The Dogecoin Chain API allows applications to communicate with a Dogecoin node using the JSON-RPC protocol. Like Bitcoin, Dogecoin relies on a UTXO (Unspent Transaction Output) model, which means balances are tracked by outputs that are explicitly spent or unspent.
+
+Alchemy's Dogecoin API gives developers a consistent interface to query blockchain data, submit transactions, and monitor network activity. This includes:
+
+* Retrieving raw or decoded transaction data
+* Querying block headers and full blocks
+* Monitoring mempool entries and states
+* Submitting and testing raw transactions
+
+If you've worked with Bitcoin or other JSON-RPC-compatible chains, the structure will feel familiar.
+
+***
+
+## Getting started
+
+### 1. Choose a package manager (npm or yarn)
+
+Select a package manager to manage your project's dependencies. The choice between `npm` and `yarn` depends on your preference or project requirements.
+
+| npm                                                                                                                       | yarn                                                                                                |
+| ------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| Begin with `npm` by following the [npm documentation](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm). | For `yarn`, refer to [yarn's installation guide](https://classic.yarnpkg.com/lang/en/docs/install). |
+
+### 2. Set up your project
+
+Open your terminal and run the following commands:
+
+<CodeGroup>
+  ```text npm
+  mkdir dogecoin-api-quickstart
+  cd dogecoin-api-quickstart
+  npm init --yes
+  ```
+
+  ```text yarn
+  mkdir dogecoin-api-quickstart
+  cd dogecoin-api-quickstart
+  yarn init --yes
+  ```
+</CodeGroup>
+
+This creates a new directory named `dogecoin-api-quickstart` and initializes a Node.js project within it.
+
+### 3. Make your first request
+
+Install Axios, a popular HTTP client, to make API requests:
+
+<CodeGroup>
+  ```bash bash
+  npm install axios
+  # Or with yarn
+  # yarn add axios
+  ```
+</CodeGroup>
+
+Create an `index.js` file in your project directory and paste the following code:
+
+<CodeGroup>
+  ```javascript javascript
+  const axios = require('axios');
+
+  const url = `https://dogecoin-mainnet.g.alchemy.com/v2/${apiKey}`;
+
+  const payload = {
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'getblockcount',
+    params: []
+  };
+
+  axios.post(url, payload)
+    .then(response => {
+      console.log('Current block height:', response.data.result);
+    })
+    .catch(error => {
+      console.error('Error fetching block count:', error);
+    });
+  ```
+</CodeGroup>
+
+Replace `apiKey` with your actual Alchemy API key that you can get from the [Alchemy Dashboard](https://dashboard.alchemy.com/signup).
+
+### 4. Run your script
+
+To execute your script and make a request to the Dogecoin API, run:
+
+<CodeGroup>
+  ```bash bash
+  node index.js
+  ```
+</CodeGroup>
+
+You should see the current block height on Dogecoin printed to your console:
+
+```shell
+Current block height: 5421894
+```
+
+## Next steps
+
+You've made your first request to the Dogecoin API. With this foundation, you can dive deeper into the [JSON-RPC methods available on Dogecoin](/docs/dogecoin/dogecoin-api-overview) and start building on it.

--- a/content/api-reference/litecoin/litecoin-api-faq.mdx
+++ b/content/api-reference/litecoin/litecoin-api-faq.mdx
@@ -1,0 +1,49 @@
+---
+title: "Litecoin API FAQ"
+description: "Frequently asked questions about the Litecoin API"
+slug: "reference/litecoin-api-faq"
+---
+
+## What is Litecoin?
+
+Litecoin (LTC) is a peer-to-peer cryptocurrency launched in 2011 by Charlie Lee. It is one of the oldest altcoins, derived from the Bitcoin codebase but with a faster block time (around 2.5 minutes) and the Scrypt proof-of-work hashing algorithm.
+
+## What is the Litecoin API?
+
+The Litecoin API allows you to interact with the Litecoin network using JSON-RPC methods. Through the API, you can retrieve data about blocks, transactions, and the mempool, as well as broadcast new transactions to the network.
+
+## How can I get started using the Litecoin API?
+
+Check out our [Litecoin API Quickstart](/docs/reference/litecoin-api-quickstart) guide for setup instructions, sample code, and your first API call.
+
+## Does Litecoin support smart contracts?
+
+Litecoin supports basic scripting, including SegWit and MWEB (MimbleWimble Extension Blocks) for privacy-preserving transactions, but does not have a full smart contract virtual machine like Ethereum.
+
+## What API standard does Litecoin use?
+
+Litecoin Core implements a standard JSON-RPC interface for querying blockchain data and submitting transactions, derived from Bitcoin Core.
+
+## What is a Litecoin API key?
+
+When accessing the Litecoin network via a node provider like Alchemy, you use an API key to send transactions and retrieve data from the network.
+
+## Which libraries can I use with the Litecoin API?
+
+You can use any HTTP client that supports JSON payloads, e.g. `axios`, `fetch`, `requests`, or `curl`. Bitcoin-Core-compatible libraries like `bitcoin-core` (Node.js) and `python-bitcoinrpc` also work with Litecoin's RPC interface.
+
+## What programming languages are compatible with the API?
+
+The API works with any programming language that can send JSON over HTTP. Common choices include JavaScript/TypeScript, Python, Go, and Java.
+
+## What is used for fees in Litecoin?
+
+Litecoin transaction fees are paid in LTC. They are calculated per virtual byte (vByte) of transaction data and are used to incentivize miners to include transactions in blocks.
+
+## What methods does Alchemy support for the Litecoin API?
+
+You can find a full list of supported JSON-RPC methods on the [Litecoin API Overview](/docs/litecoin/litecoin-api-overview) page.
+
+## My question isn't listed here, where can I get help?
+
+If you have any questions or feedback, please contact us at support@alchemy.com or open a ticket in the Alchemy Dashboard.

--- a/content/api-reference/litecoin/litecoin-api-overview.mdx
+++ b/content/api-reference/litecoin/litecoin-api-overview.mdx
@@ -1,0 +1,31 @@
+---
+title: Litecoin API Overview
+description: Overview of available Litecoin API methods
+subtitle: Comprehensive list of Litecoin JSON-RPC methods
+slug: docs/litecoin/litecoin-api-overview
+---
+
+## Litecoin APIs
+
+📙 Get started with our [Litecoin API Quickstart Guide](/docs/reference/litecoin-api-quickstart).
+
+|                                                                                                |                                                                                            |
+| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| [`createrawtransaction`](/docs/chains/litecoin/litecoin-api-endpoints/createrawtransaction)    | [`decoderawtransaction`](/docs/chains/litecoin/litecoin-api-endpoints/decoderawtransaction)|
+| [`decodescript`](/docs/chains/litecoin/litecoin-api-endpoints/decodescript)                    | [`estimatesmartfee`](/docs/chains/litecoin/litecoin-api-endpoints/estimatesmartfee)        |
+| [`getbestblockhash`](/docs/chains/litecoin/litecoin-api-endpoints/getbestblockhash)            | [`getblock`](/docs/chains/litecoin/litecoin-api-endpoints/getblock)                        |
+| [`getblockchaininfo`](/docs/chains/litecoin/litecoin-api-endpoints/getblockchaininfo)          | [`getblockcount`](/docs/chains/litecoin/litecoin-api-endpoints/getblockcount)              |
+| [`getblockfilter`](/docs/chains/litecoin/litecoin-api-endpoints/getblockfilter)                | [`getblockhash`](/docs/chains/litecoin/litecoin-api-endpoints/getblockhash)                |
+| [`getblockheader`](/docs/chains/litecoin/litecoin-api-endpoints/getblockheader)                | [`getblockstats`](/docs/chains/litecoin/litecoin-api-endpoints/getblockstats)              |
+| [`getblocktemplate`](/docs/chains/litecoin/litecoin-api-endpoints/getblocktemplate)            | [`getchaintips`](/docs/chains/litecoin/litecoin-api-endpoints/getchaintips)                |
+| [`getchaintxstats`](/docs/chains/litecoin/litecoin-api-endpoints/getchaintxstats)              | [`getconnectioncount`](/docs/chains/litecoin/litecoin-api-endpoints/getconnectioncount)    |
+| [`getdifficulty`](/docs/chains/litecoin/litecoin-api-endpoints/getdifficulty)                  | [`getindexinfo`](/docs/chains/litecoin/litecoin-api-endpoints/getindexinfo)                |
+| [`getmemoryinfo`](/docs/chains/litecoin/litecoin-api-endpoints/getmemoryinfo)                  | [`getmempoolancestors`](/docs/chains/litecoin/litecoin-api-endpoints/getmempoolancestors)  |
+| [`getmempooldescendants`](/docs/chains/litecoin/litecoin-api-endpoints/getmempooldescendants)  | [`getmempoolinfo`](/docs/chains/litecoin/litecoin-api-endpoints/getmempoolinfo)            |
+| [`getnetworkhashps`](/docs/chains/litecoin/litecoin-api-endpoints/getnetworkhashps)            | [`getnetworkinfo`](/docs/chains/litecoin/litecoin-api-endpoints/getnetworkinfo)            |
+| [`getrawmempool`](/docs/chains/litecoin/litecoin-api-endpoints/getrawmempool)                  | [`getrawtransaction`](/docs/chains/litecoin/litecoin-api-endpoints/getrawtransaction)      |
+| [`gettxout`](/docs/chains/litecoin/litecoin-api-endpoints/gettxout)                            | [`gettxoutproof`](/docs/chains/litecoin/litecoin-api-endpoints/gettxoutproof)              |
+| [`gettxoutsetinfo`](/docs/chains/litecoin/litecoin-api-endpoints/gettxoutsetinfo)              | [`sendrawtransaction`](/docs/chains/litecoin/litecoin-api-endpoints/sendrawtransaction)    |
+| [`submitblock`](/docs/chains/litecoin/litecoin-api-endpoints/submitblock)                      | [`submitheader`](/docs/chains/litecoin/litecoin-api-endpoints/submitheader)                |
+| [`submitpackage`](/docs/chains/litecoin/litecoin-api-endpoints/submitpackage)                  | [`testmempoolaccept`](/docs/chains/litecoin/litecoin-api-endpoints/testmempoolaccept)      |
+| [`validateaddress`](/docs/chains/litecoin/litecoin-api-endpoints/validateaddress)              | [`verifymessage`](/docs/chains/litecoin/litecoin-api-endpoints/verifymessage)              |

--- a/content/api-reference/litecoin/litecoin-api-quickstart.mdx
+++ b/content/api-reference/litecoin/litecoin-api-quickstart.mdx
@@ -1,0 +1,117 @@
+---
+title: "Litecoin API Quickstart"
+description: "Get started building on Litecoin and using the JSON-RPC API"
+slug: "reference/litecoin-api-quickstart"
+---
+
+# Introduction
+
+The Litecoin API gives you access to the Litecoin blockchain through a standard set of JSON-RPC methods. With this API, you can retrieve block and transaction data, inspect the mempool, broadcast transactions, and more.
+
+Litecoin uses a UTXO-based model and exposes its functionality via the JSON-RPC protocol. This quickstart will help you make your first request.
+
+***
+
+## What is the Litecoin Chain API?
+
+The Litecoin Chain API allows applications to communicate with a Litecoin node using the JSON-RPC protocol. Like Bitcoin, Litecoin relies on a UTXO (Unspent Transaction Output) model, which means balances are tracked by outputs that are explicitly spent or unspent.
+
+Alchemy's Litecoin API gives developers a consistent interface to query blockchain data, submit transactions, and monitor network activity. This includes:
+
+* Retrieving raw or decoded transaction data
+* Querying block headers and full blocks
+* Monitoring mempool entries and states
+* Submitting and testing raw transactions
+
+If you've worked with Bitcoin or other JSON-RPC-compatible chains, the structure will feel familiar.
+
+***
+
+## Getting started
+
+### 1. Choose a package manager (npm or yarn)
+
+Select a package manager to manage your project's dependencies. The choice between `npm` and `yarn` depends on your preference or project requirements.
+
+| npm                                                                                                                       | yarn                                                                                                |
+| ------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| Begin with `npm` by following the [npm documentation](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm). | For `yarn`, refer to [yarn's installation guide](https://classic.yarnpkg.com/lang/en/docs/install). |
+
+### 2. Set up your project
+
+Open your terminal and run the following commands:
+
+<CodeGroup>
+  ```text npm
+  mkdir litecoin-api-quickstart
+  cd litecoin-api-quickstart
+  npm init --yes
+  ```
+
+  ```text yarn
+  mkdir litecoin-api-quickstart
+  cd litecoin-api-quickstart
+  yarn init --yes
+  ```
+</CodeGroup>
+
+This creates a new directory named `litecoin-api-quickstart` and initializes a Node.js project within it.
+
+### 3. Make your first request
+
+Install Axios, a popular HTTP client, to make API requests:
+
+<CodeGroup>
+  ```bash bash
+  npm install axios
+  # Or with yarn
+  # yarn add axios
+  ```
+</CodeGroup>
+
+Create an `index.js` file in your project directory and paste the following code:
+
+<CodeGroup>
+  ```javascript javascript
+  const axios = require('axios');
+
+  const url = `https://litecoin-mainnet.g.alchemy.com/v2/${apiKey}`;
+
+  const payload = {
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'getblockcount',
+    params: []
+  };
+
+  axios.post(url, payload)
+    .then(response => {
+      console.log('Current block height:', response.data.result);
+    })
+    .catch(error => {
+      console.error('Error fetching block count:', error);
+    });
+  ```
+</CodeGroup>
+
+Replace `apiKey` with your actual Alchemy API key that you can get from the [Alchemy Dashboard](https://dashboard.alchemy.com/signup).
+
+### 4. Run your script
+
+To execute your script and make a request to the Litecoin API, run:
+
+<CodeGroup>
+  ```bash bash
+  node index.js
+  ```
+</CodeGroup>
+
+You should see the current block height on Litecoin printed to your console:
+
+```shell
+Current block height: 2954312
+```
+
+## Next steps
+
+You've made your first request to the Litecoin API. With this foundation, you can dive deeper into the [JSON-RPC methods available on Litecoin](/docs/litecoin/litecoin-api-overview) and start building on it.

--- a/content/docs.yml
+++ b/content/docs.yml
@@ -1463,6 +1463,7 @@ navigation:
             path: api-reference/bitcoincash/bitcoincash-api-overview.mdx
           - api: Bitcoin Cash API Endpoints
             api-name: bitcoincash
+            slug: bitcoincash-api-endpoints
           - api: UTXO API Endpoints
             api-name: utxo
             flattened: true

--- a/content/docs.yml
+++ b/content/docs.yml
@@ -1449,7 +1449,24 @@ navigation:
             path: api-reference/bitcoin/bitcoin-api-overview.mdx
           - api: Bitcoin API Endpoints
             api-name: bitcoin
+          - api: UTXO API Endpoints
+            api-name: utxo
+            flattened: true
         slug: bitcoin
+      - section: Bitcoin Cash
+        contents:
+          - page: Quickstart
+            path: api-reference/bitcoincash/bitcoincash-api-quickstart.mdx
+          - page: FAQ
+            path: api-reference/bitcoincash/bitcoincash-api-faq.mdx
+          - page: Bitcoin Cash API Overview
+            path: api-reference/bitcoincash/bitcoincash-api-overview.mdx
+          - api: Bitcoin Cash API Endpoints
+            api-name: bitcoincash
+          - api: UTXO API Endpoints
+            api-name: utxo
+            flattened: true
+        slug: bitcoincash
       - section: Blast
         contents:
           - page: Quickstart
@@ -1551,6 +1568,21 @@ navigation:
           - api: Degen API Endpoints
             api-name: degen
         slug: degen
+
+      - section: Dogecoin
+        contents:
+          - page: Quickstart
+            path: api-reference/dogecoin/dogecoin-api-quickstart.mdx
+          - page: FAQ
+            path: api-reference/dogecoin/dogecoin-api-faq.mdx
+          - page: Dogecoin API Overview
+            path: api-reference/dogecoin/dogecoin-api-overview.mdx
+          - api: Dogecoin API Endpoints
+            api-name: dogecoin
+          - api: UTXO API Endpoints
+            api-name: utxo
+            flattened: true
+        slug: dogecoin
 
       - section: Fantom
         contents:
@@ -1687,6 +1719,20 @@ navigation:
           - api: Linea API Endpoints
             api-name: linea
         slug: linea
+      - section: Litecoin
+        contents:
+          - page: Quickstart
+            path: api-reference/litecoin/litecoin-api-quickstart.mdx
+          - page: FAQ
+            path: api-reference/litecoin/litecoin-api-faq.mdx
+          - page: Litecoin API Overview
+            path: api-reference/litecoin/litecoin-api-overview.mdx
+          - api: Litecoin API Endpoints
+            api-name: litecoin
+          - api: UTXO API Endpoints
+            api-name: utxo
+            flattened: true
+        slug: litecoin
       - section: Lumia
         contents:
           - page: Lumia Deprecation Notice

--- a/redocly.yaml
+++ b/redocly.yaml
@@ -19,3 +19,4 @@ theme:
   openapi: {}
 rules:
   "security-defined": off # APIs use API key in the URL path, not headers/query/cookie
+  "no-path-trailing-slash": off # Blockbook's POST /api/v2/sendtx/ requires a mandatory trailing slash; the rule conflicts with upstream behavior

--- a/src/openapi/utxo/utxo.yaml
+++ b/src/openapi/utxo/utxo.yaml
@@ -1,0 +1,819 @@
+# yaml-language-server: $schema=https://spec.openapis.org/oas/3.1/schema/2022-10-07
+openapi: 3.1.0
+info:
+  title: 🪙 UTXO API
+  version: "1.0"
+  description: >
+    REST API for UTXO-based chains, powered by [Trezor Blockbook](https://github.com/trezor/blockbook).
+    Use these endpoints to query indexed block, transaction, address, xpub, and UTXO data on Bitcoin,
+    Bitcoin Cash, Litecoin, and Dogecoin networks. The same paths are available across all supported
+    UTXO networks — switch networks by changing the `{network}` server variable.
+servers:
+  - url: https://{network}.g.alchemy.com/v2/{apiKey}
+    variables:
+      network:
+        default: bitcoin-mainnet
+        enum:
+          - bitcoin-mainnet
+          - bitcoin-testnet4
+          - bitcoincash-mainnet
+          - bitcoincash-testnet
+          - litecoin-mainnet
+          - litecoin-testnet
+          - dogecoin-mainnet
+      apiKey:
+        default: docs-demo
+        description: Your Alchemy API key. Get one at https://dashboard.alchemy.com/
+security:
+  - apiKey: []
+paths:
+  "/api/v2/block-index/{block_height}":
+    get:
+      operationId: getBlockHashByIndex
+      summary: Get Block Hash
+      description: Returns the block hash for a given block height on the selected network.
+      tags: ["UTXO API Endpoints"]
+      parameters:
+        - $ref: "#/components/parameters/blockHeight"
+      responses:
+        "200":
+          description: Block hash for the requested height.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BlockIndexResponse"
+              example:
+                blockHash: "0000000000000000000b7b8574bc6fd285825ec2dbcbeca149121fc05b0c828c"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  "/api/v2/tx/{txid}":
+    get:
+      operationId: getTransaction
+      summary: Get Transaction
+      description: >
+        Returns normalized transaction data for the given transaction ID. Response shape is consistent
+        across UTXO networks. Empty fields are omitted.
+      tags: ["UTXO API Endpoints"]
+      parameters:
+        - $ref: "#/components/parameters/txid"
+      responses:
+        "200":
+          description: Transaction details.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Tx"
+              example:
+                txid: "8c1e3dec662d1f2a5e322ccef5eca263f98eb16723c6f990be0c88c1db113fb1"
+                version: 2
+                lockTime: 860729
+                vin:
+                  - txid: "0eb7b574373de2c88d0dc1444f49947c681d0437d21361f9ebb4dd09c62f2a66"
+                    vout: 1
+                    sequence: 4294967293
+                    n: 0
+                    addresses: ["bc1qmgwnfjlda4ns3g6g3yz74w6scnn9yu2ts82yyc"]
+                    isAddress: true
+                    value: "10106300"
+                vout:
+                  - value: "175000"
+                    n: 0
+                    hex: "76a914ecc999d554eaa3efa5e871c28f58b549c36ec51788ac"
+                    addresses: ["1Nb1ykSD7J5k4RFjJQGsrD9gxBE6jzfNa9"]
+                    isAddress: true
+                blockHash: "00000000000000000000effeb0c4460480e6a347deab95332c63007a68646ee5"
+                blockHeight: 860730
+                confirmations: 1
+                blockTime: 1725956288
+                size: 225
+                vsize: 144
+                value: "10063100"
+                valueIn: "10106300"
+                fees: "43200"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  "/api/v2/tx-specific/{txid}":
+    get:
+      operationId: getTransactionSpecific
+      summary: Get Transaction Specific
+      description: >
+        Returns transaction data in the exact format returned by the underlying coin backend, including
+        all chain-specific fields not surfaced by the normalized `/tx/{txid}` endpoint.
+      tags: ["UTXO API Endpoints"]
+      parameters:
+        - $ref: "#/components/parameters/txid"
+      responses:
+        "200":
+          description: Backend-native transaction object.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                description: Backend-specific transaction object. Shape varies by coin.
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  "/api/v2/address/{address}":
+    get:
+      operationId: getAddress
+      summary: Get Address
+      description: >
+        Returns balances and transactions for the given address. Transactions are sorted newest-first
+        by block height.
+      tags: ["UTXO API Endpoints"]
+      parameters:
+        - $ref: "#/components/parameters/address"
+        - in: query
+          name: page
+          required: false
+          description: Page of returned transactions, starting from 1.
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+        - in: query
+          name: pageSize
+          required: false
+          description: Number of transactions returned per page (max 1000).
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 1000
+            default: 1000
+        - in: query
+          name: from
+          required: false
+          description: Filter transactions starting from this block height.
+          schema:
+            type: integer
+            minimum: 0
+        - in: query
+          name: to
+          required: false
+          description: Filter transactions up to this block height.
+          schema:
+            type: integer
+            minimum: 0
+        - in: query
+          name: details
+          required: false
+          description: Level of detail to return.
+          schema:
+            type: string
+            enum: [basic, tokens, tokenBalances, txids, txslight, txs]
+            default: txids
+        - in: query
+          name: secondary
+          required: false
+          description: Secondary (fiat) currency code for balance conversion, e.g. `usd` or `eur`.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Address details, balances, and transactions.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AddressInfo"
+              example:
+                page: 1
+                totalPages: 1
+                itemsOnPage: 1000
+                address: "bc1q0wd209cv5k9pd9mhk7nspacywcj038xxdhnt5u"
+                balance: "4225100"
+                totalReceived: "4225100"
+                totalSent: "0"
+                unconfirmedBalance: "0"
+                unconfirmedTxs: 0
+                txs: 2
+                txids:
+                  - "0db6010dc0815a4bdaa505bd1ccc851056b0d53c7e4ea7af39c4d648a2c0c019"
+                  - "7532920ddc506218337cceac978cce9c7f98e27ad3226dee55f3e934e0b32e80"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  "/api/v2/xpub/{xpub}":
+    get:
+      operationId: getXpub
+      summary: Get Xpub
+      description: >
+        Returns balances and transactions for an xpub or output descriptor. Supports BIP44, BIP49,
+        BIP84, and BIP86 (Taproot) derivation schemes. The BIP version is determined by the xpub
+        prefix or by an explicit output descriptor.
+      tags: ["UTXO API Endpoints"]
+      parameters:
+        - in: path
+          name: xpub
+          required: true
+          description: Extended public key or output descriptor.
+          schema:
+            type: string
+          example: "xpub6CUGRUonZSQ4TWtTMmzXdrXDtypWKiKrhko4egpiMZbpiaQL2jkwSB1icqYh2cfDfVxdx4df189oLKnC5fSwqPfgyP3hooxujYzAu3fDVmz"
+        - in: query
+          name: page
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+        - in: query
+          name: pageSize
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 1000
+            default: 1000
+        - in: query
+          name: from
+          required: false
+          schema:
+            type: integer
+            minimum: 0
+        - in: query
+          name: to
+          required: false
+          schema:
+            type: integer
+            minimum: 0
+        - in: query
+          name: details
+          required: false
+          schema:
+            type: string
+            enum: [basic, tokens, tokenBalances, txids, txs]
+            default: txids
+        - in: query
+          name: tokens
+          required: false
+          description: Which derived addresses to return.
+          schema:
+            type: string
+            enum: [nonzero, used, derived]
+            default: nonzero
+        - in: query
+          name: secondary
+          required: false
+          description: Secondary (fiat) currency code for balance conversion.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Xpub details, balances, derived addresses, and transactions.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AddressInfo"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  "/api/v2/utxo/{descriptor}":
+    get:
+      operationId: getUtxo
+      summary: Get UTXOs
+      description: >
+        Returns the unspent transaction outputs for an address, xpub, or output descriptor. Includes
+        confirmed and unconfirmed UTXOs by default; pass `confirmed=true` to limit to confirmed only.
+        UTXOs are sorted newest-first.
+      tags: ["UTXO API Endpoints"]
+      parameters:
+        - in: path
+          name: descriptor
+          required: true
+          description: Address, xpub, or output descriptor.
+          schema:
+            type: string
+          example: "bc1q0wd209cv5k9pd9mhk7nspacywcj038xxdhnt5u"
+        - in: query
+          name: confirmed
+          required: false
+          description: When `true`, exclude unconfirmed UTXOs.
+          schema:
+            type: boolean
+            default: false
+      responses:
+        "200":
+          description: List of UTXOs.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Utxo"
+              example:
+                - txid: "a79e396a32e10856c97b95f43da7e9d2b9a11d446f7638dbd75e5e7603128cac"
+                  vout: 1
+                  value: "39748685"
+                  height: 2648043
+                  confirmations: 47
+                  coinbase: true
+                - txid: "de4f379fdc3ea9be063e60340461a014f372a018d70c3db35701654e7066b3ef"
+                  vout: 0
+                  value: "122492339065"
+                  height: 2646043
+                  confirmations: 2047
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  "/api/v2/block/{block}":
+    get:
+      operationId: getBlock
+      summary: Get Block
+      description: >
+        Returns information about a block, including transactions, by block hash or block height.
+        Results are paginated.
+      tags: ["UTXO API Endpoints"]
+      parameters:
+        - in: path
+          name: block
+          required: true
+          description: Block height (integer) or block hash (hex string).
+          schema:
+            type: string
+          example: "860730"
+        - in: query
+          name: page
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+        - in: query
+          name: pageSize
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 1000
+            default: 1000
+      responses:
+        "200":
+          description: Block details with paginated transactions.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Block"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  "/api/v2/sendtx/{hex}":
+    get:
+      operationId: sendTransactionGet
+      summary: Send Transaction (GET)
+      description: >
+        Broadcasts a signed raw transaction encoded as a hex string in the path. Returns the
+        transaction ID on success. For larger payloads, use the POST variant.
+      tags: ["UTXO API Endpoints"]
+      parameters:
+        - in: path
+          name: hex
+          required: true
+          description: Hex-encoded raw transaction bytes.
+          schema:
+            type: string
+          example: "010000000001..."
+      responses:
+        "200":
+          description: Transaction broadcast result.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SendTxResponse"
+              example:
+                result: "7c3be24063f268aaa1ed81b64776798f56088757641a34fb156c4f51ed2e9d25"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+
+  "/api/v2/sendtx":
+    post:
+      operationId: sendTransactionPost
+      summary: Send Transaction (POST)
+      description: >
+        Broadcasts a signed raw transaction by sending hex bytes in the request body. Use this for
+        larger payloads (request body limit 8 MiB). Returns the transaction ID on success.
+      tags: ["UTXO API Endpoints"]
+      requestBody:
+        required: true
+        content:
+          text/plain:
+            schema:
+              type: string
+              description: Hex-encoded raw transaction bytes.
+              example: "010000000001..."
+      responses:
+        "200":
+          description: Transaction broadcast result.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SendTxResponse"
+              example:
+                result: "7c3be24063f268aaa1ed81b64776798f56088757641a34fb156c4f51ed2e9d25"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+
+  "/api/v2/tickers-list":
+    get:
+      operationId: getTickersList
+      summary: Get Tickers List
+      description: >
+        Returns the list of available currency rate tickers (secondary currencies) for a given
+        timestamp, along with the actual data timestamp.
+      tags: ["UTXO API Endpoints"]
+      parameters:
+        - in: query
+          name: timestamp
+          required: false
+          description: Unix timestamp to query availability for. Defaults to the latest available.
+          schema:
+            type: integer
+            example: 1574346615
+      responses:
+        "200":
+          description: Available tickers.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TickersListResponse"
+              example:
+                ts: 1574346615
+                available_currencies: ["eur", "usd"]
+        "400":
+          $ref: "#/components/responses/BadRequest"
+
+  "/api/v2/tickers":
+    get:
+      operationId: getTickers
+      summary: Get Tickers
+      description: >
+        Returns the currency rate for the specified currency and timestamp. If the requested
+        currency is unavailable for that timestamp, the closest rate is returned with the
+        actual rate timestamp.
+      tags: ["UTXO API Endpoints"]
+      parameters:
+        - in: query
+          name: currency
+          required: false
+          description: Fiat or crypto currency code (e.g. `usd`, `eur`, `eth`). Omit to return all.
+          schema:
+            type: string
+            example: usd
+        - in: query
+          name: timestamp
+          required: false
+          description: Unix timestamp. Omit to return the latest.
+          schema:
+            type: integer
+            example: 1574346615
+      responses:
+        "200":
+          description: Currency rate response.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TickerRates"
+              example:
+                ts: 1574346615
+                rates:
+                  usd: 7914.5
+        "400":
+          $ref: "#/components/responses/BadRequest"
+
+  "/api/v2/balancehistory/{address}":
+    get:
+      operationId: getBalanceHistory
+      summary: Get Balance History
+      description: >
+        Returns the balance history for the specified address. Optionally enrich each bucket with
+        secondary (fiat) currency rates at the time of the transaction.
+      tags: ["UTXO API Endpoints"]
+      parameters:
+        - $ref: "#/components/parameters/address"
+        - in: query
+          name: from
+          required: true
+          description: Start of the history range as a Unix timestamp.
+          schema:
+            type: integer
+            example: 1578391200
+        - in: query
+          name: to
+          required: true
+          description: End of the history range as a Unix timestamp.
+          schema:
+            type: integer
+            example: 1578488400
+        - in: query
+          name: fiatcurrency
+          required: false
+          description: Fiat currency code to enrich each bucket with.
+          schema:
+            type: string
+            example: usd
+        - in: query
+          name: groupBy
+          required: false
+          description: Aggregation interval in seconds. Defaults to 3600.
+          schema:
+            type: integer
+            default: 3600
+      responses:
+        "200":
+          description: Balance history buckets.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/BalanceHistoryEntry"
+              example:
+                - time: 1578391200
+                  txs: 5
+                  received: "5000000"
+                  sent: "0"
+                  sentToSelf: "100000"
+                  rates:
+                    usd: 7855.9
+                - time: 1578488400
+                  txs: 1
+                  received: "0"
+                  sent: "5000000"
+                  sentToSelf: "0"
+                  rates:
+                    usd: 8283.11
+        "400":
+          $ref: "#/components/responses/BadRequest"
+
+components:
+  securitySchemes:
+    apiKey:
+      type: apiKey
+      in: query
+      name: apiKey
+      description: Alchemy API key. Pass via the `{apiKey}` server variable.
+  parameters:
+    blockHeight:
+      in: path
+      name: block_height
+      required: true
+      description: Block height as a non-negative integer.
+      schema:
+        type: integer
+        minimum: 0
+      example: 860730
+    txid:
+      in: path
+      name: txid
+      required: true
+      description: Hex-encoded transaction ID.
+      schema:
+        type: string
+      example: "8c1e3dec662d1f2a5e322ccef5eca263f98eb16723c6f990be0c88c1db113fb1"
+    address:
+      in: path
+      name: address
+      required: true
+      description: Coin-specific address string.
+      schema:
+        type: string
+      example: "bc1q0wd209cv5k9pd9mhk7nspacywcj038xxdhnt5u"
+  responses:
+    BadRequest:
+      description: Malformed request.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+          example:
+            error:
+              message: "invalid request"
+    NotFound:
+      description: Resource not found on the requested network.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+          example:
+            error:
+              message: "not found"
+  schemas:
+    Error:
+      type: object
+      properties:
+        error:
+          type: object
+          properties:
+            message:
+              type: string
+    BlockIndexResponse:
+      type: object
+      required: [blockHash]
+      properties:
+        blockHash:
+          type: string
+          description: Hex-encoded block hash for the requested height.
+    SendTxResponse:
+      type: object
+      properties:
+        result:
+          type: string
+          description: Transaction ID of the broadcast transaction.
+    Vin:
+      type: object
+      properties:
+        txid: { type: string }
+        vout: { type: integer }
+        sequence: { type: integer }
+        n: { type: integer }
+        addresses:
+          type: array
+          items: { type: string }
+        isAddress: { type: boolean }
+        value:
+          type: string
+          description: Value in the smallest denomination, as a decimal string.
+    Vout:
+      type: object
+      properties:
+        value:
+          type: string
+          description: Value in the smallest denomination, as a decimal string.
+        n: { type: integer }
+        spent: { type: boolean }
+        hex: { type: string }
+        addresses:
+          type: array
+          items: { type: string }
+        isAddress: { type: boolean }
+    Tx:
+      type: object
+      properties:
+        txid: { type: string }
+        version: { type: integer }
+        lockTime: { type: integer }
+        vin:
+          type: array
+          items:
+            $ref: "#/components/schemas/Vin"
+        vout:
+          type: array
+          items:
+            $ref: "#/components/schemas/Vout"
+        blockHash: { type: string }
+        blockHeight:
+          type: integer
+          description: Height of the block, or `-1` for unconfirmed transactions.
+        confirmations: { type: integer }
+        confirmationETABlocks:
+          type: integer
+          description: Estimated blocks to first confirmation (only set when unconfirmed).
+        confirmationETASeconds:
+          type: integer
+          description: Estimated seconds to first confirmation (only set when unconfirmed).
+        blockTime: { type: integer }
+        size: { type: integer }
+        vsize: { type: integer }
+        value:
+          type: string
+        valueIn:
+          type: string
+        fees:
+          type: string
+        hex: { type: string }
+        rbf: { type: boolean }
+    Token:
+      type: object
+      description: Derived token entry for an xpub or address.
+      properties:
+        type:
+          type: string
+          example: XPUBAddress
+        name: { type: string }
+        path: { type: string }
+        transfers: { type: integer }
+        decimals: { type: integer }
+        balance:
+          type: string
+        totalReceived:
+          type: string
+        totalSent:
+          type: string
+    AddressInfo:
+      type: object
+      properties:
+        page: { type: integer }
+        totalPages: { type: integer }
+        itemsOnPage: { type: integer }
+        address: { type: string }
+        balance:
+          type: string
+        totalReceived:
+          type: string
+        totalSent:
+          type: string
+        unconfirmedBalance:
+          type: string
+        unconfirmedTxs: { type: integer }
+        txs: { type: integer }
+        txids:
+          type: array
+          items: { type: string }
+        usedTokens: { type: integer }
+        tokens:
+          type: array
+          items:
+            $ref: "#/components/schemas/Token"
+        secondaryValue: { type: number }
+    Utxo:
+      type: object
+      required: [txid, vout, value]
+      properties:
+        txid: { type: string }
+        vout: { type: integer }
+        value:
+          type: string
+          description: Value in the smallest denomination, as a decimal string.
+        height:
+          type: integer
+          description: Block height. Omitted for unconfirmed UTXOs.
+        confirmations: { type: integer }
+        lockTime:
+          type: integer
+          description: Lock time, only set for unconfirmed UTXOs with non-zero locktime.
+        coinbase:
+          type: boolean
+          description: True if the output comes from a coinbase transaction within the first 100 confirmations.
+        address: { type: string }
+        path:
+          type: string
+          description: Derivation path. Only set when querying by xpub or descriptor.
+    Block:
+      type: object
+      properties:
+        page: { type: integer }
+        totalPages: { type: integer }
+        itemsOnPage: { type: integer }
+        hash: { type: string }
+        previousBlockHash: { type: string }
+        nextBlockHash: { type: string }
+        height: { type: integer }
+        confirmations: { type: integer }
+        size: { type: integer }
+        time: { type: integer }
+        version: { type: integer }
+        merkleRoot: { type: string }
+        nonce: { type: string }
+        bits: { type: string }
+        difficulty: { type: string }
+        txCount: { type: integer }
+        txs:
+          type: array
+          items:
+            $ref: "#/components/schemas/Tx"
+    TickersListResponse:
+      type: object
+      properties:
+        ts: { type: integer }
+        available_currencies:
+          type: array
+          items: { type: string }
+    TickerRates:
+      type: object
+      properties:
+        ts: { type: integer }
+        rates:
+          type: object
+          additionalProperties:
+            type: number
+    BalanceHistoryEntry:
+      type: object
+      properties:
+        time: { type: integer }
+        txs: { type: integer }
+        received:
+          type: string
+        sent:
+          type: string
+        sentToSelf:
+          type: string
+        rates:
+          type: object
+          additionalProperties:
+            type: number

--- a/src/openapi/utxo/utxo.yaml
+++ b/src/openapi/utxo/utxo.yaml
@@ -401,13 +401,15 @@ paths:
         "400":
           $ref: "#/components/responses/BadRequest"
 
-  "/api/v2/sendtx":
+  "/api/v2/sendtx/":
     post:
       operationId: sendTransactionPost
       summary: Send Transaction (POST)
       description: >
-        Broadcasts a signed raw transaction by sending hex bytes in the request body. Use this for
-        larger payloads (request body limit 8 MiB). Returns the transaction ID on success.
+        Broadcasts a signed raw transaction by sending hex bytes in the request body. The trailing
+        slash on the path is mandatory; see the [Blockbook API
+        reference](https://github.com/trezor/blockbook/blob/master/docs/api.md#send-transaction).
+        Use this for larger payloads (request body limit 8 MiB). Returns the transaction ID on success.
       tags: ["UTXO API Endpoints"]
       requestBody:
         required: true

--- a/src/openrpc/chains/bitcoincash/bitcoincash.yaml
+++ b/src/openrpc/chains/bitcoincash/bitcoincash.yaml
@@ -1,0 +1,54 @@
+# yaml-language-server: $schema=https://meta.open-rpc.org/
+
+$schema: https://meta.open-rpc.org/
+openrpc: 1.2.4
+info:
+  title: Alchemy Bitcoin Cash JSON-RPC Specification
+  description: A specification of the standard JSON-RPC methods for Bitcoin Cash.
+  version: 0.0.0
+servers:
+  - url: https://bitcoincash-mainnet.g.alchemy.com/v2
+    name: Bitcoin Cash Mainnet
+  - url: https://bitcoincash-testnet.g.alchemy.com/v2
+    name: Bitcoin Cash Testnet
+methods:
+  - $ref: >-
+      ../_components/bitcoin/methods.yaml#/components/methods/createrawtransaction
+  - $ref: >-
+      ../_components/bitcoin/methods.yaml#/components/methods/decoderawtransaction
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/decodescript
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/estimatesmartfee
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getbestblockhash
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getblock
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getblockchaininfo
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getblockcount
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getblockfilter
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getblockhash
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getblockheader
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getblockstats
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getblocktemplate
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getchaintips
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getchaintxstats
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getconnectioncount
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getdifficulty
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getindexinfo
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getmemoryinfo
+  - $ref: >-
+      ../_components/bitcoin/methods.yaml#/components/methods/getmempoolancestors
+  - $ref: >-
+      ../_components/bitcoin/methods.yaml#/components/methods/getmempooldescendants
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getmempoolinfo
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getnetworkhashps
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getnetworkinfo
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getrawmempool
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getrawtransaction
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/gettxout
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/gettxoutproof
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/gettxoutsetinfo
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/sendrawtransaction
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/submitblock
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/submitheader
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/submitpackage
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/testmempoolaccept
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/validateaddress
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/verifymessage

--- a/src/openrpc/chains/dogecoin/dogecoin.yaml
+++ b/src/openrpc/chains/dogecoin/dogecoin.yaml
@@ -1,0 +1,52 @@
+# yaml-language-server: $schema=https://meta.open-rpc.org/
+
+$schema: https://meta.open-rpc.org/
+openrpc: 1.2.4
+info:
+  title: Alchemy Dogecoin JSON-RPC Specification
+  description: A specification of the standard JSON-RPC methods for Dogecoin.
+  version: 0.0.0
+servers:
+  - url: https://dogecoin-mainnet.g.alchemy.com/v2
+    name: Dogecoin Mainnet
+methods:
+  - $ref: >-
+      ../_components/bitcoin/methods.yaml#/components/methods/createrawtransaction
+  - $ref: >-
+      ../_components/bitcoin/methods.yaml#/components/methods/decoderawtransaction
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/decodescript
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/estimatesmartfee
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getbestblockhash
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getblock
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getblockchaininfo
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getblockcount
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getblockfilter
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getblockhash
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getblockheader
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getblockstats
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getblocktemplate
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getchaintips
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getchaintxstats
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getconnectioncount
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getdifficulty
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getindexinfo
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getmemoryinfo
+  - $ref: >-
+      ../_components/bitcoin/methods.yaml#/components/methods/getmempoolancestors
+  - $ref: >-
+      ../_components/bitcoin/methods.yaml#/components/methods/getmempooldescendants
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getmempoolinfo
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getnetworkhashps
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getnetworkinfo
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getrawmempool
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getrawtransaction
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/gettxout
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/gettxoutproof
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/gettxoutsetinfo
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/sendrawtransaction
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/submitblock
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/submitheader
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/submitpackage
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/testmempoolaccept
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/validateaddress
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/verifymessage

--- a/src/openrpc/chains/litecoin/litecoin.yaml
+++ b/src/openrpc/chains/litecoin/litecoin.yaml
@@ -1,0 +1,54 @@
+# yaml-language-server: $schema=https://meta.open-rpc.org/
+
+$schema: https://meta.open-rpc.org/
+openrpc: 1.2.4
+info:
+  title: Alchemy Litecoin JSON-RPC Specification
+  description: A specification of the standard JSON-RPC methods for Litecoin.
+  version: 0.0.0
+servers:
+  - url: https://litecoin-mainnet.g.alchemy.com/v2
+    name: Litecoin Mainnet
+  - url: https://litecoin-testnet.g.alchemy.com/v2
+    name: Litecoin Testnet
+methods:
+  - $ref: >-
+      ../_components/bitcoin/methods.yaml#/components/methods/createrawtransaction
+  - $ref: >-
+      ../_components/bitcoin/methods.yaml#/components/methods/decoderawtransaction
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/decodescript
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/estimatesmartfee
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getbestblockhash
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getblock
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getblockchaininfo
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getblockcount
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getblockfilter
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getblockhash
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getblockheader
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getblockstats
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getblocktemplate
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getchaintips
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getchaintxstats
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getconnectioncount
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getdifficulty
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getindexinfo
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getmemoryinfo
+  - $ref: >-
+      ../_components/bitcoin/methods.yaml#/components/methods/getmempoolancestors
+  - $ref: >-
+      ../_components/bitcoin/methods.yaml#/components/methods/getmempooldescendants
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getmempoolinfo
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getnetworkhashps
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getnetworkinfo
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getrawmempool
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/getrawtransaction
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/gettxout
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/gettxoutproof
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/gettxoutsetinfo
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/sendrawtransaction
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/submitblock
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/submitheader
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/submitpackage
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/testmempoolaccept
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/validateaddress
+  - $ref: ../_components/bitcoin/methods.yaml#/components/methods/verifymessage


### PR DESCRIPTION
## Summary

Adds docs for 5 new Bitcoin-ecosystem chains launching this Thursday (Bitcoin Cash mainnet/testnet, Litecoin mainnet/testnet, Dogecoin mainnet) and a new UTXO REST API spec used across all 7 supported UTXO networks (the 5 above plus Bitcoin Mainnet and Bitcoin Testnet 4).

### JSON-RPC docs

- New OpenRPC chain specs at `src/openrpc/chains/{bitcoincash,litecoin,dogecoin}/<chain>.yaml`. Each `$ref`s the existing `src/openrpc/chains/_components/bitcoin/methods.yaml` so the 38 Bitcoin-style methods (`getblock`, `sendrawtransaction`, etc.) appear identically across the new chains. Confirmed by the requester that all 38 methods are available on all 5 new chains.
- New MDX pages under `content/api-reference/{bitcoincash,litecoin,dogecoin}/`: `<chain>-api-quickstart.mdx`, `<chain>-api-faq.mdx`, `<chain>-api-overview.mdx`, mirroring the existing Bitcoin pages.
- New chain sections inserted in `content/docs.yml` in alphabetical order: Bitcoin Cash between Bitcoin and Blast, Dogecoin between Degen and Fantom, Litecoin between Linea and Lumia.

### UTXO REST API

- New OpenAPI 3.1 spec at `src/openapi/utxo/utxo.yaml` covering the 12 Trezor [Blockbook](https://github.com/trezor/blockbook/blob/master/docs/api.md) REST endpoints the requester confirmed are exposed:
  - `GET /api/v2/block-index/{block_height}`
  - `GET /api/v2/tx/{txid}`
  - `GET /api/v2/tx-specific/{txid}`
  - `GET /api/v2/address/{address}`
  - `GET /api/v2/xpub/{xpub}`
  - `GET /api/v2/utxo/{descriptor}`
  - `GET /api/v2/block/{block}`
  - `GET /api/v2/sendtx/{hex}` and `POST /api/v2/sendtx`
  - `GET /api/v2/tickers-list`
  - `GET /api/v2/tickers`
  - `GET /api/v2/balancehistory/{address}`
- Servers cover all 7 networks via a `{network}` server variable: `bitcoin-mainnet`, `bitcoin-testnet4`, `bitcoincash-mainnet`, `bitcoincash-testnet`, `litecoin-mainnet`, `litecoin-testnet`, `dogecoin-mainnet`. Server URL pattern follows the JSON-RPC one (`https://{network}.g.alchemy.com/v2/{apiKey}`) per the requester's "same host" answer, so each path resolves to e.g. `https://bitcoincash-mainnet.g.alchemy.com/v2/{apiKey}/api/v2/tx/{txid}`. **Please confirm this composition is what node-gateway is exposing**, since I couldn't verify against a live endpoint pre-launch — if the UTXO REST is mounted without the API key in the path, the server URL needs to be adjusted to `https://{network}.g.alchemy.com` (or wherever it actually lives).
- The UTXO API is wired into each of the 4 Bitcoin-style chain sections in `docs.yml` as `- api: UTXO API Endpoints; api-name: utxo` with `flattened: true`, so users browsing Bitcoin / Bitcoin Cash / Litecoin / Dogecoin all see the UTXO endpoints under that chain.

## Validation

- `pnpm run generate:rpc` and `pnpm run validate:rpc`: both pass cleanly with the new chain specs.
- `pnpm run validate:rest`: 0 errors. The `Woohoo! Your API description is valid.` line appears for every spec including the new `utxo.yaml`. Existing warning counts in other specs are unchanged.
- Prettier: clean for all new files.

## Daikon coordination

These chain specs and the new UTXO OpenAPI are landing manually because [Daikon's](https://github.com/alchemyplatform/docs) chain-config update for these 5 chains was not yet visible from the docs-agent side at PR time. **Reviewers, please confirm with @dslovinsky** that the upstream chain-config either already includes these chains or is landing in time for the Thursday launch, otherwise the next noon-EST Daikon Update Specs run could either clobber these new chain specs (if chain-config disagrees) or leave them unmanaged (if chain-config is silent on them). I did NOT add a chain-level `x-bot-ignore` because it is per-method, not per-chain — if reviewers want temporary protection while Daniel's PR lands, happy to push a follow-up that adds explicit method-level guards.

## Open questions / things to double-check

1. The `utxo.yaml` server URL composition — confirm the `/v2/{apiKey}/api/v2/...` path is correct.
2. Examples in `_components/bitcoin/methods.yaml` are Bitcoin-mainnet-specific (real BTC block hashes, real BTC txids). Reusing them for BCH/LTC/DOGE is structurally sound but the example values won't match those chains. If we want chain-specific examples, that's a follow-up — happy to either spin a per-chain `_components/<chain>/methods.yaml` or thread chain-agnostic example data through.
3. Daikon coordination, as above.

## Linear

DOCS-71 — https://linear.app/alchemyapi/issue/DOCS-71/docs-for-5-new-bitcoin-ecosystem-chains-bch-ltc-doge-utxo-api