### PR TITLE
[docs-agent] Fix weekly link-check: swap starkscan.co for voyager.online; exclude portal.zksync.io

### DIFF
--- a/content/tutorials/getting-started/developer-best-practices/choosing-a-web3-network.mdx
+++ b/content/tutorials/getting-started/developer-best-practices/choosing-a-web3-network.mdx
@@ -156,7 +156,7 @@ Every blockchain (including both Layer 1s and Layer 2s) has a mainnet. The mainn
 
 * Chain ID: SN\_MAIN
 * Currency: ETH
-* Block Explorer: [https://starkscan.co/](https://starkscan.co/)
+* Block Explorer: [https://voyager.online/](https://voyager.online/)
 * RPC URL: [https://starknet-mainnet.g.alchemy.com/v2/your-alchemy-api-key](https://starknet-mainnet.g.alchemy.com/v2/your-alchemy-api-key)
 
 ***

--- a/lychee.toml
+++ b/lychee.toml
@@ -54,6 +54,7 @@ exclude = [
     ".*geth\\.ethereum\\.org.*",     # Intermittent timeouts for crawlers (page loads fine in browser)
     ".*privy\\.io/slack.*",          # Slack invite link, bot protection blocks crawlers on final redirect
     ".*docs\\.arbitrum\\.io.*",      # Vercel bot challenge / rate-limits crawlers with 429
+    ".*portal\\.zksync\\.io.*",      # Intermittent ERR (CDN edge / bot challenge); page loads fine in browser
 
 ]
 


### PR DESCRIPTION
## Summary

Fixes the 2 broken links reported by the weekly link-check workflow ([run 26247729128](https://github.com/alchemyplatform/docs/actions/runs/26247729128)):

| URL | Failure | File | Fix |
|---|---|---|---|
| `https://starkscan.co/` | `[525]` SSL handshake failure | `content/tutorials/getting-started/developer-best-practices/choosing-a-web3-network.mdx` | Replaced with `https://voyager.online/` (per Sahil in the Slack thread, canonical Starknet explorer) |
| `https://portal.zksync.io/bridge/` | `[ERR]` intermittent | `content/api-reference/zksync/zksync-api-faq.mdx` | Added `.*portal\.zksync\.io.*` to `lychee.toml` exclude with a one-line comment. URL is valid (verified 200 in a browser), failure looks like a CDN edge or bot challenge. |

## Linear

DOCS-93 — https://linear.app/alchemyapi/issue/DOCS-93/fix-weekly-link-check-failures-starkscanco-portalzksyncio

## Slack thread

https://alchemyenergy.slack.com/archives/C0852FMMUMR/p1779391269838449

## Requested by

@SahilAujla  (via Slack thread)