### PR TITLE
[docs-agent] Add Stellar Standard Methods section to Compute Unit Costs page

### DIFF
--- a/content/api-reference/pricing-resources/pricing/compute-unit-costs.mdx
+++ b/content/api-reference/pricing-resources/pricing/compute-unit-costs.mdx
@@ -662,6 +662,23 @@ On average, a typical webhook or WebSocket subscription event is about 1000 byte
 | ------------------------- | -- |
 | eth\_getWithdrawalProof   | 20 |
 
+# Stellar: Standard Methods
+
+| Method               | CU |
+| -------------------- | -- |
+| getEvents            | 20 |
+| getFeeStats          | 20 |
+| getHealth            | 20 |
+| getLatestLedger      | 20 |
+| getLedgerEntries     | 20 |
+| getLedgers           | 50 |
+| getNetwork           | 20 |
+| getTransaction       | 40 |
+| getTransactions      | 50 |
+| getVersionInfo       | 20 |
+| sendTransaction      | 20 |
+| simulateTransaction  | 20 |
+
 # Sui: Standard Methods
 
 | Method                                   | CU |


### PR DESCRIPTION
## Summary

Adds a new `Stellar: Standard Methods` section to the [Compute Unit Costs](https://www.alchemy.com/docs/reference/compute-unit-costs) page covering the 12 Soroban JSON-RPC 2.0 methods Alchemy supports on Stellar (`STELLAR_MAINNET` / `STELLAR_TESTNET`). CU values were sourced from the chain-config `topconfig.yml` (Stellar block) and provided by the requester.

Placement: between `MegaETH: Specific Methods` and `Sui: Standard Methods`, per the requested ordering.

| Method | CU |
| --- | --- |
| getEvents | 20 |
| getFeeStats | 20 |
| getHealth | 20 |
| getLatestLedger | 20 |
| getLedgerEntries | 20 |
| getLedgers | 50 |
| getNetwork | 20 |
| getTransaction | 40 |
| getTransactions | 50 |
| getVersionInfo | 20 |
| sendTransaction | 20 |
| simulateTransaction | 20 |

Methods are alphabetized to match the existing convention used in the Sui and Tron sections.

## Linear

DOCS-75 — https://linear.app/alchemyapi/issue/DOCS-75/add-stellar-methods-section-to-compute-unit-costs-page

## Requested by

@dexterliu (via Slack thread)