### PR TITLE
Add Auth0 OAuth coverage to Privy migration docs

### DIFF
--- a/content/wallets/wallet-integrations/privy/jwt-auth-migration.mdx
+++ b/content/wallets/wallet-integrations/privy/jwt-auth-migration.mdx
@@ -1,21 +1,25 @@
 ---
-title: "Migrate JWT authentication from Alchemy to Privy"
-description: "Step-by-step guide to migrate embedded wallets from Alchemy to Privy when using JWT (JSON Web Token) authentication."
+title: "Migrate JWT or Auth0 OAuth authentication from Alchemy to Privy"
+description: "Step-by-step guide to migrate embedded wallets from Alchemy to Privy when using JWT (JSON Web Token) or Auth0 OAuth authentication."
 slug: wallets/wallet-integrations/privy/jwt-auth-migration
 ---
 
-This guide is for developers who authenticate users with Alchemy Signer using **JWT (JSON Web Token) authentication** and need to migrate to Privy.
+This guide is for developers who authenticate users with Alchemy Signer using **JWT (JSON Web Token) authentication** or **Auth0 as an OAuth provider** (e.g., GitHub, Twitter via Auth0) and need to migrate to Privy.
 
-<Info>If you use standard auth methods (email, Google, passkeys) with the React SDK, use the [React migration guide](/docs/wallets/wallet-integrations/privy/react-migration) instead.</Info>
+<Info>If you use standard auth methods (email, Google, passkeys) with the React SDK — and you do **not** authenticate via Auth0 — use the [React migration guide](/docs/wallets/wallet-integrations/privy/react-migration) instead.</Info>
+
+<Note>
+**Why Auth0 OAuth users follow this guide:** Privy treats Auth0 as a custom JWT auth integration, so Auth0 OAuth users cannot use the React migration SDK (which handles email, Google, passkeys). The Privy-side setup is identical to the JWT path. The only difference is how you authenticate with the Alchemy signer during migration — you use Auth0 OAuth parameters instead of a JWT token.
+</Note>
 
 <Note>Before starting, read the [signer migration overview](/docs/wallets/wallet-integrations/privy/signer-migration-overview) to confirm your account type (Modular Account v2 vs. another implementation) and connection type (EIP-7702 vs. ERC-4337). Apps not on MAv2, or using pure 4337, need to adjust a step in this guide — the overview's [Edge cases](/docs/wallets/wallet-integrations/privy/signer-migration-overview#edge-cases) section walks through each.</Note>
 
-## How JWT migration differs from standard migration
+## How this migration differs from the standard React migration
 
-With JWT auth, you control both sides of authentication — your server generates JWTs, and both Alchemy and your new provider accept them. This simplifies the migration because:
+With JWT or Auth0 OAuth auth, you control both sides of authentication — your server generates JWTs (or Auth0 handles OAuth), and both Alchemy and your new provider accept them. This simplifies the migration because:
 
-* **No user export/import needed** (unless you also use other auth methods) — both providers authenticate via your JWT
-* **JWTs are reusable** — they're not one-time-use tokens, so the same JWT can authenticate with both Alchemy and Privy in a single session
+* **No user export/import needed** (unless you also use other auth methods) — both providers authenticate via your JWT or Auth0 OAuth token
+* **Tokens are reusable** — JWTs are not one-time-use tokens, and Auth0 OAuth sessions persist, so the same authentication can work with both Alchemy and Privy in a single session
 * **Migration detection is your responsibility** — since there's no Privy-side metadata, you track which users have migrated in your own database
 
 ## Choose your integration path
