### PR TITLE
Update Hyperliquid wallet recipe for v5 + privy

### DIFF
--- a/content/wallets/pages/recipes/hyperliquid-wallets.mdx
+++ b/content/wallets/pages/recipes/hyperliquid-wallets.mdx
@@ -162,7 +162,6 @@ export function SendTransaction({ signer }: { signer: LocalAccount }) {
       ],
     });
 
-    console.log("HyperEVM call ID:", id);
     setStatus("waiting");
 
     const result = await client.waitForCallsStatus({ id });
@@ -309,7 +308,6 @@ export async function sendHyperliquidOrder({
   });
 
   const result = await client.waitForCallsStatus({ id });
-  console.log("Hyperliquid order call ID:", id);
   console.log("Hyperliquid order status:", result.status);
 
   return result;

--- a/content/wallets/pages/recipes/hyperliquid-wallets.mdx
+++ b/content/wallets/pages/recipes/hyperliquid-wallets.mdx
@@ -81,9 +81,22 @@ export function usePrivySigner() {
   const [signer, setSigner] = useState<LocalAccount>();
 
   useEffect(() => {
-    if (!wallet || signer) return;
-    toViemAccount({ wallet }).then(setSigner);
-  }, [wallet, signer]);
+    let isCurrentWallet = true;
+
+    if (!wallet) {
+      setSigner(undefined);
+      return;
+    }
+
+    setSigner(undefined);
+    toViemAccount({ wallet }).then((account) => {
+      if (isCurrentWallet) setSigner(account);
+    });
+
+    return () => {
+      isCurrentWallet = false;
+    };
+  }, [wallet]);
 
   return signer;
 }

--- a/content/wallets/pages/recipes/hyperliquid-wallets.mdx
+++ b/content/wallets/pages/recipes/hyperliquid-wallets.mdx
@@ -1,177 +1,213 @@
 ---
 title: Hyperliquid Transactions Quickstart
-description: Step-by-step guide to let users send transactions on hyperliquid.
+description: Step-by-step guide to let users send transactions on Hyperliquid.
 slug: wallets/recipes/hyperliquid-wallets
 ---
 
-<Markdown src="../../shared/v4-code-banner.mdx" />
+By the end of this tutorial, you will have a React application that uses [Privy](/docs/wallets/third-party/signers/privy) for embedded wallet authentication and [`@alchemy/wallet-apis`](/docs/wallets/quickstart) to send sponsored HyperEVM transactions.
 
-By the end of this tutorial, you’ll have an application integrated with Wallet APIs, enabling email and social login for user authentication, and the ability to sign and send transactions seamlessly.
+## 1. Install packages
 
-***
+Install Wallet APIs, Privy, and viem:
 
