### PR TITLE
[docs-agent] Add per-chain UTXO sub-section with overview page (BTC/BCH/LTC/DOGE)

### DIFF
--- a/content/api-reference/bitcoin/utxo.mdx
+++ b/content/api-reference/bitcoin/utxo.mdx
@@ -1,0 +1,45 @@
+---
+title: UTXO
+description: Understand how the Unspent Transaction Output (UTXO) model tracks balances on Bitcoin.
+subtitle: The model Bitcoin uses to track user balances
+slug: docs/bitcoin/utxo
+---
+
+Bitcoin uses the **Unspent Transaction Output (UTXO) model** to track user balances, in contrast to the **account model** used by Ethereum and other EVM chains.
+
+## UTXO-based model
+
+UTXO stands for *Unspent Transaction Output*. Instead of tracking an account's overall balance, the network maintains a set of UTXOs: outputs from past transactions that credit specific addresses with a specific amount.
+
+When someone says they own 3 BTC, what they actually hold is one or more UTXOs that together sum to 3 BTC. To spend that balance, a wallet selects specific UTXOs as inputs to a new transaction.
+
+## What is a UTXO?
+
+A UTXO is the output of a previous transaction that has not yet been spent. Every time a transaction is confirmed:
+
+* The inputs reference one or more UTXOs from previous transactions.
+* The outputs create new UTXOs credited to the recipient addresses.
+* Any leftover value (input minus output minus fee) returns to the sender as a "change" UTXO.
+
+So each transaction consumes old UTXOs and produces new ones. The full set of UTXOs at any point in time represents the network's spendable state.
+
+## Properties of UTXOs
+
+* **Non-fungible.** Each UTXO is a distinct object referenced by its transaction ID and output index.
+* **Specific to spend.** To spend a UTXO you must refer to that exact UTXO, not just an aggregate balance.
+* **Change creates new UTXOs.** Any leftover from the input value becomes a new UTXO sent back to the spender.
+* **Single-use.** A UTXO can only be spent once; double-spending is prevented at consensus.
+* **Script-locked.** Each UTXO carries a locking script that defines the conditions under which it can be spent (typically a signature from the owning private key).
+
+## Account model vs UTXO model
+
+|                    | Account model (Ethereum, EVM chains)                        | UTXO model (Bitcoin)                                                              |
+| ------------------ | ----------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| User balance       | Single overall account state (e.g. address X holds 4.2 ETH) | Sum of specific UTXOs (e.g. address X owns 29 UTXOs totalling 2.65 BTC)           |
+| Query model        | Direct: read account balance                                | Compute: aggregate over an address's UTXOs                                        |
+| Privacy            | Repeated address use correlates activity                    | Rotating addresses per output is the recommended privacy model                    |
+| Transaction model  | State transition: balance update                            | Input/output: consume UTXOs, create new ones                                      |
+
+## Querying UTXO data with Alchemy
+
+Alchemy's UTXO API gives you a clean REST interface to fetch Bitcoin addresses, balances, balance history, UTXOs, and block/transaction data. See the UTXO API endpoints in the sidebar, or the [UTXO migration guide](https://www.alchemy.com/docs/bitcoin/utxo-migration-guide) if you're moving from QuickNode, BlockCypher, or Blockdaemon.

