### PR TITLE
[docs-agent] Weekly style audit fixes 2026-05-13

### DIFF
--- a/content/api-reference/bitcoin/utxo-migration-guide.mdx
+++ b/content/api-reference/bitcoin/utxo-migration-guide.mdx
@@ -134,7 +134,7 @@ Source: [Alchemy Get balance history](/docs/chains/bitcoin/utxo-api-endpoints/ut
 | Address                  | Passed in `params` array             | Passed in URL path                     |
 | Time range               | Passed as strings in `params` object | Passed as query parameters             |
 | Response wrapper         | Wrapped in `jsonrpc`, `id`, `result` | Clean JSON array, no wrapper           |
-| Fiat rates in response   | Included via `fiatcurrency` param    | Included via `fiatcurrency` query param |
+| Fiat rates in response   | Included via `fiatcurrency` parameter | Included via `fiatcurrency` query parameter |
 
 ## Migrating from BlockCypher
 
@@ -296,7 +296,7 @@ If there's a feature you need, let us know. Contact us at [data-services-product
 * **How do I enable UTXO endpoints on my Alchemy account?**
   * Purchase the UTXO add-on for your desired chain directly from the Alchemy dashboard. Once enabled, you can start making REST API calls immediately.
 * **I'm migrating from BlockCypher. How different is the integration?**
-  * BlockCypher and Alchemy both use REST GET endpoints, so the migration is the most straightforward of the three. The main changes are the base URL pattern, field naming convention (`snake_case` vs `camelCase`), and authentication method (query param vs URL path).
+  * BlockCypher and Alchemy both use REST GET endpoints, so the migration is the most straightforward of the three. The main changes are the base URL pattern, field naming convention (`snake_case` vs `camelCase`), and authentication method (query parameter vs URL path).
 * **I'm migrating from Blockdaemon. Does Alchemy support the same data?**
   * Alchemy provides richer address data than Blockdaemon's `bd_getbalance` method, including total received, total sent, and transaction counts - all from a single REST call with no JSON-RPC wrapper. Alchemy also offers balance history, which is not available through Blockdaemon's Bitcoin RPC.
 * **Where can I get help with my migration?**


### PR DESCRIPTION
Weekly audit fix for an ERROR-level style violation found in PRs merged this week.

## Files fixed

- `content/api-reference/bitcoin/utxo-migration-guide.mdx` — replaced three prose occurrences of `param` with `parameter` to match `STYLE_RULES.md` preferred terminology (line 292: "Use parameter in prose instead of param"). Two occurrences on the differences table row for fiat rates, one in the migration FAQ.

## Scope

Only ERROR-level terminology issues are addressed. The threshold per the weekly audit playbook is "wrong terminology repeated in multiple places within the same file" — three prose `param` uses in one file met that bar.

Warning-level findings noted but skipped per the playbook:
- One `on-chain` in `content/api-reference/bitcoincash/bitcoincash-api-faq.mdx` (single instance).
- One filler word `easy` in the migration guide ("we are here to make it easy").
- Title Case template headings on legacy index/overview pages (recurring weekly pattern, already documented).
- `apiKey` undefined in BCH/LTC/DOGE quickstart code samples (matches existing chain quickstart template across the repo; docs-wide change out of scope for an audit PR).
- Vague `# Introduction` heading on the new BCH/LTC/DOGE quickstart pages (matches existing template).
