### PR TITLE
[docs-agent] Use paramStructure: by-name for Solana Photon methods

### DIFF
--- a/src/openrpc/chains/_components/solana/methods.yaml
+++ b/src/openrpc/chains/_components/solana/methods.yaml
@@ -1129,7 +1129,7 @@ components:
     getCompressedAccount:
       name: getCompressedAccount
       description: |
-        Returns the compressed account matching the given `address` or `hash`. Provide exactly one of the two — blank fields are omitted from the JSON-RPC payload.
+        Returns the compressed account matching the given `address` or `hash`. Photon's JSON-RPC for this method accepts the params as a positional pair `[address, hash]` — pass `null` for whichever identifier you are not using.
 
         - `address` queries compressed accounts created with a Light Protocol address.
         - `hash` queries by the merkle-tree leaf hash and works for every compressed account.
@@ -1137,12 +1137,14 @@ components:
       params:
         - name: address
           required: false
-          description: Pubkey of the compressed account to query. Leave blank to query by `hash` instead. The underlying Photon API also accepts an explicit `null` here, but the Try It widget omits the field from the payload when blank.
+          description: Pubkey of the compressed account to query. Pass `null` to query by `hash` instead.
           schema:
-            $ref: ./base-types.yaml#/components/schemas/Pubkey
+            oneOf:
+              - $ref: ./base-types.yaml#/components/schemas/Pubkey
+              - type: "null"
         - name: hash
           required: false
-          description: Hash of the compressed account to query. Leave blank to query by `address` instead.
+          description: Hash of the compressed account to query. Pass `null` to query by `address` instead.
           schema:
             oneOf:
               - $ref: ./compression.yaml#/components/schemas/Hash
@@ -1150,13 +1152,15 @@ components:
       examples:
         - name: getCompressedAccount example
           params:
+            - name: address
+              value: null
             - name: hash
               value: "3KC9cKQhhzEPjwuyQaohM6SGaZu1ukKRZw2QRgc1sYVL"
           result:
             name: Compressed account
             value:
               context:
-                slot: 419133524
+                slot: 419139544
               value:
                 hash: 3KC9cKQhhzEPjwuyQaohM6SGaZu1ukKRZw2QRgc1sYVL
                 address:
@@ -1170,26 +1174,6 @@ components:
                 leafIndex: 832574
                 seq: 877634
                 slotCreated: 357735227
-      x-fern-examples:
-        - name: getCompressedAccount example
-          params:
-            hash: "3KC9cKQhhzEPjwuyQaohM6SGaZu1ukKRZw2QRgc1sYVL"
-          result:
-            context:
-              slot: 419133524
-            value:
-              hash: 3KC9cKQhhzEPjwuyQaohM6SGaZu1ukKRZw2QRgc1sYVL
-              address: null
-              data:
-                discriminator: 2
-                data: RhAVR6AmcnFercuAcoi9gbc/hIy3UBfL/FeQkTk7SE8I8WaM+ETZsH8YD96DZJdZG7IPY2fuP8pCP/oQV1de4R5hETEZAAAAAAAA
-                dataHash: mkARkU6arYpeTacykBCEytKihySvzGJXbkG5PbwhieQ
-              owner: cTokenmWW8bLPjZEBAUgYy3zKxQZW6VKi7bqNFEVv3m
-              lamports: 0
-              tree: smt6ukQDSPPYHSshQovmiRUjG9jGFq2hW9vgrDFk5Yz
-              leafIndex: 832574
-              seq: 877634
-              slotCreated: 357735227
       result:
         name: Compressed account
         description: The compressed account data with context information. `value` is `null` when no compressed account matches the supplied `address` or `hash`.

--- a/src/openrpc/chains/_components/solana/methods.yaml
+++ b/src/openrpc/chains/_components/solana/methods.yaml
@@ -1149,7 +1149,7 @@ components:
         - name: getCompressedAccount example
           params:
             - name: hash
-              value: "11111111111111111111111111111111"
+              value: "3KC9cKQhhzEPjwuyQaohM6SGaZu1ukKRZw2QRgc1sYVL"
       result:
         name: Compressed account
         description: The compressed account data with context information.
@@ -1169,7 +1169,7 @@ components:
         - name: getCompressedAccountProof example
           params:
             - name: hash
-              value: "11157t3sqMV725NVRLrVQbAu98Jjfk1uCKehJnXXQs"
+              value: "3KC9cKQhhzEPjwuyQaohM6SGaZu1ukKRZw2QRgc1sYVL"
       result:
         name: Compressed account proof
         description: The merkle proof for the compressed account.
@@ -1248,7 +1248,7 @@ components:
         - name: getCompressedBalance example
           params:
             - name: hash
-              value: "11111111111111111111111111111111"
+              value: "3KC9cKQhhzEPjwuyQaohM6SGaZu1ukKRZw2QRgc1sYVL"
       result:
         name: Compressed balance
         description: The lamport balance of the compressed account.
@@ -1333,7 +1333,7 @@ components:
         - name: getCompressedTokenAccountBalance example
           params:
             - name: hash
-              value: "11111111111111111111111111111111"
+              value: "3KC9cKQhhzEPjwuyQaohM6SGaZu1ukKRZw2QRgc1sYVL"
       result:
         name: Token account balance
         description: The token balance of the compressed token account.
@@ -1521,7 +1521,7 @@ components:
         - name: getCompressionSignaturesForAccount example
           params:
             - name: hash
-              value: "11111111111111111111111111111111"
+              value: "3KC9cKQhhzEPjwuyQaohM6SGaZu1ukKRZw2QRgc1sYVL"
       result:
         name: Signatures
         description: The transaction signatures that touched the compressed account.
@@ -1731,7 +1731,8 @@ components:
           params:
             - name: hashes
               value:
-                - "11157t3sqMV725NVRLrVQbAu98Jjfk1uCKehJnXXQs"
+                - "3KC9cKQhhzEPjwuyQaohM6SGaZu1ukKRZw2QRgc1sYVL"
+                - "41GMzTte97MK7eZqo5rb7JNjABrm4r4XkhSCVZdZgtka"
       result:
         name: Compressed account proofs
         description: An array of merkle proofs for the requested compressed accounts.
@@ -1766,8 +1767,8 @@ components:
           params:
             - name: hashes
               value:
-                - "11157t3sqMV725NVRLrVQbAu98Jjfk1uCKehJnXXQs"
-                - "1117mWrzzrZr312ebPDHu8tbfMwFNvCvMbr6WepCNG"
+                - "3KC9cKQhhzEPjwuyQaohM6SGaZu1ukKRZw2QRgc1sYVL"
+                - "41GMzTte97MK7eZqo5rb7JNjABrm4r4XkhSCVZdZgtka"
       result:
         name: Compressed accounts
         description: A list of compressed accounts.
@@ -1865,7 +1866,7 @@ components:
           params:
             - name: hashes
               value:
-                - "11157t3sqMV725NVRLrVQbAu98Jjfk1uCKehJnXXQs"
+                - "3KC9cKQhhzEPjwuyQaohM6SGaZu1ukKRZw2QRgc1sYVL"
             - name: newAddressesWithTrees
               value: []
       result:
@@ -1898,7 +1899,7 @@ components:
           params:
             - name: hashes
               value:
-                - "11111111111111111111111111111111"
+                - "3KC9cKQhhzEPjwuyQaohM6SGaZu1ukKRZw2QRgc1sYVL"
             - name: newAddressesWithTrees
               value: []
       result:

--- a/src/openrpc/chains/_components/solana/methods.yaml
+++ b/src/openrpc/chains/_components/solana/methods.yaml
@@ -1169,7 +1169,7 @@ components:
         - name: getCompressedAccountProof example
           params:
             - name: hash
-              value: "11111111111111111111111111111111"
+              value: "11157t3sqMV725NVRLrVQbAu98Jjfk1uCKehJnXXQs"
       result:
         name: Compressed account proof
         description: The merkle proof for the compressed account.
@@ -1731,7 +1731,7 @@ components:
           params:
             - name: hashes
               value:
-                - "11111111111111111111111111111111"
+                - "11157t3sqMV725NVRLrVQbAu98Jjfk1uCKehJnXXQs"
       result:
         name: Compressed account proofs
         description: An array of merkle proofs for the requested compressed accounts.
@@ -1865,7 +1865,7 @@ components:
           params:
             - name: hashes
               value:
-                - "11111111111111111111111111111111"
+                - "11157t3sqMV725NVRLrVQbAu98Jjfk1uCKehJnXXQs"
             - name: newAddressesWithTrees
               value: []
       result:

--- a/src/openrpc/chains/_components/solana/methods.yaml
+++ b/src/openrpc/chains/_components/solana/methods.yaml
@@ -1150,6 +1150,24 @@ components:
           params:
             - name: hash
               value: "3KC9cKQhhzEPjwuyQaohM6SGaZu1ukKRZw2QRgc1sYVL"
+          result:
+            name: Compressed account
+            value:
+              context:
+                slot: 418485594
+              value:
+                hash: 3KC9cKQhhzEPjwuyQaohM6SGaZu1ukKRZw2QRgc1sYVL
+                address:
+                data:
+                  discriminator: 2
+                  data: RhAVR6AmcnFercuAcoi9gbc/hIy3UBfL/FeQkTk7SE8I8WaM+ETZsH8YD96DZJdZG7IPY2fuP8pCP/oQV1de4R5hETEZAAAAAAAA
+                  dataHash: mkARkU6arYpeTacykBCEytKihySvzGJXbkG5PbwhieQ
+                owner: cTokenmWW8bLPjZEBAUgYy3zKxQZW6VKi7bqNFEVv3m
+                lamports: 0
+                tree: smt6ukQDSPPYHSshQovmiRUjG9jGFq2hW9vgrDFk5Yz
+                leafIndex: 832574
+                seq: 877634
+                slotCreated: 357735227
       result:
         name: Compressed account
         description: The compressed account data with context information.
@@ -1170,6 +1188,44 @@ components:
           params:
             - name: hash
               value: "3KC9cKQhhzEPjwuyQaohM6SGaZu1ukKRZw2QRgc1sYVL"
+          result:
+            name: Compressed account proof
+            value:
+              context:
+                slot: 418485597
+              value:
+                proof:
+                  - "11111111111111111111111111111111"
+                  - 3CFKteYSRSkp9EGFPzibgzCPtNuJ5HeZ31fAsBpgcHwZ
+                  - 274k4KPY5VhmU5pCwwJzyHaY4AH4m7SjnZnyj44UitJc
+                  - 3CmsXgfnFjYnFqFGA5FVuTyAA5ENV9GBr1bA3cR47EUJ
+                  - 2SUP3mBiZBKzepZqxbCoDoV9CvN9xs2nMiPjUwQ3fQti
+                  - 42SthPRZV4F3Mek5eCGvoETaef5wNwepuoiKaJU18dTf
+                  - hSLgVeN68pDxYpGWLVxCLJM2frDcSGgDS56fBm7Jmgp
+                  - 3xecC71yJecUMwMXABUQyGpQg5wPkuPQQghNSiHuzBL2
+                  - 3zqgQREMZJBWWxHeArhiso6FGVgTfuz9Xf1hwZLwah4k
+                  - eeqRZmXrLxGYiK5zwp4Y72ZHSskwfqdybaH71q2s2cu
+                  - CHGptQh7F7FAQFr2ebVQBCNCoWDfkjrWENtBFaSuBQK
+                  - 2bD5R8x94VURvzqGL5RufxMgJ1euhvQ9MY4FDiTze8D4
+                  - 2CZ6PSkWbhfZ2nkNQWeFRg5NUGkUb6sWoGYZtVSbZnTP
+                  - 2RWPLU8J4Qkg13n63cdMndfZLe9vsim44PRAn1q8y356
+                  - Qi4hMgGVaYVCdxWQ51AiS7YwrDmVsgjZ3X5H84uje2R
+                  - 24b4LHNs5nXTTxncoYdPbBXnvjjp6ez6fbBWxPw7qLUK
+                  - 49zPcCTw2nmguqspeAb3VM8PLjcK5Qfb4oMvKeTDPeqm
+                  - 2tiUSe34eNxNuXXtPPG8F2dw92v2fM5eWEawSfmBvLQ5
+                  - aWKg77LjEQpuFcgyvA5ZwJjggnS4evyG3hwvVLurFud
+                  - Ea7WrnMfZdfBjCKa5obZeg2fST94H645dX4GB9PsZaG
+                  - 3KLopoPRRZeH3H4i1csrJXkfkwX4gjeTRnFsJZvKotPJ
+                  - AEvtmNEdsHtCzZjfwvak4of5rV3XUUA1qoLNEGVDvui
+                  - 2fomPS2xUPwXxVF8hx5YtMpBHmQKSZKushUiWYsy9Eqx
+                  - 3Pi3nRu4fWpnW5rYDAoraX1Q2xDCRQ24Dq8TEY7gaSBn
+                  - 3dbMMyehykAriNZ8FMJgPc1N6YSzm9ZfV2HcW9sbaXzP
+                  - 4EE5KQnQ6Tvo78gGhTu8serpJV4srbRhYZ3rdvCiRa5e
+                root: 3m3ZNkLWeTSGdVCejt4QK4dMcAVyckJvoBhBA8VDeHUd
+                leafIndex: 832574
+                hash: 3KC9cKQhhzEPjwuyQaohM6SGaZu1ukKRZw2QRgc1sYVL
+                merkleTree: smt6ukQDSPPYHSshQovmiRUjG9jGFq2hW9vgrDFk5Yz
+                rootSeq: 3076052
       result:
         name: Compressed account proof
         description: The merkle proof for the compressed account.
@@ -1208,6 +1264,23 @@ components:
           params:
             - name: owner
               value: "bukwBg6C8VAHsuak1dPm5Teiu3eWe78xakgTL8QjVbW"
