### PR TITLE
Rename Bitcoin: UTXO REST API Methods section to UTXO REST API Methods

### DIFF
--- a/content/api-reference/pricing-resources/pricing/compute-unit-costs.mdx
+++ b/content/api-reference/pricing-resources/pricing/compute-unit-costs.mdx
@@ -592,7 +592,7 @@ On average, a typical byte-priced webhook or WebSocket subscription event is abo
 | sendrawtransaction                                        | 10  |
 | submitpackage                                             | 10  |
 
-# Bitcoin: UTXO REST API Methods
+# UTXO REST API Methods
 
 | Method                                                    | CU  |
 | --------------------------------------------------------- | --- |


### PR DESCRIPTION
## Summary
- Renames the "Bitcoin: UTXO REST API Methods" section on the Compute Unit Costs page to "UTXO REST API Methods" — the REST API endpoints apply to all UTXO chains (Bitcoin, Litecoin, Dogecoin, Bitcoin Cash), not just Bitcoin.

## Test plan
- [ ] Preview the Compute Unit Costs page and confirm the section heading reads "UTXO REST API Methods"
- [ ] Confirm no internal links pointed at the old `#bitcoin-utxo-rest-api-methods` anchor

🤖 Generated with [Claude Code](https://claude.com/claude-code)