### PR TITLE
[docs-agent] Rename Token API spec title from "Private Transactions API" to "Token"

### DIFF
--- a/src/openrpc/alchemy/token/token.yaml
+++ b/src/openrpc/alchemy/token/token.yaml
@@ -3,8 +3,8 @@
 $schema: https://meta.open-rpc.org/
 openrpc: 1.2.4
 info:
-  title: Alchemy Private Transactions API JSON-RPC Specification
-  description: A specification of the standard JSON-RPC methods for Private Transactions API.
+  title: Alchemy Token JSON-RPC Specification
+  description: A specification of the standard JSON-RPC methods for Token API.
   version: 0.0.0
 servers:
   - url: https://eth-mainnet.g.alchemy.com/v2


### PR DESCRIPTION
## Summary

The OpenRPC spec at `src/openrpc/alchemy/token/token.yaml` had `info.title: Alchemy Private Transactions API JSON-RPC Specification`. The docs metadata builder fetches this from `dev-docs.alchemy.com/alchemy/json-rpc/token.json`, extracts the product name (`Private Transactions API`), and appends ` API`. The result, visible on Google for `alchemy_getTokenBalances` and other Token API methods, was:

> alchemy_getTokenBalances - Private Transactions API API
> Returns ERC-20 token balances for a given address on Private Transactions API.

Two bugs in one: wrong product name (this is the Token API, not Private Transactions) and a duplicated "API" caused by the spec title already ending in "API".

## Change

```yaml
# Before
info:
  title: Alchemy Private Transactions API JSON-RPC Specification
  description: A specification of the standard JSON-RPC methods for Private Transactions API.

# After
info:
  title: Alchemy Token JSON-RPC Specification
  description: A specification of the standard JSON-RPC methods for Token API.
```

This matches the shape used by `solana-das.yaml` (`Alchemy Solana JSON-RPC Specification` → `Solana API`) and `solana-photon.yaml` (`Alchemy Solana Photon JSON-RPC Specification` → `Solana Photon API`), where the spec carries only the product name and the builder appends ` API`. Resulting SERP title is `alchemy_getTokenBalances - Token API`.

## Out of scope

The same duplicated-API pattern likely affects the other Alchemy specs that include "API" in their title (`bundler.yaml`, `debug.yaml`, `trace.yaml`, `transfers.yaml`, `transaction-simulation.yaml`, `transactions-receipt.yaml`, `userop-sim.yaml`, `gas-manager-coverage.yaml`). Those need verification on Google before flipping to "Product" shape, and would be a follow-up sweep PR.

## Validation

- `pnpm run generate:rpc`: OK
- `pnpm run validate:rpc`: OK (both json-rpc and chains)

## Linear

DOCS-90 — https://linear.app/alchemyapi/issue/DOCS-90/rename-token-api-spec-title-from-private-transactions-api-to-token

## Requested by

@Onewaysidewalks (via Slack thread)