+          result:
+            name: Compressed accounts
+            value:
+              context:
+                slot: 418485602
+              value:
+                items:
+                  - hash: 2U9KV9sCU5MtJaDTKVkuuEbagVEBL9BQSfUBsaiEP6Cf
+                    address:
+                    data:
+                    owner: bukwBg6C8VAHsuak1dPm5Teiu3eWe78xakgTL8QjVbW
+                    lamports: 1855202212
+                    tree: smt4vjXvdjDFzvRMUxwTWnSy4c7cKkMaHuPrGsdDH7V
+                    leafIndex: 838169
+                    seq: 884595
+                    slotCreated: 357735567
+                cursor:
       result:
         name: Compressed accounts
         description: A paginated list of compressed accounts owned by the given Pubkey.
@@ -1238,6 +1311,12 @@ components:
           params:
             - name: hash
               value: "2U9KV9sCU5MtJaDTKVkuuEbagVEBL9BQSfUBsaiEP6Cf"
+          result:
+            name: Compressed balance
+            value:
+              context:
+                slot: 418485605
+              value: 1855202212
       result:
         name: Compressed balance
         description: The lamport balance of the compressed account.
@@ -1258,6 +1337,12 @@ components:
           params:
             - name: owner
               value: "bukwBg6C8VAHsuak1dPm5Teiu3eWe78xakgTL8QjVbW"
+          result:
+            name: Compressed balance
+            value:
+              context:
+                slot: 418485607
+              value: 1855202212
       result:
         name: Compressed balance
         description: The total compressed lamport balance for the owner.
@@ -1293,6 +1378,18 @@ components:
           params:
             - name: mint
               value: "5iVmFCCwJTuuw7p4FrxYoZ1bUNdjg14j7uv5hMsMpump"
+          result:
+            name: Token holders
+            value:
+              context:
+                slot: 418485610
+              value:
+                items:
+                  - owner: bukwBg6C8VAHsuak1dPm5Teiu3eWe78xakgTL8QjVbW
+                    balance: 108197404958
+                  - owner: 5STUuhrL8kJ4up9spEY39VJ6ibQCFrg8x8cRV5UeEcfv
+                    balance: 0
+                cursor: 111111115STUuhrL8kJ4up9spEY39VJ6ibQCFrg8x8cRV5UeEcfv
       result:
         name: Token holders
         description: A paginated list of owner balances for the given mint.
@@ -1323,6 +1420,13 @@ components:
           params:
             - name: hash
               value: "3KC9cKQhhzEPjwuyQaohM6SGaZu1ukKRZw2QRgc1sYVL"
+          result:
+            name: Token account balance
+            value:
+              context:
+                slot: 418485614
+              value:
+                amount: 108197404958
       result:
         name: Token account balance
         description: The token balance of the compressed token account.
@@ -1368,6 +1472,14 @@ components:
           params:
             - name: delegate
               value: "bukwBg6C8VAHsuak1dPm5Teiu3eWe78xakgTL8QjVbW"
+          result:
+            name: Compressed token accounts
+            value:
+              context:
+                slot: 418485617
+              value:
+                items: []
+                cursor:
       result:
         name: Compressed token accounts
         description: A paginated list of compressed token accounts delegated to the given Pubkey.
@@ -1410,6 +1522,54 @@ components:
           params:
             - name: owner
               value: "bukwBg6C8VAHsuak1dPm5Teiu3eWe78xakgTL8QjVbW"
+          result:
+            name: Compressed token accounts
+            value:
+              context:
+                slot: 418485619
+              value:
+                items:
+                  - account:
+                      hash: 3KC9cKQhhzEPjwuyQaohM6SGaZu1ukKRZw2QRgc1sYVL
+                      address:
+                      data:
+                        discriminator: 2
+                        data: RhAVR6AmcnFercuAcoi9gbc/hIy3UBfL/FeQkTk7SE8I8WaM+ETZsH8YD96DZJdZG7IPY2fuP8pCP/oQV1de4R5hETEZAAAAAAAA
+                        dataHash: mkARkU6arYpeTacykBCEytKihySvzGJXbkG5PbwhieQ
+                      owner: cTokenmWW8bLPjZEBAUgYy3zKxQZW6VKi7bqNFEVv3m
+                      lamports: 0
+                      tree: smt6ukQDSPPYHSshQovmiRUjG9jGFq2hW9vgrDFk5Yz
+                      leafIndex: 832574
+                      seq: 877634
+                      slotCreated: 357735227
+                    tokenData:
+                      mint: 5iVmFCCwJTuuw7p4FrxYoZ1bUNdjg14j7uv5hMsMpump
+                      owner: bukwBg6C8VAHsuak1dPm5Teiu3eWe78xakgTL8QjVbW
+                      amount: 108197404958
+                      delegate:
+                      state: initialized
+                      tlv:
+                  - account:
+                      hash: 41GMzTte97MK7eZqo5rb7JNjABrm4r4XkhSCVZdZgtka
+                      address:
+                      data:
+                        discriminator: 2
+                        data: xvp6877brTo9ZfNqq8l0MbG75MLS9uDkfKYCA0UvXWEI8WaM+ETZsH8YD96DZJdZG7IPY2fuP8pCP/oQV1de4VSupSIAAAAAAAAA
+                        dataHash: QTbeX3k5dHae2N2C5bdkuznGgQnkW2c7BmCdjZevSgL
+                      owner: cTokenmWW8bLPjZEBAUgYy3zKxQZW6VKi7bqNFEVv3m
+                      lamports: 0
+                      tree: smt3AFtReRGVcrP11D6bSLEaKdUmrGfaTNowMVccJeu
+                      leafIndex: 833491
+                      seq: 879099
+                      slotCreated: 357734692
+                    tokenData:
+                      mint: EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
+                      owner: bukwBg6C8VAHsuak1dPm5Teiu3eWe78xakgTL8QjVbW
+                      amount: 581283412
+                      delegate:
+                      state: initialized
+                      tlv:
+                cursor: 4yjijviL58sF59PKQDgt3CUyFfUYArdpgfuVsuM7qoADzJn7oNmJkaY6MBFFBwDemdCJ2bZUCuAnHw7azAswvSoC
       result:
         name: Compressed token accounts
         description: A paginated list of compressed token accounts owned by the given Pubkey.
@@ -1452,6 +1612,18 @@ components:
           params:
             - name: owner
               value: "bukwBg6C8VAHsuak1dPm5Teiu3eWe78xakgTL8QjVbW"
+          result:
+            name: Compressed token balances
+            value:
+              context:
+                slot: 418485622
+              value:
+                token_balances:
+                  - mint: 5iVmFCCwJTuuw7p4FrxYoZ1bUNdjg14j7uv5hMsMpump
+                    balance: 108197404958
+                  - mint: EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
+                    balance: 581283412
+                cursor: EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
       result:
         name: Compressed token balances
         description: A paginated list of compressed token balances for the owner.
@@ -1494,6 +1666,18 @@ components:
           params:
             - name: owner
               value: "bukwBg6C8VAHsuak1dPm5Teiu3eWe78xakgTL8QjVbW"
+          result:
+            name: Compressed token balances
+            value:
+              context:
+                slot: 418485624
+              value:
+                items:
+                  - mint: 5iVmFCCwJTuuw7p4FrxYoZ1bUNdjg14j7uv5hMsMpump
+                    balance: 108197404958
+                  - mint: EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
+                    balance: 581283412
+                cursor: EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
       result:
         name: Compressed token balances
         description: A paginated list of compressed token balances for the owner.
@@ -1514,6 +1698,16 @@ components:
           params:
             - name: hash
               value: "3KC9cKQhhzEPjwuyQaohM6SGaZu1ukKRZw2QRgc1sYVL"
+          result:
+            name: Signatures
+            value:
+              context:
+                slot: 418485627
+              value:
+                items:
+                  - signature: 2M5XHXBGZSwqYw6HN5TfReiamMXghcJEdwLJCyUPgoAo2kJrSt7EZnS43WRqx1Fiq95W5SV2n86oAKgDARrLLG3u
+                    slot: 357735227
+                    blockTime: 1754278913
       result:
         name: Signatures
         description: The transaction signatures that touched the compressed account.
@@ -1552,6 +1746,14 @@ components:
           params:
             - name: address
               value: "11111112cMQwSC9qirWGjZM6gLGwW69X22mqwLLGP"
+          result:
+            name: Signatures
+            value:
+              context:
+                slot: 418485631
+              value:
+                items: []
+                cursor:
       result:
         name: Signatures
         description: A paginated list of transaction signatures.
@@ -1587,6 +1789,17 @@ components:
           params:
             - name: owner
               value: "bukwBg6C8VAHsuak1dPm5Teiu3eWe78xakgTL8QjVbW"
+          result:
+            name: Signatures
+            value:
+              context:
+                slot: 418486615
+              value:
+                items:
+                  - signature: 4gXfktAZhE9kr2DrHgdg4PcLKaFBxBCqem7QazyQF54njJ1aMu9EzvMgwcY1eaSuTxeHNbFp9bKcd6BWyJwpRvgE
+                    slot: 357735567
+                    blockTime: 1754279048
+                cursor:
       result:
         name: Signatures
         description: A paginated list of transaction signatures.
@@ -1622,6 +1835,20 @@ components:
           params:
             - name: owner
               value: "bukwBg6C8VAHsuak1dPm5Teiu3eWe78xakgTL8QjVbW"
+          result:
+            name: Signatures
+            value:
+              context:
+                slot: 418485901
+              value:
+                items:
+                  - signature: 2M5XHXBGZSwqYw6HN5TfReiamMXghcJEdwLJCyUPgoAo2kJrSt7EZnS43WRqx1Fiq95W5SV2n86oAKgDARrLLG3u
+                    slot: 357735227
+                    blockTime: 1754278913
+                  - signature: NtPpU9CV6FwxHXFFGtxdfHav8Xyw4wKRwbvGvUUsUMjaPYUTuHhnXZtKKC1aGbBxXUawfSVZNp23o7t4FvuKD1Z
+                    slot: 357734692
+                    blockTime: 1754278702
+                cursor: YLGNsKSoA4qyyYAoR3gfCGoq5Kushh5Dx5pv7AHivCekT2nqjdDXBJHVxuv47KS3nL6ZiuQecDREFryMVE1FoUVkePaxrwjYX9
       result:
         name: Signatures
         description: A paginated list of transaction signatures.
@@ -1635,6 +1862,10 @@ components:
       examples:
         - name: getIndexerHealth example
           params: []
+          result:
+            name: Health status
+            value: ok
+              ...
       result:
         name: Health status
         description: Returns `ok` when the indexer is healthy.
@@ -1648,6 +1879,10 @@ components:
       examples:
         - name: getIndexerSlot example
           params: []
+          result:
+            name: Indexer slot
+            value: 418485744
+              ...
       result:
         name: Indexer slot
         description: The latest slot indexed by the compression indexer.
@@ -1676,6 +1911,20 @@ components:
       examples:
         - name: getLatestCompressionSignatures example
           params: []
+          result:
+            name: Signatures
+            value:
+              context:
+                slot: 418485747
+              value:
+                items:
+                  - signature: 3VSXkFYMW7Nh73QMRUkM69vo6b6rFzng6KMaxpfeaC8Y5dcyLaqPr6cQR5ryWWG1ciq66rT46e7Xn3MJDNtQ7JAS
+                    slot: 418485507
+                    blockTime: 1778278932
+                  - signature: 4vz61F3eENQizAqDjoVMUm8ce7EKGMiVSQWtUcwEetbefZc1FP5DEajN4XZZa1emUVKQpWPTHaqdNgkJeYFxnUbQ
+                    slot: 418485502
+                    blockTime: 1778278930
+                cursor: 4kwtPUJmAis732mGAuMozNPEXfziYaYJbaHa1FqbTqqjwuvTqHAj6e3Bh87rriGFDzZK3HqsmpYG1nvhhXRCHYuoFrBggK9PSr2
       result:
         name: Signatures
         description: A paginated list of recent compression-related transaction signatures.
@@ -1704,6 +1953,21 @@ components:
       examples:
         - name: getLatestNonVotingSignatures example
           params: []
+          result:
+            name: Signatures
+            value:
+              context:
+                slot: 418485750
+              value:
+                items:
+                  - signature: 64kTvtd4hvcfvZvbQX28yd4Mn639Jakj8TFw1uij1tzWLq7RbSVbEu496Q8qoRL7yozcieRNyNyJKc9nFhncAuzU
+                    slot: 418485750
+                    blockTime: 1778279027
+                    error:
+                  - signature: 64Rkbkbpvu3b72bqwKSvWcVSLyhWjGVzWkZ6hqawJ6kyS4SmMH8YfUZ8P88VsehfgJdrZSQa45ytQiFRXK22Wuv1
+                    slot: 418485750
+                    blockTime: 1778279027
+                    error:
       result:
         name: Signatures
         description: A list of recent non-voting transaction signatures with their error status.
@@ -1734,6 +1998,76 @@ components:
               value: "3KC9cKQhhzEPjwuyQaohM6SGaZu1ukKRZw2QRgc1sYVL"
             - name: hash2
               value: "41GMzTte97MK7eZqo5rb7JNjABrm4r4XkhSCVZdZgtka"
