### PR TITLE
[docs-agent] Add /eth/v1/beacon/states/{state_id}/pending_partial_withdrawals to Compute Unit Costs

### DIFF
--- a/content/api-reference/pricing-resources/pricing/compute-unit-costs.mdx
+++ b/content/api-reference/pricing-resources/pricing/compute-unit-costs.mdx
@@ -500,6 +500,7 @@ On average, a typical byte-priced webhook or WebSocket subscription event is abo
 | /eth/v1/beacon/states/\{state\_id}/finality\_checkpoints       | 20  |
 | /eth/v1/beacon/states/\{state\_id}/fork                        | 20  |
 | /eth/v1/beacon/states/\{state\_id}/pending\_consolidations     | 20  |
+| /eth/v1/beacon/states/\{state\_id}/pending\_partial\_withdrawals | 20  |
 | /eth/v1/beacon/states/\{state\_id}/root                        | 20  |
 | /eth/v1/beacon/states/\{state\_id}/sync\_committees            | 20  |
 | /eth/v1/beacon/states/\{state\_id}/validator\_balances         | 20  |


### PR DESCRIPTION
## Summary

Add a new row to the Ethereum Beacon Standard HTTP API Methods table on the [Compute Unit Costs](https://www.alchemy.com/docs/reference/compute-unit-costs) page for `/eth/v1/beacon/states/{state_id}/pending_partial_withdrawals` at 20 CU.

Placed alphabetically between `pending_consolidations` and `root` (per the requester's instruction).

## Linear

DOCS-82 — https://linear.app/alchemyapi/issue/DOCS-82/add-ethv1beaconstatesstate-idpending-partial-withdrawals-to-compute

## Requested by

@dexterliu (via Slack thread)