@@ -28,6 +32,10 @@ This guide covers two paths. Both share the same Privy dashboard setup (Steps 1�
 | **Auth hook** | `useSubscribeToJwtAuthWithFlag` (React SDK) | REST API: exchange JWT for a Privy `userSigner` |
 | **Wallet import** | `useImportWallet` hook (client-side) | `@privy-io/node` SDK or REST API `/v1/wallets/import/*` |
 | **Private key exposure** | Briefly in client memory during export→import | On your server during export→import |
+
+<Info>
+**Auth0 OAuth users:** Both client-side and server-side paths apply to you. The table above references JWT-specific hooks, but the Privy-side setup (Steps 1–2) is the same. The key difference is in [Step 4b](#4b-build-the-client-side-migration-flow) where you authenticate with the Alchemy signer using Auth0 OAuth parameters instead of a JWT token.
+</Info>
 
 ## Step 1: Add a migration tracking field to your user database
 
@@ -44,6 +52,10 @@ Or use whatever mechanism fits your stack — a boolean field, a status enum, a 
 ### 2a. Create a Privy app and configure JWT verification
 
 This setup is the same regardless of whether you choose the client-side or server-side path.
+
+<Info>
+**Auth0 OAuth users:** Even though your Alchemy users authenticate via Auth0 OAuth, Privy treats Auth0 as a JWT-based integration. Follow this same Privy JWT setup — provide your Auth0 JWKS endpoint or public key, and the JWT claim containing the user's unique ID.
+</Info>
 
 1. Go to the [Privy Dashboard](https://dashboard.privy.io/) and create an app
 2. Request access to **Custom Auth Support** in the **Integrations > Plugins** tab
@@ -151,41 +163,84 @@ See the [Privy JWT usage docs](https://docs.privy.io) for full details.
 
 The migration happens in a single session where the user is authenticated with both Alchemy and Privy simultaneously.
 
-```tsx
-// useImportWallet is a React hook — call it at the component/hook level, not inside async functions
-const {importWallet} = useImportWallet();
+<Tabs>
+  <Tab title="JWT auth">
+    ```tsx
+    // useImportWallet is a React hook — call it at the component/hook level, not inside async functions
+    const {importWallet} = useImportWallet();
 
-async function handleMigration(userId: string) {
-  // 1. Get JWT from your auth provider (same token Privy is already using)
-  const jwt = await getToken();
+    async function handleMigration(userId: string) {
+      // 1. Get JWT from your auth provider (same token Privy is already using)
+      const jwt = await getToken();
 
-  // 2. Check if user needs migration
-  const user = await getUserFromDB(userId);
-  if (!user.signer_migrated) {
-    // 3. Authenticate with Alchemy using the SAME JWT
-    const alchemySigner = new AlchemyWebSigner({
-      client: {
-        connection: {apiKey: 'YOUR_ALCHEMY_API_KEY'},
-        iframeConfig: {iframeContainerId: 'alchemy-signer-iframe-container'},
-      },
-    });
-    await alchemySigner.authenticate({type: 'jwt', token: jwt});
+      // 2. Check if user needs migration
+      const user = await getUserFromDB(userId);
+      if (!user.signer_migrated) {
+        // 3. Authenticate with Alchemy using the SAME JWT
+        const alchemySigner = new AlchemyWebSigner({
+          client: {
+            connection: {apiKey: 'YOUR_ALCHEMY_API_KEY'},
+            iframeConfig: {iframeContainerId: 'alchemy-signer-iframe-container'},
+          },
+        });
+        await alchemySigner.authenticate({type: 'jwt', token: jwt});
 
-    // 4. Export private key from Alchemy
-    const privateKey = await alchemySigner.exportPrivateKey();
+        // 4. Export private key from Alchemy
+        const privateKey = await alchemySigner.exportPrivateKey();
 
-    // 5. Import into Privy
-    await importWallet({privateKey});
+        // 5. Import into Privy
+        await importWallet({privateKey});
 
-    // 6. Mark migration complete
-    await updateUserDB(userId, {signer_migrated: true});
-  }
-}
-```
+        // 6. Mark migration complete
+        await updateUserDB(userId, {signer_migrated: true});
+      }
+    }
+    ```
+  </Tab>
+  <Tab title="Auth0 OAuth">
+    ```tsx
+    // useImportWallet is a React hook — call it at the component/hook level, not inside async functions
+    const {importWallet} = useImportWallet();
+
+    async function handleMigration(userId: string) {
+      // 1. Check if user needs migration
+      const user = await getUserFromDB(userId);
+      if (!user.signer_migrated) {
+        // 2. Authenticate with Alchemy using Auth0 OAuth
+        const alchemySigner = new AlchemyWebSigner({
+          client: {
+            connection: {apiKey: 'YOUR_ALCHEMY_API_KEY'},
+            iframeConfig: {iframeContainerId: 'alchemy-signer-iframe-container'},
+          },
+        });
+        await alchemySigner.authenticate({
+          type: 'oauth',
+          authProviderId: 'auth0',
+          auth0Connection: 'github', // Use your Auth0 connection name
+          mode: 'popup',
+        });
+
+        // 3. Export private key from Alchemy
+        const privateKey = await alchemySigner.exportPrivateKey();
+
+        // 4. Import into Privy
+        await importWallet({privateKey});
+
+        // 5. Mark migration complete
+        await updateUserDB(userId, {signer_migrated: true});
+      }
+    }
+    ```
+
+    <Info>
+    Replace `'github'` in `auth0Connection` with the connection name from your Auth0 dashboard (e.g., `'twitter'`, `'linkedin'`). If you omit `auth0Connection`, users will see the Auth0 provider selection screen. See the [Auth0 authentication reference](/docs/wallets/signer/authentication/auth0) for details.
+    </Info>
+  </Tab>
+</Tabs>
 
 ### 4c. Export details
 
-The snippet in 4b already authenticates with Alchemy using the same JWT and calls `exportPrivateKey()`. A note on when to use the encrypted variant:
+The snippet in 4b already authenticates with Alchemy (using a JWT or Auth0 OAuth, depending on your path) and calls `exportPrivateKey()`. A note on when to use the encrypted variant:
 
 ```tsx
 // Plaintext export — fine for the fully client-side flow above
@@ -231,7 +286,7 @@ await db.users.update(userId, {signer_migrated: true});
 ## Server-side path (import only)
 
 <Warning>
-Alchemy's JWT signer runs in the browser via `AlchemyWebSigner` — there is no supported path for authenticating an Alchemy JWT signer from a backend. That means the **export from Alchemy must still happen client-side** (as in 4a–4c above). This server-side path only covers the **import side**: your client exports the key from Alchemy, ships it to your server, and your server imports it into Privy using the `@privy-io/node` SDK.
+Alchemy's signer runs in the browser via `AlchemyWebSigner` — there is no supported path for authenticating an Alchemy signer (JWT or Auth0 OAuth) from a backend. That means the **export from Alchemy must still happen client-side** (as in 4a–4c above). This server-side path only covers the **import side**: your client exports the key from Alchemy, ships it to your server, and your server imports it into Privy using the `@privy-io/node` SDK.
 
 For most apps, the fully client-side path in 4a–4e is simpler. Use this path only if you have a specific reason to move the import to the server — for example, to attach policies, owners, or additional signers at import time.
 </Warning>
@@ -406,7 +461,7 @@ await db.users.update(userId, {signer_migrated: true});
 
 Unlike the React migration, JWT migration does **not require a user export/import step** — unless your users also use other auth methods (email, Google, etc.) alongside JWT.
 
-**If JWT is your only auth method:**
+**If JWT or Auth0 OAuth is your only auth method:**
 
 * Deploy your updated app
 * Users authenticate via JWT with Privy going forward
@@ -417,6 +472,10 @@ Unlike the React migration, JWT migration does **not require a user export/impor
 
 * You still need to export users from Alchemy and import into Privy (see [React migration guide Step 4](/docs/wallets/wallet-integrations/privy/react-migration#step-4-deploy-your-updated-app-export-users-and-import-into-privy))
 * Follow the same Deploy → Export → Import sequence
+
+<Info>
+**Auth0 OAuth users:** If Auth0 is your only authentication method, no user export/import is needed — Auth0 OAuth works the same as JWT in this regard. Privy authenticates users via the same Auth0 JWT under the hood.
+</Info>
 
 ### Next steps
 
@@ -429,9 +488,9 @@ After migration, follow the Privy guides for using embedded wallets:
 
 ## Important notes
 
-### No user export/import needed (JWT-only)
+### No user export/import needed (JWT / Auth0 OAuth only)
 
-Because JWT authentication is controlled by your server, both Alchemy and Privy can verify the same JWT. There's no user metadata to transfer — your server is the source of truth for user identity. The only thing being migrated is the private key material.
+Because JWT and Auth0 OAuth authentication are controlled by your server (or Auth0), both Alchemy and Privy can verify the same token. There's no user metadata to transfer — your server (or Auth0) is the source of truth for user identity. The only thing being migrated is the private key material.
 
 ### Security considerations
 
@@ -445,8 +504,8 @@ The [React migration SDK](/docs/wallets/wallet-integrations/privy/react-migratio
 ## FAQ
 
 <AccordionGroup>
-  <Accordion title="Can I use the React migration SDK with JWT auth?">
-    The React migration SDK supports standard auth methods (email, Google, passkeys). If your users authenticated exclusively via JWT, use this guide instead. If you have a mix of JWT and standard auth users, you may need both paths.
+  <Accordion title="Can I use the React migration SDK with JWT or Auth0 OAuth auth?">
+    The React migration SDK supports standard auth methods (email, Google, passkeys). If your users authenticated exclusively via JWT or Auth0 OAuth, use this guide instead. If you have a mix of JWT/Auth0 and standard auth users, you may need both paths.
   </Accordion>
 
   <Accordion title="Are JWTs one-time use?">
@@ -463,5 +522,13 @@ The [React migration SDK](/docs/wallets/wallet-integrations/privy/react-migratio
 
   <Accordion title="Which path should I choose — client-side or server-side?">
     If you already have a React or React Native app with Alchemy's client SDK, the client-side path is the most straightforward — it mirrors the flow you already have. If your architecture is backend-driven (e.g., your server holds keys or controls wallet operations), the server-side path keeps everything on the server without requiring a client SDK integration.
+  </Accordion>
+
+  <Accordion title="I use Auth0 as an OAuth provider. Why am I in the JWT guide?">
+    Privy treats Auth0 as a custom JWT auth integration. The React migration SDK does not handle Auth0 OAuth, so you follow this guide instead. The only code difference is in Step 4b: you authenticate with the Alchemy signer using `{type: 'oauth', authProviderId: 'auth0', auth0Connection: '...'}` instead of `{type: 'jwt', token: jwt}`. Everything else — Privy setup, key export, import, migration tracking — is identical.
+  </Accordion>
+
+  <Accordion title="Do I need to pass auth0Connection when authenticating with Alchemy during migration?">
+    It depends on your setup. If you pass `auth0Connection` (e.g., `'github'`), users go directly to that provider's login. If you omit it, they'll see the Auth0 provider selection screen. Use whatever matches your current app's Auth0 configuration. See the [Auth0 authentication reference](/docs/wallets/signer/authentication/auth0) for details.
   </Accordion>
 </AccordionGroup>

--- a/content/wallets/wallet-integrations/privy/jwt-auth-migration.mdx
+++ b/content/wallets/wallet-integrations/privy/jwt-auth-migration.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Migrate JWT or Auth0 OAuth authentication from Alchemy to Privy"
-description: "Step-by-step guide to migrate embedded wallets from Alchemy to Privy when using JWT (JSON Web Token) or Auth0 OAuth authentication."
+title: "Migrate JWT or Auth0 authentication from Alchemy to Privy"
+description: "Step-by-step guide to migrate embedded wallets from Alchemy to Privy when using JWT (JSON Web Token) or Auth0 authentication."
 slug: wallets/wallet-integrations/privy/jwt-auth-migration
 ---
 
@@ -9,17 +9,17 @@ This guide is for developers who authenticate users with Alchemy Signer using **
 <Info>If you use standard auth methods (email, Google, passkeys) with the React SDK — and you do **not** authenticate via Auth0 — use the [React migration guide](/docs/wallets/wallet-integrations/privy/react-migration) instead.</Info>
 
 <Note>
-**Why Auth0 OAuth users follow this guide:** Privy treats Auth0 as a custom JWT auth integration, so Auth0 OAuth users cannot use the React migration SDK (which handles email, Google, passkeys). The Privy-side setup is identical to the JWT path. The only difference is how you authenticate with the Alchemy signer during migration — you use Auth0 OAuth parameters instead of a JWT token.
+**Why Auth0 users follow this guide:** Privy treats Auth0 as a custom JWT auth integration, so Auth0 users cannot use the React migration SDK. The Privy-side setup is identical to the JWT path. The only difference is how you authenticate with the Alchemy signer during migration.
 </Note>
 
 <Note>Before starting, read the [signer migration overview](/docs/wallets/wallet-integrations/privy/signer-migration-overview) to confirm your account type (Modular Account v2 vs. another implementation) and connection type (EIP-7702 vs. ERC-4337). Apps not on MAv2, or using pure 4337, need to adjust a step in this guide — the overview's [Edge cases](/docs/wallets/wallet-integrations/privy/signer-migration-overview#edge-cases) section walks through each.</Note>
 
 ## How this migration differs from the standard React migration
 
-With JWT or Auth0 OAuth auth, you control both sides of authentication — your server generates JWTs (or Auth0 handles OAuth), and both Alchemy and your new provider accept them. This simplifies the migration because:
+With JWT auth, you control both sides of authentication — your server generates JWTs, and both Alchemy and your new provider accept them. This simplifies the migration because:
 
-* **No user export/import needed** (unless you also use other auth methods) — both providers authenticate via your JWT or Auth0 OAuth token
-* **Tokens are reusable** — JWTs are not one-time-use tokens, and Auth0 OAuth sessions persist, so the same authentication can work with both Alchemy and Privy in a single session
+* **No user export/import needed** (unless you also use other auth methods) — both providers authenticate via your JWT
+* **JWTs are reusable** — they're not one-time-use tokens, so the same JWT can authenticate with both Alchemy and Privy in a single session
 * **Migration detection is your responsibility** — since there's no Privy-side metadata, you track which users have migrated in your own database
 
 ## Choose your integration path
@@ -34,7 +34,7 @@ This guide covers two paths. Both share the same Privy dashboard setup (Steps 1�
 | **Private key exposure** | Briefly in client memory during export→import | On your server during export→import |
 
 <Info>
-**Auth0 OAuth users:** Both client-side and server-side paths apply to you. The table above references JWT-specific hooks, but the Privy-side setup (Steps 1–2) is the same. The key difference is in [Step 4b](#4b-build-the-client-side-migration-flow) where you authenticate with the Alchemy signer using Auth0 OAuth parameters instead of a JWT token.
+**Auth0 users:** Auth0 is a client-side flow, so use the **client-side path**. The Privy-side setup (Steps 1–2) is the same as JWT. The key difference is in [Step 4b](#4b-build-the-client-side-migration-flow) where you authenticate with the Alchemy signer using Auth0 parameters instead of a JWT token.
 </Info>
 
 ## Step 1: Add a migration tracking field to your user database
@@ -54,7 +54,7 @@ Or use whatever mechanism fits your stack — a boolean field, a status enum, a 
 This setup is the same regardless of whether you choose the client-side or server-side path.
 
 <Info>
-**Auth0 OAuth users:** Even though your Alchemy users authenticate via Auth0 OAuth, Privy treats Auth0 as a JWT-based integration. Follow this same Privy JWT setup — provide your Auth0 JWKS endpoint or public key, and the JWT claim containing the user's unique ID.
+**Auth0 users:** Even though your Alchemy users authenticate via Auth0, Privy treats Auth0 as a JWT-based integration. Follow this same Privy JWT setup — provide your Auth0 JWKS endpoint or public key, and the JWT claim containing the user's unique ID.
 </Info>
 
 1. Go to the [Privy Dashboard](https://dashboard.privy.io/) and create an app
@@ -197,7 +197,7 @@ The migration happens in a single session where the user is authenticated with b
     }
     ```
   </Tab>
-  <Tab title="Auth0 OAuth">
+  <Tab title="Auth0">
     ```tsx
     // useImportWallet is a React hook — call it at the component/hook level, not inside async functions
     const {importWallet} = useImportWallet();
@@ -206,7 +206,7 @@ The migration happens in a single session where the user is authenticated with b
       // 1. Check if user needs migration
       const user = await getUserFromDB(userId);
       if (!user.signer_migrated) {
-        // 2. Authenticate with Alchemy using Auth0 OAuth
+        // 2. Authenticate with Alchemy using Auth0
         const alchemySigner = new AlchemyWebSigner({
           client: {
             connection: {apiKey: 'YOUR_ALCHEMY_API_KEY'},
@@ -240,7 +240,7 @@ The migration happens in a single session where the user is authenticated with b
 
 ### 4c. Export details
 
-The snippet in 4b already authenticates with Alchemy (using a JWT or Auth0 OAuth, depending on your path) and calls `exportPrivateKey()`. A note on when to use the encrypted variant:
+The snippet in 4b already authenticates with Alchemy and calls `exportPrivateKey()`. A note on when to use the encrypted variant:
 
 ```tsx
 // Plaintext export — fine for the fully client-side flow above
@@ -286,7 +286,7 @@ await db.users.update(userId, {signer_migrated: true});
 ## Server-side path (import only)
 
 <Warning>
-Alchemy's signer runs in the browser via `AlchemyWebSigner` — there is no supported path for authenticating an Alchemy signer (JWT or Auth0 OAuth) from a backend. That means the **export from Alchemy must still happen client-side** (as in 4a–4c above). This server-side path only covers the **import side**: your client exports the key from Alchemy, ships it to your server, and your server imports it into Privy using the `@privy-io/node` SDK.
+Alchemy's JWT signer runs in the browser via `AlchemyWebSigner` — there is no supported path for authenticating an Alchemy JWT signer from a backend. That means the **export from Alchemy must still happen client-side** (as in 4a–4c above). This server-side path only covers the **import side**: your client exports the key from Alchemy, ships it to your server, and your server imports it into Privy using the `@privy-io/node` SDK.
 
 For most apps, the fully client-side path in 4a–4e is simpler. Use this path only if you have a specific reason to move the import to the server — for example, to attach policies, owners, or additional signers at import time.
 </Warning>
@@ -461,7 +461,7 @@ await db.users.update(userId, {signer_migrated: true});
 
 Unlike the React migration, JWT migration does **not require a user export/import step** — unless your users also use other auth methods (email, Google, etc.) alongside JWT.
 
-**If JWT or Auth0 OAuth is your only auth method:**
+**If this is your only auth method:**
 
 * Deploy your updated app
 * Users authenticate via JWT with Privy going forward
@@ -472,10 +472,6 @@ Unlike the React migration, JWT migration does **not require a user export/impor
 
 * You still need to export users from Alchemy and import into Privy (see [React migration guide Step 4](/docs/wallets/wallet-integrations/privy/react-migration#step-4-deploy-your-updated-app-export-users-and-import-into-privy))
 * Follow the same Deploy → Export → Import sequence
-
-<Info>
-**Auth0 OAuth users:** If Auth0 is your only authentication method, no user export/import is needed — Auth0 OAuth works the same as JWT in this regard. Privy authenticates users via the same Auth0 JWT under the hood.
-</Info>
 
 ### Next steps
 
@@ -488,9 +484,9 @@ After migration, follow the Privy guides for using embedded wallets:
 
 ## Important notes
 
-### No user export/import needed (JWT / Auth0 OAuth only)
+### No user export/import needed
 
-Because JWT and Auth0 OAuth authentication are controlled by your server (or Auth0), both Alchemy and Privy can verify the same token. There's no user metadata to transfer — your server (or Auth0) is the source of truth for user identity. The only thing being migrated is the private key material.
+Because authentication is controlled by your server (or Auth0), both Alchemy and Privy can verify the same token. There's no user metadata to transfer — your server is the source of truth for user identity. The only thing being migrated is the private key material.
 
 ### Security considerations
 
@@ -504,8 +500,8 @@ The [React migration SDK](/docs/wallets/wallet-integrations/privy/react-migratio
 ## FAQ
 
 <AccordionGroup>
-  <Accordion title="Can I use the React migration SDK with JWT or Auth0 OAuth auth?">
-    The React migration SDK supports standard auth methods (email, Google, passkeys). If your users authenticated exclusively via JWT or Auth0 OAuth, use this guide instead. If you have a mix of JWT/Auth0 and standard auth users, you may need both paths.
+  <Accordion title="Can I use the React migration SDK instead?">
+    The React migration SDK supports standard auth methods (email, Google, passkeys). If your users authenticated exclusively via JWT or Auth0, use this guide instead. If you have a mix of JWT/Auth0 and standard auth users, you may need both paths.
   </Accordion>
 
   <Accordion title="Are JWTs one-time use?">
@@ -525,7 +521,7 @@ The [React migration SDK](/docs/wallets/wallet-integrations/privy/react-migratio
   </Accordion>
 
   <Accordion title="I use Auth0 as an OAuth provider. Why am I in the JWT guide?">
-    Privy treats Auth0 as a custom JWT auth integration. The React migration SDK does not handle Auth0 OAuth, so you follow this guide instead. The only code difference is in Step 4b: you authenticate with the Alchemy signer using `{type: 'oauth', authProviderId: 'auth0', auth0Connection: '...'}` instead of `{type: 'jwt', token: jwt}`. Everything else — Privy setup, key export, import, migration tracking — is identical.
+    Privy treats Auth0 as a custom JWT auth integration. The React migration SDK does not handle Auth0, so you follow this guide instead. The only code difference is in Step 4b: you authenticate with the Alchemy signer using `{type: 'oauth', authProviderId: 'auth0', auth0Connection: '...'}` instead of `{type: 'jwt', token: jwt}`. Everything else — Privy setup, key export, import, migration tracking — is identical.
   </Accordion>
 
   <Accordion title="Do I need to pass auth0Connection when authenticating with Alchemy during migration?">

--- a/content/wallets/wallet-integrations/privy/react-migration.mdx
+++ b/content/wallets/wallet-integrations/privy/react-migration.mdx
@@ -8,7 +8,7 @@ This guide walks you through migrating the **signer** for your app and users' em
 
 After completing this migration, users will log in with Privy (wallet addresses are preserved, assets are maintained) and transactions will continue to be sent and sponsored by Alchemy.
 
-<Info>This guide is for **React** apps using standard auth methods (email, Google, passkeys). For non-React frameworks, [reach out](mailto:support@alchemy.com) for support. If you authenticate users with **JWT** or **Auth0 as an OAuth provider** (e.g., GitHub via Auth0), use the [JWT / Auth0 OAuth migration guide](/docs/wallets/wallet-integrations/privy/jwt-auth-migration) instead.</Info>
+<Info>This guide is for **React** apps using standard auth methods (email, Google, passkeys). For non-React frameworks, [reach out](mailto:support@alchemy.com) for support. If you authenticate users with **JWT** or **Auth0** (e.g., GitHub via Auth0), use the [JWT / Auth0 migration guide](/docs/wallets/wallet-integrations/privy/jwt-auth-migration) instead.</Info>
 
 <Note>Before starting, read the [signer migration overview](/docs/wallets/wallet-integrations/privy/signer-migration-overview) to confirm your account type (Modular Account v2 vs. another implementation) and connection type (EIP-7702 vs. ERC-4337). Apps not on MAv2, or using pure 4337, need to adjust a step in this guide — the overview's [Edge cases](/docs/wallets/wallet-integrations/privy/signer-migration-overview#edge-cases) section walks through each.</Note>
 

--- a/content/wallets/wallet-integrations/privy/react-migration.mdx
+++ b/content/wallets/wallet-integrations/privy/react-migration.mdx
@@ -8,7 +8,7 @@ This guide walks you through migrating the **signer** for your app and users' em
 
 After completing this migration, users will log in with Privy (wallet addresses are preserved, assets are maintained) and transactions will continue to be sent and sponsored by Alchemy.
 
-<Info>This guide is for **React** apps. For non-React frameworks, [reach out](mailto:support@alchemy.com) for support. If you authenticate users with JWT (JSON Web Token) authentication instead of standard auth methods, use the [JWT auth migration guide](/docs/wallets/wallet-integrations/privy/jwt-auth-migration) instead.</Info>
+<Info>This guide is for **React** apps using standard auth methods (email, Google, passkeys). For non-React frameworks, [reach out](mailto:support@alchemy.com) for support. If you authenticate users with **JWT** or **Auth0 as an OAuth provider** (e.g., GitHub via Auth0), use the [JWT / Auth0 OAuth migration guide](/docs/wallets/wallet-integrations/privy/jwt-auth-migration) instead.</Info>
 
 <Note>Before starting, read the [signer migration overview](/docs/wallets/wallet-integrations/privy/signer-migration-overview) to confirm your account type (Modular Account v2 vs. another implementation) and connection type (EIP-7702 vs. ERC-4337). Apps not on MAv2, or using pure 4337, need to adjust a step in this guide — the overview's [Edge cases](/docs/wallets/wallet-integrations/privy/signer-migration-overview#edge-cases) section walks through each.</Note>
 

--- a/content/wallets/wallet-integrations/privy/signer-migration-overview.mdx
+++ b/content/wallets/wallet-integrations/privy/signer-migration-overview.mdx
@@ -9,11 +9,11 @@ This page is the landing guide for moving the **signer** (auth + key custody) fo
 <Info>
 Pick the detailed guide that matches your app:
 * **[React migration](/docs/wallets/wallet-integrations/privy/react-migration)** — the default path. React apps using standard auth methods (email, Google, passkeys, etc.).
-* **[JWT / Auth0 OAuth migration](/docs/wallets/wallet-integrations/privy/jwt-auth-migration)** — for apps authenticating users with JWT (JSON Web Token) or with Auth0 as an OAuth provider (e.g., GitHub via Auth0). Privy treats Auth0 as a custom JWT integration, so both cases follow the same guide.
+* **[JWT / Auth0 migration](/docs/wallets/wallet-integrations/privy/jwt-auth-migration)** — for apps authenticating users with JWT (JSON Web Token) or with Auth0 (e.g., GitHub via Auth0). Privy treats Auth0 as a custom JWT integration, so both cases follow the same guide.
 </Info>
 
 <Note>
-If your migration path does not make use of React, JWT, or Auth0 OAuth authentication, please [reach out to the team](#get-help) for assistance in the service migration!
+If your migration path does not make use of React, JWT, or Auth0 authentication, please [reach out to the team](#get-help) for assistance in the service migration!
 </Note>
 
 ## What to expect
@@ -31,7 +31,7 @@ At a high level, the React migration is two steps:
   </Step>
 </Steps>
 
-For the full, runnable walkthrough — including user export/import and cleanup — follow the [React migration guide](/docs/wallets/wallet-integrations/privy/react-migration). If you authenticate users with JWT or use Auth0 as an OAuth provider, follow the [JWT / Auth0 OAuth migration guide](/docs/wallets/wallet-integrations/privy/jwt-auth-migration) instead.
+For the full, runnable walkthrough — including user export/import and cleanup — follow the [React migration guide](/docs/wallets/wallet-integrations/privy/react-migration). If you authenticate users with JWT or use Auth0 as an OAuth provider, follow the [JWT / Auth0 migration guide](/docs/wallets/wallet-integrations/privy/jwt-auth-migration) instead.
 
 ## Prerequisites
 

--- a/content/wallets/wallet-integrations/privy/signer-migration-overview.mdx
+++ b/content/wallets/wallet-integrations/privy/signer-migration-overview.mdx
@@ -9,11 +9,11 @@ This page is the landing guide for moving the **signer** (auth + key custody) fo
 <Info>
 Pick the detailed guide that matches your app:
 * **[React migration](/docs/wallets/wallet-integrations/privy/react-migration)** — the default path. React apps using standard auth methods (email, Google, passkeys, etc.).
-* **[JWT auth migration](/docs/wallets/wallet-integrations/privy/jwt-auth-migration)** — special case for apps authenticating users with JWT (JSON Web Token).
+* **[JWT / Auth0 OAuth migration](/docs/wallets/wallet-integrations/privy/jwt-auth-migration)** — for apps authenticating users with JWT (JSON Web Token) or with Auth0 as an OAuth provider (e.g., GitHub via Auth0). Privy treats Auth0 as a custom JWT integration, so both cases follow the same guide.
 </Info>
 
 <Note>
-If your migration path does not make use of React or JWT authentication, please [reach out to the team](#get-help) for assistance in the service migration!
+If your migration path does not make use of React, JWT, or Auth0 OAuth authentication, please [reach out to the team](#get-help) for assistance in the service migration!
 </Note>
 
 ## What to expect
@@ -31,7 +31,7 @@ At a high level, the React migration is two steps:
   </Step>
 </Steps>
 
-For the full, runnable walkthrough — including user export/import and cleanup — follow the [React migration guide](/docs/wallets/wallet-integrations/privy/react-migration). If you authenticate users with JWT, follow the [JWT auth migration guide](/docs/wallets/wallet-integrations/privy/jwt-auth-migration) instead.
+For the full, runnable walkthrough — including user export/import and cleanup — follow the [React migration guide](/docs/wallets/wallet-integrations/privy/react-migration). If you authenticate users with JWT or use Auth0 as an OAuth provider, follow the [JWT / Auth0 OAuth migration guide](/docs/wallets/wallet-integrations/privy/jwt-auth-migration) instead.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary
- Auth0 OAuth users need to follow the JWT migration guide (not React migration) because Privy treats Auth0 as a custom JWT integration
- Added `<Tabs>` in Step 4b of the JWT guide showing Auth0 OAuth authenticate params vs JWT params
- Updated overview and React guide to route Auth0 users correctly, added callouts and 2 new FAQ entries

## Test plan
- [ ] Run docs dev server and verify all three pages render correctly
- [ ] Confirm `<Tabs>` component renders in jwt-auth-migration (Step 4b)
- [ ] Verify all internal links resolve
- [ ] Read through Auth0 OAuth path end-to-end for coherence

🤖 Generated with [Claude Code](https://claude.com/claude-code)