### PR TITLE
[docs-agent] Update Solana Yellowstone gRPC pricing to $75/TB

### DIFF
--- a/content/api-reference/pricing-resources/pricing/compute-unit-costs.mdx
+++ b/content/api-reference/pricing-resources/pricing/compute-unit-costs.mdx
@@ -198,7 +198,7 @@ For more details, check out the [Compute Units](/docs/reference/compute-units#wh
 
 | Bandwidth | CU     |
 | --------- | ------ |
-| 1 TB    | $80 |
+| 1 TB    | $75 |
 
 * Amount will be pro-rated based on bytes streamed. [Contact us](https://www.alchemy.com/contact-sales) for pre-committed bulk discounts.
 


### PR DESCRIPTION
## Summary

Updates the Solana Yellowstone gRPC bandwidth pricing row on the [compute unit costs page](https://www.alchemy.com/docs/reference/compute-unit-costs#solana-yellowstone-grpc) from $80 to $75 per TB.

## Linear

[DOCS-87](https://linear.app/alchemyapi/issue/DOCS-87/update-solana-yellowstone-grpc-pricing-on-compute-unit-costs-page)

## Requested by

@limawebdev1 (via Slack thread)