### PR TITLE
[docs-agent] Fix baseline lychee link-check errors blocking PRs

### DIFF
--- a/content/api-reference/data/webhooks/custom-webhooks-quickstart/custom-webhooks-quickstart.mdx
+++ b/content/api-reference/data/webhooks/custom-webhooks-quickstart/custom-webhooks-quickstart.mdx
@@ -27,7 +27,7 @@ Alchemy leverages GraphQL's expressiveness to allow developers to self-define th
 * **Token activity** - Get all token-related activity via Custom Webhooks, including approvals, staking, mints, burns, transfers and anything else you need. No more enriching data from a bunch of fragmented sources.
 * **Marketplace activity** - Track marketplace activity at a granularity that's most useful for you. From protocols like UniswapV2Factory to OpenSea's Wyvern contracts, easily ingest swaps or atomic trades that represent more than one transfer event.
 * **Oracle activity** - Find out right away anytime there is an attestation of off-chain data like ETH or DAI prices.
-* **Data ingestion** - Ingest whatever data stream is useful for your business, from full block receipts to transaction activity, contract creations and more. If you're looking to ingest data into a DApp and want to see a real-time example, check out our [sample repl project](https://replit.com/@AlLuken/ETH-USDC-Custom-Webhook#index.js), fork it, and build on top of it!
+* **Data ingestion** - Ingest whatever data stream is useful for your business, from full block receipts to transaction activity, contract creations and more.
 * **Anything else** - Alchemy Notify’s Custom Webhooks are truly an open canvas, giving you the tools to get any combination of data your app needs.
 
 <Tip title="Don’t have an API key?" icon="star">

--- a/content/wallets/pages/recipes/onramp-funds.mdx
+++ b/content/wallets/pages/recipes/onramp-funds.mdx
@@ -4,7 +4,7 @@ description: Step-by-step guide to let users buy crypto with Coinbase Onramp and
 slug: wallets/recipes/onramp-funds
 ---
 