-## Getting Started Instructions
-
-## 1. Create a Custom Chain Config
-
-Extend [viem’s custom chains](https://viem.sh/docs/chains/introduction#custom-chains) to create a chain definition for HyperEVM, as it's not a defined chain on viem yet. This is the chain config you’ll be passing into your viem client in step #3.
-
-```tsx
-import { defineChain } from "viem";
-
-export const hype = defineChain({
-  id: 999,
-  name: "Hype",
-  nativeCurrency: {
-    decimals: 18,
-    name: "Hype",
-    symbol: "HYPE",
-  },
-  rpcUrls: {
-    default: {
-      http: ["https://hyperliquid-mainnet.g.alchemy.com/v2/{API_KEY}"],
-      webSocket: ["wss://hyperliquid-mainnet.g.alchemy.com/v2/{API_KEY}"],
-    },
-  },
-  blockExplorers: {
-    default: { name: "Explorer", url: "https://hyperevmscan.io/" },
-  },
-});
+<CodeGroup>
+```shell npm
+npm install @alchemy/wallet-apis @privy-io/react-auth viem
 ```
 
-Wrap it in `defineAlchemyChain` to create an alchemy chain to pass into your `config.tsx`
-
-```tsx
-import { defineAlchemyChain } from "@account-kit/infra";
-
-const chain = defineAlchemyChain({
-    chain: hype,
-    rpcBaseUrl: `https://hyperliquid-mainnet.g.alchemy.com/v2/${API_KEY}`,
-});
-
-...
-//config.tsx
-export const config = createConfig(
-  {
-    transport: alchemy({ apiKey: "API_KEY" }),
-    chain: chain,
-    ssr: true, // more about ssr: https://www.alchemy.com/docs/wallets/troubleshooting/ssr
-    storage: cookieStorage, // more about persisting state with cookies: https://www.alchemy.com/docs/wallets/troubleshooting/ssr#persisting-the-account-state
-    enablePopupOauth: true, // must be set to "true" if you plan on using popup rather than redirect in the social login flow
-    policyId: "policy_id",
-  },
-  uiConfig
-);
+```shell bun
+bun add @alchemy/wallet-apis @privy-io/react-auth viem
 ```
 
-## 2. Set up web2 login with authentication
+```shell yarn
+yarn add @alchemy/wallet-apis @privy-io/react-auth viem
+```
 
-#### Working with React?
+```shell pnpm
+pnpm add @alchemy/wallet-apis @privy-io/react-auth viem
+```
+</CodeGroup>
 
-Follow this [Quickstart](https://www.alchemy.com/docs/wallets/react/quickstart) guide to set up a new project.
+You will also need:
 
-The most important step is getting your API key (`NEXT_PUBLIC_ALCHEMY_API_KEY`) and ensuring your project is configured correctly on the dashboard. Make sure you have Hyperliquid enabled as a network on your app.
+* An Alchemy API key for an app with Hyperliquid enabled.
+* A Gas Manager policy ID for sponsoring gas.
+* A Privy App ID with embedded Ethereum wallets enabled.
 
-<img src="https://alchemyapi-res.cloudinary.com/image/upload/v1764187310/docs/aa-sdk/images/hyperliquid-account-config.png" alt="Hyperliquid account config" />
+Make sure Hyperliquid is enabled as a network on your Alchemy app and that your gas policy is linked to the same app.
 
 <img src="https://alchemyapi-res.cloudinary.com/image/upload/v1764187311/docs/aa-sdk/images/hyperliquid-dashboard-support.png" alt="Hyperliquid dashboard support" />
 
-Next, navigate to your `page.tsx`, and get the embedded EOA address using [useSigner()](https://github.com/alchemyplatform/aa-sdk/blob/v4.x.x/account-kit/react/src/hooks/useSigner.ts). This new embedded EOA will be where user assets live and will sign transactions.
+## 2. Configure Privy
 
-```tsx
-const signer = useSigner();
+Wrap your app with `PrivyProvider` and configure Privy to create an embedded Ethereum wallet when a user logs in.
+
+```tsx title="App.tsx"
+import { PrivyProvider } from "@privy-io/react-auth";
+
+export function App() {
+  return (
+    <PrivyProvider
+      appId={process.env.NEXT_PUBLIC_PRIVY_APP_ID!}
+      config={{
+        embeddedWallets: {
+          ethereum: {
+            createOnLogin: "all-users",
+          },
+          showWalletUIs: false,
+        },
+      }}
+    >
+      <YourApp />
+    </PrivyProvider>
+  );
+}
 ```
 
-Note: to access your embedded EOA, you need to have finished authentication. To check your authentication status, use [useSignerStatus()](https://github.com/alchemyplatform/aa-sdk/blob/v4.x.x/account-kit/react/src/hooks/useSignerStatus.ts). For example:
+## 3. Get the Privy signer
 
-```tsx
-...
- if (signerStatus.isConnected && signer) {
-        const address = signer.getAddress();
-        console.log("Connected signer address:", address);
-      }
- ...
+Use Privy's `toViemAccount` helper to convert the embedded wallet into a viem-compatible signer. Wallet APIs uses this signer to sign the prepared smart account operations.
+
+```tsx title="usePrivySigner.ts"
+import { toViemAccount, useWallets } from "@privy-io/react-auth";
+import { useEffect, useState } from "react";
+import type { LocalAccount } from "viem";
+
+export function usePrivySigner() {
+  const {
+    wallets: [wallet],
+  } = useWallets();
+
+  const [signer, setSigner] = useState<LocalAccount>();
+
+  useEffect(() => {
+    if (!wallet || signer) return;
+    toViemAccount({ wallet }).then(setSigner);
+  }, [wallet, signer]);
+
+  return signer;
+}
 ```
 
-#### Not working with React?
+## 4. Create a HyperEVM client
 
-That’s okay! There are lower level methods available to access the authentication provider.
+`viem` exports the HyperEVM chain as `hyperEvm`. Pass it to `createSmartWalletClient` with your Privy signer and Alchemy transport.
 
-Follow this [Quickstart](https://www.alchemy.com/docs/wallets/signer/quickstart), to use the `@account-kit/signer` package directly to create and use wallets.
+```ts title="walletClient.ts"
+import {
+  alchemyWalletTransport,
+  createSmartWalletClient,
+} from "@alchemy/wallet-apis";
+import type { LocalAccount } from "viem";
+import { hyperEvm } from "viem/chains";
 
-#### Create an authentication instance
-
-```tsx
-import { AlchemyWebSigner } from "@account-kit/signer";
-
-export const signer = new AlchemyWebSigner({
-  client: {
-    connection: {
-      apiKey: "API_KEY",
+export function createHyperliquidWalletClient(signer: LocalAccount) {
+  return createSmartWalletClient({
+    signer,
+    transport: alchemyWalletTransport({
+      apiKey: process.env.NEXT_PUBLIC_ALCHEMY_API_KEY!,
+    }),
+    chain: hyperEvm,
+    paymaster: {
+      policyId: process.env.NEXT_PUBLIC_ALCHEMY_GAS_POLICY_ID!,
     },
-    iframeConfig: {
-      iframeContainerId: "alchemy-signer-iframe-container",
-    },
-  },
-});
+  });
+}
 ```
 
-#### Authenticate a user
+<Tip>
+  To test on Hyperliquid testnet, import `hyperliquidEvmTestnet` from `viem/chains` instead and configure the matching network and gas policy in the Alchemy Dashboard.
+</Tip>
 
-Next, authenticate your user before you can use the authentication provider. In this example, email auth is used, but a number of other auth methods are supported. Check out the [guides](https://www.alchemy.com/docs/wallets/react/react-hooks) to complete authentication.
+## 5. Send a transaction
 
-```tsx
-import { signer } from "./signer";
+HyperEVM currently uses [non-7702 mode](/docs/wallets/transactions/using-eip-7702#how-to-use-non-7702-mode) with Wallet APIs. Request a smart account first, then pass the returned smart account address to `sendCalls`.
 
-const result = await signer.authenticate({
-  type: "email",
-  email: "example@mail.com",
-});
-...
+`requestAccount` returns a stable address for the signer and request parameters. The client caches the result, so you can keep this call in the send handler for a compact example or store the address in your app state if you prefer.
+
+```tsx title="SendTransaction.tsx"
+import { useCallback, useMemo, useState } from "react";
+import { zeroAddress } from "viem";
+import type { LocalAccount } from "viem";
+import { createHyperliquidWalletClient } from "./walletClient";
+
+export function SendTransaction({ signer }: { signer: LocalAccount }) {
+  const client = useMemo(
+    () => createHyperliquidWalletClient(signer),
+    [signer],
+  );
+  const [status, setStatus] = useState<string>();
+
+  const sendTransaction = useCallback(async () => {
+    setStatus("sending");
+
+    const { address } = await client.requestAccount({
+      creationHint: { accountType: "sma-b" },
+    });
+
+    const { id } = await client.sendCalls({
+      account: address,
+      calls: [
+        {
+          to: zeroAddress,
+          value: 0n,
+          data: "0x",
+        },
+      ],
+    });
+
+    setStatus("waiting");
+
+    const result = await client.waitForCallsStatus({ id });
+    const transactionHash = result.receipts?.[0]?.transactionHash;
+
+    setStatus(result.status);
+    console.log("HyperEVM transaction hash:", transactionHash);
+  }, [client]);
+
+  return (
+    <button onClick={sendTransaction} disabled={status === "sending"}>
+      {status === "sending" ? "Sending..." : "Send transaction"}
+    </button>
+  );
+}
 ```
 
-Once you finish authenticating, you can access the authentication provider!
+Render the button after the user logs in and Privy has created the signer:
 
-## 3. Send Transactions
+```tsx title="Wallet.tsx"
+import { usePrivy } from "@privy-io/react-auth";
+import { SendTransaction } from "./SendTransaction";
+import { usePrivySigner } from "./usePrivySigner";
 
-Got your embedded EOA address? Now you are ready to send transactions! The authentication provider supports signing messages as raw hashes. Use methods including `signMessage`, `signTypedData`, and `signTransaction`.
+export function Wallet() {
+  const { ready, authenticated, login, logout } = usePrivy();
+  const signer = usePrivySigner();
 
-```tsx
-const signedTx = await signer.signTransaction(txRequest);
+  if (!ready) return <p>Loading...</p>;
+
+  if (!authenticated) {
+    return <button onClick={() => login()}>Login with Privy</button>;
+  }
+
+  return (
+    <div>
+      <button onClick={() => logout()}>Logout</button>
+      {signer ? <SendTransaction signer={signer} /> : <p>Loading signer...</p>}
+    </div>
+  );
+}
 ```
 
-Then use a generic wallet client to send transactions. For example, if you are using viem, use the `toViemAccount` method which allows you to use the authentication provider with a [WalletClient](https://viem.sh/docs/clients/wallet#local-accounts-private-key-mnemonic-etc).
+## 6. Send a HyperCore Writer action
 
-```tsx
-import { createWalletClient, http, custom, parseEther } from "viem";
+You can also sponsor HyperEVM contract calls that interact with HyperCore. The example below encodes a `sendRawAction` call to the HyperCore Writer contract.
 
-export const walletClient = createWalletClient({
-  transport: http("https://hyperliquid-mainnet.g.alchemy.com/v2/{API_KEY}"),
-  chain: Hype,
-  account: signer.toViemAccount(),
-});
+<Warning>
+  This encodes a real HyperCore order action. Use testnet or replace the order parameters before sending from a production wallet.
+</Warning>
 
-const txRequest = await walletClient.prepareTransactionRequest({
-  account: acct,
-  to: "0x0000000000000000000000000000000000000000",
-  value: parseEther("0.0001"),
-});
-
-// Sign transaction
-
-const txHash = await walletClient.sendRawTransaction({
-  serializedTransaction: signedTx,
-});
-```
-
-## 4. Sponsoring transactions
-
-Gas sponsorship lets your users send transactions on HyperEVM without holding the native token for gas. To start, make sure you have a gas policy ID configured in your app dashboard and pass it to your client initialization. Learn more in [Sponsor Gas](https://www.alchemy.com/docs/wallets/transactions/sponsor-gas).
-
-As an example, the following sponsors a HyperEVM transaction opening a limit order, using the HyperCore Writer contract. Start by creating some helpers to encode the call.
-
-```ts
-// hyperliquidOrder.ts
+```ts title="hyperliquidOrder.ts"
 import {
   encodeAbiParameters,
   encodeFunctionData,
@@ -204,7 +240,7 @@ export const HYPERLIQUID_CALLDATA = (() => {
     [asset, isBuy, limitPx, sz, reduceOnly, encodedTif, cloid],
   );
 
-  // encoding version (1 byte) + action ID (3 bytes)
+  // Encoding version (1 byte) + action ID (3 bytes).
   const prefix = new Uint8Array([0x01, 0x00, 0x00, 0x01]);
 
   const payload = hexToBytes(payloadHex);
@@ -230,84 +266,47 @@ export const HYPERLIQUID_CALLDATA = (() => {
 })();
 ```
 
-### Using React
+Then request the user's smart account and pass the encoded call to `sendCalls`:
 
-If you are working in React, you can use the [useSendUserOperation](https://github.com/alchemyplatform/aa-sdk/blob/v4.x.x/account-kit/react/src/hooks/useSendUserOperation.ts) hook. Make sure you have set up your config from step 1.
-
-```tsx
-import React from "react";
+```ts title="sendHyperliquidOrder.ts"
+import { createHyperliquidWalletClient } from "./walletClient";
 import {
-  useSendUserOperation,
-  useSmartAccountClient,
-} from "@account-kit/react";
-import { CORE_WRITER_ADDRESS, HYPERLIQUID_CALLDATA } from "./hyperliquidOrder";
+  CORE_WRITER_ADDRESS,
+  HYPERLIQUID_CALLDATA,
+} from "./hyperliquidOrder";
+import type { LocalAccount } from "viem";
 
-function ComponentWithSendUserOperation() {
-  const { client } = useSmartAccountClient({});
+export async function sendHyperliquidOrder(signer: LocalAccount) {
+  const client = createHyperliquidWalletClient(signer);
 
-  const { sendUserOperation, isSendingUserOperation } = useSendUserOperation({
-    client,
-    waitForTxn: true,
-    onSuccess: ({ hash, request }) => {
-      // [optional] handle success
-    },
-    onError: (error) => {
-      // [optional] handle error
-    },
+  const { address } = await client.requestAccount({
+    creationHint: { accountType: "sma-b" },
   });
 
-  return (
-    <div>
-      <button
-        onClick={() =>
-          sendUserOperation({
-            uo: {
-              target: CORE_WRITER_ADDRESS,
-              data: HYPERLIQUID_CALLDATA,
-              value: 0n,
-            },
-          })
-        }
-        disabled={isSendingUserOperation}
-      >
-        {isSendingUserOperation ? "Sending..." : "Send UO"}
-      </button>
-    </div>
-  );
+  const { id } = await client.sendCalls({
+    account: address,
+    calls: [
+      {
+        to: CORE_WRITER_ADDRESS,
+        data: HYPERLIQUID_CALLDATA,
+        value: 0n,
+      },
+    ],
+  });
+
+  const result = await client.waitForCallsStatus({ id });
+  console.log("Hyperliquid order status:", result.status);
+  console.log("Transaction hash:", result.receipts?.[0]?.transactionHash);
+
+  return result;
 }
-
-export default ComponentWithSendUserOperation;
-```
-
-### Without React
-
-If you are not using React, you can send the same user operation directly with the [Modular Account V2 client](https://github.com/alchemyplatform/aa-sdk/blob/v4.x.x/account-kit/smart-contracts/src/ma-v2/client/client.ts) in account-kit, passing in the chain config from step 1 and signer from step 2.
-
-```ts
-import { createModularAccountV2Client } from "@account-kit/smart-contracts";
-import { CORE_WRITER_ADDRESS, HYPERLIQUID_CALLDATA } from "./hyperliquidOrder";
-
-const modularAccountV2Client = await createModularAccountV2Client({
-  chain, // chain config from step 1
-  signer, // signer from step 2
-  transport,
-  policyId: "policy_id",
-});
-
-await modularAccountV2Client.sendUserOperation({
-  uo: {
-    target: CORE_WRITER_ADDRESS,
-    data: HYPERLIQUID_CALLDATA,
-    value: 0n,
-  },
-});
 ```
 
 ### Resources
 
-* [Alchemy Signer](https://www.alchemy.com/docs/wallets/signer/what-is-a-signer)
-* [Connect your EOAs](https://www.alchemy.com/docs/wallets/react/login-methods/eoa-login)
-* [Alchemy Gas Sponsorship](https://www.alchemy.com/docs/wallets/transactions/sponsor-gas)
-* [Viem Custom Chain Support](https://viem.sh/docs/chains/introduction#custom-chains)
-* [Full Example](https://github.com/aashkrishnan/hyperevmguide/blob/ash/hyperevm/app/page.tsx)
-* [Bridge Funds to Hype](https://debridge.finance/)
+* [Privy with Wallet APIs](/docs/wallets/third-party/signers/privy)
+* [Send transactions](/docs/wallets/transactions/send-transactions)
+* [Sponsor gas](/docs/wallets/transactions/sponsor-gas)
+* [EIP-7702 with Wallet APIs](/docs/wallets/transactions/using-eip-7702)
+* [Viem chain definitions](https://viem.sh/docs/chains/introduction)
+* [Bridge funds to HYPE](https://debridge.finance/)

--- a/content/wallets/pages/recipes/hyperliquid-wallets.mdx
+++ b/content/wallets/pages/recipes/hyperliquid-wallets.mdx
@@ -81,22 +81,9 @@ export function usePrivySigner() {
   const [signer, setSigner] = useState<LocalAccount>();
 
   useEffect(() => {
-    let isCurrentWallet = true;
-
-    if (!wallet) {
-      setSigner(undefined);
-      return;
-    }
-
-    setSigner(undefined);
-    toViemAccount({ wallet }).then((account) => {
-      if (isCurrentWallet) setSigner(account);
-    });
-
-    return () => {
-      isCurrentWallet = false;
-    };
-  }, [wallet]);
+    if (!wallet || signer) return;
+    toViemAccount({ wallet }).then(setSigner);
+  }, [wallet, signer]);
 
   return signer;
 }
@@ -153,20 +140,12 @@ export function SendTransaction({ signer }: { signer: LocalAccount }) {
   const [status, setStatus] = useState<string>();
 
   useEffect(() => {
-    let isCurrentClient = true;
-
     setAccountAddress(undefined);
     client
       .requestAccount({
         creationHint: { accountType: "sma-b" },
       })
-      .then(({ address }) => {
-        if (isCurrentClient) setAccountAddress(address);
-      });
-
-    return () => {
-      isCurrentClient = false;
-    };
+      .then(({ address }) => setAccountAddress(address));
   }, [client]);
 
   const sendTransaction = useCallback(async () => {

--- a/content/wallets/pages/recipes/hyperliquid-wallets.mdx
+++ b/content/wallets/pages/recipes/hyperliquid-wallets.mdx
@@ -136,12 +136,12 @@ export function createHyperliquidWalletClient(signer: LocalAccount) {
 
 HyperEVM currently uses [non-7702 mode](/docs/wallets/transactions/using-eip-7702#how-to-use-non-7702-mode) with Wallet APIs. Request a smart account first, then pass the returned smart account address to `sendCalls`.
 
-`requestAccount` returns a stable address for the signer and request parameters. The client caches the result, so you can keep this call in the send handler for a compact example or store the address in your app state if you prefer.
+`requestAccount` returns a stable address for the signer and request parameters. The example below stores it in React state, so each send can pass the same address to `sendCalls` without requesting the account again.
 
 ```tsx title="SendTransaction.tsx"
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { zeroAddress } from "viem";
-import type { LocalAccount } from "viem";
+import type { Address, LocalAccount } from "viem";
 import { createHyperliquidWalletClient } from "./walletClient";
 
 export function SendTransaction({ signer }: { signer: LocalAccount }) {
@@ -149,17 +149,31 @@ export function SendTransaction({ signer }: { signer: LocalAccount }) {
     () => createHyperliquidWalletClient(signer),
     [signer],
   );
+  const [accountAddress, setAccountAddress] = useState<Address>();
   const [status, setStatus] = useState<string>();
 
+  useEffect(() => {
+    let isCurrentClient = true;
+
+    setAccountAddress(undefined);
+    client
+      .requestAccount({
+        creationHint: { accountType: "sma-b" },
+      })
+      .then(({ address }) => {
+        if (isCurrentClient) setAccountAddress(address);
+      });
+
+    return () => {
+      isCurrentClient = false;
+    };
+  }, [client]);
+
   const sendTransaction = useCallback(async () => {
+    if (!accountAddress) return;
     setStatus("sending");
-
-    const { address } = await client.requestAccount({
-      creationHint: { accountType: "sma-b" },
-    });
-
     const { id } = await client.sendCalls({
-      account: address,
+      account: accountAddress,
       calls: [
         {
           to: zeroAddress,
@@ -169,18 +183,24 @@ export function SendTransaction({ signer }: { signer: LocalAccount }) {
       ],
     });
 
+    console.log("HyperEVM call ID:", id);
     setStatus("waiting");
 
     const result = await client.waitForCallsStatus({ id });
-    const transactionHash = result.receipts?.[0]?.transactionHash;
-
     setStatus(result.status);
-    console.log("HyperEVM transaction hash:", transactionHash);
-  }, [client]);
+  }, [accountAddress, client]);
+
+  const isPending = status === "sending" || status === "waiting";
 
   return (
-    <button onClick={sendTransaction} disabled={status === "sending"}>
-      {status === "sending" ? "Sending..." : "Send transaction"}
+    <button onClick={sendTransaction} disabled={!accountAddress || isPending}>
+      {!accountAddress
+        ? "Loading account..."
+        : status === "sending"
+          ? "Sending..."
+          : status === "waiting"
+            ? "Waiting..."
+            : "Send transaction"}
     </button>
   );
 }
@@ -279,7 +299,7 @@ export const HYPERLIQUID_CALLDATA = (() => {
 })();
 ```
 
-Then request the user's smart account and pass the encoded call to `sendCalls`:
+Then reuse the stored smart account address and pass the encoded call to `sendCalls`:
 
 ```ts title="sendHyperliquidOrder.ts"
 import { createHyperliquidWalletClient } from "./walletClient";
@@ -287,17 +307,19 @@ import {
   CORE_WRITER_ADDRESS,
   HYPERLIQUID_CALLDATA,
 } from "./hyperliquidOrder";
-import type { LocalAccount } from "viem";
+import type { Address, LocalAccount } from "viem";
 
-export async function sendHyperliquidOrder(signer: LocalAccount) {
+export async function sendHyperliquidOrder({
+  signer,
+  accountAddress,
+}: {
+  signer: LocalAccount;
+  accountAddress: Address;
+}) {
   const client = createHyperliquidWalletClient(signer);
 
-  const { address } = await client.requestAccount({
-    creationHint: { accountType: "sma-b" },
-  });
-
   const { id } = await client.sendCalls({
-    account: address,
+    account: accountAddress,
     calls: [
       {
         to: CORE_WRITER_ADDRESS,
@@ -308,8 +330,8 @@ export async function sendHyperliquidOrder(signer: LocalAccount) {
   });
 
   const result = await client.waitForCallsStatus({ id });
+  console.log("Hyperliquid order call ID:", id);
   console.log("Hyperliquid order status:", result.status);
-  console.log("Transaction hash:", result.receipts?.[0]?.transactionHash);
 
   return result;
 }


### PR DESCRIPTION
## Description

Updates the high-traffic Hyperliquid Transactions Quickstart to use SDK v5 Wallet APIs with Privy embedded wallets as the signer.

## Related Issues

N/A

## Changes Made

- Replaces the v4 Account Kit and Alchemy Signer flow with `@alchemy/wallet-apis`, Privy, and viem's `hyperEvm` chain.
- Documents the sponsored HyperEVM `requestAccount`/`sendCalls` flow in non-7702 mode, including a HyperCore Writer example.
- Removes stale v4 imagery and refreshes resource links for current Wallet APIs docs.

## Testing

- `pnpm exec prettier --check content/wallets/pages/recipes/hyperliquid-wallets.mdx`
- `git diff --check`
- Typechecked and build-checked smoke snippets in `/Users/jacob.hobbs/dev/jakehobbs/privy-v5-example`
- Live HyperEVM no-op via Privy Node and Wallet APIs completed successfully

* [x] I have tested these changes locally
* [ ] I have run the validation scripts (`pnpm run validate`)
* [ ] I have checked that the documentation builds correctly

🤖 Generated with [Codex](https://Codex.com/Codex)