+          result:
+            name: Compressed account proofs
+            value:
+              context:
+                slot: 418485753
+              value:
+                - proof:
+                    - "11111111111111111111111111111111"
+                    - 3CFKteYSRSkp9EGFPzibgzCPtNuJ5HeZ31fAsBpgcHwZ
+                    - 274k4KPY5VhmU5pCwwJzyHaY4AH4m7SjnZnyj44UitJc
+                    - 3CmsXgfnFjYnFqFGA5FVuTyAA5ENV9GBr1bA3cR47EUJ
+                    - 2SUP3mBiZBKzepZqxbCoDoV9CvN9xs2nMiPjUwQ3fQti
+                    - 42SthPRZV4F3Mek5eCGvoETaef5wNwepuoiKaJU18dTf
+                    - hSLgVeN68pDxYpGWLVxCLJM2frDcSGgDS56fBm7Jmgp
+                    - 3xecC71yJecUMwMXABUQyGpQg5wPkuPQQghNSiHuzBL2
+                    - 3zqgQREMZJBWWxHeArhiso6FGVgTfuz9Xf1hwZLwah4k
+                    - eeqRZmXrLxGYiK5zwp4Y72ZHSskwfqdybaH71q2s2cu
+                    - CHGptQh7F7FAQFr2ebVQBCNCoWDfkjrWENtBFaSuBQK
+                    - 2bD5R8x94VURvzqGL5RufxMgJ1euhvQ9MY4FDiTze8D4
+                    - 2CZ6PSkWbhfZ2nkNQWeFRg5NUGkUb6sWoGYZtVSbZnTP
+                    - 2RWPLU8J4Qkg13n63cdMndfZLe9vsim44PRAn1q8y356
+                    - Qi4hMgGVaYVCdxWQ51AiS7YwrDmVsgjZ3X5H84uje2R
+                    - 24b4LHNs5nXTTxncoYdPbBXnvjjp6ez6fbBWxPw7qLUK
+                    - 49zPcCTw2nmguqspeAb3VM8PLjcK5Qfb4oMvKeTDPeqm
+                    - 2tiUSe34eNxNuXXtPPG8F2dw92v2fM5eWEawSfmBvLQ5
+                    - aWKg77LjEQpuFcgyvA5ZwJjggnS4evyG3hwvVLurFud
+                    - Ea7WrnMfZdfBjCKa5obZeg2fST94H645dX4GB9PsZaG
+                    - 3KLopoPRRZeH3H4i1csrJXkfkwX4gjeTRnFsJZvKotPJ
+                    - AEvtmNEdsHtCzZjfwvak4of5rV3XUUA1qoLNEGVDvui
+                    - 2fomPS2xUPwXxVF8hx5YtMpBHmQKSZKushUiWYsy9Eqx
+                    - 3Pi3nRu4fWpnW5rYDAoraX1Q2xDCRQ24Dq8TEY7gaSBn
+                    - 3dbMMyehykAriNZ8FMJgPc1N6YSzm9ZfV2HcW9sbaXzP
+                    - 4EE5KQnQ6Tvo78gGhTu8serpJV4srbRhYZ3rdvCiRa5e
+                  root: 3m3ZNkLWeTSGdVCejt4QK4dMcAVyckJvoBhBA8VDeHUd
+                  leafIndex: 832574
+                  hash: 3KC9cKQhhzEPjwuyQaohM6SGaZu1ukKRZw2QRgc1sYVL
+                  merkleTree: smt6ukQDSPPYHSshQovmiRUjG9jGFq2hW9vgrDFk5Yz
+                  rootSeq: 3076052
+                - proof:
+                    - "11111111111111111111111111111111"
+                    - 3CFKteYSRSkp9EGFPzibgzCPtNuJ5HeZ31fAsBpgcHwZ
+                    - 274k4KPY5VhmU5pCwwJzyHaY4AH4m7SjnZnyj44UitJc
+                    - 2HZcobpCoz6JbutPkspDsyo6DS98WYXDtGJPHTXnRfyF
+                    - 3yP5iEu8dorEBmRFeJbDik3SXaoWfAhJBoqjezL3LzCC
+                    - 2GDE67NjgjexGhbNZYWboxJnHaztcUNPeQrwnEHioms9
+                    - 3hfwSZEcRLQJLd1q5Y2cKxJw6DH9D9rwmkxmvJPTXgbw
+                    - 13m4UNC6zmBh7nkYwxj8JM4NRgsBn9S4ntdXi1h3GjmS
+                    - e6vLaQaJ2zukHuJ4WzvZYgsuqKbNr12QECqT7Wpig3K
+                    - 43Ph7zdSXhRz2JRTfNGTkwgrNNhBdDW69q5mtfjiW2JX
+                    - 2ZQxxGVwKNS5WuTRreG79RZgxUeewPCUV27Cf2D9nysj
+                    - 2DpmP474nnqZeGxajaxn7WaFeAf3RXt3Fmbn61Gg1qcs
+                    - 2qtvn5gbtE7pmZaJBsq7VNXAhfrRfFPdQXaFWXWnhPNs
+                    - meuYRJykwQ8cz7UzsmM9aKnH1MViyyhjGnvCj8xHk5o
+                    - 2WsnV6MXTeVZbKagjwrw5vV2gXZ8abpkrZMgddscxmwt
+                    - TMRdzA9GdBpuNNzsMGKsZ5EtQZTZjdeBGDZFWN8hVyd
+                    - ghySSJYYdWoByRzLv6q6zoJZ9L3BoNUWWrf1nYRKpA5
+                    - 3nB7c8a7qucm5M9tozYbgrnRS8XkQ2G2wrBK3h643e5u
+                    - qH2bLEEVszriPCrPmRFB1QPUstqNv6vhUmeDT1SSjE7
+                    - gQzwyiYBucpZNM3hdaj9jvTnk1bXiAJTPViw6fZLSKS
+                    - 3te1zneHCY9Zyj5nTYCJ6zeancgDTxbSSzwnkQZAu1VV
+                    - 3LayKjhK8uZAW3nVxJtSYeMJ6RcfaERskgboTPZB123v
+                    - 2fomPS2xUPwXxVF8hx5YtMpBHmQKSZKushUiWYsy9Eqx
+                    - 3Pi3nRu4fWpnW5rYDAoraX1Q2xDCRQ24Dq8TEY7gaSBn
+                    - 3dbMMyehykAriNZ8FMJgPc1N6YSzm9ZfV2HcW9sbaXzP
+                    - 4EE5KQnQ6Tvo78gGhTu8serpJV4srbRhYZ3rdvCiRa5e
+                  root: 46RAhrCDLwQu1NDpNbE3EX3cPWi5UhCsvyxrWpDv4rXx
+                  leafIndex: 833491
+                  hash: 41GMzTte97MK7eZqo5rb7JNjABrm4r4XkhSCVZdZgtka
+                  merkleTree: smt3AFtReRGVcrP11D6bSLEaKdUmrGfaTNowMVccJeu
+                  rootSeq: 3117517
       result:
         name: Compressed account proofs
         description: An array of merkle proofs for the requested compressed accounts.
@@ -1770,6 +2104,37 @@ components:
               value:
                 - "3KC9cKQhhzEPjwuyQaohM6SGaZu1ukKRZw2QRgc1sYVL"
                 - "41GMzTte97MK7eZqo5rb7JNjABrm4r4XkhSCVZdZgtka"
+          result:
+            name: Compressed accounts
+            value:
+              context:
+                slot: 418485756
+              value:
+                items:
+                  - hash: 3KC9cKQhhzEPjwuyQaohM6SGaZu1ukKRZw2QRgc1sYVL
+                    address:
+                    data:
+                      discriminator: 2
+                      data: RhAVR6AmcnFercuAcoi9gbc/hIy3UBfL/FeQkTk7SE8I8WaM+ETZsH8YD96DZJdZG7IPY2fuP8pCP/oQV1de4R5hETEZAAAAAAAA
+                      dataHash: mkARkU6arYpeTacykBCEytKihySvzGJXbkG5PbwhieQ
+                    owner: cTokenmWW8bLPjZEBAUgYy3zKxQZW6VKi7bqNFEVv3m
+                    lamports: 0
+                    tree: smt6ukQDSPPYHSshQovmiRUjG9jGFq2hW9vgrDFk5Yz
+                    leafIndex: 832574
+                    seq: 877634
+                    slotCreated: 357735227
+                  - hash: 41GMzTte97MK7eZqo5rb7JNjABrm4r4XkhSCVZdZgtka
+                    address:
+                    data:
+                      discriminator: 2
+                      data: xvp6877brTo9ZfNqq8l0MbG75MLS9uDkfKYCA0UvXWEI8WaM+ETZsH8YD96DZJdZG7IPY2fuP8pCP/oQV1de4VSupSIAAAAAAAAA
+                      dataHash: QTbeX3k5dHae2N2C5bdkuznGgQnkW2c7BmCdjZevSgL
+                    owner: cTokenmWW8bLPjZEBAUgYy3zKxQZW6VKi7bqNFEVv3m
+                    lamports: 0
+                    tree: smt3AFtReRGVcrP11D6bSLEaKdUmrGfaTNowMVccJeu
+                    leafIndex: 833491
+                    seq: 879099
+                    slotCreated: 357734692
       result:
         name: Compressed accounts
         description: A list of compressed accounts.
@@ -1793,6 +2158,47 @@ components:
           params:
             - name: address
               value: "11111112cMQwSC9qirWGjZM6gLGwW69X22mqwLLGP"
+          result:
+            name: New address proofs
+            value:
+              context:
+                slot: 418485760
+              value:
+                - root: 3DubmFrufJatPqWdb2izLjjozHRHELEYhKGFaP8YV2CK
+                  address: 11111112cMQwSC9qirWGjZM6gLGwW69X22mqwLLGP
+                  lowerRangeAddress: "11111111111111111111111111111111"
+                  higherRangeAddress: 1118ZE8WhrMeAxmaCDTBMZry8D7FHxWyMVviQ7ms8K
+                  nextIndex: 230968
+                  proof:
+                    - 34cMT7MjFrs8hLp2zHMrPJHKkUxBDBwBTNck77wLjjcY
+                    - 1UzwPfgaZS2ZWkFQ7cP56NwmMQPS9yetvZgWCZYKtYt
+                    - 3B2iSozqyZrKt4TdvctxxjbJYSKf4jVErf4bJ4vMujGW
+                    - 2wJz9tuzC46GAaxhyKi6wqzGA39X13LCPvAB1a9WtYAt
+                    - 3ohYpkt2Gpz4qHB61ZZ5Rs2YQDh7sK1VuDarfq4x8HyN
+                    - 3o2ScgCzUj6XyeYko8B9ksQ4w6jA5bZ9rWBwTCkNVDKB
+                    - 28F55i4iTnqFvk4ciaJWtVuMgxPNcK9i75kj3DvmnfnB
+                    - 38MMrS2XfDUQL3ewJykxMtQ4KoZfdKKZYh5xDuNn6S6w
+                    - up31cXRHYuHDpc9BsspaamUfx8hDdCsjX4mBEjnrgcU
+                    - 3bnRB7vSFgPAzsqbX3KJtJ5oSjV8Sr8n5ewf2va3FL4Q
+                    - 3CSuWf41reb1FoNQHkyFm9qy4dS25gbYEFjtmryhNyhb
+                    - 3rhYm7xonQhEzWiCMezUw53QKv5SeajUJ8Jt6fiupRoq
+                    - f4kvuNs9vPY9avd2uic3fVuznUdZyytg14dchHQgu2F
+                    - 3e8RphHoRzP8A1rFNnSsSrRg1rB4fdfWhV5ShxCNRAHS
+                    - 4EaPXh3REUuFLXeXJp4hk2hFV2EzihYVxqb4fRQLpvy2
+                    - 46XvVyoJPo8eATFksrXgBgqX9vX9qKcMXXvQHS28W6xZ
+                    - 3TV4zwC5V7qTDnRxciFWjxkVQEgABcVYCJPM9ENxMUzo
+                    - eFRoWaaSmZpEegagSx6se5aBbTS7iyrBB4hfgXfeci3
+                    - 3HKMMSXVXH5M7tSZjkn6n1sD9XN8kkJEyu72tgSZB6i6
+                    - qwrBacu8tAVPtNiEwN1tbD7Sma3gEubXKAdruYt5m59
+                    - 3EdF4zvu7uwW7xYdnaKUPzqDY5Msq9FfWn6HgEnRTkDB
+                    - 2jzv6Z8vEXSYRXQCFnVYvzgJ2RfyDN1QEjdHm6CBvJUg
+                    - 2fomPS2xUPwXxVF8hx5YtMpBHmQKSZKushUiWYsy9Eqx
+                    - 3Pi3nRu4fWpnW5rYDAoraX1Q2xDCRQ24Dq8TEY7gaSBn
+                    - 3dbMMyehykAriNZ8FMJgPc1N6YSzm9ZfV2HcW9sbaXzP
+                    - 4EE5KQnQ6Tvo78gGhTu8serpJV4srbRhYZ3rdvCiRa5e
+                  merkleTree: amt1Ayt45jfbdw5YSo7iz6WZxUmnZsQTYXy82hVwyC2
+                  rootSeq: 1167121
+                  lowElementLeafIndex: 0
       result:
         name: New address proofs
         description: An array of non-inclusion proofs for the requested addresses.
@@ -1818,6 +2224,47 @@ components:
               value:
                 address: "11111112cMQwSC9qirWGjZM6gLGwW69X22mqwLLGP"
                 tree: "amt1Ayt45jfbdw5YSo7iz6WZxUmnZsQTYXy82hVwyC2"
