### PR TITLE
Remove v5 beta notices across wallet docs (22 files)

### DIFF
--- a/content/wallets/pages/concepts/smart-account-client.mdx
+++ b/content/wallets/pages/concepts/smart-account-client.mdx
@@ -4,8 +4,6 @@ description: Configure smart wallet client
 slug: wallets/concepts/smart-account-client
 ---
 
-<Info>`@alchemy/wallet-apis` (v5.x.x) is currently in beta but is the recommended replacement for `@account-kit/wallet-client` (v4.x.x). If you run into any issues, please [reach out](mailto:support@alchemy.com).</Info>
-
 A smart wallet client is the main interface used to interact with smart wallets and take actions like sending transactions, batching transactions, swapping, sponsoring gas, and more.
 
 ## How it works

--- a/content/wallets/pages/recipes/programmatic-wallet-creation.mdx
+++ b/content/wallets/pages/recipes/programmatic-wallet-creation.mdx
@@ -4,8 +4,6 @@ description: Generate a signer, initialize a Smart Wallet Client, sponsor gas wi
 slug: wallets/recipes/programmatic-wallet-creation
 ---
 
-<Info>`@alchemy/wallet-apis` (v5.x.x) is currently in beta but is the recommended replacement for `@account-kit/wallet-client` (v4.x.x). If you run into any issues, please [reach out](mailto:support@alchemy.com).</Info>
-
 This recipe shows how to programmatically create a smart wallet: you’ll generate a signer, spin up a Smart Wallet Client, read the counterfactual address before deployment and deploy the account by sending your first gas sponsored `UserOperation` (prepared → signed → sent).
 
 <Steps>

--- a/content/wallets/pages/recipes/smart-wallets-aave.mdx
+++ b/content/wallets/pages/recipes/smart-wallets-aave.mdx
@@ -7,8 +7,6 @@ description: >-
 slug: wallets/recipes/smart-wallets-aave
 ---
 
-<Info>`@alchemy/wallet-apis` (v5.x.x) is currently in beta but is the recommended replacement for `@account-kit/wallet-client` (v4.x.x). If you run into any issues, please [reach out](mailto:support@alchemy.com).</Info>
-
 Learn how to build DeFi applications that interact with Aave using Wallet APIs. This recipe covers supplying and withdrawing assets with both the [Core library](/docs/wallets/reference/aa-sdk/core) and the [Wallet APIs](/docs/wallets/api-reference/smart-wallets/wallet-api-endpoints/wallet-request-account) for seamless user experiences.
 
 ## Prerequisites

--- a/content/wallets/pages/resources/migration-v5.mdx
+++ b/content/wallets/pages/resources/migration-v5.mdx
@@ -4,8 +4,6 @@ description: Migration guide from @account-kit/wallet-client (v4) to @alchemy/wa
 slug: wallets/resources/migration-v5
 ---
 
-<Info>`@alchemy/wallet-apis` (v5.x.x) is currently in beta but is the recommended replacement for `@account-kit/wallet-client` (v4.x.x). If you run into any issues, please [reach out](mailto:support@alchemy.com).</Info>
-
 `@account-kit/wallet-client` is now `@alchemy/wallet-apis`. This guide covers what changed and how to migrate.
 
 ## Installation

--- a/content/wallets/pages/signer/authentication/server-wallets.mdx
+++ b/content/wallets/pages/signer/authentication/server-wallets.mdx
@@ -4,8 +4,6 @@ description: Control wallets programmatically using access keys
 slug: wallets/authentication/login-methods/server-wallets
 ---
 
-<Info>`@alchemy/wallet-apis` (v5.x.x) is currently in beta but is the recommended replacement for `@account-kit/wallet-client` (v4.x.x). If you run into any issues, please [reach out](mailto:support@alchemy.com).</Info>
-
 <Tip>
   Server wallets are in early access. Contact wallets@alchemy.com for help
   getting up and running.

--- a/content/wallets/pages/smart-wallets/quickstart/sdk.mdx
+++ b/content/wallets/pages/smart-wallets/quickstart/sdk.mdx
@@ -4,7 +4,7 @@ description: Get started with Alchemy Wallet APIs using the SDK. Install the @al
 ---
 
 <Note>
