### PR TITLE
Add Sonic Blaze testnet deprecation notice

### DIFF
--- a/content/api-reference/node-api/node-supported-chains.mdx
+++ b/content/api-reference/node-api/node-supported-chains.mdx
@@ -341,7 +341,7 @@ Alchemy supports both EVM and non-EVM chains, view API references below:
 | Metis | Metis Mainnet | https://metis-mainnet.g.alchemy.com/v2/API_KEY |
 | Sonic | Sonic Mainnet | https://sonic-mainnet.g.alchemy.com/v2/API_KEY |
 | Sonic | Sonic Testnet | https://sonic-testnet.g.alchemy.com/v2/API_KEY |
-| Sonic | Sonic Blaze | https://sonic-blaze.g.alchemy.com/v2/API_KEY |
+| Sonic | Sonic Blaze (deprecated June 12, 2026 — [migrate to Sonic Testnet](/docs/reference/sonic-blaze-deprecation-notice)) | https://sonic-blaze.g.alchemy.com/v2/API_KEY |
 | Sei | Sei Mainnet | https://sei-mainnet.g.alchemy.com/v2/API_KEY |
 | Sei | Sei Testnet | https://sei-testnet.g.alchemy.com/v2/API_KEY |
 | XMTP | XMTP Ropsten | https://xmtp-ropsten.g.alchemy.com/v2/API_KEY |

--- a/content/api-reference/node-api/node-supported-chains.mdx
+++ b/content/api-reference/node-api/node-supported-chains.mdx
@@ -341,7 +341,7 @@ Alchemy supports both EVM and non-EVM chains, view API references below:
 | Metis | Metis Mainnet | https://metis-mainnet.g.alchemy.com/v2/API_KEY |
 | Sonic | Sonic Mainnet | https://sonic-mainnet.g.alchemy.com/v2/API_KEY |
 | Sonic | Sonic Testnet | https://sonic-testnet.g.alchemy.com/v2/API_KEY |
-| Sonic | Sonic Blaze (deprecated June 12, 2026 — [migrate to Sonic Testnet](/docs/reference/sonic-blaze-deprecation-notice)) | https://sonic-blaze.g.alchemy.com/v2/API_KEY |
+| Sonic | Sonic Blaze (deprecating June 12, 2026 — [migrate to Sonic Testnet](/docs/reference/sonic-blaze-deprecation-notice)) | https://sonic-blaze.g.alchemy.com/v2/API_KEY |
 | Sei | Sei Mainnet | https://sei-mainnet.g.alchemy.com/v2/API_KEY |
 | Sei | Sei Testnet | https://sei-testnet.g.alchemy.com/v2/API_KEY |
 | XMTP | XMTP Ropsten | https://xmtp-ropsten.g.alchemy.com/v2/API_KEY |

--- a/content/api-reference/sonic/sonic-api-quickstart.mdx
+++ b/content/api-reference/sonic/sonic-api-quickstart.mdx
@@ -5,6 +5,10 @@ subtitle: How to get started building on Sonic using Alchemy
 slug: reference/sonic-api-quickstart
 ---
 
+<Warning title="Sonic Blaze testnet deprecation">
+  Support for the **Sonic Blaze** testnet ends on **June 12, 2026**. Migrate to **Sonic Testnet** (`sonic-testnet`) before then. See the [Sonic Blaze Deprecation Notice](/docs/reference/sonic-blaze-deprecation-notice) for details.
+</Warning>
+
 <Tip title="Don't have an API key?" icon="star">
   Build faster with production-ready APIs, smart wallets and rollup infrastructure across 70+ chains. Create your free Alchemy API key and{" "}
   <a href="https://dashboard.alchemy.com/signup">get started today</a>.

--- a/content/api-reference/sonic/sonic-blaze-deprecation-notice.mdx
+++ b/content/api-reference/sonic/sonic-blaze-deprecation-notice.mdx
@@ -1,0 +1,28 @@
+---
+title: Sonic Blaze Testnet Deprecation Notice
+description: Important notice regarding the deprecation of the Sonic Blaze testnet and how to migrate to Sonic Testnet
+slug: reference/sonic-blaze-deprecation-notice
+---
+
+## ⚠️ Deprecation Notice
+
+**Alchemy will fully deprecate support for the Sonic Blaze testnet on June 12, 2026.** After this date, requests to Sonic Blaze endpoints (`sonic-blaze`) will no longer be supported.
+
+Sonic Blaze is being deprecated because it was [sunset by Sonic Labs on May 1, 2025](https://x.com/SonicLabs/status/2034664628903629171). Sonic Mainnet and Sonic Testnet remain fully supported.
+
+## Migrate to Sonic Testnet
+
+Please move your traffic to **Sonic Testnet** (Sonic's current testnet) before June 12, 2026:
+
+1. Enable **Sonic Testnet** for your app on the [Endpoints page in the Dashboard](https://dashboard.alchemy.com/).
+2. Update your endpoint URL from `sonic-blaze` to `sonic-testnet` in your codebase:
+
+```text
+https://sonic-testnet.g.alchemy.com/v2/YOUR_ALCHEMY_API_KEY
+```
+
+No other changes are required. See the [Sonic API Quickstart](/docs/reference/sonic-api-quickstart) to get started.
+
+## Need help?
+
+If you have any questions or need assistance migrating, contact us at support@alchemy.com or open a ticket in the [Alchemy Dashboard](https://dashboard.alchemy.com/).

--- a/content/api-reference/sonic/sonic-blaze-deprecation-notice.mdx
+++ b/content/api-reference/sonic/sonic-blaze-deprecation-notice.mdx
@@ -8,7 +8,7 @@ slug: reference/sonic-blaze-deprecation-notice
 
 **Alchemy will fully deprecate support for the Sonic Blaze testnet on June 12, 2026.** After this date, requests to Sonic Blaze endpoints (`sonic-blaze`) will no longer be supported.
 
-Sonic Blaze is being deprecated because it was [sunset by Sonic Labs on May 1, 2025](https://x.com/SonicLabs/status/2034664628903629171). Sonic Mainnet and Sonic Testnet remain fully supported.
+Sonic Blaze is being deprecated because it was [sunset by Sonic Labs on May 1, 2026](https://x.com/SonicLabs/status/2034664628903629171). Sonic Mainnet and Sonic Testnet remain fully supported.
 
 ## Migrate to Sonic Testnet
 

--- a/content/docs.yml
+++ b/content/docs.yml
@@ -2065,6 +2065,8 @@ navigation:
             path: api-reference/sonic/sonic-api-faq.mdx
           - page: Sonic API Overview
             path: api-reference/sonic/sonic-api-overview.mdx
+          - page: Sonic Blaze Deprecation Notice
+            path: api-reference/sonic/sonic-blaze-deprecation-notice.mdx
           - api: Sonic API Endpoints
             api-name: sonic
         slug: sonic


### PR DESCRIPTION
## Summary
- Kicks off the docs side of the [Sonic Blaze deprecation](https://app.notion.com/p/372069f2006680a7ab88de78ebb5b298). Sonic Blaze was sunset by Sonic Labs on May 1; Alchemy support ends **June 12**.
- Adds a dedicated **Sonic Blaze Deprecation Notice** page with migration steps (`sonic-blaze` → `sonic-testnet`) and links it in the Sonic nav.
- Surfaces a `<Warning>` callout at the top of the **Sonic API Quickstart**.
- Marks **Sonic Blaze** as being deprecated in the supported chains table with a migration link.

Made with [Cursor](https://cursor.com)