+          result:
+            name: New address proofs
+            value:
+              context:
+                slot: 418485763
+              value:
+                - root: 3DubmFrufJatPqWdb2izLjjozHRHELEYhKGFaP8YV2CK
+                  address: 11111112cMQwSC9qirWGjZM6gLGwW69X22mqwLLGP
+                  lowerRangeAddress: "11111111111111111111111111111111"
+                  higherRangeAddress: 1118ZE8WhrMeAxmaCDTBMZry8D7FHxWyMVviQ7ms8K
+                  nextIndex: 230968
+                  proof:
+                    - 34cMT7MjFrs8hLp2zHMrPJHKkUxBDBwBTNck77wLjjcY
+                    - 1UzwPfgaZS2ZWkFQ7cP56NwmMQPS9yetvZgWCZYKtYt
+                    - 3B2iSozqyZrKt4TdvctxxjbJYSKf4jVErf4bJ4vMujGW
+                    - 2wJz9tuzC46GAaxhyKi6wqzGA39X13LCPvAB1a9WtYAt
+                    - 3ohYpkt2Gpz4qHB61ZZ5Rs2YQDh7sK1VuDarfq4x8HyN
+                    - 3o2ScgCzUj6XyeYko8B9ksQ4w6jA5bZ9rWBwTCkNVDKB
+                    - 28F55i4iTnqFvk4ciaJWtVuMgxPNcK9i75kj3DvmnfnB
+                    - 38MMrS2XfDUQL3ewJykxMtQ4KoZfdKKZYh5xDuNn6S6w
+                    - up31cXRHYuHDpc9BsspaamUfx8hDdCsjX4mBEjnrgcU
+                    - 3bnRB7vSFgPAzsqbX3KJtJ5oSjV8Sr8n5ewf2va3FL4Q
+                    - 3CSuWf41reb1FoNQHkyFm9qy4dS25gbYEFjtmryhNyhb
+                    - 3rhYm7xonQhEzWiCMezUw53QKv5SeajUJ8Jt6fiupRoq
+                    - f4kvuNs9vPY9avd2uic3fVuznUdZyytg14dchHQgu2F
+                    - 3e8RphHoRzP8A1rFNnSsSrRg1rB4fdfWhV5ShxCNRAHS
+                    - 4EaPXh3REUuFLXeXJp4hk2hFV2EzihYVxqb4fRQLpvy2
+                    - 46XvVyoJPo8eATFksrXgBgqX9vX9qKcMXXvQHS28W6xZ
+                    - 3TV4zwC5V7qTDnRxciFWjxkVQEgABcVYCJPM9ENxMUzo
+                    - eFRoWaaSmZpEegagSx6se5aBbTS7iyrBB4hfgXfeci3
+                    - 3HKMMSXVXH5M7tSZjkn6n1sD9XN8kkJEyu72tgSZB6i6
+                    - qwrBacu8tAVPtNiEwN1tbD7Sma3gEubXKAdruYt5m59
+                    - 3EdF4zvu7uwW7xYdnaKUPzqDY5Msq9FfWn6HgEnRTkDB
+                    - 2jzv6Z8vEXSYRXQCFnVYvzgJ2RfyDN1QEjdHm6CBvJUg
+                    - 2fomPS2xUPwXxVF8hx5YtMpBHmQKSZKushUiWYsy9Eqx
+                    - 3Pi3nRu4fWpnW5rYDAoraX1Q2xDCRQ24Dq8TEY7gaSBn
+                    - 3dbMMyehykAriNZ8FMJgPc1N6YSzm9ZfV2HcW9sbaXzP
+                    - 4EE5KQnQ6Tvo78gGhTu8serpJV4srbRhYZ3rdvCiRa5e
+                  merkleTree: amt1Ayt45jfbdw5YSo7iz6WZxUmnZsQTYXy82hVwyC2
+                  rootSeq: 1167121
+                  lowElementLeafIndex: 0
       result:
         name: New address proofs
         description: An array of non-inclusion proofs for the requested (address, tree) pairs.
@@ -1838,6 +2285,188 @@ components:
           params:
             - name: signature
               value: "2M5XHXBGZSwqYw6HN5TfReiamMXghcJEdwLJCyUPgoAo2kJrSt7EZnS43WRqx1Fiq95W5SV2n86oAKgDARrLLG3u"
+          result:
+            name: Transaction with compression info
+            value:
+              transaction:
+                slot: 357735227
+                transaction:
+                  - AUNU25v9P3vM794BYWijMVNsZx0V1j9daXYLS3QVTX8sr/BWJGe2Kftl2eycN/7nWXxFTvfYnPhMHojwtd3XWQyAAQALEKYEOITZsTZ04JUgRlndqiUEv47ibPrNlpgoezHT5qXJDQHJoqUdq5rQgjeV7HXa15zD...(truncated)
+                  - base64
+                meta:
+                  err:
+                  status:
+                    Ok:
+                  fee: 5140
+                  preBalances:
+                    - 47955282
+                    - 9746107860
+                    - 2039280
+                    - 2039280
+                    - 2039280
+                    - 1
+                    - 1
+                    - 1141440
+                    - 1141440
+                    - 4534961825
+                    - 1141440
+                    - 1141440
+                    - 1141441
+                    - 1392000
+                    - 479783646
+                    - 0
+                  postBalances:
+                    - 47949842
+                    - 9746108160
+                    - 2039280
+                    - 2039280
+                    - 2039280
+                    - 1
+                    - 1
+                    - 1141440
+                    - 1141440
+                    - 4534961825
+                    - 1141440
+                    - 1141440
+                    - 1141441
+                    - 1392000
+                    - 479783646
+                    - 0
+                  innerInstructions:
+                    - index: 2
+                      instructions:
+                        - programIdIndex: 9
+                          accounts:
+                            - 3
+                            - 2
+                            - 0
+                          data: 3JYH8H8DArPR
+                          stackHeight: 2
+                        - programIdIndex: 8
+                          accounts:
+                            - 0
+                            - 14
+                            - 13
+                            - 12
+                            - 15
+                            - 11
+                            - 10
+                            - 8
+                            - 8
+                            - 5
+                            - 8
+                            - 1
+                          data: 6uxfRrqz7k19jZzDZgmuRKQLqNipRu4PLoNaJqnsnQFWPr9SQLnEgq3krLcs4YPa9WXziMwNSoSc1E3Q6q6oQsh5TLwCcDuv8zND4n8rwpstxfd61wP1Vo2v33mBGETFxp3iruMoUHndNR8me6F1p73AQStU47MCppji9SMd7Lj4wzJehsE2MczF8xC6FbYAY7NoQzVNuVwLERwMuaXZqh23bZ7MpPQxmfHqE1m7ZEozj1fMoZQfSEjxEmgid3t4HNd9y
+                          stackHeight: 2
+                        - programIdIndex: 11
+                          accounts:
+                            - 0
+                            - 15
+                            - 13
+                            - 5
+                            - 1
+                          data: 5wPdbtbk7M4b3JSHrvzzbr316bwYx8ZFiBFo977zJUzhf4zwCVPsyxPP1T5dBc
+                          stackHeight: 3
+                        - programIdIndex: 5
+                          accounts:
+                            - 0
+                            - 1
+                          data: 3Bxs48DZ3Zx6m4mD
+                          stackHeight: 4
+                        - programIdIndex: 12
+                          accounts: []
+                          data: 11112kX1UPPxVh1DqEGPf6pdnNUf7avKrEfBeq5PRHE8jM1tzTDg7Yie66SAGjHsnzsZfU4fepRwkwwuJrM1QnC6K4E6zTLSKUXPZf1ciXBExb8SZptUhCzTRPnswKfBCxBGahQhij3nS3PqQfYGphycJKjdg7pBvKySqJ3MNc4as8EhNQV2WxTDSNCkdtBMULESEGzh1BbTrW1h9kupfotKVGeRKHMbV6oKqXQTkzhoMwrfUYa5kVpNinNMJ7AT7NHKP7Kjanm5K859KCJQaiu9fsDq2uqL1xLQ3N4HJ8Yc3SQ3J2G83nUhDnneLKZwR7ri6BTmnSrao8EB8syW7JcfqcQdo7Cbk4xXofCi7AYxVErfJZPXoX4YhWcUn7AwwHmotaucbXfZdemo1Ryzw
+                          stackHeight: 3
+                  logMessages:
+                    - Program ComputeBudget111111111111111111111111111111 invoke [1]
+                    - Program ComputeBudget111111111111111111111111111111 success
+                    - Program ComputeBudget111111111111111111111111111111 invoke [1]
+                  preTokenBalances:
+                    - accountIndex: 2
+                      mint: 5iVmFCCwJTuuw7p4FrxYoZ1bUNdjg14j7uv5hMsMpump
+                      uiTokenAmount:
+                        uiAmount:
+                        decimals: 6
+                        amount: "0"
+                        uiAmountString: "0"
+                      owner: GXtd2izAiMJPwMEjfgTRH3d7k9mjn4Jq3JrWFv9gySYy
+                      programId: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
+                    - accountIndex: 3
+                      mint: 5iVmFCCwJTuuw7p4FrxYoZ1bUNdjg14j7uv5hMsMpump
+                      uiTokenAmount:
+                        uiAmount: 109290.308038
+                        decimals: 6
+                        amount: "109290308038"
+                        uiAmountString: "109290.308038"
+                      owner: CB4QpcVCYGwiHgbwkY3XQ1pg4KM5cPH7XqymJuz1h7xU
+                      programId: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
+                    - accountIndex: 4
+                      mint: 5iVmFCCwJTuuw7p4FrxYoZ1bUNdjg14j7uv5hMsMpump
+                      uiTokenAmount:
+                        uiAmount: 187.239702
+                        decimals: 6
+                        amount: "187239702"
+                        uiAmountString: "187.239702"
+                      owner: 5STUuhrL8kJ4up9spEY39VJ6ibQCFrg8x8cRV5UeEcfv
+                      programId: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
+                  postTokenBalances:
+                    - accountIndex: 2
+                      mint: 5iVmFCCwJTuuw7p4FrxYoZ1bUNdjg14j7uv5hMsMpump
+                      uiTokenAmount:
+                        uiAmount: 108197.404958
+                        decimals: 6
+                        amount: "108197404958"
+                        uiAmountString: "108197.404958"
+                      owner: GXtd2izAiMJPwMEjfgTRH3d7k9mjn4Jq3JrWFv9gySYy
+                      programId: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
+                    - accountIndex: 3
+                      mint: 5iVmFCCwJTuuw7p4FrxYoZ1bUNdjg14j7uv5hMsMpump
+                      uiTokenAmount:
+                        uiAmount:
+                        decimals: 6
+                        amount: "0"
+                        uiAmountString: "0"
+                      owner: CB4QpcVCYGwiHgbwkY3XQ1pg4KM5cPH7XqymJuz1h7xU
+                      programId: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
+                    - accountIndex: 4
+                      mint: 5iVmFCCwJTuuw7p4FrxYoZ1bUNdjg14j7uv5hMsMpump
+                      uiTokenAmount:
+                        uiAmount: 1280.142782
+                        decimals: 6
+                        amount: "1280142782"
+                        uiAmountString: "1280.142782"
+                      owner: 5STUuhrL8kJ4up9spEY39VJ6ibQCFrg8x8cRV5UeEcfv
+                      programId: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
+                  rewards: []
+                  loadedAddresses:
+                    writable: []
+                    readonly: []
+                  computeUnitsConsumed: 121277
+                version: 0
+                blockTime: 1754278913
+              compressionInfo:
+                closedAccounts: []
+                openedAccounts:
+                  - account:
+                      hash: 3KC9cKQhhzEPjwuyQaohM6SGaZu1ukKRZw2QRgc1sYVL
+                      address:
+                      data:
+                        discriminator: 2
+                        data: RhAVR6AmcnFercuAcoi9gbc/hIy3UBfL/FeQkTk7SE8I8WaM+ETZsH8YD96DZJdZG7IPY2fuP8pCP/oQV1de4R5hETEZAAAAAAAA
+                        dataHash: mkARkU6arYpeTacykBCEytKihySvzGJXbkG5PbwhieQ
+                      owner: cTokenmWW8bLPjZEBAUgYy3zKxQZW6VKi7bqNFEVv3m
+                      lamports: 0
+                      tree: smt6ukQDSPPYHSshQovmiRUjG9jGFq2hW9vgrDFk5Yz
+                      leafIndex: 832574
+                      seq: 877634
+                      slotCreated: 357735227
+                    optionalTokenData:
+                      mint: 5iVmFCCwJTuuw7p4FrxYoZ1bUNdjg14j7uv5hMsMpump
+                      owner: bukwBg6C8VAHsuak1dPm5Teiu3eWe78xakgTL8QjVbW
+                      amount: 108197404958
+                      delegate:
+                      state: initialized
+                      tlv:
       result:
         name: Transaction with compression info
         description: The transaction details with associated compression state changes.
@@ -1871,6 +2500,154 @@ components:
                 - "3KC9cKQhhzEPjwuyQaohM6SGaZu1ukKRZw2QRgc1sYVL"
             - name: newAddressesWithTrees
               value: []
+          result:
+            name: Validity proof
+            value:
+              value:
+                compressedProof:
+                  a:
+                    - 137
+                    - 120
+                    - 225
+                    - 50
+                    - 35
+                    - 37
+                    - 217
+                    - 168
+                    - 180
+                    - 77
+                    - 132
+                    - 146
+                    - 64
+                    - 67
+                    - 127
+                    - 65
+                    - 64
+                    - 218
+                    - 225
+                    - 174
+                    - 237
+                    - 207
+                    - 126
+                    - 51
+                    - 11
+                    - 73
+                    - 253
+                    - 33
+                    - 75
+                    - 142
+                    - 156
+                    - 91
+                  b:
+                    - 157
+                    - 135
+                    - 252
+                    - 227
+                    - 186
+                    - 245
+                    - 104
+                    - 103
+                    - 251
+                    - 118
+                    - 181
+                    - 193
+                    - 77
+                    - 63
+                    - 151
+                    - 245
+                    - 77
+                    - 132
+                    - 117
+                    - 200
+                    - 198
+                    - 157
+                    - 191
+                    - 71
+                    - 40
+                    - 193
+                    - 133
+                    - 100
+                    - 63
+                    - 179
+                    - 163
+                    - 69
+                    - 7
+                    - 107
+                    - 113
+                    - 131
+                    - 16
+                    - 8
+                    - 82
+                    - 88
+                    - 228
+                    - 70
+                    - 34
+                    - 31
+                    - 144
+                    - 89
+                    - 96
+                    - 250
+                    - 23
+                    - 97
+                    - 223
+                    - 53
+                    - 224
+                    - 38
+                    - 47
+                    - 191
+                    - 216
+                    - 122
+                    - 95
+                    - 182
+                    - 35
+                    - 188
+                    - 200
+                    - 149
+                  c:
+                    - 152
+                    - 247
+                    - 87
+                    - 117
+                    - 121
+                    - 61
+                    - 80
+                    - 83
+                    - 136
+                    - 201
+                    - 120
+                    - 76
+                    - 47
+                    - 196
+                    - 167
+                    - 233
+                    - 17
+                    - 39
+                    - 234
+                    - 101
+                    - 122
+                    - 111
+                    - 120
+                    - 79
+                    - 250
+                    - 35
+                    - 55
+                    - 5
+                    - 203
+                    - 51
+                    - 89
+                    - 209
+                roots:
+                  - 3m3ZNkLWeTSGdVCejt4QK4dMcAVyckJvoBhBA8VDeHUd
+                rootIndices:
+                  - 1652
+                leafIndices:
+                  - 832574
+                leaves:
+                  - 3KC9cKQhhzEPjwuyQaohM6SGaZu1ukKRZw2QRgc1sYVL
+                merkleTrees:
+                  - smt6ukQDSPPYHSshQovmiRUjG9jGFq2hW9vgrDFk5Yz
+              context:
+                slot: 418485767
       result:
         name: Validity proof
         description: A ZK validity proof with context for inclusion and non-inclusion claims.
