### PR TITLE
[docs-agent] Remove Local development section from Alchemy MCP Server page

### DIFF
--- a/content/tutorials/build-with-ai/alchemy-mcp-server.mdx
+++ b/content/tutorials/build-with-ai/alchemy-mcp-server.mdx
@@ -404,10 +404,6 @@ Call Alchemy's REST APIs for enriched blockchain data. All require `select_app` 
 
 We support **100+ blockchains** including Ethereum, Base, Polygon, Arbitrum, Optimism, Solana, Starknet, zkSync, Scroll, Linea, Mantle, Blast, and many more. Use `list_chains` to see the full list.
 
-## Local development
-
-To run your own instance of the MCP server, see the setup instructions on GitHub: [alchemyplatform/alchemy-mcp-server](https://github.com/alchemyplatform/alchemy-mcp-server). Note that the open-source repo and the hosted server at `mcp.alchemy.com` are maintained separately and may not be in sync.
-
 ## Related tools
 
 * [Agent Skills](docs/alchemy-agent-skills) teach your coding agent every Alchemy API at the source-code level


### PR DESCRIPTION
## Summary

Removes the **Local development** section from `content/tutorials/build-with-ai/alchemy-mcp-server.mdx`. The hosted server at `mcp.alchemy.com` is the canonical surface; the open-source repo callout (plus the caveat that the OSS and hosted server "may not be in sync") was creating confusion. Dropping the section keeps the page focused on connecting clients to the hosted server.

No redirect needed: this is a section deletion on an existing page, the page slug (`/docs/alchemy-mcp-server`) is unchanged, and the fragment `#local-development` was not linked from any other page in `content/`.

## Linear

[DOCS-89](https://linear.app/alchemyapi/issue/DOCS-89/remove-local-development-section-from-alchemy-mcp-server-page)

## Requested by

@CodesMcCabe (via Slack thread)