### PR TITLE
feat: support remote openrpc specs

### DIFF
--- a/scripts/generate-open-api.sh
+++ b/scripts/generate-open-api.sh
@@ -71,11 +71,13 @@ done
 
 # --- Remote specs ---
 # Specs hosted externally that should be included alongside local specs.
-# Config lives in content/remote-specs.json as an array of { name, url } objects.
+# Config lives in content/remote-specs.json as an array of { name, url, type? } objects.
+# Only OpenAPI entries are processed here; entries with "type": "openrpc" are
+# handled by the RPC generator. A missing type defaults to OpenAPI.
 remote_specs_file="content/remote-specs.json"
 
 if [ -f "$remote_specs_file" ]; then
-  for entry in $(jq -c '.[]' "$remote_specs_file"); do
+  for entry in $(jq -c '.[] | select((.type // "openapi") == "openapi")' "$remote_specs_file"); do
     name=$(echo "$entry" | jq -r '.name')
     url=$(echo "$entry" | jq -r '.url')
     filename="${output_dir}/alchemy/rest/${name}.json"

--- a/scripts/generate-rpc.ts
+++ b/scripts/generate-rpc.ts
@@ -1,10 +1,18 @@
 import { mkdirSync, readdirSync } from "fs";
 
-import { generateOpenRpcSpec } from "../src/utils/generateRpcSpecs.ts";
+import {
+  generateOpenRpcSpec,
+  generateRemoteOpenRpcSpec,
+} from "../src/utils/generateRpcSpecs.ts";
 import {
   type DerefErrorGroup,
   handleDerefErrors,
 } from "../src/utils/generationHelpers.js";
+import {
+  filterRemoteSpecsByType,
+  getOverriddenNames,
+  readRemoteSpecs,
+} from "../src/utils/remoteSpecs.ts";
 
 const isHiddenDir = (file: string) =>
   !file.startsWith("_") && !file.startsWith(".");
@@ -31,10 +39,20 @@ const main = async () => {
     }
   });
 
+  // Remote OpenRPC specs win over local specs that share the same name, so
+  // wallet-api (and others) can move remote with only a config change.
+  const remoteOpenRpcSpecs = filterRemoteSpecsByType(
+    readRemoteSpecs(),
+    "openrpc",
+  );
+  const overriddenNames = getOverriddenNames(remoteOpenRpcSpecs);
+
   // generate alchemy API OpenRPC specs
   const alchemyApisDir = `${SCHEMAS_ROOT}/alchemy`;
   const alchemyOutputDir = `${OUTPUT_ROOT}/alchemy/json-rpc`;
-  const allAlchemyApiFiles = readdirSync(alchemyApisDir).filter(isHiddenDir);
+  const allAlchemyApiFiles = readdirSync(alchemyApisDir)
+    .filter(isHiddenDir)
+    .filter((api) => !overriddenNames.has(api));
 
   mkdirSync(alchemyOutputDir, { recursive: true });
 
@@ -46,10 +64,20 @@ const main = async () => {
     }
   });
 
+  // generate remote alchemy OpenRPC specs into the same json-rpc spec path
+  const remotePromises = remoteOpenRpcSpecs.map(async (spec) => {
+    try {
+      await generateRemoteOpenRpcSpec(spec.url, alchemyOutputDir, spec.name);
+    } catch (err: unknown) {
+      handleDerefErrors(err, spec.name, missingTokens, genErrors);
+    }
+  });
+
   // Wait for all promises to complete
   const results = await Promise.allSettled([
     ...chainPromises,
     ...alchemyPromises,
+    ...remotePromises,
   ]);
 
   // Report all errors at once

--- a/src/utils/__tests__/__fixtures__/remote-openrpc.yaml
+++ b/src/utils/__tests__/__fixtures__/remote-openrpc.yaml
@@ -1,0 +1,26 @@
+# Minimal OpenRPC fixture used to exercise remote spec generation.
+# The $ref below verifies that the generator dereferences before writing.
+openrpc: 1.2.4
+info:
+  title: Test Remote OpenRPC API
+  version: 0.0.0
+servers:
+  - url: https://example.com/v2
+    name: Test
+methods:
+  - name: test_getThing
+    params:
+      - name: address
+        required: true
+        schema:
+          $ref: "#/components/schemas/Address"
+    result:
+      name: thing
+      schema:
+        type: string
+components:
+  schemas:
+    Address:
+      title: Address
+      type: string
+      pattern: "^0x[a-fA-F0-9]{40}$"

