### PR TITLE
[docs-agent] Fix WebSocket URL on Subscription API Overview

### DIFF
--- a/content/api-reference/websockets/subscription-api.mdx
+++ b/content/api-reference/websockets/subscription-api.mdx
@@ -98,7 +98,7 @@ Next, install a command line tool for making WebSocket requests such as [wscat](
 
 <CodeGroup>
   ```shell Shell
-  $ wscat -c wss://eth-mainnet.ws.g.alchemy.com/v2/demo
+  $ wscat -c wss://eth-mainnet.g.alchemy.com/v2/demo
 
   // create subscription
 


### PR DESCRIPTION
## Summary

The `wscat` example on the Subscription API Overview page (`content/api-reference/websockets/subscription-api.mdx:101`) used `wss://eth-mainnet.ws.g.alchemy.com/v2/demo`, but every other WebSocket URL in the docs (70+ matches across `content/`) uses `wss://eth-mainnet.g.alchemy.com/v2/demo` with no `.ws` subdomain. The sibling [Best Practices for Using WebSockets in Web3](https://www.alchemy.com/docs/reference/best-practices-for-using-websockets-in-web3#subscribe-to-ethereum-blockchain-updates) page is the closest example. Alchemy's RPC marketing page also documents the no-`.ws` form:

> Websocket: `wss://eth-mainnet.g.alchemy.com/v2/<api-key>`
> ([alchemy.com/rpc/ethereum](https://www.alchemy.com/rpc/ethereum))

This drops `.ws` from the one outlier line so the Subscription API Overview matches the canonical form used everywhere else.

## Verification

```
$ grep -rn "ws\.g\.alchemy\.com" content/ src/
(no matches)
```

## Linear

DOCS-85 — https://linear.app/alchemyapi/issue/DOCS-85/fix-websocket-url-on-subscription-api-overview-page-remove-ws

## Requested by

@seansing (via Slack thread)
