### PR TITLE
[docs-agent] Stellar API Try It: populate working defaults for all 12 methods

### DIFF
--- a/src/openrpc/chains/_components/custom/methods.yaml
+++ b/src/openrpc/chains/_components/custom/methods.yaml
@@ -1970,11 +1970,15 @@ components:
             latestLedger: 50000
             oldestLedger: 1
             ledgerRetentionWindow: 17280
+      examples:
+        - name: getHealth example
+          params: []
 
     sendTransaction:
       name: sendTransaction
       summary: Send transaction
       description: Submits a signed transaction to the network.
+      paramStructure: by-name
       params:
         - name: transaction
           required: true
@@ -1986,11 +1990,22 @@ components:
         description: Transaction submission result.
         schema:
           type: object
+      examples:
+        - name: sendTransaction example
+          description: |
+            Submits a base64-encoded TransactionEnvelope XDR. The default value below is an unsigned envelope
+            that calls `name()` on the native XLM Stellar Asset Contract; resubmitting it returns
+            `status: "ERROR"` with an `errorResultXdr` so you can see the response shape without sending real funds.
+            Replace the value with your own signed envelope to actually submit a transaction.
+          params:
+            - name: transaction
+              value: "AAAAAgAAAAA7mRE4Dv6Yi6CokA6xz+RPNm99vpRr7QdyQPf2JN8VxQAAAGQAAAAAAAAAZQAAAAEAAAAAAAAAAAAAAABp/P05AAAAAAAAAAEAAAAAAAAAGAAAAAAAAAABJbT82FmuwvpjSEOMSJs8PBDJi20hvk/TyzDLaJU++XcAAAAEbmFtZQAAAAAAAAAAAAAAAAAAAAA="
 
     getTransaction:
       name: getTransaction
       summary: Get transaction
       description: Returns the details and status of a submitted transaction by its hash.
+      paramStructure: by-name
       params:
         - name: hash
           required: true
@@ -2013,11 +2028,20 @@ components:
             latestLedgerCloseTime: { type: integer }
             oldestLedger: { type: integer }
             oldestLedgerCloseTime: { type: integer }
+      examples:
+        - name: getTransaction example
+          description: |
+            Looks up a real successful Stellar mainnet transaction. Stellar RPC retains transactions
+            for ~14 days, so this hash will eventually age out and need to be replaced with a fresher one.
+          params:
+            - name: hash
+              value: "86d85a0db4d7cdf2aa8e4b633e050e8c3c138deae7cac62ff4d4ff5fb732fe96"
 
     getTransactions:
       name: getTransactions
       summary: Get transactions
       description: Returns a paginated list of transactions from the network.
+      paramStructure: by-name
       params:
         - name: startLedger
           required: false
@@ -2046,11 +2070,24 @@ components:
             transactions: { type: array, items: { type: object } }
             latestLedger: { type: integer }
             cursor: { type: string }
+      examples:
+        - name: getTransactions example
+          description: |
+            Returns one transaction starting at a recent mainnet ledger. Stellar RPC keeps roughly
+            the last 14 days of transactions; if the example ledger has aged out, replace `startLedger`
+            with a value within the current retention window (see `oldestLedger` from `getHealth`).
+          params:
+            - name: startLedger
+              value: 62462511
+            - name: pagination
+              value:
+                limit: 1
 
     simulateTransaction:
       name: simulateTransaction
       summary: Simulate transaction
       description: Simulates a transaction invocation to estimate resource fees, required authorizations, and return values without submitting to the network.
+      paramStructure: by-name
       params:
         - name: transaction
           required: true
@@ -2083,3 +2120,14 @@ components:
             latestLedger: { type: integer }
             minResourceFee: { type: string }
             transactionData: { type: string }