--- a/src/utils/__tests__/generateRpcSpecs.test.ts
+++ b/src/utils/__tests__/generateRpcSpecs.test.ts
@@ -1,0 +1,56 @@
+import { mkdtempSync, readFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import type { DerefedOpenRpcDoc } from "../../types/openRpc.ts";
+import { generateRemoteOpenRpcSpec } from "../generateRpcSpecs.ts";
+import { validateRpcSpec } from "../validateRpcSpec.ts";
+
+const FIXTURE = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "__fixtures__",
+  "remote-openrpc.yaml",
+);
+
+describe("generateRemoteOpenRpcSpec", () => {
+  let outputDir: string;
+
+  beforeEach(() => {
+    outputDir = mkdtempSync(join(tmpdir(), "rpc-spec-"));
+  });
+
+  afterEach(() => {
+    rmSync(outputDir, { recursive: true, force: true });
+  });
+
+  test("dereferences a source spec and writes {name}.json", async () => {
+    await generateRemoteOpenRpcSpec(FIXTURE, outputDir, "wallet-api");
+
+    const written = JSON.parse(
+      readFileSync(join(outputDir, "wallet-api.json"), "utf-8"),
+    ) as DerefedOpenRpcDoc;
+
+    expect(written.info.title).toBe("Test Remote OpenRPC API");
+    // components are stripped during formatting once dereferenced
+    expect(written).not.toHaveProperty("components");
+
+    // the $ref param schema was dereferenced inline
+    const param = written.methods[0].params[0];
+    expect(param.schema).toMatchObject({
+      type: "string",
+      pattern: "^0x[a-fA-F0-9]{40}$",
+    });
+  });
+
+  test("produces a valid OpenRPC document", async () => {
+    await generateRemoteOpenRpcSpec(FIXTURE, outputDir, "token");
+
+    const written = JSON.parse(
+      readFileSync(join(outputDir, "token.json"), "utf-8"),
+    ) as DerefedOpenRpcDoc;
+
+    expect(() => validateRpcSpec(written)).not.toThrow();
+  });
+});

--- a/src/utils/__tests__/remoteSpecs.test.ts
+++ b/src/utils/__tests__/remoteSpecs.test.ts
@@ -1,0 +1,145 @@
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import {
+  filterRemoteSpecsByType,
+  getOverriddenNames,
+  parseRemoteSpecs,
+  readRemoteSpecs,
+} from "../remoteSpecs.ts";
+
+describe("remoteSpecs", () => {
+  describe("parseRemoteSpecs", () => {
+    test("defaults omitted type to openapi", () => {
+      const specs = parseRemoteSpecs([
+        { name: "admin-api", url: "https://example.com/openapi.yaml" },
+      ]);
+
+      expect(specs).toEqual([
+        {
+          name: "admin-api",
+          url: "https://example.com/openapi.yaml",
+          type: "openapi",
+        },
+      ]);
+    });
+
+    test("preserves explicit openapi and openrpc types", () => {
+      const specs = parseRemoteSpecs([
+        {
+          name: "rest-api",
+          url: "https://example.com/a.yaml",
+          type: "openapi",
+        },
+        {
+          name: "wallet-api",
+          url: "https://example.com/b.yaml",
+          type: "openrpc",
+        },
+      ]);
+
+      expect(specs.map((spec) => spec.type)).toEqual(["openapi", "openrpc"]);
+    });
+
+    test("throws when the registry is not an array", () => {
+      expect(() => parseRemoteSpecs({})).toThrow(/must be an array/);
+    });
+
+    test("throws when name is missing", () => {
+      expect(() =>
+        parseRemoteSpecs([{ url: "https://example.com/a.yaml" }]),
+      ).toThrow(/missing a non-empty "name"/);
+    });
+
+    test("throws when url is missing", () => {
+      expect(() => parseRemoteSpecs([{ name: "no-url" }])).toThrow(
+        /missing a non-empty "url"/,
+      );
+    });
+
+    test("throws on an unknown type", () => {
+      expect(() =>
+        parseRemoteSpecs([
+          { name: "bad", url: "https://example.com/a.yaml", type: "graphql" },
+        ]),
+      ).toThrow(/invalid type "graphql"/);
+    });
+  });
+
+  describe("filterRemoteSpecsByType", () => {
+    test("returns only entries of the requested type", () => {
+      const specs = parseRemoteSpecs([
+        { name: "rest", url: "https://example.com/a.yaml" },
+        { name: "rpc", url: "https://example.com/b.yaml", type: "openrpc" },
+      ]);
+
+      expect(filterRemoteSpecsByType(specs, "openrpc")).toEqual([
+        { name: "rpc", url: "https://example.com/b.yaml", type: "openrpc" },
+      ]);
+      expect(filterRemoteSpecsByType(specs, "openapi")).toEqual([
+        { name: "rest", url: "https://example.com/a.yaml", type: "openapi" },
+      ]);
+    });
+  });
+
+  describe("getOverriddenNames", () => {
+    test("collects names so matching local specs are skipped", () => {
+      const specs = parseRemoteSpecs([
+        {
+          name: "wallet-api",
+          url: "https://example.com/b.yaml",
+          type: "openrpc",
+        },
+      ]);
+
+      const overridden = getOverriddenNames(specs);
+      const localSpecs = ["wallet-api", "token", "trace"];
+
+      expect(overridden.has("wallet-api")).toBe(true);
+      expect(localSpecs.filter((name) => !overridden.has(name))).toEqual([
+        "token",
+        "trace",
+      ]);
+    });
+  });
+
+  describe("readRemoteSpecs", () => {
+    let dir: string;
+
+    beforeEach(() => {
+      dir = mkdtempSync(join(tmpdir(), "remote-specs-"));
+    });
+
+    afterEach(() => {
+      rmSync(dir, { recursive: true, force: true });
+    });
+
+    test("reads and parses a registry file", () => {
+      const path = join(dir, "remote-specs.json");
+      writeFileSync(
+        path,
+        JSON.stringify([
+          {
+            name: "wallet-api",
+            url: "https://example.com/b.yaml",
+            type: "openrpc",
+          },
+        ]),
+      );
+
+      expect(readRemoteSpecs(path)).toEqual([
+        {
+          name: "wallet-api",
+          url: "https://example.com/b.yaml",
+          type: "openrpc",
+        },
+      ]);
+    });
+
+    test("returns an empty array when the registry file is missing", () => {
+      expect(readRemoteSpecs(join(dir, "does-not-exist.json"))).toEqual([]);
+    });
+  });
+});