--- a/content/api-reference/bitcoincash/utxo.mdx
+++ b/content/api-reference/bitcoincash/utxo.mdx
@@ -1,0 +1,45 @@
+---
+title: UTXO
+description: Understand how the Unspent Transaction Output (UTXO) model tracks balances on Bitcoin Cash.
+subtitle: The model Bitcoin Cash uses to track user balances
+slug: docs/bitcoincash/utxo
+---
+
+Bitcoin Cash uses the **Unspent Transaction Output (UTXO) model** to track user balances, in contrast to the **account model** used by Ethereum and other EVM chains.
+
+## UTXO-based model
+
+UTXO stands for *Unspent Transaction Output*. Instead of tracking an account's overall balance, the network maintains a set of UTXOs: outputs from past transactions that credit specific addresses with a specific amount.
+
+When someone says they own 3 BCH, what they actually hold is one or more UTXOs that together sum to 3 BCH. To spend that balance, a wallet selects specific UTXOs as inputs to a new transaction.
+
+## What is a UTXO?
+
+A UTXO is the output of a previous transaction that has not yet been spent. Every time a transaction is confirmed:
+
+* The inputs reference one or more UTXOs from previous transactions.
+* The outputs create new UTXOs credited to the recipient addresses.
+* Any leftover value (input minus output minus fee) returns to the sender as a "change" UTXO.
+
+So each transaction consumes old UTXOs and produces new ones. The full set of UTXOs at any point in time represents the network's spendable state.
+
+## Properties of UTXOs
+
+* **Non-fungible.** Each UTXO is a distinct object referenced by its transaction ID and output index.
+* **Specific to spend.** To spend a UTXO you must refer to that exact UTXO, not just an aggregate balance.
+* **Change creates new UTXOs.** Any leftover from the input value becomes a new UTXO sent back to the spender.
+* **Single-use.** A UTXO can only be spent once; double-spending is prevented at consensus.
+* **Script-locked.** Each UTXO carries a locking script that defines the conditions under which it can be spent (typically a signature from the owning private key).
+
+## Account model vs UTXO model
+
+|                    | Account model (Ethereum, EVM chains)                        | UTXO model (Bitcoin Cash)                                                         |
+| ------------------ | ----------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| User balance       | Single overall account state (e.g. address X holds 4.2 ETH) | Sum of specific UTXOs (e.g. address X owns 29 UTXOs totalling 2.65 BCH)           |
+| Query model        | Direct: read account balance                                | Compute: aggregate over an address's UTXOs                                        |
+| Privacy            | Repeated address use correlates activity                    | Rotating addresses per output is the recommended privacy model                    |
+| Transaction model  | State transition: balance update                            | Input/output: consume UTXOs, create new ones                                      |
+
+## Querying UTXO data with Alchemy
+
+Alchemy's UTXO API gives you a clean REST interface to fetch Bitcoin Cash addresses, balances, balance history, UTXOs, and block/transaction data. See the UTXO API endpoints in the sidebar, or the [UTXO migration guide](https://www.alchemy.com/docs/bitcoin/utxo-migration-guide) if you're moving from QuickNode, BlockCypher, or Blockdaemon.

--- a/content/api-reference/dogecoin/utxo.mdx
+++ b/content/api-reference/dogecoin/utxo.mdx
@@ -1,0 +1,45 @@
+---
+title: UTXO
+description: Understand how the Unspent Transaction Output (UTXO) model tracks balances on Dogecoin.
+subtitle: The model Dogecoin uses to track user balances
+slug: docs/dogecoin/utxo
+---
+
+Dogecoin uses the **Unspent Transaction Output (UTXO) model** to track user balances, in contrast to the **account model** used by Ethereum and other EVM chains.
+
+## UTXO-based model
+
+UTXO stands for *Unspent Transaction Output*. Instead of tracking an account's overall balance, the network maintains a set of UTXOs: outputs from past transactions that credit specific addresses with a specific amount.
+
+When someone says they own 3 DOGE, what they actually hold is one or more UTXOs that together sum to 3 DOGE. To spend that balance, a wallet selects specific UTXOs as inputs to a new transaction.
+
+## What is a UTXO?
+
+A UTXO is the output of a previous transaction that has not yet been spent. Every time a transaction is confirmed:
+
+* The inputs reference one or more UTXOs from previous transactions.
+* The outputs create new UTXOs credited to the recipient addresses.
+* Any leftover value (input minus output minus fee) returns to the sender as a "change" UTXO.
+
+So each transaction consumes old UTXOs and produces new ones. The full set of UTXOs at any point in time represents the network's spendable state.
+
+## Properties of UTXOs
+
+* **Non-fungible.** Each UTXO is a distinct object referenced by its transaction ID and output index.
+* **Specific to spend.** To spend a UTXO you must refer to that exact UTXO, not just an aggregate balance.
+* **Change creates new UTXOs.** Any leftover from the input value becomes a new UTXO sent back to the spender.
+* **Single-use.** A UTXO can only be spent once; double-spending is prevented at consensus.
+* **Script-locked.** Each UTXO carries a locking script that defines the conditions under which it can be spent (typically a signature from the owning private key).
+
+## Account model vs UTXO model
+
+|                    | Account model (Ethereum, EVM chains)                        | UTXO model (Dogecoin)                                                             |
+| ------------------ | ----------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| User balance       | Single overall account state (e.g. address X holds 4.2 ETH) | Sum of specific UTXOs (e.g. address X owns 29 UTXOs totalling 2.65 DOGE)          |
+| Query model        | Direct: read account balance                                | Compute: aggregate over an address's UTXOs                                        |
+| Privacy            | Repeated address use correlates activity                    | Rotating addresses per output is the recommended privacy model                    |
+| Transaction model  | State transition: balance update                            | Input/output: consume UTXOs, create new ones                                      |
+
+## Querying UTXO data with Alchemy
+
+Alchemy's UTXO API gives you a clean REST interface to fetch Dogecoin addresses, balances, balance history, UTXOs, and block/transaction data. See the UTXO API endpoints in the sidebar, or the [UTXO migration guide](https://www.alchemy.com/docs/bitcoin/utxo-migration-guide) if you're moving from QuickNode, BlockCypher, or Blockdaemon.

