### PR TITLE
[docs-agent] Fix Solana DAS options schema (showInscription typo + add missing options param)

### DIFF
--- a/src/openrpc/alchemy/solana-das/solana-das.yaml
+++ b/src/openrpc/alchemy/solana-das/solana-das.yaml
@@ -22,7 +22,7 @@ methods:
           $ref: ../../chains/_components/solana/asset.yaml#/components/schemas/AssetId
       - name: displayOptions
         required: false
-        description: Options for display formatting.
+        description: Optional response shaping flags. The server also accepts `options` as an alias of this field, but only one of `displayOptions` or `options` may be present per request.
         schema:
           $ref: ../../chains/_components/solana/asset.yaml#/components/schemas/DisplayOptions
     examples:
@@ -49,7 +49,7 @@ methods:
             $ref: ../../chains/_components/solana/asset.yaml#/components/schemas/AssetId
       - name: displayOptions
         required: false
-        description: Options for display formatting.
+        description: Optional response shaping flags. The server also accepts `options` as an alias of this field, but only one of `displayOptions` or `options` may be present per request.
         schema:
           $ref: ../../chains/_components/solana/asset.yaml#/components/schemas/DisplayOptions
     examples:
@@ -161,6 +161,11 @@ methods:
         description: Retrieve assets after this cursor.
         schema:
           type: string
+      - name: options
+        required: false
+        description: Optional response shaping flags. The server also accepts `displayOptions` as an alias of this field, but only one of `options` or `displayOptions` may be present per request.
+        schema:
+          $ref: ../../chains/_components/solana/asset.yaml#/components/schemas/DisplayOptions
     examples:
       - name: getAssetsByAuthority example
         params:
@@ -236,7 +241,7 @@ methods:
           type: string
       - name: options
         required: false
-        description: Options for display formatting.
+        description: Optional response shaping flags. The server also accepts `displayOptions` as an alias of this field, but only one of `options` or `displayOptions` may be present per request.
         schema:
           $ref: ../../chains/_components/solana/asset.yaml#/components/schemas/DisplayOptions
     examples:
@@ -321,6 +326,11 @@ methods:
         description: Retrieve assets after this cursor.
         schema:
           type: string
+      - name: options
+        required: false
+        description: Optional response shaping flags. The server also accepts `displayOptions` as an alias of this field, but only one of `options` or `displayOptions` may be present per request.
+        schema:
+          $ref: ../../chains/_components/solana/asset.yaml#/components/schemas/DisplayOptions
     examples:
       - name: getAssetsByGroup example
         params:
@@ -398,6 +408,11 @@ methods:
         description: Retrieve assets after this cursor.
         schema:
           type: string
+      - name: options
+        required: false
+        description: Optional response shaping flags. The server also accepts `displayOptions` as an alias of this field, but only one of `options` or `displayOptions` may be present per request.
+        schema:
+          $ref: ../../chains/_components/solana/asset.yaml#/components/schemas/DisplayOptions
     examples:
       - name: getAssetsByCreator example
         params:

--- a/src/openrpc/chains/_components/solana/asset.yaml
+++ b/src/openrpc/chains/_components/solana/asset.yaml
@@ -8,35 +8,29 @@ components:
     DisplayOptions:
       title: Display Options
       type: object
-      description: Options for display formatting.
+      description: >
+        Optional response shaping flags accepted by the Alchemy DAS proxy.
+        All flags are booleans and default to `false`.
       properties:
         showUnverifiedCollections:
           type: boolean
-          description: Display unverified collections.
+          description: Show unverified collections instead of skipping them.
           default: false
         showCollectionMetadata:
           type: boolean
-          description: Display collection metadata.
-          default: false
-        showFungible:
-          type: boolean
-          description: Display all fungible tokens.
-          default: false
-        showNativeBalance:
-          type: boolean
-          description: Display native SOL balance.
-          default: false
-        showInscriptions:
-          type: boolean
-          description: Display inscriptions.
+          description: Show metadata for the collection.
           default: false
         showZeroBalance:
           type: boolean
           description: Display assets with zero balance.
           default: false
-        showGrandTotal:
+        showInscription:
           type: boolean
-          description: Display grand total.
+          description: Display inscription details.
+          default: false
+        showFungible:
+          type: boolean
+          description: Include fungible assets in the result.
           default: false
 
     GetAssetConfig:


### PR DESCRIPTION
## Summary

The Solana DAS API docs listed a `displayOptions` / `options` schema that was out of sync with what the Alchemy DAS proxy actually accepts, scattered across six methods. This PR aligns the spec with the live backend.

Confirmed against `solana-mainnet.g.alchemy.com/v2/docs-demo` — the server enumerates the canonical 5-flag set verbatim in its `unknown field ... expected one of ...` error:

```
showUnverifiedCollections, showCollectionMetadata, showZeroBalance, showInscription, showFungible
```

All boolean, all default `false`. Note `showInscription` is singular.

### Shared `DisplayOptions` schema (`src/openrpc/chains/_components/solana/asset.yaml`)

* Rename `showInscriptions` → `showInscription` (the plural spelling is rejected by the backend).
* Drop `showNativeBalance` (rejected).
* Drop `showGrandTotal` (rejected).
* Tighten property descriptions to match the `searchAssets` reference.

### Per-method updates (`src/openrpc/alchemy/solana-das/solana-das.yaml`)

| Method | Change |
| --- | --- |
| `getAsset` | Refresh existing `displayOptions` description with the `options` alias note. |
| `getAssets` | Same. |
| `getAssetsByOwner` | Refresh existing `options` description with the `displayOptions` alias note. |
| `getAssetsByAuthority` | **Add** missing `options` param using the shared schema. |
| `getAssetsByCreator` | **Add** missing `options` param using the shared schema. |
| `getAssetsByGroup` | **Add** missing `options` param using the shared schema. |

All six methods now mirror the alias note pattern from `searchAssets`: the backend accepts both `options` and `displayOptions` as aliases, but only one may be present per request (`duplicate field` error otherwise, confirmed live).

### Verification

* `pnpm run generate:rpc` ✅
* `pnpm run validate:rpc` ✅
* Live API smoke tests against `solana-mainnet.g.alchemy.com/v2/docs-demo`:
  * `getAsset` with the new 5-flag `displayOptions` → 200 with the requested asset.
  * `getAssetsByGroup` with `options.showCollectionMetadata: true` → 200 with 2 items.
  * `getAssetsByAuthority` with `displayOptions` alias → 200 with 2 items.
  * `getAssetsByAuthority` with BOTH `options` and `displayOptions` set → `duplicate field` error (confirms the alias note's "only one may be present" caveat).

## Linear

[DOCS-92](https://linear.app/alchemyapi/issue/DOCS-92/fix-solana-das-api-docs-correct-showinscription-typo-drop-unsupported)

## Requested by

@victorbware (via Slack thread)