--- a/src/utils/generateRpcSpecs.ts
+++ b/src/utils/generateRpcSpecs.ts
@@ -8,19 +8,18 @@ import { validateRpcSpec } from "./validateRpcSpec.ts";
 const SERVER_URL_FINAL_KEY = "x-alchemy-server-url-final" as const;
 
 /**
- * Generates an OpenRPC specification for the Alchemy JSON-RPC API.
- * @param srcDir - The source directory containing the Alchemy OpenRPC schema
+ * Generates an OpenRPC specification from a source (local file path or remote URL)
+ * and writes it to `{outputDir}/{name}.json`.
+ * @param source - Path or URL to the OpenRPC schema to dereference
  * @param outputDir - The output directory where the generated OpenRPC specification will be saved
- * @param filename - The name of the Alchemy OpenRPC schema file
+ * @param name - The output spec name; wallet-api preserves its curated method order
  */
-export const generateOpenRpcSpec = async (
-  srcDir: string,
+const generateOpenRpcSpecFromSource = async (
+  source: string,
   outputDir: string,
-  filename: string,
+  name: string,
 ) => {
-  const schemaDir = `${srcDir}/${filename}`;
-
-  const spec = (await dereference(`${schemaDir}/${filename}.yaml`, {
+  const spec = (await dereference(source, {
     dereference: {
       preservedProperties: ["title", "description", "type", "pattern"],
     },
@@ -50,12 +49,45 @@ export const generateOpenRpcSpec = async (
         }),
   };
 
-  // wallet api sorts by method popularity
-  const shouldSort = !schemaDir.includes("wallet-api");
+  // wallet-api's source order is curated by method popularity, so preserve it.
+  const shouldSort = !name.includes("wallet-api");
 
   const formattedSpec = await formatOpenRpcDoc(fullSpec, shouldSort);
 
   validateRpcSpec(formattedSpec);
 
-  writeOpenRpcDoc(outputDir, filename, formattedSpec);
+  writeOpenRpcDoc(outputDir, name, formattedSpec);
+};
+
+/**
+ * Generates an OpenRPC specification for a local Alchemy JSON-RPC schema.
+ * @param srcDir - The source directory containing the Alchemy OpenRPC schema
+ * @param outputDir - The output directory where the generated OpenRPC specification will be saved
+ * @param filename - The name of the Alchemy OpenRPC schema file (also the output name)
+ */
+export const generateOpenRpcSpec = async (
+  srcDir: string,
+  outputDir: string,
+  filename: string,
+) => {
+  const schemaDir = `${srcDir}/${filename}`;
+  await generateOpenRpcSpecFromSource(
+    `${schemaDir}/${filename}.yaml`,
+    outputDir,
+    filename,
+  );
+};
+
+/**
+ * Generates an OpenRPC specification from a remote URL.
+ * @param url - URL to the remote OpenRPC schema
+ * @param outputDir - The output directory where the generated OpenRPC specification will be saved
+ * @param name - The output spec name (used for the filename)
+ */
+export const generateRemoteOpenRpcSpec = async (
+  url: string,
+  outputDir: string,
+  name: string,
+) => {
+  await generateOpenRpcSpecFromSource(url, outputDir, name);
 };

--- a/src/utils/remoteSpecs.ts
+++ b/src/utils/remoteSpecs.ts
@@ -1,0 +1,94 @@
+import { readFileSync } from "fs";
+
+/** Path to the remote specs registry, relative to the repo root. */
+export const REMOTE_SPECS_PATH = "content/remote-specs.json";
+
+export type RemoteSpecType = "openapi" | "openrpc";
+
+export interface RemoteSpec {
+  name: string;
+  url: string;
+  /** Spec format. Omitted entries default to "openapi" for backward compatibility. */
+  type: RemoteSpecType;
+}
+
+/**
+ * Parses and validates a single remote spec entry.
+ * @throws Error if required fields are missing or the type is invalid
+ */
+const parseRemoteSpec = (entry: unknown, index: number): RemoteSpec => {
+  if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
+    throw new Error(
+      `${REMOTE_SPECS_PATH} entry at index ${index} must be an object`,
+    );
+  }
+
+  const { name, url, type } = entry as Record<string, unknown>;
+
+  if (typeof name !== "string" || name.length === 0) {
+    throw new Error(
+      `${REMOTE_SPECS_PATH} entry at index ${index} is missing a non-empty "name"`,
+    );
+  }
+
+  if (typeof url !== "string" || url.length === 0) {
+    throw new Error(
+      `${REMOTE_SPECS_PATH} entry "${name}" is missing a non-empty "url"`,
+    );
+  }
+
+  // Omitted type defaults to OpenAPI so existing entries keep working.
+  let specType: RemoteSpecType = "openapi";
+  if (type !== undefined) {
+    if (type !== "openapi" && type !== "openrpc") {
+      throw new Error(
+        `${REMOTE_SPECS_PATH} entry "${name}" has invalid type "${String(
+          type,
+        )}" (expected "openapi" or "openrpc")`,
+      );
+    }
+    specType = type;
+  }
+
+  return { name, url, type: specType };
+};
+
+/**
+ * Parses the raw contents of the remote specs registry into validated entries.
+ * @throws Error if the registry is not an array or any entry is invalid
+ */
+export const parseRemoteSpecs = (raw: unknown): RemoteSpec[] => {
+  if (!Array.isArray(raw)) {
+    throw new Error(`${REMOTE_SPECS_PATH} must be an array of spec entries`);
+  }
+  return raw.map((entry, index) => parseRemoteSpec(entry, index));
+};
+
+/**
+ * Reads and parses the remote specs registry from disk.
+ * Returns an empty array when the registry file does not exist.
+ * @param path - Path to the registry file (defaults to {@link REMOTE_SPECS_PATH})
+ */
+export const readRemoteSpecs = (path = REMOTE_SPECS_PATH): RemoteSpec[] => {
+  let contents: string;
+  try {
+    contents = readFileSync(path, "utf-8");
+  } catch {
+    return [];
+  }
+  return parseRemoteSpecs(JSON.parse(contents));
+};
+
+/** Returns only the entries matching the given spec type. */
+export const filterRemoteSpecsByType = (
+  specs: RemoteSpec[],
+  type: RemoteSpecType,
+): RemoteSpec[] => specs.filter((spec) => spec.type === type);
+
+/**
+ * Names of local specs overridden by a remote entry. When a remote OpenRPC
+ * entry shares a name with a local spec, the remote entry wins and local
+ * generation for that name is skipped.
+ */
+export const getOverriddenNames = (specs: RemoteSpec[]): Set<string> =>
+  new Set(specs.map((spec) => spec.name));


### PR DESCRIPTION
## Description

Adds support for OpenRPC entries in `content/remote-specs.json` so externally hosted JSON-RPC specs can generate into the existing `alchemy/json-rpc` output path.

## Related Issues

N/A

## Changes Made

- Added shared TypeScript parsing for remote spec entries with OpenAPI defaulting.
- Updated REST generation to ignore OpenRPC remote entries and RPC generation to fetch/process them, overriding local same-name RPC specs.
- Added unit coverage and a minimal remote OpenRPC fixture.

## Testing

- `pnpm vitest run src/utils/__tests__/remoteSpecs.test.ts src/utils/__tests__/generateRpcSpecs.test.ts`
- `pnpm run typecheck`
- `pnpm run generate`
- `pnpm run validate`
- `pnpm run build` is not available in this content-only repo; `package.json` has no `build` script.

* [x] I have tested these changes locally
* [x] I have run the validation scripts (`pnpm run validate`)
* [ ] I have checked that the documentation builds correctly