--- a/content/api-reference/litecoin/utxo.mdx
+++ b/content/api-reference/litecoin/utxo.mdx
@@ -1,0 +1,45 @@
+---
+title: UTXO
+description: Understand how the Unspent Transaction Output (UTXO) model tracks balances on Litecoin.
+subtitle: The model Litecoin uses to track user balances
+slug: docs/litecoin/utxo
+---
+
+Litecoin uses the **Unspent Transaction Output (UTXO) model** to track user balances, in contrast to the **account model** used by Ethereum and other EVM chains.
+
+## UTXO-based model
+
+UTXO stands for *Unspent Transaction Output*. Instead of tracking an account's overall balance, the network maintains a set of UTXOs: outputs from past transactions that credit specific addresses with a specific amount.
+
+When someone says they own 3 LTC, what they actually hold is one or more UTXOs that together sum to 3 LTC. To spend that balance, a wallet selects specific UTXOs as inputs to a new transaction.
+
+## What is a UTXO?
+
+A UTXO is the output of a previous transaction that has not yet been spent. Every time a transaction is confirmed:
+
+* The inputs reference one or more UTXOs from previous transactions.
+* The outputs create new UTXOs credited to the recipient addresses.
+* Any leftover value (input minus output minus fee) returns to the sender as a "change" UTXO.
+
+So each transaction consumes old UTXOs and produces new ones. The full set of UTXOs at any point in time represents the network's spendable state.
+
+## Properties of UTXOs
+
+* **Non-fungible.** Each UTXO is a distinct object referenced by its transaction ID and output index.
+* **Specific to spend.** To spend a UTXO you must refer to that exact UTXO, not just an aggregate balance.
+* **Change creates new UTXOs.** Any leftover from the input value becomes a new UTXO sent back to the spender.
+* **Single-use.** A UTXO can only be spent once; double-spending is prevented at consensus.
+* **Script-locked.** Each UTXO carries a locking script that defines the conditions under which it can be spent (typically a signature from the owning private key).
+
+## Account model vs UTXO model
+
+|                    | Account model (Ethereum, EVM chains)                        | UTXO model (Litecoin)                                                             |
+| ------------------ | ----------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| User balance       | Single overall account state (e.g. address X holds 4.2 ETH) | Sum of specific UTXOs (e.g. address X owns 29 UTXOs totalling 2.65 LTC)           |
+| Query model        | Direct: read account balance                                | Compute: aggregate over an address's UTXOs                                        |
+| Privacy            | Repeated address use correlates activity                    | Rotating addresses per output is the recommended privacy model                    |
+| Transaction model  | State transition: balance update                            | Input/output: consume UTXOs, create new ones                                      |
+
+## Querying UTXO data with Alchemy
+
+Alchemy's UTXO API gives you a clean REST interface to fetch Litecoin addresses, balances, balance history, UTXOs, and block/transaction data. See the UTXO API endpoints in the sidebar, or the [UTXO migration guide](https://www.alchemy.com/docs/bitcoin/utxo-migration-guide) if you're moving from QuickNode, BlockCypher, or Blockdaemon.

--- a/content/docs.yml
+++ b/content/docs.yml
@@ -1447,13 +1447,18 @@ navigation:
             path: api-reference/bitcoin/bitcoin-api-faq.mdx
           - page: Bitcoin API Overview
             path: api-reference/bitcoin/bitcoin-api-overview.mdx
