### PR TITLE
[docs-agent] UTXO API: hardcode chain-specific server URLs (no network dropdown)

### DIFF
--- a/src/openapi/utxo-bitcoincash/utxo-bitcoincash.yaml
+++ b/src/openapi/utxo-bitcoincash/utxo-bitcoincash.yaml
@@ -9,13 +9,8 @@ info:
     Bitcoin Cash networks. The same paths are available on every UTXO chain Alchemy supports —
     switch chains using the chain-specific overview pages or by changing the host.
 servers:
-  - url: https://{network}.g.alchemy.com/v2
-    variables:
-      network:
-        default: bitcoincash-mainnet
-        enum:
-          - bitcoincash-mainnet
-          - bitcoincash-testnet
+  - url: https://bitcoincash-mainnet.g.alchemy.com/v2
+    description: Bitcoin Cash mainnet
 paths:
   "/{apiKey}/api/v2/block-index/{block_height}":
     get:

--- a/src/openapi/utxo-dogecoin/utxo-dogecoin.yaml
+++ b/src/openapi/utxo-dogecoin/utxo-dogecoin.yaml
@@ -9,12 +9,8 @@ info:
     Dogecoin. The same paths are available on every UTXO chain Alchemy supports — switch chains
     using the chain-specific overview pages or by changing the host.
 servers:
-  - url: https://{network}.g.alchemy.com/v2
-    variables:
-      network:
-        default: dogecoin-mainnet
-        enum:
-          - dogecoin-mainnet
+  - url: https://dogecoin-mainnet.g.alchemy.com/v2
+    description: Dogecoin mainnet
 paths:
   "/{apiKey}/api/v2/block-index/{block_height}":
     get:

--- a/src/openapi/utxo-litecoin/utxo-litecoin.yaml
+++ b/src/openapi/utxo-litecoin/utxo-litecoin.yaml
@@ -9,13 +9,8 @@ info:
     Litecoin networks. The same paths are available on every UTXO chain Alchemy supports —
     switch chains using the chain-specific overview pages or by changing the host.
 servers:
-  - url: https://{network}.g.alchemy.com/v2
-    variables:
-      network:
-        default: litecoin-mainnet
-        enum:
-          - litecoin-mainnet
-          - litecoin-testnet
+  - url: https://litecoin-mainnet.g.alchemy.com/v2
+    description: Litecoin mainnet
 paths:
   "/{apiKey}/api/v2/block-index/{block_height}":
     get:


### PR DESCRIPTION
## Summary

On the Bitcoin Cash, Litecoin, and Dogecoin UTXO API method pages, the rendered `Server` field exposed a network-picker dropdown because each per-chain spec used a templated `https://{network}.g.alchemy.com/v2` server URL with a `network` enum. Andra reported that even after PR #1302 restricted each chain's enum to that chain's own mainnet/testnet, the dropdown UI itself was still a distraction.

This PR collapses each per-chain UTXO spec down to a single literal server URL (no variables, no enum, no dropdown):

| Chain | Spec | Server URL |
|---|---|---|
| Bitcoin Cash | `src/openapi/utxo-bitcoincash/utxo-bitcoincash.yaml` | `https://bitcoincash-mainnet.g.alchemy.com/v2` |
| Litecoin | `src/openapi/utxo-litecoin/utxo-litecoin.yaml` | `https://litecoin-mainnet.g.alchemy.com/v2` |
| Dogecoin | `src/openapi/utxo-dogecoin/utxo-dogecoin.yaml` | `https://dogecoin-mainnet.g.alchemy.com/v2` |

## Trade-off

Testnet variants (`bitcoincash-testnet`, `litecoin-testnet`) are dropped from the spec. Testnet users can swap the host manually in curl. The OpenAPI source still documents the path shapes correctly; only the host picker UI is removed.

## Out of scope

* Bitcoin UTXO pages: the shared `src/openapi/utxo/utxo.yaml` is intentionally untouched. It still exposes the 7-network enum on the Bitcoin page. If reviewers want BTC pages to follow the same single-URL pattern, that's a follow-up.

## Validation

* `pnpm run validate:rest` — all three modified specs validate cleanly.

## Linear

[DOCS-83](https://linear.app/alchemyapi/issue/DOCS-83/utxo-api-chain-specific-curl-examples-on-bch-ltc-doge-pages)

## Requested by

@andra-catana (via Slack thread)