+      examples:
+        - name: simulateTransaction example
+          description: |
+            Simulates a read-only call to `name()` on the native XLM Stellar Asset Contract
+            (`CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA`). The envelope is unsigned —
+            simulation never checks signatures, sequence numbers, or time bounds, so this example
+            is stable indefinitely and returns the SCV-encoded string `"native"` in `results[0].xdr`
+            along with a populated `minResourceFee`, `transactionData`, and `events`.
+          params:
+            - name: transaction
+              value: "AAAAAgAAAAA7mRE4Dv6Yi6CokA6xz+RPNm99vpRr7QdyQPf2JN8VxQAAAGQAAAAAAAAAZQAAAAEAAAAAAAAAAAAAAABp/P05AAAAAAAAAAEAAAAAAAAAGAAAAAAAAAABJbT82FmuwvpjSEOMSJs8PBDJi20hvk/TyzDLaJU++XcAAAAEbmFtZQAAAAAAAAAAAAAAAAAAAAA="

--- a/src/openrpc/chains/_components/stellar/methods.yaml
+++ b/src/openrpc/chains/_components/stellar/methods.yaml
@@ -108,6 +108,29 @@ components:
             title: xdrFormat
             type: string
             description: Specifies whether XDR should be encoded as Base64 (default or 'base64') or JSON ('json').
+      examples:
+        - name: Native XLM transfer events
+          description: |
+            Returns up to 2 native XLM `transfer` contract events emitted from the Stellar Asset Contract
+            (`CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA`) starting near the current head.
+            Stellar RPC retains roughly the last 7 days of events, so `startLedger` may need to be bumped
+            forward over time. The first topic `AAAADwAAAAh0cmFuc2Zlcg==` is the SCV-encoded `transfer` symbol.
+          params:
+            - name: startLedger
+              value: 62463000
+            - name: filters
+              value:
+                - type: contract
+                  contractIds:
+                    - CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA
+                  topics:
+                    - - AAAADwAAAAh0cmFuc2Zlcg==
+                      - "*"
+                      - "*"
+                      - "**"
+            - name: pagination
+              value:
+                limit: 2
       result:
         name: getEventsResult
         schema:
@@ -192,6 +215,9 @@ components:
         url: https://developers.stellar.org/docs/data/apis/rpc/api-reference/methods/getFeeStats
       paramStructure: by-name
       params: []
+      examples:
+        - name: getFeeStats example
+          params: []
       result:
         name: getFeeStatsResult
         schema:
@@ -313,6 +339,9 @@ components:
         url: https://developers.stellar.org/docs/data/apis/rpc/api-reference/methods/getLatestLedger
       paramStructure: by-name
       params: []
+      examples:
+        - name: getLatestLedger example
+          params: []
       result:
         name: getLatestLedgerResponse
         schema:
@@ -372,6 +401,20 @@ components:
             title: xdrFormat
             type: string
             description: Specifies whether XDR should be encoded as Base64 (default or 'base64') or JSON ('json').