-  [`@alchemy/wallet-apis`](https://github.com/alchemyplatform/aa-sdk/tree/v5.x.x/packages/wallet-apis) (v5.x.x) is the recommended SDK and is currently in beta. If you're still on v4.x.x, see the [migration guide](/docs/wallets/resources/migration-v5).
+  [`@alchemy/wallet-apis`](https://github.com/alchemyplatform/aa-sdk/tree/main/packages/wallet-apis) (v5.x.x) is the recommended SDK. If you're still on v4.x.x, see the [migration guide](/docs/wallets/resources/migration-v5).
 </Note>
 
 ### 1. Install

--- a/content/wallets/pages/smart-wallets/session-keys/sdk.mdx
+++ b/content/wallets/pages/smart-wallets/session-keys/sdk.mdx
@@ -5,8 +5,6 @@ url: https://alchemy.com/docs/wallets/reference/wallet-apis-session-keys/sdk
 slug: wallets/reference/wallet-apis-session-keys/sdk
 ---
 
-<Info>`@alchemy/wallet-apis` (v5.x.x) is currently in beta but is the recommended replacement for `@account-kit/wallet-client` (v4.x.x). If you run into any issues, please [reach out](mailto:support@alchemy.com).</Info>
-
 ### 1. Install
 
 You need `@alchemy/wallet-apis` and `viem`. This guide uses `privateKeyToAccount` from `viem/accounts` as the owner for demonstration purposes.

--- a/content/wallets/pages/transactions/cross-chain-swap-tokens/client.mdx
+++ b/content/wallets/pages/transactions/cross-chain-swap-tokens/client.mdx
@@ -1,5 +1,3 @@
-<Info>`@alchemy/wallet-apis` (v5.x.x) is currently in beta but is the recommended replacement for `@account-kit/wallet-client` (v4.x.x). If you run into any issues, please [reach out](mailto:support@alchemy.com).</Info>
-
 <Info>
   **Important**: Cross-chain swaps do not support `postCalls`. You cannot batch
   additional actions after a cross-chain swap completes.

--- a/content/wallets/pages/transactions/pay-gas-with-any-token/client.mdx
+++ b/content/wallets/pages/transactions/pay-gas-with-any-token/client.mdx
@@ -1,5 +1,3 @@
-<Info>`@alchemy/wallet-apis` (v5.x.x) is currently in beta but is the recommended replacement for `@account-kit/wallet-client` (v4.x.x). If you run into any issues, please [reach out](mailto:support@alchemy.com).</Info>
-
 Use the `paymaster` capability on the smart wallet client [`sendCalls`](/docs/wallets/reference/wallet-apis/functions/sendCalls) or [`prepareCalls`](/docs/wallets/reference/wallet-apis/functions/prepareCalls) actions. Set `autoApprove: true` in `postOpSettings` to automatically handle token approvals — the exact amount needed for gas is calculated and approved in the same operation.
 
 <CodeBlocks>

--- a/content/wallets/pages/transactions/retry-transactions/client.mdx
+++ b/content/wallets/pages/transactions/retry-transactions/client.mdx
@@ -1,5 +1,3 @@
-<Info>`@alchemy/wallet-apis` (v5.x.x) is currently in beta but is the recommended replacement for `@account-kit/wallet-client` (v4.x.x). If you run into any issues, please [reach out](mailto:support@alchemy.com).</Info>
-
 When re-sending calls without a `nonceOverride`, the client automatically uses the same nonce as the pending transaction, replacing it. See the [`sendCalls` SDK reference](/docs/wallets/reference/wallet-apis/functions/sendCalls) for full parameter descriptions.
 
 You'll need the following env variables:

--- a/content/wallets/pages/transactions/send-batch-transactions/client.mdx
+++ b/content/wallets/pages/transactions/send-batch-transactions/client.mdx
@@ -1,5 +1,3 @@
-<Info>`@alchemy/wallet-apis` (v5.x.x) is currently in beta but is the recommended replacement for `@account-kit/wallet-client` (v4.x.x). If you run into any issues, please [reach out](mailto:support@alchemy.com).</Info>
-
 You can batch transactions using either the smart wallet client [`sendCalls`](/docs/wallets/reference/wallet-apis/functions/sendCalls) or [`prepareCalls`](/docs/wallets/reference/wallet-apis/functions/prepareCalls) actions.
 
 <CodeBlocks>

--- a/content/wallets/pages/transactions/send-parallel-transactions/client.mdx
+++ b/content/wallets/pages/transactions/send-parallel-transactions/client.mdx
@@ -1,5 +1,3 @@
-<Info>`@alchemy/wallet-apis` (v5.x.x) is currently in beta but is the recommended replacement for `@account-kit/wallet-client` (v4.x.x). If you run into any issues, please [reach out](mailto:support@alchemy.com).</Info>
-
 Use the `nonceOverride` capability on the smart wallet client's [`sendCalls`](/docs/wallets/reference/wallet-apis/functions/sendCalls) or [`prepareCalls`](/docs/wallets/reference/wallet-apis/functions/prepareCalls) action.
 
 You'll need the following env variables:

--- a/content/wallets/pages/transactions/send-transactions/client.mdx
+++ b/content/wallets/pages/transactions/send-transactions/client.mdx
@@ -1,5 +1,3 @@
-<Info>`@alchemy/wallet-apis` (v5.x.x) is currently in beta but is the recommended replacement for `@account-kit/wallet-client` (v4.x.x). If you run into any issues, please [reach out](mailto:support@alchemy.com).</Info>
-
 You can send transactions using the smart wallet client [`sendCalls`](/docs/wallets/reference/wallet-apis/functions/sendCalls) action.
 
 <CodeBlocks>

--- a/content/wallets/pages/transactions/send-transactions/prepare-calls/client.mdx
+++ b/content/wallets/pages/transactions/send-transactions/prepare-calls/client.mdx
@@ -1,5 +1,3 @@
-<Info>`@alchemy/wallet-apis` (v5.x.x) is currently in beta but is the recommended replacement for `@account-kit/wallet-client` (v4.x.x). If you run into any issues, please [reach out](mailto:support@alchemy.com).</Info>
-
 You can use smart wallet client actions to prepare, sign, and send transactions.
 
 <CodeBlocks>

--- a/content/wallets/pages/transactions/signing/sign-messages/client-raw.mdx
+++ b/content/wallets/pages/transactions/signing/sign-messages/client-raw.mdx
@@ -1,5 +1,3 @@
-<Info>`@alchemy/wallet-apis` (v5.x.x) is currently in beta but is the recommended replacement for `@account-kit/wallet-client` (v4.x.x). If you run into any issues, please [reach out](mailto:support@alchemy.com).</Info>
-
 See the [`signMessage` SDK reference](/docs/wallets/reference/wallet-apis/functions/signMessage) for full parameter descriptions.
 
 <CodeBlocks>

--- a/content/wallets/pages/transactions/signing/sign-messages/client-text.mdx
+++ b/content/wallets/pages/transactions/signing/sign-messages/client-text.mdx
@@ -1,5 +1,3 @@
-<Info>`@alchemy/wallet-apis` (v5.x.x) is currently in beta but is the recommended replacement for `@account-kit/wallet-client` (v4.x.x). If you run into any issues, please [reach out](mailto:support@alchemy.com).</Info>
-
 See the [`signMessage` SDK reference](/docs/wallets/reference/wallet-apis/functions/signMessage) for full parameter descriptions.
 
 <CodeBlocks>

--- a/content/wallets/pages/transactions/signing/sign-typed-data/client.mdx
+++ b/content/wallets/pages/transactions/signing/sign-typed-data/client.mdx
@@ -1,5 +1,3 @@
-<Info>`@alchemy/wallet-apis` (v5.x.x) is currently in beta but is the recommended replacement for `@account-kit/wallet-client` (v4.x.x). If you run into any issues, please [reach out](mailto:support@alchemy.com).</Info>
-
 See the [`signTypedData` SDK reference](/docs/wallets/reference/wallet-apis/functions/signTypedData) for full parameter descriptions.
 
 <CodeBlocks>

--- a/content/wallets/pages/transactions/sponsor-gas/client.mdx
+++ b/content/wallets/pages/transactions/sponsor-gas/client.mdx
@@ -1,5 +1,3 @@
-<Info>`@alchemy/wallet-apis` (v5.x.x) is currently in beta but is the recommended replacement for `@account-kit/wallet-client` (v4.x.x). If you run into any issues, please [reach out](mailto:support@alchemy.com).</Info>
-
 Use the `paymaster` capability on the smart wallet client [`sendCalls`](/docs/wallets/reference/wallet-apis/functions/sendCalls) or [`prepareCalls`](/docs/wallets/reference/wallet-apis/functions/prepareCalls) actions.
 
 <CodeBlocks>

--- a/content/wallets/pages/transactions/swap-tokens/client.mdx
+++ b/content/wallets/pages/transactions/swap-tokens/client.mdx
@@ -1,5 +1,3 @@
-<Info>`@alchemy/wallet-apis` (v5.x.x) is currently in beta but is the recommended replacement for `@account-kit/wallet-client` (v4.x.x). If you run into any issues, please [reach out](mailto:support@alchemy.com).</Info>
-
 You need the following environment variables:
 
 * `ALCHEMY_API_KEY`: An [API key](https://dashboard.alchemy.com/apps)

--- a/content/wallets/pages/transactions/undelegate-account/client.mdx
+++ b/content/wallets/pages/transactions/undelegate-account/client.mdx
@@ -1,5 +1,3 @@
-<Info>`@alchemy/wallet-apis` (v5.x.x) is currently in beta but is the recommended replacement for `@account-kit/wallet-client` (v4.x.x). If you run into any issues, please [reach out](mailto:support@alchemy.com).</Info>
-
 Use the [`undelegateAccount`](/docs/wallets/reference/wallet-apis/functions/undelegateAccount) action on the smart wallet client to remove EIP-7702 delegation and restore the account to a plain EOA. Gas is sponsored via a BSO policy.
 
 <CodeBlocks>

--- a/content/wallets/pages/transactions/using-eip-7702/client.mdx
+++ b/content/wallets/pages/transactions/using-eip-7702/client.mdx
@@ -1,5 +1,3 @@
-<Info>`@alchemy/wallet-apis` (v5.x.x) is currently in beta but is the recommended replacement for `@account-kit/wallet-client` (v4.x.x). If you run into any issues, please [reach out](mailto:support@alchemy.com).</Info>
-
 EIP-7702 is the default mode for Wallet APIs. Create a client with your owner and use `sendCalls` - the SDK automatically handles authorization requests to delegate the EOA to Modular Account v2 when needed.
 
 <Warning>

--- a/content/wallets/shared/v4-accordion.mdx
+++ b/content/wallets/shared/v4-accordion.mdx
@@ -1,7 +1,7 @@
-<Accordion title="Using @account-kit/wallet-client (v4.x.x)?">
-The examples on this page use `@alchemy/wallet-apis` (v5.x.x). If you're using `@account-kit/wallet-client` (v4.x.x), the client setup looks like this:
+<Accordion title="Using @account-kit/wallet-client (v4)?">
+The examples on this page use `@alchemy/wallet-apis` (v5). If you're using `@account-kit/wallet-client` (v4), the client setup looks like this:
 
-```ts title="client.ts (v4.x.x)"
+```ts title="client.ts (v4)"
 import { LocalAccountSigner } from "@aa-sdk/core";
 import { createSmartWalletClient } from "@account-kit/wallet-client";
 import { alchemy, sepolia } from "@account-kit/infra";
@@ -18,12 +18,12 @@ export const client = createSmartWalletClient({
 });
 ```
 
-Key v4.x.x differences:
-* **Account address** must be specified on the client or per action (`from` or `account`). In v5.x.x, the client automatically uses the owner's address as the account address via [EIP-7702](/docs/wallets/transactions/using-eip-7702).
+Key v4 differences:
+* **Account address** must be specified on the client or per action (`from` or `account`). In v5, the client automatically uses the owner's address as the account address via [EIP-7702](/docs/wallets/transactions/using-eip-7702).
 * **Chain imports** come directly from `@account-kit/infra` instead of `viem/chains`.
 * **Numeric values** use hex strings: `value: "0x0"` instead of `value: BigInt(0)`.
-* In v4.x.x, the **paymaster capability** on `prepareCalls` or `sendCalls` is called `paymasterService` instead of `paymaster`, or you can set the `policyId` directly on the client.
-* **Owners** use `LocalAccountSigner` / `WalletClientSigner` from `@aa-sdk/core`. In v5.x.x, a viem `LocalAccount` or `WalletClient` is used directly.
+* In v4, the **paymaster capability** on `prepareCalls` or `sendCalls` is called `paymasterService` instead of `paymaster`, or you can set the `policyId` directly on the client.
+* **Owners** use `LocalAccountSigner` / `WalletClientSigner` from `@aa-sdk/core`. In v5, a viem `LocalAccount` or `WalletClient` is used directly.
 
 See the [full migration guide](/docs/wallets/resources/migration-v5) for a complete cheat sheet.
 </Accordion>


### PR DESCRIPTION
## Summary
- Remove `<Info>` beta banners from 20 wallet docs pages — v5 (`@alchemy/wallet-apis`) is now GA
- Update quickstart `<Note>`: GitHub link `tree/v5.x.x` → `tree/main`, drop "currently in beta"
- Simplify `v4-accordion.mdx` version labels from `(v5.x.x)`/`(v4.x.x)` to `(v5)`/`(v4)`

## Test plan
- [ ] Spot-check a few wallet docs pages to confirm beta banners are gone and content reads correctly
- [ ] Verify quickstart Note renders with updated GitHub link
- [ ] Verify v4 accordion still renders and diff list is accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)