@@ -1904,6 +2681,158 @@ components:
                 - "3KC9cKQhhzEPjwuyQaohM6SGaZu1ukKRZw2QRgc1sYVL"
             - name: newAddressesWithTrees
               value: []
+          result:
+            name: Validity proof
+            value:
+              value:
+                compressedProof:
+                  a:
+                    - 133
+                    - 149
+                    - 159
+                    - 232
+                    - 145
+                    - 170
+                    - 148
+                    - 133
+                    - 93
+                    - 45
+                    - 75
+                    - 166
+                    - 162
+                    - 82
+                    - 214
+                    - 173
+                    - 242
+                    - 17
+                    - 241
+                    - 235
+                    - 152
+                    - 251
+                    - 55
+                    - 220
+                    - 222
+                    - 252
+                    - 115
+                    - 171
+                    - 39
+                    - 115
+                    - 42
+                    - 163
+                  b:
+                    - 26
+                    - 198
+                    - 234
+                    - 90
+                    - 55
+                    - 117
+                    - 246
+                    - 146
+                    - 226
+                    - 87
+                    - 34
+                    - 142
+                    - 221
+                    - 6
+                    - 158
+                    - 121
+                    - 20
+                    - 6
+                    - 234
+                    - 81
+                    - 70
+                    - 30
+                    - 124
+                    - 244
+                    - 84
+                    - 192
+                    - 193
+                    - 73
+                    - 0
+                    - 241
+                    - 250
+                    - 187
+                    - 30
+                    - 184
+                    - 140
+                    - 107
+                    - 93
+                    - 137
+                    - 248
+                    - 224
+                    - 206
+                    - 114
+                    - 215
+                    - 188
+                    - 22
+                    - 50
+                    - 48
+                    - 155
+                    - 254
+                    - 96
+                    - 23
+                    - 196
+                    - 102
+                    - 22
+                    - 78
+                    - 70
+                    - 212
+                    - 194
+                    - 47
+                    - 207
+                    - 26
+                    - 75
+                    - 162
+                    - 133
+                  c:
+                    - 23
+                    - 31
+                    - 187
+                    - 40
+                    - 79
+                    - 251
+                    - 205
+                    - 75
+                    - 163
+                    - 130
+                    - 101
+                    - 233
+                    - 248
+                    - 179
+                    - 30
+                    - 22
+                    - 126
+                    - 239
+                    - 223
+                    - 134
+                    - 213
+                    - 242
+                    - 122
+                    - 45
+                    - 108
+                    - 222
+                    - 214
+                    - 38
+                    - 59
+                    - 137
+                    - 133
+                    - 21
+                accounts:
+                  - hash: 3KC9cKQhhzEPjwuyQaohM6SGaZu1ukKRZw2QRgc1sYVL
+                    root: 3m3ZNkLWeTSGdVCejt4QK4dMcAVyckJvoBhBA8VDeHUd
+                    rootIndex:
+                      rootIndex: 1652
+                      proveByIndex: false
+                    leafIndex: 832574
+                    merkleContext:
+                      treeType: 1
+                      tree: smt6ukQDSPPYHSshQovmiRUjG9jGFq2hW9vgrDFk5Yz
+                      queue: nfq6uzaNZ5n3EWF4t64M93AWzLGt5dXTikEA9fFRktv
+                      cpiContext:
+                      nextTreeContext:
+                addresses: []
+              context:
+                slot: 418485770
       result:
         name: Validity proof
         description: A ZK validity proof with V2 merkle context for inclusion and non-inclusion claims.

--- a/src/openrpc/chains/_components/solana/methods.yaml
+++ b/src/openrpc/chains/_components/solana/methods.yaml
@@ -1178,7 +1178,10 @@ components:
 
     getCompressedAccountsByOwner:
       name: getCompressedAccountsByOwner
-      description: Returns the compressed accounts owned by the given Pubkey.
+      description: |
+        Returns the compressed accounts owned by the given Pubkey.
+
+        Advanced filters (`dataSlice`, `filters`) are supported by the underlying Photon API but are not modeled in this Try It widget. To use them, send the request directly with `dataSlice: { offset, length }` and/or `filters: [{ memcmp: { offset, bytes } }]` added to the `params` object.
       paramStructure: by-name
       params:
         - name: owner
@@ -1193,20 +1196,6 @@ components:
             oneOf:
               - $ref: ./compression.yaml#/components/schemas/Hash
               - type: "null"
-        - name: dataSlice
-          required: false
-          description: Optional account data slice to return.
-          schema:
-            oneOf:
-              - $ref: ./compression.yaml#/components/schemas/DataSlice
-              - type: "null"
-        - name: filters
-          required: false
-          description: Optional filters to apply to the account data.
-          schema:
-            type: array
-            items:
-              $ref: ./compression.yaml#/components/schemas/FilterSelector
         - name: limit
           required: false
           description: Maximum number of accounts to return.
@@ -1218,7 +1207,7 @@ components:
         - name: getCompressedAccountsByOwner example
           params:
             - name: owner
-              value: "11111112cMQwSC9qirWGjZM6gLGwW69X22mqwLLGP"
+              value: "bukwBg6C8VAHsuak1dPm5Teiu3eWe78xakgTL8QjVbW"
       result:
         name: Compressed accounts
         description: A paginated list of compressed accounts owned by the given Pubkey.
@@ -1248,7 +1237,7 @@ components:
         - name: getCompressedBalance example
           params:
             - name: hash
-              value: "3KC9cKQhhzEPjwuyQaohM6SGaZu1ukKRZw2QRgc1sYVL"
+              value: "2U9KV9sCU5MtJaDTKVkuuEbagVEBL9BQSfUBsaiEP6Cf"
       result:
         name: Compressed balance
         description: The lamport balance of the compressed account.
@@ -1268,7 +1257,7 @@ components:
         - name: getCompressedBalanceByOwner example
           params:
             - name: owner
-              value: "11111112cMQwSC9qirWGjZM6gLGwW69X22mqwLLGP"
+              value: "bukwBg6C8VAHsuak1dPm5Teiu3eWe78xakgTL8QjVbW"
       result:
         name: Compressed balance
         description: The total compressed lamport balance for the owner.
@@ -1303,7 +1292,7 @@ components:
         - name: getCompressedMintTokenHolders example
           params:
             - name: mint
-              value: "11111112cMQwSC9qirWGjZM6gLGwW69X22mqwLLGP"
+              value: "5iVmFCCwJTuuw7p4FrxYoZ1bUNdjg14j7uv5hMsMpump"
       result:
         name: Token holders
         description: A paginated list of owner balances for the given mint.
@@ -1342,7 +1331,10 @@ components:
 
     getCompressedTokenAccountsByDelegate:
       name: getCompressedTokenAccountsByDelegate
-      description: Returns the compressed token accounts delegated to the given Pubkey.
+      description: |
+        Returns the compressed token accounts delegated to the given Pubkey.
+
+        Compressed token delegation is rare on mainnet, so most Pubkeys (including the example value) currently return an empty `items` array. To see a non-empty response, supply a Pubkey that has been set as the SPL-Token-2022 delegate on a compressed token account.
       paramStructure: by-name
       params:
         - name: delegate
@@ -1375,7 +1367,7 @@ components:
         - name: getCompressedTokenAccountsByDelegate example
           params:
             - name: delegate
-              value: "11111112cMQwSC9qirWGjZM6gLGwW69X22mqwLLGP"
+              value: "bukwBg6C8VAHsuak1dPm5Teiu3eWe78xakgTL8QjVbW"
       result:
         name: Compressed token accounts
         description: A paginated list of compressed token accounts delegated to the given Pubkey.
@@ -1417,7 +1409,7 @@ components:
         - name: getCompressedTokenAccountsByOwner example
           params:
             - name: owner
-              value: "11111112cMQwSC9qirWGjZM6gLGwW69X22mqwLLGP"
+              value: "bukwBg6C8VAHsuak1dPm5Teiu3eWe78xakgTL8QjVbW"
       result:
         name: Compressed token accounts
         description: A paginated list of compressed token accounts owned by the given Pubkey.
@@ -1459,7 +1451,7 @@ components:
         - name: getCompressedTokenBalancesByOwner example
           params:
             - name: owner
-              value: "11111112cMQwSC9qirWGjZM6gLGwW69X22mqwLLGP"
+              value: "bukwBg6C8VAHsuak1dPm5Teiu3eWe78xakgTL8QjVbW"
       result:
         name: Compressed token balances
         description: A paginated list of compressed token balances for the owner.
@@ -1501,7 +1493,7 @@ components:
         - name: getCompressedTokenBalancesByOwnerV2 example
           params:
             - name: owner
-              value: "11111112cMQwSC9qirWGjZM6gLGwW69X22mqwLLGP"
+              value: "bukwBg6C8VAHsuak1dPm5Teiu3eWe78xakgTL8QjVbW"
       result:
         name: Compressed token balances
         description: A paginated list of compressed token balances for the owner.
@@ -1530,7 +1522,10 @@ components:
 
     getCompressionSignaturesForAddress:
       name: getCompressionSignaturesForAddress
-      description: Returns the transaction signatures that closed or opened a compressed account at the given address.
+      description: |
+        Returns the transaction signatures that closed or opened a compressed account at the given address.
+
+        This is for Light-Protocol style compressed accounts that have an `address` set (rather than the more common hash-only compressed token accounts). Most Pubkeys currently return an empty `items` array because the addressed-compressed-account namespace is not yet widely populated.
       paramStructure: by-name
       params:
         - name: address
@@ -1591,7 +1586,7 @@ components:
         - name: getCompressionSignaturesForOwner example
           params:
             - name: owner
-              value: "11111112cMQwSC9qirWGjZM6gLGwW69X22mqwLLGP"
+              value: "bukwBg6C8VAHsuak1dPm5Teiu3eWe78xakgTL8QjVbW"
       result:
         name: Signatures
         description: A paginated list of transaction signatures.
@@ -1626,7 +1621,7 @@ components:
         - name: getCompressionSignaturesForTokenOwner example
           params:
             - name: owner
-              value: "11111112cMQwSC9qirWGjZM6gLGwW69X22mqwLLGP"
+              value: "bukwBg6C8VAHsuak1dPm5Teiu3eWe78xakgTL8QjVbW"
       result:
         name: Signatures
         description: A paginated list of transaction signatures.
@@ -1717,22 +1712,28 @@ components:
 
     getMultipleCompressedAccountProofs:
       name: getMultipleCompressedAccountProofs
-      description: Returns merkle proofs for the compressed accounts with the given hashes.
+      description: |
+        Returns merkle proofs for the compressed accounts with the given hashes.
+
+        The Photon API expects the JSON-RPC `params` array to be the list of hashes itself (each positional element is one hash). The spec models the first two positional slots; pass additional hashes as additional positional elements when needed.
       params:
-        - name: hashes
+        - name: hash
           required: true
-          description: An array of compressed account hashes to query.
+          description: First compressed account hash to query.
           schema:
-            type: array
-            items:
-              $ref: ./compression.yaml#/components/schemas/Hash
+            $ref: ./compression.yaml#/components/schemas/Hash
+        - name: hash2
+          required: false
+          description: Optional additional compressed account hash to query.
+          schema:
+            $ref: ./compression.yaml#/components/schemas/Hash
       examples:
         - name: getMultipleCompressedAccountProofs example
           params:
-            - name: hashes
-              value:
-                - "3KC9cKQhhzEPjwuyQaohM6SGaZu1ukKRZw2QRgc1sYVL"
-                - "41GMzTte97MK7eZqo5rb7JNjABrm4r4XkhSCVZdZgtka"
+            - name: hash
+              value: "3KC9cKQhhzEPjwuyQaohM6SGaZu1ukKRZw2QRgc1sYVL"
+            - name: hash2
+              value: "41GMzTte97MK7eZqo5rb7JNjABrm4r4XkhSCVZdZgtka"
       result:
         name: Compressed account proofs
         description: An array of merkle proofs for the requested compressed accounts.
@@ -1777,21 +1778,21 @@ components:
 
     getMultipleNewAddressProofs:
       name: getMultipleNewAddressProofs
-      description: Returns non-inclusion proofs for the given addresses, used when creating compressed accounts.
+      description: |
+        Returns non-inclusion proofs for the given addresses, used when creating compressed accounts.
+
+        The Photon API expects the JSON-RPC `params` array to be the list of addresses itself (each positional element is one Pubkey). The spec models the first positional slot; pass additional addresses as additional positional elements when needed.
       params:
-        - name: addresses
+        - name: address
           required: true
-          description: An array of addresses to prove non-inclusion for.
+          description: First address to prove non-inclusion for.
           schema:
-            type: array
-            items:
-              $ref: ./base-types.yaml#/components/schemas/Pubkey
+            $ref: ./base-types.yaml#/components/schemas/Pubkey
       examples:
         - name: getMultipleNewAddressProofs example
           params:
-            - name: addresses
-              value:
-                - "11111112cMQwSC9qirWGjZM6gLGwW69X22mqwLLGP"
+            - name: address
+              value: "11111112cMQwSC9qirWGjZM6gLGwW69X22mqwLLGP"
       result:
         name: New address proofs
         description: An array of non-inclusion proofs for the requested addresses.
@@ -1800,22 +1801,23 @@ components:
 
     getMultipleNewAddressProofsV2:
       name: getMultipleNewAddressProofsV2
-      description: Returns non-inclusion proofs for the given (address, tree) pairs, used when creating compressed accounts.
+      description: |
+        Returns non-inclusion proofs for the given (address, tree) pairs, used when creating compressed accounts.
+
+        The Photon API expects the JSON-RPC `params` array to be the list of pairs itself (each positional element is one `{ address, tree }` object). The spec models the first positional slot; pass additional pairs as additional positional elements when needed.
       params:
-        - name: addressesWithTrees
+        - name: addressWithTree
           required: true
-          description: An array of address and tree Pubkey pairs to prove non-inclusion for.
+          description: First address paired with the merkle tree Pubkey it should be inserted into.
           schema:
-            type: array
-            items:
-              $ref: ./compression.yaml#/components/schemas/AddressWithTree
+            $ref: ./compression.yaml#/components/schemas/AddressWithTree
       examples:
         - name: getMultipleNewAddressProofsV2 example
           params:
-            - name: addressesWithTrees
+            - name: addressWithTree
               value:
-                - address: "11111112cMQwSC9qirWGjZM6gLGwW69X22mqwLLGP"
-                  tree: "11111112cMQwSC9qirWGjZM6gLGwW69X22mqwLLGP"
+                address: "11111112cMQwSC9qirWGjZM6gLGwW69X22mqwLLGP"
+                tree: "amt1Ayt45jfbdw5YSo7iz6WZxUmnZsQTYXy82hVwyC2"
       result:
         name: New address proofs
         description: An array of non-inclusion proofs for the requested (address, tree) pairs.
@@ -1835,7 +1837,7 @@ components:
         - name: getTransactionWithCompressionInfo example
           params:
             - name: signature
-              value: "5J8H5sTvEhnGcB4R8K1n7mfoiWUD9RzPVGES7e3WxC7c"
+              value: "2M5XHXBGZSwqYw6HN5TfReiamMXghcJEdwLJCyUPgoAo2kJrSt7EZnS43WRqx1Fiq95W5SV2n86oAKgDARrLLG3u"
       result:
         name: Transaction with compression info
         description: The transaction details with associated compression state changes.

--- a/src/openrpc/chains/_components/solana/methods.yaml
+++ b/src/openrpc/chains/_components/solana/methods.yaml
@@ -1170,6 +1170,26 @@ components:
                 leafIndex: 832574
                 seq: 877634
                 slotCreated: 357735227
+      x-fern-examples:
+        - name: getCompressedAccount example
+          params:
+            hash: "3KC9cKQhhzEPjwuyQaohM6SGaZu1ukKRZw2QRgc1sYVL"
+          result:
+            context:
+              slot: 419133524
+            value:
+              hash: 3KC9cKQhhzEPjwuyQaohM6SGaZu1ukKRZw2QRgc1sYVL
+              address: null
+              data:
+                discriminator: 2
+                data: RhAVR6AmcnFercuAcoi9gbc/hIy3UBfL/FeQkTk7SE8I8WaM+ETZsH8YD96DZJdZG7IPY2fuP8pCP/oQV1de4R5hETEZAAAAAAAA
+                dataHash: mkARkU6arYpeTacykBCEytKihySvzGJXbkG5PbwhieQ
+              owner: cTokenmWW8bLPjZEBAUgYy3zKxQZW6VKi7bqNFEVv3m
+              lamports: 0
+              tree: smt6ukQDSPPYHSshQovmiRUjG9jGFq2hW9vgrDFk5Yz
+              leafIndex: 832574
+              seq: 877634
+              slotCreated: 357735227
       result:
         name: Compressed account
         description: The compressed account data with context information. `value` is `null` when no compressed account matches the supplied `address` or `hash`.

--- a/src/openrpc/chains/_components/solana/methods.yaml
+++ b/src/openrpc/chains/_components/solana/methods.yaml
@@ -1518,11 +1518,13 @@ components:
           params:
             - name: owner
               value: "bukwBg6C8VAHsuak1dPm5Teiu3eWe78xakgTL8QjVbW"
+            - name: limit
+              value: 1
           result:
             name: Compressed token accounts
             value:
               context:
-                slot: 418485619
+                slot: 419096770
               value:
                 items:
                   - account:
@@ -1545,27 +1547,7 @@ components:
                       delegate:
                       state: initialized
                       tlv:
-                  - account:
-                      hash: 41GMzTte97MK7eZqo5rb7JNjABrm4r4XkhSCVZdZgtka
-                      address:
-                      data:
-                        discriminator: 2
-                        data: xvp6877brTo9ZfNqq8l0MbG75MLS9uDkfKYCA0UvXWEI8WaM+ETZsH8YD96DZJdZG7IPY2fuP8pCP/oQV1de4VSupSIAAAAAAAAA
-                        dataHash: QTbeX3k5dHae2N2C5bdkuznGgQnkW2c7BmCdjZevSgL
-                      owner: cTokenmWW8bLPjZEBAUgYy3zKxQZW6VKi7bqNFEVv3m
-                      lamports: 0
-                      tree: smt3AFtReRGVcrP11D6bSLEaKdUmrGfaTNowMVccJeu
-                      leafIndex: 833491
-                      seq: 879099
-                      slotCreated: 357734692
-                    tokenData:
-                      mint: EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
-                      owner: bukwBg6C8VAHsuak1dPm5Teiu3eWe78xakgTL8QjVbW
-                      amount: 581283412
-                      delegate:
-                      state: initialized
-                      tlv:
-                cursor: 4yjijviL58sF59PKQDgt3CUyFfUYArdpgfuVsuM7qoADzJn7oNmJkaY6MBFFBwDemdCJ2bZUCuAnHw7azAswvSoC
+                cursor: 2QFE3NN4UdCFuek6gubUmahYKq9BA9QSvhp1vARpSCmWd96FJkrZhnNMbVC8U2oUPEkXqSiiszrhweAhbpnRpVCJ
       result:
         name: Compressed token accounts
         description: A paginated list of compressed token accounts owned by the given Pubkey.

--- a/src/openrpc/chains/_components/solana/methods.yaml
+++ b/src/openrpc/chains/_components/solana/methods.yaml
@@ -1128,23 +1128,17 @@ components:
     # ZK Compression methods (Photon indexer)
     getCompressedAccount:
       name: getCompressedAccount
-      description: Returns the compressed account with the given address or hash. Provide either `address` or `hash`.
+      description: |
+        Returns the compressed account with the given hash.
+
+        The underlying Photon API also accepts an `address` Pubkey as an alternative to `hash` (compressed accounts created with a Light Protocol address). To query by address instead, send the request directly with `params: { "address": "<pubkey>" }`. The Try It widget here exposes only `hash` because addressed compressed accounts are rare on mainnet and rendering both fields produced an unusable default form.
       paramStructure: by-name
       params:
-        - name: address
-          required: false
-          description: Pubkey of the compressed account to query.
-          schema:
-            oneOf:
-              - $ref: ./base-types.yaml#/components/schemas/Pubkey
-              - type: "null"
         - name: hash
-          required: false
+          required: true
           description: Hash of the compressed account to query.
           schema:
-            oneOf:
-              - $ref: ./compression.yaml#/components/schemas/Hash
-              - type: "null"
+            $ref: ./compression.yaml#/components/schemas/Hash
       examples:
         - name: getCompressedAccount example
           params:
@@ -1264,11 +1258,13 @@ components:
           params:
             - name: owner
               value: "bukwBg6C8VAHsuak1dPm5Teiu3eWe78xakgTL8QjVbW"
+            - name: limit
+              value: 1
           result:
             name: Compressed accounts
             value:
               context:
-                slot: 418485602
+                slot: 418890736
               value:
                 items:
                   - hash: 2U9KV9sCU5MtJaDTKVkuuEbagVEBL9BQSfUBsaiEP6Cf
@@ -1280,7 +1276,7 @@ components:
                     leafIndex: 838169
                     seq: 884595
                     slotCreated: 357735567
-                cursor:
+                cursor: 2U9KV9sCU5MtJaDTKVkuuEbagVEBL9BQSfUBsaiEP6Cf
       result:
         name: Compressed accounts
         description: A paginated list of compressed accounts owned by the given Pubkey.

--- a/src/openrpc/chains/_components/solana/methods.yaml
+++ b/src/openrpc/chains/_components/solana/methods.yaml
@@ -1129,42 +1129,40 @@ components:
     getCompressedAccount:
       name: getCompressedAccount
       description: |
-        Returns the compressed account with the given hash.
+        Returns the compressed account matching the given `address` or `hash`. Provide exactly one of the two — blank fields are omitted from the JSON-RPC payload.
 
-        The underlying Photon API also accepts an `address` Pubkey as an alternative to `hash` (compressed accounts created with a Light Protocol address). To query by address instead, send the request directly with `params: { "address": "<pubkey>" }`. The Try It widget here exposes only `hash` because addressed compressed accounts are rare on mainnet and rendering both fields produced an unusable default form.
+        - `address` queries compressed accounts created with a Light Protocol address.
+        - `hash` queries by the merkle-tree leaf hash and works for every compressed account.
       paramStructure: by-name
       params:
-        - name: hash
-          required: true
-          description: Hash of the compressed account to query.
+        - name: address
+          required: false
+          description: Pubkey of the compressed account to query. Leave blank to query by `hash` instead.
           schema:
-            $ref: ./compression.yaml#/components/schemas/Hash
+            oneOf:
+              - $ref: ./base-types.yaml#/components/schemas/Pubkey
+              - type: "null"
+        - name: hash
+          required: false
+          description: Hash of the compressed account to query. Leave blank to query by `address` instead.
+          schema:
+            oneOf:
+              - $ref: ./compression.yaml#/components/schemas/Hash
+              - type: "null"
       examples:
         - name: getCompressedAccount example
           params:
-            - name: hash
+            - name: address
               value: "3KC9cKQhhzEPjwuyQaohM6SGaZu1ukKRZw2QRgc1sYVL"
           result:
             name: Compressed account
             value:
               context:
-                slot: 418485594
+                slot: 419132638
               value:
-                hash: 3KC9cKQhhzEPjwuyQaohM6SGaZu1ukKRZw2QRgc1sYVL
-                address:
-                data:
-                  discriminator: 2
-                  data: RhAVR6AmcnFercuAcoi9gbc/hIy3UBfL/FeQkTk7SE8I8WaM+ETZsH8YD96DZJdZG7IPY2fuP8pCP/oQV1de4R5hETEZAAAAAAAA
-                  dataHash: mkARkU6arYpeTacykBCEytKihySvzGJXbkG5PbwhieQ
-                owner: cTokenmWW8bLPjZEBAUgYy3zKxQZW6VKi7bqNFEVv3m
-                lamports: 0
-                tree: smt6ukQDSPPYHSshQovmiRUjG9jGFq2hW9vgrDFk5Yz
-                leafIndex: 832574
-                seq: 877634
-                slotCreated: 357735227
       result:
         name: Compressed account
-        description: The compressed account data with context information.
+        description: The compressed account data with context information. `value` is `null` when no compressed account matches the supplied `address` or `hash`.
         schema:
           $ref: ./compression.yaml#/components/schemas/AccountResult
 

--- a/src/openrpc/chains/_components/solana/methods.yaml
+++ b/src/openrpc/chains/_components/solana/methods.yaml
@@ -1128,20 +1128,28 @@ components:
     # ZK Compression methods (Photon indexer)
     getCompressedAccount:
       name: getCompressedAccount
-      description: Returns the compressed account with the given address or hash.
+      description: Returns the compressed account with the given address or hash. Provide either `address` or `hash`.
+      paramStructure: by-name
       params:
-        - name: Account identifier
-          required: true
-          description: The compressed account to query, identified by either its address or its hash.
+        - name: address
+          required: false
+          description: Pubkey of the compressed account to query.
           schema:
-            $ref: ./compression.yaml#/components/schemas/GetCompressedAccountParams
+            oneOf:
+              - $ref: ./base-types.yaml#/components/schemas/Pubkey
+              - type: "null"
+        - name: hash
+          required: false
+          description: Hash of the compressed account to query.
+          schema:
+            oneOf:
+              - $ref: ./compression.yaml#/components/schemas/Hash
+              - type: "null"
       examples:
         - name: getCompressedAccount example
           params:
-            - name: Account identifier
-              value:
-                address: null
-                hash: "11111111111111111111111111111111"
+            - name: hash
+              value: "11111111111111111111111111111111"
       result:
         name: Compressed account
         description: The compressed account data with context information.
@@ -1171,18 +1179,46 @@ components:
     getCompressedAccountsByOwner:
       name: getCompressedAccountsByOwner
       description: Returns the compressed accounts owned by the given Pubkey.
+      paramStructure: by-name
       params:
-        - name: Configuration
+        - name: owner
           required: true
-          description: Owner Pubkey and optional pagination, filter, and data slice settings.
+          description: Pubkey of the owner whose compressed accounts to query.
           schema:
