### PR TITLE
[docs-agent] Fix "singing key" typo on Notify API Quickstart

### DIFF
--- a/content/api-reference/data/webhooks/webhooks-quickstart/notify-api-quickstart.mdx
+++ b/content/api-reference/data/webhooks/webhooks-quickstart/notify-api-quickstart.mdx
@@ -378,7 +378,7 @@ To make your webhooks secure, you can verify that they originated from Alchemy b
 
 ### Find your signing key
 
-To find your signing key, navigate to the [webhooks dashboard](https://dashboard.alchemy.com/apps/latest/webhooks), select your webhook, and copy the singing key from the top right of that webhook's detail page.
+To find your signing key, navigate to the [webhooks dashboard](https://dashboard.alchemy.com/apps/latest/webhooks), select your webhook, and copy the signing key from the top right of that webhook's detail page.
 
 ### Validate the signature received
 


### PR DESCRIPTION
## Summary

Single-character typo fix on the [Notify API Quickstart](https://www.alchemy.com/docs/reference/notify-api-quickstart#webhook-signature) page. The "Find your signing key" section said "copy the singing key" instead of "copy the signing key".

Confirmed via `grep -rnE "\bsinging\b" content/ src/` that this is the only occurrence in the repo.

## Linear

[DOCS-91](https://linear.app/alchemyapi/issue/DOCS-91/fix-singing-key-typo-on-notify-api-quickstart)

## Requested by

@richardjaee (via Slack thread)