+      examples:
+        - name: Account and contract instance entries
+          description: |
+            Looks up two stable mainnet ledger entries: the **Account** entry for the Circle USDC issuer
+            (`GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN`) and the
+            **ContractInstance** entry for the native XLM Stellar Asset Contract
+            (`CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA`). Both are permanent ledger
+            entries, so this example is stable indefinitely. To build your own `LedgerKey`s see
+            [Building ledger keys](https://developers.stellar.org/docs/data/apis/rpc/api-reference/methods/getLedgerEntries#building-ledger-keys).
+          params:
+            - name: keys
+              value:
+                - "AAAAAAAAAAA7mRE4Dv6Yi6CokA6xz+RPNm99vpRr7QdyQPf2JN8VxQ=="
+                - "AAAABgAAAAEltPzYWa7C+mNIQ4xImzw8EMmLbSG+T9PLMMtolT75dwAAABQAAAAB"
       result:
         name: getLedgerEntriesResult
         schema:
@@ -442,6 +485,19 @@ components:
             title: xdrFormat
             type: string
             description: Specifies whether XDR should be encoded as Base64 (default or 'base64') or JSON ('json').
+      examples:
+        - name: Two ledgers from a stable historical sequence
+          description: |
+            Returns two consecutive ledger summaries starting at sequence 60,000,000.
+            Unlike `getEvents` and `getTransactions` (which retain ~7 and ~14 days respectively),
+            Alchemy's Stellar mainnet RPC retains full ledger history back to genesis (ledger 2),
+            so this example is stable indefinitely.
+          params:
+            - name: startLedger
+              value: 60000000
+            - name: pagination
+              value:
+                limit: 2
       result:
         name: getLedgersResult
         schema:
@@ -497,6 +553,9 @@ components:
         url: https://developers.stellar.org/docs/data/apis/rpc/api-reference/methods/getNetwork
       paramStructure: by-name
       params: []
+      examples:
+        - name: getNetwork example
+          params: []
       result:
         name: getNetworkResult
         schema:
@@ -643,6 +702,9 @@ components:
         url: https://developers.stellar.org/docs/data/apis/rpc/api-reference/methods/getVersionInfo
       paramStructure: by-name
       params: []
+      examples:
+        - name: getVersionInfo example
+          params: []
       result:
         name: getVersionInfoResult
         schema:


### PR DESCRIPTION
## Summary

The 12 Stellar JSON-RPC methods on https://www.alchemy.com/docs/stellar/stellar-api-overview all had empty Try It defaults because the OpenRPC source carried no `examples` blocks. On top of that, the 5 methods sourced from `_components/custom/methods.yaml` were missing `paramStructure: by-name`, so even users supplying a real value would hit `invalid parameters / cannot unmarshal array into Go value of type protocol.GetTransactionRequest` because Try It serialized the request positionally.

This PR adds `paramStructure: by-name` (where missing) and an `examples` block to every method, all verified live against `https://stellar-mainnet.g.alchemy.com/v2/docs-demo`.

### Per-method default values

| Method | Default value | Stable? |
| --- | --- | --- |
| `getEvents` | `startLedger: 62463000`, native XLM SAC `transfer` filter, `limit: 2` | ~7 days (server retention) |
| `getFeeStats` | no params | Yes |
| `getHealth` | no params | Yes |
| `getLatestLedger` | no params | Yes |
| `getLedgerEntries` | `keys` = [Account LedgerKey for Circle USDC issuer, ContractInstance LedgerKey for native XLM SAC] | Yes |
| `getLedgers` | `startLedger: 60000000`, `limit: 2` | Yes (Alchemy mainnet RPC retains full ledger history back to ledger 2) |
| `getNetwork` | no params | Yes |
| `getTransaction` | `hash: 86d85a0d…fe96` (recent successful mainnet tx) | ~14 days |
| `getTransactions` | `startLedger: 62462511`, `limit: 1` | ~14 days |
| `getVersionInfo` | no params | Yes |
| `sendTransaction` | unsigned envelope calling `name()` on the native XLM SAC; returns `status: ERROR` with `errorResultXdr` so the response schema is fully populated without spending real funds | Yes |
| `simulateTransaction` | same unsigned envelope (simulation never checks signatures, sequence numbers, or time bounds); returns `"native"` as the SCV-encoded `name()` result with populated `minResourceFee`, `transactionData`, `events`, `results` | Yes |

### Live validation

```
getEvents              error=null  result_present=true
getFeeStats            error=null  result_present=true
getHealth              error=null  result_present=true
getLatestLedger        error=null  result_present=true
getLedgerEntries       error=null  result_present=true
getLedgers             error=null  result_present=true
getNetwork             error=null  result_present=true
getTransaction         error=null  result_present=true
getTransactions        error=null  result_present=true
getVersionInfo         error=null  result_present=true
sendTransaction        error=null  result_present=true
simulateTransaction    error=null  result_present=true
```

### Caveat on staleness

`getEvents`, `getTransactions`, and `getTransaction` rely on values within Stellar RPC's retention window (~7 days for events, ~14 days for transactions). Their example values will eventually need to be refreshed; the other 9 methods are stable indefinitely.

### Files changed

- `src/openrpc/chains/_components/custom/methods.yaml` — added `paramStructure: by-name` to `getTransaction`, `getTransactions`, `sendTransaction`, `simulateTransaction`, plus `examples` blocks to all 5 stellar-shared methods. Verified that no other chain refs these (only `chains/stellar/stellar.yaml` does).
- `src/openrpc/chains/_components/stellar/methods.yaml` — added `examples` blocks to the 7 Stellar-specific methods.

`pnpm run validate:rpc` passes.

## Linear

DOCS-74 — https://linear.app/alchemyapi/issue/DOCS-74/stellar-api-try-it-populate-working-default-values-fix-paramstructure

## Requested by

@dexterliu (via Slack thread)