-This recipe demonstrates how to integrate the Coinbase Onramp into an app that uses **embedded smart wallets**. It uses the [Coinbase Developer Platform](https://docs.cdp.coinbase.com/onramp/docs/api-onramp-initializing) and assumes you've configured your Wallet APIs integration using `@account-kit/react`.
+This recipe demonstrates how to integrate the Coinbase Onramp into an app that uses **embedded smart wallets**. It uses the [Coinbase Developer Platform](https://docs.cdp.coinbase.com/onramp/introduction/welcome) and assumes you've configured your Wallet APIs integration using `@account-kit/react`.
 
 > **Goal**: Let users seamlessly buy crypto (e.g. ETH) via card and fund their smart wallet directly.
 
@@ -353,7 +353,7 @@ Users can now click "Buy Crypto", complete their purchase in a popup, and immedi
 
 ## Resources
 
-* [Coinbase Onramp API](https://docs.cdp.coinbase.com/onramp/docs/api-onramp-initializing)
+* [Coinbase Onramp API](https://docs.cdp.coinbase.com/onramp/introduction/welcome)
 * [Alchemy Wallet APIs Quickstart](https://www.alchemy.com/docs/wallets/react/quickstart)
 * [Coinbase Onchainkit](https://www.npmjs.com/package/@coinbase/onchainkit)
 * [Coinbase getOnrampBuyUrl](https://docs.cdp.coinbase.com/onramp/coinbase-hosted-onramp/generating-onramp-url)

--- a/content/wallets/pages/recipes/onramp-funds.mdx
+++ b/content/wallets/pages/recipes/onramp-funds.mdx
@@ -356,5 +356,5 @@ Users can now click "Buy Crypto", complete their purchase in a popup, and immedi
 * [Coinbase Onramp API](https://docs.cdp.coinbase.com/onramp/docs/api-onramp-initializing)
 * [Alchemy Wallet APIs Quickstart](https://www.alchemy.com/docs/wallets/react/quickstart)
 * [Coinbase Onchainkit](https://www.npmjs.com/package/@coinbase/onchainkit)
-* [Coinbase getOnrampBuyUrl](https://docs.base.org/onchainkit/fund/get-onramp-buy-url)
+* [Coinbase getOnrampBuyUrl](https://docs.cdp.coinbase.com/onramp/coinbase-hosted-onramp/generating-onramp-url)
 * [JWT and Session Token Example](https://github.com/coinbase/onramp-demo-application/blob/51733031e49ed4b505291ee7acbdbee429dceb3c/app/utils/sessionTokenApi.ts)

--- a/content/wallets/pages/recipes/programmatic-wallet-creation.mdx
+++ b/content/wallets/pages/recipes/programmatic-wallet-creation.mdx
@@ -247,4 +247,4 @@ This recipe shows how to programmatically create a smart wallet: you’ll genera
   </Step>
 </Steps>
 
-You have now learned how to programmatically create a smart wallet. Use the call ID to track your transaction via the [wallet APIs](/docs/wallets/reference/wallet-apis/functions/getCallsStatus).
+You have now learned how to programmatically create a smart wallet. Use the call ID to track your transaction via the [`wallet_getCallsStatus`](/docs/wallets/api-reference/smart-wallets/wallet-api-endpoints/wallet-get-calls-status) endpoint.

--- a/content/wallets/wallet-integrations/privy/jwt-auth-migration.mdx
+++ b/content/wallets/wallet-integrations/privy/jwt-auth-migration.mdx
@@ -71,7 +71,7 @@ While existing users still need migrating, you don't want Privy to auto-create a
 >
 ```
 
-**For new users (signing up after your migration is live):** because you track migration status in your own database (Step 1), new users start with `signer_migrated = true` (no Alchemy wallet to migrate). Create a Privy wallet for them explicitly after login — either by calling [`createWallet`](https://docs.privy.io/wallets/using-wallets/ethereum/create-a-wallet) from the client SDK or via the `@privy-io/node` SDK server-side. Once all existing users have migrated, switch `createOnLogin` back to `"users-without-wallets"` and you can drop the explicit creation call.
+**For new users (signing up after your migration is live):** because you track migration status in your own database (Step 1), new users start with `signer_migrated = true` (no Alchemy wallet to migrate). Create a Privy wallet for them explicitly after login — either by calling [`createWallet`](https://docs.privy.io/wallets/wallets/create/create-a-wallet) from the client SDK or via the `@privy-io/node` SDK server-side. Once all existing users have migrated, switch `createOnLogin` back to `"users-without-wallets"` and you can drop the explicit creation call.
 
 ## Step 3: Reconnect sending and gas sponsorship
 

--- a/lychee.toml
+++ b/lychee.toml
@@ -50,6 +50,10 @@ exclude = [
     ".*developer\\.offchainlabs\\.com.*", # Rate-limits crawlers with 429
     ".*openai\\.com/index/.*",       # Returns 404 to bot traffic
     ".*www\\.starknetjs\\.com.*",    # SSL cert valid only for *.netlify.app, not the custom domain
+    ".*investopedia\\.com.*",        # Bot protection blocks crawlers with 403 (hostname_blocked)
+    ".*geth\\.ethereum\\.org.*",     # Intermittent timeouts for crawlers (page loads fine in browser)
+    ".*privy\\.io/slack.*",          # Slack invite link, bot protection blocks crawlers on final redirect
+    ".*docs\\.arbitrum\\.io.*",      # Vercel bot challenge / rate-limits crawlers with 429
 
 ]
 


### PR DESCRIPTION
## Summary

The Link Check (lychee) CI job has been failing on every PR with the same 8 baseline errors that aren't introduced by the changing PR. Audited each one: 4 are real broken links and 4 are bot-protection false positives where the link works in a browser but lychee gets blocked.

## Real link fixes (4)

| File | Old URL | Why broken | New URL |
| --- | --- | --- | --- |
| `content/wallets/wallet-integrations/privy/jwt-auth-migration.mdx` | `docs.privy.io/wallets/using-wallets/ethereum/create-a-wallet` | Privy reorganized docs; old URL 404s | `docs.privy.io/wallets/wallets/create/create-a-wallet` (verified via `docs.privy.io/sitemap.xml`) |
| `content/wallets/pages/recipes/onramp-funds.mdx` | `docs.base.org/onchainkit/fund/get-onramp-buy-url` | Base deprecated OnchainKit; its `migrate-from-onchainkit` page also 404s | `docs.cdp.coinbase.com/onramp/coinbase-hosted-onramp/generating-onramp-url` (the actively maintained CDP equivalent for `getOnrampBuyUrl`) |
| `content/wallets/pages/recipes/programmatic-wallet-creation.mdx` | `/docs/wallets/reference/wallet-apis/functions/getCallsStatus` | Never existed at that path | `/docs/wallets/api-reference/smart-wallets/wallet-api-endpoints/wallet-get-calls-status` (matches the rest of the codebase, verified live) |
| `content/api-reference/data/webhooks/custom-webhooks-quickstart/custom-webhooks-quickstart.mdx` | `replit.com/@AlLuken/ETH-USDC-Custom-Webhook#index.js` | Replit project deleted (real 404) | Removed the sentence referencing it; no equivalent demo to swap in |

## Bot-protection false positives added to `lychee.toml` (4)

Each verified manually: live page works in a browser, but the crawler gets a hostile response.

| Domain | What happens | Reason |
| --- | --- | --- |
| `investopedia.com` | 403 with `x-block-reason: hostname_blocked` | Blocks non-browser UAs |
| `geth.ethereum.org` | lychee timeout; curl returns 200 fast | Intermittent for crawlers |
| `privy.io/slack` | 308 redirect chain ending at Slack 403 | Slack workspace invite, canonical Privy community link |
| `docs.arbitrum.io` | 429 with `x-vercel-challenge-token` | Vercel rate-limits/challenges bots |

## After merge

`Link Check` should be green on every subsequent PR that doesn't introduce new broken links. The PR-checks workflow runs lychee against all of `./content` on any PR touching `content/**/*.md(x)`, so this fix unblocks every content PR currently in flight.

## Linear

[DOCS-88](https://linear.app/alchemyapi/issue/DOCS-88/fix-baseline-lychee-link-check-errors-blocking-prs)

## Requested by

@SahilAujla (via Slack thread)