### PR TITLE
docs: clarify client-side jwt migration setup

### DIFF
--- a/content/wallets/wallet-integrations/privy/jwt-auth-migration.mdx
+++ b/content/wallets/wallet-integrations/privy/jwt-auth-migration.mdx
@@ -87,17 +87,13 @@ While existing users still need migrating, you don't want Privy to auto-create a
 
 ## Step 3: Reconnect sending and gas sponsorship
 
-Install `@alchemy/wallet-apis` and wire up `createSmartWalletClient`. See the [Privy signer integration guide](/docs/wallets/third-party/signers/privy) for full setup details, or follow the [React migration guide Step 2](/docs/wallets/wallet-integrations/privy/react-migration#step-2-reconnect-sending-and-gas-sponsorship) for a walkthrough.
+This step applies before either migration path below, including client-side migrations. Install `@alchemy/wallet-apis` and wire up `createSmartWalletClient`. See the [Privy signer integration guide](/docs/wallets/third-party/signers/privy) for full setup details, or follow the [React migration guide Step 2](/docs/wallets/wallet-integrations/privy/react-migration#step-2-reconnect-sending-and-gas-sponsorship) for a walkthrough.
 
 ***
 
 ## Client-side path
 
 Use this path if you have a React or React Native app and want the migration to happen in the user's browser/device.
-
-<Info>
-Client-side migrations still need to reconnect sending and gas sponsorship after Privy auth is wired up. Follow the [React migration guide Step 2](/docs/wallets/wallet-integrations/privy/react-migration#step-2-reconnect-sending-and-gas-sponsorship) to connect Privy wallets to Alchemy's transaction infrastructure.
-</Info>
 
 ### 4a. Integrate Privy auth (client-side)
 

--- a/content/wallets/wallet-integrations/privy/jwt-auth-migration.mdx
+++ b/content/wallets/wallet-integrations/privy/jwt-auth-migration.mdx
@@ -95,6 +95,10 @@ Install `@alchemy/wallet-apis` and wire up `createSmartWalletClient`. See the [P
 
 Use this path if you have a React or React Native app and want the migration to happen in the user's browser/device.
 
+<Info>
+Client-side migrations still need to reconnect sending and gas sponsorship after Privy auth is wired up. Follow the [React migration guide Step 2](/docs/wallets/wallet-integrations/privy/react-migration#step-2-reconnect-sending-and-gas-sponsorship) to connect Privy wallets to Alchemy's transaction infrastructure.
+</Info>
+
 ### 4a. Integrate Privy auth (client-side)
 
 Instead of calling a Privy login function directly, you subscribe the Privy SDK to your existing auth provider's state using the `useSubscribeToJwtAuthWithFlag` hook. Privy will automatically authenticate when your provider reports the user is logged in.

--- a/content/wallets/wallet-integrations/privy/jwt-auth-migration.mdx
+++ b/content/wallets/wallet-integrations/privy/jwt-auth-migration.mdx
@@ -87,13 +87,15 @@ While existing users still need migrating, you don't want Privy to auto-create a
 
 ## Step 3: Reconnect sending and gas sponsorship
 
-This step applies before either migration path below, including client-side migrations. Install `@alchemy/wallet-apis` and wire up `createSmartWalletClient`. See the [Privy signer integration guide](/docs/wallets/third-party/signers/privy) for full setup details, or follow the [React migration guide Step 2](/docs/wallets/wallet-integrations/privy/react-migration#step-2-reconnect-sending-and-gas-sponsorship) for a walkthrough.
+This step applies before either migration path below. Install `@alchemy/wallet-apis` and wire up `createSmartWalletClient`. See the [Privy signer integration guide](/docs/wallets/third-party/signers/privy) for full setup details, or follow the [React migration guide Step 2](/docs/wallets/wallet-integrations/privy/react-migration#step-2-reconnect-sending-and-gas-sponsorship) for a walkthrough.
 
 ***
 
 ## Client-side path
 
 Use this path if you have a React or React Native app and want the migration to happen in the user's browser/device.
+
+Before building the client-side flow, complete [Step 3](#step-3-reconnect-sending-and-gas-sponsorship) so your Privy wallets are connected to Alchemy's transaction infrastructure.
 
 ### 4a. Integrate Privy auth (client-side)
 


### PR DESCRIPTION
## Summary
- Add a client-side path note that JWT/Auth0 migrations still need sending and gas sponsorship reconnected.
- Link directly to React migration guide Step 2 for the Privy-to-Alchemy wallet setup.

## Test plan
- [x] Checked MDX diagnostics for `content/wallets/wallet-integrations/privy/jwt-auth-migration.mdx`

🤖 Generated with [Codex](https://Codex.com/Codex)

Made with [Cursor](https://cursor.com)