-          - page: UTXO migration guide
-            path: api-reference/bitcoin/utxo-migration-guide.mdx
           - api: Bitcoin API Endpoints
             api-name: bitcoin
-          - api: UTXO API Endpoints
-            api-name: utxo
-            flattened: true
+          - section: UTXO
+            skip-slug: true
+            contents:
+              - page: UTXO
+                path: api-reference/bitcoin/utxo.mdx
+              - page: UTXO migration guide
+                path: api-reference/bitcoin/utxo-migration-guide.mdx
+              - api: UTXO API Endpoints
+                api-name: utxo
+                flattened: true
         slug: bitcoin
       - section: Bitcoin Cash
         contents:
@@ -1466,9 +1471,16 @@ navigation:
           - api: Bitcoin Cash API Endpoints
             api-name: bitcoincash
             slug: bitcoincash-api-endpoints
-          - api: UTXO API Endpoints
-            api-name: utxo
-            flattened: true
+          - section: UTXO
+            skip-slug: true
+            contents:
+              - page: UTXO
+                path: api-reference/bitcoincash/utxo.mdx
+              - link: UTXO migration guide
+                href: /docs/bitcoin/utxo-migration-guide
+              - api: UTXO API Endpoints
+                api-name: utxo
+                flattened: true
         slug: bitcoincash
       - section: Blast
         contents:
@@ -1582,9 +1594,16 @@ navigation:
             path: api-reference/dogecoin/dogecoin-api-overview.mdx
           - api: Dogecoin API Endpoints
             api-name: dogecoin
-          - api: UTXO API Endpoints
-            api-name: utxo
-            flattened: true
+          - section: UTXO
+            skip-slug: true
+            contents:
+              - page: UTXO
+                path: api-reference/dogecoin/utxo.mdx
+              - link: UTXO migration guide
+                href: /docs/bitcoin/utxo-migration-guide
+              - api: UTXO API Endpoints
+                api-name: utxo
+                flattened: true
         slug: dogecoin
 
       - section: Fantom
@@ -1732,9 +1751,16 @@ navigation:
             path: api-reference/litecoin/litecoin-api-overview.mdx
           - api: Litecoin API Endpoints
             api-name: litecoin
-          - api: UTXO API Endpoints
-            api-name: utxo
-            flattened: true
+          - section: UTXO
+            skip-slug: true
+            contents:
+              - page: UTXO
+                path: api-reference/litecoin/utxo.mdx
+              - link: UTXO migration guide
+                href: /docs/bitcoin/utxo-migration-guide
+              - api: UTXO API Endpoints
+                api-name: utxo
+                flattened: true
         slug: litecoin
       - section: Lumia
         contents:


### PR DESCRIPTION
## Summary

Adds a dedicated UTXO sub-section to each of the four UTXO chains (Bitcoin, Bitcoin Cash, Litecoin, Dogecoin) in the sidebar. Each sub-section contains:

1. A new UTXO overview page explaining the Unspent Transaction Output model. Content adapted from the existing [UTXO vs Account models](https://www.alchemy.com/docs/utxo-vs-account-models) educational page, focused on the UTXO half with a chain-specific intro and ticker.
2. A reference to the shared UTXO migration guide.
3. The existing UTXO API Endpoints entry, moved from the chain's top level into the new sub-section.

`skip-slug: true` is set on each new sub-section, so existing `/docs/chains/<chain>/utxo-api-endpoints/...` URLs continue to resolve unchanged.

For BCH / LTC / DOGE, the migration guide is referenced via a `link:` entry pointing at the canonical `/docs/bitcoin/utxo-migration-guide` URL, rather than a duplicate `page:` `path:` (Fern requires each MDX path to appear at most once in the nav). For Bitcoin, the existing top-level migration guide entry is moved into the new UTXO sub-section as a normal `page:` reference.

**Changes:**
- New pages: `content/api-reference/{bitcoin,bitcoincash,litecoin,dogecoin}/utxo.mdx`
- `content/docs.yml`: restructured the four chain sections

## Linear

[DOCS-79](https://linear.app/alchemyapi/issue/DOCS-79/docs-add-utxo-sub-section-per-chain-bitcoin-bch-ltc-doge-with-overview)

## Requested by

@andra-catana (via Slack thread)