-            $ref: ./compression.yaml#/components/schemas/GetCompressedAccountsByOwnerParams
+            $ref: ./base-types.yaml#/components/schemas/Pubkey
+        - name: cursor
+          required: false
+          description: Pagination cursor returned by a previous response.
+          schema:
+            oneOf:
+              - $ref: ./compression.yaml#/components/schemas/Hash
+              - type: "null"
+        - name: dataSlice
+          required: false
+          description: Optional account data slice to return.
+          schema:
+            oneOf:
+              - $ref: ./compression.yaml#/components/schemas/DataSlice
+              - type: "null"
+        - name: filters
+          required: false
+          description: Optional filters to apply to the account data.
+          schema:
+            type: array
+            items:
+              $ref: ./compression.yaml#/components/schemas/FilterSelector
+        - name: limit
+          required: false
+          description: Maximum number of accounts to return.
+          schema:
+            oneOf:
+              - $ref: ./compression.yaml#/components/schemas/Limit
+              - type: "null"
       examples:
         - name: getCompressedAccountsByOwner example
           params:
-            - name: Configuration
-              value:
-                owner: "11111112cMQwSC9qirWGjZM6gLGwW69X22mqwLLGP"
+            - name: owner
+              value: "11111112cMQwSC9qirWGjZM6gLGwW69X22mqwLLGP"
       result:
         name: Compressed accounts
         description: A paginated list of compressed accounts owned by the given Pubkey.
@@ -1191,20 +1227,28 @@ components:
 
     getCompressedBalance:
       name: getCompressedBalance
-      description: Returns the balance for the compressed account with the given address or hash.
+      description: Returns the balance for the compressed account with the given address or hash. Provide either `address` or `hash`.
+      paramStructure: by-name
       params:
-        - name: Account identifier
-          required: true
-          description: The compressed account to query, identified by either its address or its hash.
+        - name: address
+          required: false
+          description: Pubkey of the compressed account to query.
           schema:
-            $ref: ./compression.yaml#/components/schemas/GetCompressedAccountParams
+            oneOf:
+              - $ref: ./base-types.yaml#/components/schemas/Pubkey
+              - type: "null"
+        - name: hash
+          required: false
+          description: Hash of the compressed account to query.
+          schema:
+            oneOf:
+              - $ref: ./compression.yaml#/components/schemas/Hash
+              - type: "null"
       examples:
         - name: getCompressedBalance example
           params:
-            - name: Account identifier
-              value:
-                address: null
-                hash: "11111111111111111111111111111111"
+            - name: hash
+              value: "11111111111111111111111111111111"
       result:
         name: Compressed balance
         description: The lamport balance of the compressed account.
@@ -1234,18 +1278,32 @@ components:
     getCompressedMintTokenHolders:
       name: getCompressedMintTokenHolders
       description: Returns owners of compressed token accounts for the given mint, ranked by balance.
+      paramStructure: by-name
       params:
-        - name: Configuration
+        - name: mint
           required: true
-          description: Mint Pubkey and optional pagination settings.
+          description: Pubkey of the mint whose token holders to query.
           schema:
-            $ref: ./compression.yaml#/components/schemas/GetCompressedMintTokenHoldersParams
+            $ref: ./base-types.yaml#/components/schemas/Pubkey
+        - name: cursor
+          required: false
+          description: Pagination cursor returned by a previous response.
+          schema:
+            oneOf:
+              - $ref: ./compression.yaml#/components/schemas/Base58String
+              - type: "null"
+        - name: limit
+          required: false
+          description: Maximum number of holders to return.
+          schema:
+            oneOf:
+              - $ref: ./compression.yaml#/components/schemas/Limit
+              - type: "null"
       examples:
         - name: getCompressedMintTokenHolders example
           params:
-            - name: Configuration
-              value:
-                mint: "11111112cMQwSC9qirWGjZM6gLGwW69X22mqwLLGP"
+            - name: mint
+              value: "11111112cMQwSC9qirWGjZM6gLGwW69X22mqwLLGP"
       result:
         name: Token holders
         description: A paginated list of owner balances for the given mint.
@@ -1254,20 +1312,28 @@ components:
 
     getCompressedTokenAccountBalance:
       name: getCompressedTokenAccountBalance
-      description: Returns the balance for the compressed token account with the given address or hash.
+      description: Returns the balance for the compressed token account with the given address or hash. Provide either `address` or `hash`.
+      paramStructure: by-name
       params:
-        - name: Account identifier
-          required: true
-          description: The compressed token account to query, identified by either its address or its hash.
+        - name: address
+          required: false
+          description: Pubkey of the compressed token account to query.
           schema:
-            $ref: ./compression.yaml#/components/schemas/GetCompressedAccountParams
+            oneOf:
+              - $ref: ./base-types.yaml#/components/schemas/Pubkey
+              - type: "null"
+        - name: hash
+          required: false
+          description: Hash of the compressed token account to query.
+          schema:
+            oneOf:
+              - $ref: ./compression.yaml#/components/schemas/Hash
+              - type: "null"
       examples:
         - name: getCompressedTokenAccountBalance example
           params:
-            - name: Account identifier
-              value:
-                address: null
-                hash: "11111111111111111111111111111111"
+            - name: hash
+              value: "11111111111111111111111111111111"
       result:
         name: Token account balance
         description: The token balance of the compressed token account.
@@ -1277,18 +1343,39 @@ components:
     getCompressedTokenAccountsByDelegate:
       name: getCompressedTokenAccountsByDelegate
       description: Returns the compressed token accounts delegated to the given Pubkey.
+      paramStructure: by-name
       params:
-        - name: Configuration
+        - name: delegate
           required: true
-          description: Delegate Pubkey and optional mint filter and pagination settings.
+          description: Pubkey of the delegate.
           schema:
-            $ref: ./compression.yaml#/components/schemas/GetCompressedTokenAccountsByDelegateParams
+            $ref: ./base-types.yaml#/components/schemas/Pubkey
+        - name: mint
+          required: false
+          description: Optional mint Pubkey to filter accounts by.
+          schema:
+            oneOf:
+              - $ref: ./base-types.yaml#/components/schemas/Pubkey
+              - type: "null"
+        - name: cursor
+          required: false
+          description: Pagination cursor returned by a previous response.
+          schema:
+            oneOf:
+              - $ref: ./compression.yaml#/components/schemas/Base58String
+              - type: "null"
+        - name: limit
+          required: false
+          description: Maximum number of accounts to return.
+          schema:
+            oneOf:
+              - $ref: ./compression.yaml#/components/schemas/Limit
+              - type: "null"
       examples:
         - name: getCompressedTokenAccountsByDelegate example
           params:
-            - name: Configuration
-              value:
-                delegate: "11111112cMQwSC9qirWGjZM6gLGwW69X22mqwLLGP"
+            - name: delegate
+              value: "11111112cMQwSC9qirWGjZM6gLGwW69X22mqwLLGP"
       result:
         name: Compressed token accounts
         description: A paginated list of compressed token accounts delegated to the given Pubkey.
@@ -1298,18 +1385,39 @@ components:
     getCompressedTokenAccountsByOwner:
       name: getCompressedTokenAccountsByOwner
       description: Returns the compressed token accounts owned by the given Pubkey.
+      paramStructure: by-name
       params:
-        - name: Configuration
+        - name: owner
           required: true
-          description: Owner Pubkey and optional mint filter and pagination settings.
+          description: Pubkey of the owner whose compressed token accounts to query.
           schema:
-            $ref: ./compression.yaml#/components/schemas/GetCompressedTokenAccountsByOwnerParams
+            $ref: ./base-types.yaml#/components/schemas/Pubkey
+        - name: mint
+          required: false
+          description: Optional mint Pubkey to filter accounts by.
+          schema:
+            oneOf:
+              - $ref: ./base-types.yaml#/components/schemas/Pubkey
+              - type: "null"
+        - name: cursor
+          required: false
+          description: Pagination cursor returned by a previous response.
+          schema:
+            oneOf:
+              - $ref: ./compression.yaml#/components/schemas/Base58String
+              - type: "null"
+        - name: limit
+          required: false
+          description: Maximum number of accounts to return.
+          schema:
+            oneOf:
+              - $ref: ./compression.yaml#/components/schemas/Limit
+              - type: "null"
       examples:
         - name: getCompressedTokenAccountsByOwner example
           params:
-            - name: Configuration
-              value:
-                owner: "11111112cMQwSC9qirWGjZM6gLGwW69X22mqwLLGP"
+            - name: owner
+              value: "11111112cMQwSC9qirWGjZM6gLGwW69X22mqwLLGP"
       result:
         name: Compressed token accounts
         description: A paginated list of compressed token accounts owned by the given Pubkey.
@@ -1319,18 +1427,39 @@ components:
     getCompressedTokenBalancesByOwner:
       name: getCompressedTokenBalancesByOwner
       description: Returns the compressed token balances for the given Pubkey.
+      paramStructure: by-name
       params:
-        - name: Configuration
+        - name: owner
           required: true
-          description: Owner Pubkey and optional mint filter and pagination settings.
+          description: Pubkey of the owner whose compressed token balances to query.
           schema:
-            $ref: ./compression.yaml#/components/schemas/GetCompressedTokenBalancesByOwnerParams
+            $ref: ./base-types.yaml#/components/schemas/Pubkey
+        - name: mint
+          required: false
+          description: Optional mint Pubkey to filter balances by.
+          schema:
+            oneOf:
+              - $ref: ./base-types.yaml#/components/schemas/Pubkey
+              - type: "null"
+        - name: cursor
+          required: false
+          description: Pagination cursor returned by a previous response.
+          schema:
+            oneOf:
+              - $ref: ./compression.yaml#/components/schemas/Base58String
+              - type: "null"
+        - name: limit
+          required: false
+          description: Maximum number of balances to return.
+          schema:
+            oneOf:
+              - $ref: ./compression.yaml#/components/schemas/Limit
+              - type: "null"
       examples:
         - name: getCompressedTokenBalancesByOwner example
           params:
-            - name: Configuration
-              value:
-                owner: "11111112cMQwSC9qirWGjZM6gLGwW69X22mqwLLGP"
+            - name: owner
+              value: "11111112cMQwSC9qirWGjZM6gLGwW69X22mqwLLGP"
       result:
         name: Compressed token balances
         description: A paginated list of compressed token balances for the owner.
@@ -1340,18 +1469,39 @@ components:
     getCompressedTokenBalancesByOwnerV2:
       name: getCompressedTokenBalancesByOwnerV2
       description: Returns the compressed token balances for the given Pubkey.
+      paramStructure: by-name
       params:
-        - name: Configuration
+        - name: owner
           required: true
-          description: Owner Pubkey and optional mint filter and pagination settings.
+          description: Pubkey of the owner whose compressed token balances to query.
           schema:
-            $ref: ./compression.yaml#/components/schemas/GetCompressedTokenBalancesByOwnerParams
+            $ref: ./base-types.yaml#/components/schemas/Pubkey
+        - name: mint
+          required: false
+          description: Optional mint Pubkey to filter balances by.
+          schema:
+            oneOf:
+              - $ref: ./base-types.yaml#/components/schemas/Pubkey
+              - type: "null"
+        - name: cursor
+          required: false
+          description: Pagination cursor returned by a previous response.
+          schema:
+            oneOf:
+              - $ref: ./compression.yaml#/components/schemas/Base58String
+              - type: "null"
+        - name: limit
+          required: false
+          description: Maximum number of balances to return.
+          schema:
+            oneOf:
+              - $ref: ./compression.yaml#/components/schemas/Limit
+              - type: "null"
       examples:
         - name: getCompressedTokenBalancesByOwnerV2 example
           params:
-            - name: Configuration
-              value:
-                owner: "11111112cMQwSC9qirWGjZM6gLGwW69X22mqwLLGP"
+            - name: owner
+              value: "11111112cMQwSC9qirWGjZM6gLGwW69X22mqwLLGP"
       result:
         name: Compressed token balances
         description: A paginated list of compressed token balances for the owner.
@@ -1381,18 +1531,32 @@ components:
     getCompressionSignaturesForAddress:
       name: getCompressionSignaturesForAddress
       description: Returns the transaction signatures that closed or opened a compressed account at the given address.
+      paramStructure: by-name
       params:
-        - name: Configuration
+        - name: address
           required: true
-          description: Address Pubkey and optional pagination settings.
+          description: Pubkey of the compressed account address.
           schema:
-            $ref: ./compression.yaml#/components/schemas/GetCompressionSignaturesForAddressParams
+            $ref: ./base-types.yaml#/components/schemas/Pubkey
+        - name: cursor
+          required: false
+          description: Pagination cursor returned by a previous response.
+          schema:
+            oneOf:
+              - type: string
+              - type: "null"
+        - name: limit
+          required: false
+          description: Maximum number of signatures to return.
+          schema:
+            oneOf:
+              - $ref: ./compression.yaml#/components/schemas/Limit
+              - type: "null"
       examples:
         - name: getCompressionSignaturesForAddress example
           params:
-            - name: Configuration
-              value:
-                address: "11111112cMQwSC9qirWGjZM6gLGwW69X22mqwLLGP"
+            - name: address
+              value: "11111112cMQwSC9qirWGjZM6gLGwW69X22mqwLLGP"
       result:
         name: Signatures
         description: A paginated list of transaction signatures.
@@ -1402,18 +1566,32 @@ components:
     getCompressionSignaturesForOwner:
       name: getCompressionSignaturesForOwner
       description: Returns the transaction signatures involving compressed accounts owned by the given Pubkey.
+      paramStructure: by-name
       params:
-        - name: Configuration
+        - name: owner
           required: true
-          description: Owner Pubkey and optional pagination settings.
+          description: Pubkey of the owner whose compression-related signatures to query.
           schema:
-            $ref: ./compression.yaml#/components/schemas/GetCompressionSignaturesForOwnerParams
+            $ref: ./base-types.yaml#/components/schemas/Pubkey
+        - name: cursor
+          required: false
+          description: Pagination cursor returned by a previous response.
+          schema:
+            oneOf:
+              - type: string
+              - type: "null"
+        - name: limit
+          required: false
+          description: Maximum number of signatures to return.
+          schema:
+            oneOf:
+              - $ref: ./compression.yaml#/components/schemas/Limit
+              - type: "null"
       examples:
         - name: getCompressionSignaturesForOwner example
           params:
-            - name: Configuration
-              value:
-                owner: "11111112cMQwSC9qirWGjZM6gLGwW69X22mqwLLGP"
+            - name: owner
+              value: "11111112cMQwSC9qirWGjZM6gLGwW69X22mqwLLGP"
       result:
         name: Signatures
         description: A paginated list of transaction signatures.
@@ -1423,18 +1601,32 @@ components:
     getCompressionSignaturesForTokenOwner:
       name: getCompressionSignaturesForTokenOwner
       description: Returns the transaction signatures involving compressed token accounts owned by the given Pubkey.
+      paramStructure: by-name
       params:
-        - name: Configuration
+        - name: owner
           required: true
-          description: Owner Pubkey and optional pagination settings.
+          description: Pubkey of the owner whose compressed token signatures to query.
           schema:
-            $ref: ./compression.yaml#/components/schemas/GetCompressionSignaturesForOwnerParams
+            $ref: ./base-types.yaml#/components/schemas/Pubkey
+        - name: cursor
+          required: false
+          description: Pagination cursor returned by a previous response.
+          schema:
+            oneOf:
+              - type: string
+              - type: "null"
+        - name: limit
+          required: false
+          description: Maximum number of signatures to return.
+          schema:
+            oneOf:
+              - $ref: ./compression.yaml#/components/schemas/Limit
+              - type: "null"
       examples:
         - name: getCompressionSignaturesForTokenOwner example
           params:
-            - name: Configuration
-              value:
-                owner: "11111112cMQwSC9qirWGjZM6gLGwW69X22mqwLLGP"
+            - name: owner
+              value: "11111112cMQwSC9qirWGjZM6gLGwW69X22mqwLLGP"
       result:
         name: Signatures
         description: A paginated list of transaction signatures.
@@ -1470,12 +1662,22 @@ components:
     getLatestCompressionSignatures:
       name: getLatestCompressionSignatures
       description: Returns the most recent transaction signatures involving compressed state.
+      paramStructure: by-name
       params:
-        - name: Configuration
+        - name: cursor
           required: false
-          description: Optional pagination settings.
+          description: Pagination cursor returned by a previous response.
           schema:
-            $ref: ./compression.yaml#/components/schemas/GetLatestSignaturesParams
+            oneOf:
+              - type: string
+              - type: "null"
+        - name: limit
+          required: false
+          description: Maximum number of signatures to return.
+          schema:
+            oneOf:
+              - $ref: ./compression.yaml#/components/schemas/Limit
+              - type: "null"
       examples:
         - name: getLatestCompressionSignatures example
           params: []
@@ -1488,12 +1690,22 @@ components:
     getLatestNonVotingSignatures:
       name: getLatestNonVotingSignatures
       description: Returns the most recent non-voting transaction signatures observed by the indexer.
+      paramStructure: by-name
       params:
-        - name: Configuration
+        - name: cursor
           required: false
-          description: Optional pagination settings.
+          description: Pagination cursor returned by a previous response.
           schema:
-            $ref: ./compression.yaml#/components/schemas/GetLatestSignaturesParams
+            oneOf:
+              - type: string
+              - type: "null"
+        - name: limit
+          required: false
+          description: Maximum number of signatures to return.
+          schema:
+            oneOf:
+              - $ref: ./compression.yaml#/components/schemas/Limit
+              - type: "null"
       examples:
         - name: getLatestNonVotingSignatures example
           params: []
@@ -1528,22 +1740,34 @@ components:
 
     getMultipleCompressedAccounts:
       name: getMultipleCompressedAccounts
-      description: Returns the compressed accounts with the given addresses or hashes.
+      description: Returns the compressed accounts with the given addresses or hashes. Provide either `addresses` or `hashes`.
+      paramStructure: by-name
       params:
-        - name: Account identifiers
-          required: true
-          description: Provide either an `addresses` array or a `hashes` array to identify the accounts.
+        - name: addresses
+          required: false
+          description: An array of compressed account addresses to query.
           schema:
-            $ref: ./compression.yaml#/components/schemas/GetMultipleCompressedAccountsParams
+            oneOf:
+              - type: array
+                items:
+                  $ref: ./base-types.yaml#/components/schemas/Pubkey
+              - type: "null"
+        - name: hashes
+          required: false
+          description: An array of compressed account hashes to query.
+          schema:
+            oneOf:
+              - type: array
+                items:
+                  $ref: ./compression.yaml#/components/schemas/Hash
+              - type: "null"
       examples:
         - name: getMultipleCompressedAccounts example
           params:
-            - name: Account identifiers
+            - name: hashes
               value:
-                addresses: null
-                hashes:
-                  - "11157t3sqMV725NVRLrVQbAu98Jjfk1uCKehJnXXQs"
-                  - "1117mWrzzrZr312ebPDHu8tbfMwFNvCvMbr6WepCNG"
+                - "11157t3sqMV725NVRLrVQbAu98Jjfk1uCKehJnXXQs"
+                - "1117mWrzzrZr312ebPDHu8tbfMwFNvCvMbr6WepCNG"
       result:
         name: Compressed accounts
         description: A list of compressed accounts.
@@ -1620,20 +1844,30 @@ components:
     getValidityProof:
       name: getValidityProof
       description: Returns a single ZK validity proof for the given compressed account hashes and/or new addresses.
+      paramStructure: by-name
       params:
-        - name: Configuration
-          required: true
-          description: Compressed account hashes to prove inclusion for and/or new addresses to prove non-inclusion for.
+        - name: hashes
+          required: false
+          description: Compressed account hashes to prove inclusion for.
           schema:
-            $ref: ./compression.yaml#/components/schemas/GetValidityProofParams
+            type: array
+            items:
+              $ref: ./compression.yaml#/components/schemas/Hash
+        - name: newAddressesWithTrees
+          required: false
+          description: New addresses paired with their merkle tree Pubkeys, to prove non-inclusion for.
+          schema:
+            type: array
+            items:
+              $ref: ./compression.yaml#/components/schemas/AddressWithTree
       examples:
         - name: getValidityProof example
           params:
-            - name: Configuration
+            - name: hashes
               value:
-                hashes:
-                  - "11111111111111111111111111111111"
-                newAddressesWithTrees: []
+                - "11111111111111111111111111111111"
+            - name: newAddressesWithTrees
+              value: []
       result:
         name: Validity proof
         description: A ZK validity proof with context for inclusion and non-inclusion claims.
@@ -1643,20 +1877,30 @@ components:
     getValidityProofV2:
       name: getValidityProofV2
       description: Returns a single ZK validity proof for the given compressed account hashes and/or new addresses, with V2 merkle context information.
+      paramStructure: by-name
       params:
-        - name: Configuration
-          required: true
-          description: Compressed account hashes to prove inclusion for and/or new addresses to prove non-inclusion for.
+        - name: hashes
+          required: false
+          description: Compressed account hashes to prove inclusion for.
           schema:
-            $ref: ./compression.yaml#/components/schemas/GetValidityProofParams
+            type: array
+            items:
+              $ref: ./compression.yaml#/components/schemas/Hash
+        - name: newAddressesWithTrees
+          required: false
+          description: New addresses paired with their merkle tree Pubkeys, to prove non-inclusion for.
+          schema:
+            type: array
+            items:
+              $ref: ./compression.yaml#/components/schemas/AddressWithTree
       examples:
         - name: getValidityProofV2 example
           params:
-            - name: Configuration
+            - name: hashes
               value:
-                hashes:
-                  - "11111111111111111111111111111111"
-                newAddressesWithTrees: []
+                - "11111111111111111111111111111111"
+            - name: newAddressesWithTrees
+              value: []
       result:
         name: Validity proof
         description: A ZK validity proof with V2 merkle context for inclusion and non-inclusion claims.

--- a/src/openrpc/chains/_components/solana/methods.yaml
+++ b/src/openrpc/chains/_components/solana/methods.yaml
@@ -1137,11 +1137,9 @@ components:
       params:
         - name: address
           required: false
-          description: Pubkey of the compressed account to query. Leave blank to query by `hash` instead.
+          description: Pubkey of the compressed account to query. Leave blank to query by `hash` instead. The underlying Photon API also accepts an explicit `null` here, but the Try It widget omits the field from the payload when blank.
           schema:
-            oneOf:
-              - $ref: ./base-types.yaml#/components/schemas/Pubkey
-              - type: "null"
+            $ref: ./base-types.yaml#/components/schemas/Pubkey
         - name: hash
           required: false
           description: Hash of the compressed account to query. Leave blank to query by `address` instead.

--- a/src/openrpc/chains/_components/solana/methods.yaml
+++ b/src/openrpc/chains/_components/solana/methods.yaml
@@ -1152,14 +1152,26 @@ components:
       examples:
         - name: getCompressedAccount example
           params:
-            - name: address
+            - name: hash
               value: "3KC9cKQhhzEPjwuyQaohM6SGaZu1ukKRZw2QRgc1sYVL"
           result:
             name: Compressed account
             value:
               context:
-                slot: 419132638
+                slot: 419133524
               value:
+                hash: 3KC9cKQhhzEPjwuyQaohM6SGaZu1ukKRZw2QRgc1sYVL
+                address:
+                data:
+                  discriminator: 2
+                  data: RhAVR6AmcnFercuAcoi9gbc/hIy3UBfL/FeQkTk7SE8I8WaM+ETZsH8YD96DZJdZG7IPY2fuP8pCP/oQV1de4R5hETEZAAAAAAAA
+                  dataHash: mkARkU6arYpeTacykBCEytKihySvzGJXbkG5PbwhieQ
+                owner: cTokenmWW8bLPjZEBAUgYy3zKxQZW6VKi7bqNFEVv3m
+                lamports: 0
+                tree: smt6ukQDSPPYHSshQovmiRUjG9jGFq2hW9vgrDFk5Yz
+                leafIndex: 832574
+                seq: 877634
+                slotCreated: 357735227
       result:
         name: Compressed account
         description: The compressed account data with context information. `value` is `null` when no compressed account matches the supplied `address` or `hash`.


### PR DESCRIPTION
## Summary

Most Solana Photon API methods were broken in the docs Try It widget. Reported in #dx-docs-feedback by Vivek and Daniel: clicking Try It on `getCompressedMintTokenHolders` (and most siblings) returned `invalid type: map, expected a base58 encoded string`.

The Helius Photon RPC server expects JSON-RPC **by-name** params (a bare object) for any method whose params are a struct, but our spec at `src/openrpc/chains/_components/solana/methods.yaml` defined those methods with a single positional `Configuration` param wrapping a struct schema. The Try It widget therefore serialized requests as `params: [{...}]`, and Photon's serde rejected it because it tried to read the first positional element expecting a base58 string.

This PR switches the 17 affected methods to OpenRPC `paramStructure: by-name` with flattened top-level params (mint, cursor, limit, etc.), matching the existing `solana-das` pattern. The Try It widget now generates `params: {...}` and round-trips cleanly against `solana-mainnet.g.alchemy.com`.

### Verification (live API)

| method | before (`params: [{…}]`) | after (`params: {…}`) |
| --- | --- | --- |
| getCompressedMintTokenHolders | error | 200 OK |
| getCompressedAccountsByOwner | error | 200 OK |
| getCompressedTokenAccountsByOwner | error | 200 OK with results |
| getMultipleCompressedAccounts | error | 200 OK |
| getLatestCompressionSignatures (with `limit: 1`) | error | 200 OK |

### Methods updated (17)

`getCompressedAccount`, `getCompressedAccountsByOwner`, `getCompressedBalance`, `getCompressedMintTokenHolders`, `getCompressedTokenAccountBalance`, `getCompressedTokenAccountsByDelegate`, `getCompressedTokenAccountsByOwner`, `getCompressedTokenBalancesByOwner`, `getCompressedTokenBalancesByOwnerV2`, `getCompressionSignaturesForAddress`, `getCompressionSignaturesForOwner`, `getCompressionSignaturesForTokenOwner`, `getLatestCompressionSignatures`, `getLatestNonVotingSignatures`, `getMultipleCompressedAccounts`, `getValidityProof`, `getValidityProofV2`.

### Out of scope (separate follow-up)

Three Photon methods take a top-level `Vec<T>` (the entire `params` array IS the argument):

- `getMultipleCompressedAccountProofs` (hashes: array)
- `getMultipleNewAddressProofs` (addresses: array)
- `getMultipleNewAddressProofsV2` (addressesWithTrees: array of objects)

These are also broken in Try It because the spec wraps them as `params: [<array>]` while Photon wants `params: <array>` directly. By-name (`{"hashes": [...]}`) does NOT work for these either — Photon rejects it. OpenRPC's data model can't cleanly express "params IS this Vec" without varargs support, so this needs a separate design decision (likely a static curl example or a Try It override).

Methods working both ways and not requiring changes: `getCompressedAccountProof`, `getCompressedBalanceByOwner`, `getCompressionSignaturesForAccount`, `getTransactionWithCompressionInfo`, `getIndexerHealth`, `getIndexerSlot`.

### Notes

- The unreferenced `*Params` schemas in `src/openrpc/chains/_components/solana/compression.yaml` (`GetCompressedMintTokenHoldersParams`, etc.) are now unused. Left in place for this PR to keep the diff minimal; happy to drop them in a follow-up if reviewers prefer.
- `pnpm run generate:rpc` and `pnpm run validate:rpc` both pass.
- Lint warnings present on `main` (pre-existing on `scripts/upload-specs.ts` and `src/content-indexer/indexers/changelog.ts`) are unrelated to this change.

## Linear

DOCS-72 — https://linear.app/alchemyapi/issue/DOCS-72/solana-photon-api-try-it-rejects-struct-params-paramstructure-by-name

## Requested by

@dslovinsky (via Slack thread)