### PR TITLE
DX-2945: Sunset notice on compute-unit-costs page

### DIFF
--- a/content/api-reference/pricing-resources/pricing/compute-unit-costs.mdx
+++ b/content/api-reference/pricing-resources/pricing/compute-unit-costs.mdx
@@ -4,6 +4,13 @@ description: "A breakdown of Alchemy's compute unit costs per method, chain, and
 slug: "reference/compute-unit-costs"
 ---
 
+<Warning title="This page is being sunset">
+  Per-method compute unit and throughput compute unit costs are now shown
+  directly on each method's reference page, next to the endpoint URL. Use
+  the method docs as the source of truth — this aggregated table will be
+  removed in a future update.
+</Warning>
+
 <Tip title="Don't have an API key?" icon="star">
   Unlock millions of requests and free archive data on all chains. [Get started for free](https://dashboard.alchemy.com/signup)
 </Tip>

--- a/content/api-reference/pricing-resources/pricing/compute-unit-costs.mdx
+++ b/content/api-reference/pricing-resources/pricing/compute-unit-costs.mdx
@@ -6,9 +6,8 @@ slug: "reference/compute-unit-costs"
 
 <Warning title="This page is being sunset">
   Per-method compute unit and throughput compute unit costs are now shown
-  directly on each method's reference page, next to the endpoint URL. Use
-  the method docs as the source of truth — this aggregated table will be
-  removed in a future update.
+  directly on each method's reference page. This table will be removed in
+  a future update.
 </Warning>
 
 <Tip title="Don't have an API key?" icon="star">


### PR DESCRIPTION
Part of [DX-2945](https://linear.app/alchemyapi/issue/DX-2945/render-cu-cost-and-throughput-cu-inline-on-rpc-method-docs-pages).

Adds a \`Warning\` callout to the top of the aggregated Compute Unit Costs page directing readers to each method's reference page (where CU + throughput CU now render inline) and noting the page will be removed in a future update.

Lands independently of #1316 and OMGWINNING/docs-site#330 — the callout is true today regardless of whether the inline chips are live yet, since the docs-site PR ships the renderer behind an "if present" check.

## Test plan

- [ ] Preview: confirm the Warning callout renders correctly at the top of the page.
- [ ] Spot-check that no other content on the page shifted unexpectedly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)