### PR TITLE
[codex] Improve agent wallet docs

### DIFF
--- a/content/tutorials/build-with-ai/agent-wallets.mdx
+++ b/content/tutorials/build-with-ai/agent-wallets.mdx
@@ -11,20 +11,77 @@ The session is approved in the Alchemy Dashboard, expires automatically, and can
 
 ## Capabilities
 
-| Area | Supported today | Discovery |
-|---|---|---|
-| Chains | EVM wallet operations on supported Alchemy wallet networks. Solana sends on supported Solana networks. Swaps and bridges are EVM mainnet-only. | `alchemy evm network list`, `alchemy solana network list` |
-| EVM sends | Native token and ERC-20 sends with `alchemy evm send`. ENS recipients work where the selected network/client can resolve them. | `alchemy evm send --help` |
-| Contract writes | State-changing EVM calls with inline signatures, ABI files, JSON args, and optional ETH value. | `alchemy evm contract call --help` |
-| Approvals | ERC-20 approve, reset, and revoke flows. Unlimited approvals require confirmation or `--yes`. | `alchemy evm approve --help` |
-| Swaps | Same-chain EVM mainnet swap quotes and execution with slippage controls. | `alchemy evm swap quote --help`, `alchemy evm swap execute --help` |
-| Bridges | EVM mainnet bridge quotes and execution from `-n, --network` to `--to-network`. Source and destination networks must differ. | `alchemy xchain bridge quote --help`, `alchemy xchain bridge execute --help` |
-| Solana sends | SOL and SPL token sends, dry runs, associated token account handling, and optional session signing. | `alchemy solana send --help` |
-| Status | EVM smart-wallet call IDs, EVM transaction hashes, and Solana signatures. | `alchemy evm status --help`, `alchemy solana status --help` |
-| Sponsorship | EVM gas sponsorship with `--gas-sponsored --gas-policy-id <id>`. Solana fee sponsorship with `--fee-sponsored --fee-policy-id <id>`. | CLI help and Gas Manager policies in the Dashboard |
-| Session capabilities | `evm.signMessage`, `evm.signTypedData`, `evm.signAuthorization`, `evm.prepareCalls`, `evm.sendCalls`, and `solana.signTransaction`. | `alchemy --json --no-interactive wallet status --verify` |
-| Limits | The session signer does not support direct raw EVM transaction signing. Use CLI commands that execute through Alchemy smart-wallet calls. Gas and fee sponsorship policies are not wallet spend limits. | Command help and `wallet status --verify` |
-| Revocation | `alchemy wallet disconnect` clears local session state and revokes remote sessions when the CLI is authenticated. Dashboard revocation is also supported. | `alchemy --json --no-interactive wallet disconnect` |
+<CardGroup cols={2}>
+  <Card title="EVM actions" icon="code">
+    Send native tokens or ERC-20s, execute contract calls, manage ERC-20 approvals,
+    swap on EVM mainnets, and bridge between EVM mainnets.
+  </Card>
+  <Card title="Solana sends" icon="bolt">
+    Send SOL or SPL tokens, run dry runs, handle associated token accounts, and use
+    session signing for supported CLI flows.
+  </Card>
+  <Card title="Sponsorship" icon="wallet">
+    Request EVM gas sponsorship with `--gas-sponsored --gas-policy-id <id>` or
+    Solana fee sponsorship with `--fee-sponsored --fee-policy-id <id>`.
+  </Card>
+  <Card title="Session control" icon="shield">
+    Approve sessions in the Dashboard, inspect capabilities with `wallet status
+    --verify`, and revoke access from the CLI or Dashboard.
+  </Card>
+</CardGroup>
+
+<AccordionGroup>
+  <Accordion title="Detailed capability reference">
+    **Chains:** EVM wallet operations run on supported Alchemy wallet networks.
+    Solana sends run on supported Solana networks. Swaps and bridges are EVM
+    mainnet-only.
+
+    **EVM sends:** `alchemy evm send` supports native token and ERC-20 sends. ENS
+    recipients work where the selected network/client can resolve them.
+
+    **Contract writes:** `alchemy evm contract call` supports state-changing EVM
+    calls with inline signatures, ABI files, JSON args, and optional ETH value.
+
+    **Approvals:** `alchemy evm approve` supports ERC-20 approve, reset, and
+    revoke flows. Unlimited approvals require confirmation or `--yes`.
+
+    **Swaps:** `alchemy evm swap quote` and `alchemy evm swap execute` support
+    same-chain EVM mainnet swaps with slippage controls.
+
+    **Bridges:** `alchemy xchain bridge quote` and `alchemy xchain bridge execute`
+    support EVM mainnet bridges from `-n, --network` to `--to-network`.
+
+    **Status:** `alchemy evm status` checks smart-wallet call IDs and EVM
+    transaction hashes. `alchemy solana status` checks Solana signatures.
+  </Accordion>
+  <Accordion title="Session capabilities and limits">
+    A session can include `evm.signMessage`, `evm.signTypedData`,
+    `evm.signAuthorization`, `evm.prepareCalls`, `evm.sendCalls`, and
+    `solana.signTransaction`.
+
+    The session signer does not support direct raw EVM transaction signing. Use
+    CLI commands that execute through Alchemy smart-wallet calls.
+
+    Gas and fee sponsorship policies control transaction fees. They are not
+    wallet spend limits.
+  </Accordion>
+  <Accordion title="Discovery commands">
+    Use these commands when an agent needs the current wallet contract:
+
+    ```bash
+    alchemy --json --no-interactive wallet status --verify
+    alchemy --json --no-interactive agent-prompt --scope wallet
+    alchemy evm network list
+    alchemy solana network list
+    ```
+
+    For the latest published CLI surface, use:
+
+    ```bash
+    npx -y @alchemy/cli@latest --json --no-interactive agent-prompt --scope wallet
+    ```
+  </Accordion>
+</AccordionGroup>
 
 ## Connect a session
 
@@ -45,51 +102,57 @@ alchemy --json --no-interactive wallet status --verify
 
 The response includes the active signer, session expiry, chain-specific session metadata, backend status, and enabled signer capabilities.
 
-## End-to-end EVM example
+## Examples
 
-This workflow checks funding, previews a send, broadcasts it, checks status, and revokes the session.
+<Tabs>
+  <Tab title="EVM">
+    This workflow checks funding, previews a send, broadcasts it, checks status,
+    and revokes the session.
 
-```bash
-alchemy auth
-alchemy wallet connect --mode session --instance-name codex-terminal
-alchemy wallet use session
+    ```bash
+    alchemy auth
+    alchemy wallet connect --mode session --instance-name codex-terminal
+    alchemy wallet use session
 
-alchemy --json --no-interactive wallet address
-alchemy --json --no-interactive evm data balance <session_evm_address> -n base-mainnet
+    alchemy --json --no-interactive wallet address
+    alchemy --json --no-interactive evm data balance <session_evm_address> -n base-mainnet
 
-alchemy --json --no-interactive evm send <recipient> 0.001 \
-  -n base-mainnet \
-  --dry-run
+    alchemy --json --no-interactive evm send <recipient> 0.001 \
+      -n base-mainnet \
+      --dry-run
 
-alchemy --json --no-interactive evm send <recipient> 0.001 \
-  -n base-mainnet \
-  --signer session
+    alchemy --json --no-interactive evm send <recipient> 0.001 \
+      -n base-mainnet \
+      --signer session
 
-alchemy --json --no-interactive evm status <call-id-or-tx-hash> -n base-mainnet
-alchemy --json --no-interactive wallet disconnect
-```
+    alchemy --json --no-interactive evm status <call-id-or-tx-hash> -n base-mainnet
+    alchemy --json --no-interactive wallet disconnect
+    ```
 
-For sponsored gas, pass a Gas Manager policy:
+    For sponsored gas, pass a Gas Manager policy:
 
-```bash
-alchemy --json --no-interactive evm send <recipient> 0.001 \
-  -n base-mainnet \
-  --signer session \
-  --gas-sponsored \
-  --gas-policy-id <gas-policy-id>
-```
+    ```bash
+    alchemy --json --no-interactive evm send <recipient> 0.001 \
+      -n base-mainnet \
+      --signer session \
+      --gas-sponsored \
+      --gas-policy-id <gas-policy-id>
+    ```
+  </Tab>
 
-## Solana example
+  <Tab title="Solana">
+    Use the same session signer for SOL or SPL token sends.
 
-Use the same session signer for SOL or SPL token sends:
+    ```bash
+    alchemy --json --no-interactive solana send <recipient_pubkey> 0.01 \
+      -n solana-mainnet \
+      --signer session
+    ```
 
-```bash
-alchemy --json --no-interactive solana send <recipient_pubkey> 0.01 \
-  -n solana-mainnet \
-  --signer session
-```
-
-Add `--token <mint>` for SPL tokens. Add `--fee-sponsored --fee-policy-id <fee-policy-id>` to request Solana fee sponsorship.
+    Add `--token <mint>` for SPL tokens. Add `--fee-sponsored
+    --fee-policy-id <fee-policy-id>` to request Solana fee sponsorship.
+  </Tab>
+</Tabs>
 
 ## Machine-readable contract
 
@@ -106,83 +169,95 @@ alchemy --json --no-interactive agent-prompt --scope wallet
 alchemy --json --no-interactive wallet status --verify
 ```
 
-You can also include this compact manifest in an agent skill or system prompt:
+<Accordion title="Compact capability manifest">
+  Include this in an agent skill or system prompt when the agent cannot call
+  `agent-prompt` at runtime.
 
-```json
-{
-  "alchemyAgentWallets": {
-    "sourceOfTruth": {
-      "latestCli": "npx -y @alchemy/cli@latest --json --no-interactive agent-prompt --scope wallet",
-      "installedCli": "alchemy --json --no-interactive agent-prompt --scope wallet",
-      "sessionStatus": "alchemy --json --no-interactive wallet status --verify"
-    },
-    "session": {
-      "approval": "dashboard",
-      "privateKeyExposure": "never_exposed_to_agent",
-      "revocation": ["alchemy wallet disconnect", "dashboard"],
-      "expiryField": "expiresAt",
-      "capabilities": [
-        "evm.signMessage",
-        "evm.signTypedData",
-        "evm.signAuthorization",
-        "evm.prepareCalls",
-        "evm.sendCalls",
-        "solana.signTransaction"
+  ```json
+  {
+    "alchemyAgentWallets": {
+      "sourceOfTruth": {
+        "latestCli": "npx -y @alchemy/cli@latest --json --no-interactive agent-prompt --scope wallet",
+        "installedCli": "alchemy --json --no-interactive agent-prompt --scope wallet",
+        "sessionStatus": "alchemy --json --no-interactive wallet status --verify"
+      },
+      "session": {
+        "approval": "dashboard",
+        "privateKeyExposure": "never_exposed_to_agent",
+        "revocation": ["alchemy wallet disconnect", "dashboard"],
+        "expiryField": "expiresAt",
+        "capabilities": [
+          "evm.signMessage",
+          "evm.signTypedData",
+          "evm.signAuthorization",
+          "evm.prepareCalls",
+          "evm.sendCalls",
+          "solana.signTransaction"
+        ]
+      },
+      "evm": {
+        "operations": [
+          "native_send",
+          "erc20_send",
+          "contract_call",
+          "erc20_approve_reset_revoke",
+          "swap_quote",
+          "swap_execute",
+          "bridge_quote",
+          "bridge_execute",
+          "status"
+        ],
+        "sponsorshipFlags": ["--gas-sponsored", "--gas-policy-id <id>"],
+        "directRawTransactionSigning": false,
+        "limits": ["swaps_evm_mainnet_only", "bridges_evm_mainnet_only"]
+      },
+      "solana": {
+        "operations": ["sol_send", "spl_token_send", "status"],
+        "sponsorshipFlags": ["--fee-sponsored", "--fee-policy-id <id>"]
+      },
+      "agentRules": [
+        "Use --json --no-interactive in automation.",
+        "Run wallet status --verify before state-changing wallet actions.",
+        "Run balance, allowance, or quote checks before spending.",
+        "Use --dry-run where available before broadcast.",
+        "Treat sponsorship policies as fee controls, not wallet spend limits.",
+        "Disconnect or revoke the session after the workflow."
       ]
-    },
-    "evm": {
-      "operations": [
-        "native_send",
-        "erc20_send",
-        "contract_call",
-        "erc20_approve_reset_revoke",
-        "swap_quote",
-        "swap_execute",
-        "bridge_quote",
-        "bridge_execute",
-        "status"
-      ],
-      "sponsorshipFlags": ["--gas-sponsored", "--gas-policy-id <id>"],
-      "directRawTransactionSigning": false,
-      "limits": ["swaps_evm_mainnet_only", "bridges_evm_mainnet_only"]
-    },
-    "solana": {
-      "operations": ["sol_send", "spl_token_send", "status"],
-      "sponsorshipFlags": ["--fee-sponsored", "--fee-policy-id <id>"]
-    },
-    "agentRules": [
-      "Use --json --no-interactive in automation.",
-      "Run wallet status --verify before state-changing wallet actions.",
-      "Run balance, allowance, or quote checks before spending.",
-      "Use --dry-run where available before broadcast.",
-      "Treat sponsorship policies as fee controls, not wallet spend limits.",
-      "Disconnect or revoke the session after the workflow."
-    ]
+    }
   }
-}
-```
+  ```
+</Accordion>
 
-## Dashboard controls
+## Operational details
 
-Use the [Agent Wallets dashboard](https://dashboard.alchemy.com/products/agent-wallet/evm-wallet) to create wallets, approve terminal sessions, fund wallets through onramps, send from the wallet, and revoke sessions.
+<AccordionGroup>
+  <Accordion title="Dashboard controls">
+    Use the [Agent Wallets dashboard](https://dashboard.alchemy.com/products/agent-wallet/evm-wallet)
+    to create wallets, approve terminal sessions, fund wallets through onramps,
+    send from the wallet, and revoke sessions.
+  </Accordion>
+  <Accordion title="How sessions execute">
+    EVM session actions execute through Alchemy smart-wallet calls such as
+    `wallet_prepareCalls` and `wallet_sendCalls`. The CLI uses those calls for
+    nonce handling, preflight behavior, call IDs, status polling, batch-call
+    support where the command uses it, and optional paymaster capabilities.
 
-## How sessions execute
+    Solana session actions sign transactions for supported CLI flows such as SOL
+    and SPL token sends.
+  </Accordion>
+  <Accordion title="Local wallet fallback">
+    Use a local wallet only when you intentionally want local key material:
 
-EVM session actions execute through Alchemy smart-wallet calls such as `wallet_prepareCalls` and `wallet_sendCalls`. The CLI uses those calls for nonce handling, preflight behavior, call IDs, status polling, batch-call support where the command uses it, and optional paymaster capabilities.
+    ```bash
+    alchemy wallet connect --mode local
+    alchemy wallet connect --mode local --import ./evm-private-key.txt
+    alchemy wallet use local
+    ```
 
-Solana session actions sign transactions for supported CLI flows such as SOL and SPL token sends.
-
-## Local wallet fallback
-
-Use a local wallet only when you intentionally want local key material:
-
-```bash
-alchemy wallet connect --mode local
-alchemy wallet connect --mode local --import ./evm-private-key.txt
-alchemy wallet use local
-```
-
-If both a session signer and a local EVM signer are configured, the CLI defaults to the session signer and prints a warning.
+    If both a session signer and a local EVM signer are configured, the CLI
+    defaults to the session signer and prints a warning.
+  </Accordion>
+</AccordionGroup>
 
 ## Next steps
 

--- a/content/tutorials/build-with-ai/agent-wallets.mdx
+++ b/content/tutorials/build-with-ai/agent-wallets.mdx
@@ -21,12 +21,11 @@ The session is approved in the Alchemy Dashboard, expires automatically, and can
     session signing for supported CLI flows.
   </Card>
   <Card title="Sponsorship" icon="wallet">
-    Request EVM gas sponsorship with `--gas-sponsored --gas-policy-id <id>` or
-    Solana fee sponsorship with `--fee-sponsored --fee-policy-id <id>`.
+    Request EVM gas sponsorship or Solana fee sponsorship with a policy ID.
   </Card>
   <Card title="Session control" icon="shield">
-    Approve sessions in the Dashboard, inspect capabilities with `wallet status
-    --verify`, and revoke access from the CLI or Dashboard.
+    Approve sessions in the Dashboard, inspect the active session, and revoke
+    access from the CLI or Dashboard.
   </Card>
 </CardGroup>
 

--- a/content/tutorials/build-with-ai/agent-wallets.mdx
+++ b/content/tutorials/build-with-ai/agent-wallets.mdx
@@ -1,45 +1,34 @@
 ---
 title: Agent Wallets
-description: Give your AI agent an Alchemy-managed wallet session for onchain actions through the Alchemy CLI, with dashboard approval, revocation, sponsorship, and machine-readable capability discovery.
-subtitle: Give your agent an approved wallet session for sending tokens, calling contracts, swapping, bridging, and checking transaction status from the Alchemy CLI.
+description: Give an agent an approved Alchemy wallet session for onchain actions through the Alchemy CLI.
+subtitle: Use Agent Wallets to send tokens, call contracts, swap, bridge, sponsor gas, and check status from the Alchemy CLI.
 slug: docs/agent-wallets
 ---
 
-Agent Wallets let your AI agent execute onchain workflows through an approved Alchemy wallet session. The agent gets a scoped signing session for CLI actions; it does not receive or handle the wallet private key.
+Agent Wallets give an agent an approved CLI session for onchain actions. The agent can use wallet-aware Alchemy CLI commands, but it does not receive or handle the wallet private key.
 
-Use Agent Wallets when your agent needs to:
+The session is approved in the Alchemy Dashboard, expires automatically, and can be revoked from the Dashboard or with `alchemy wallet disconnect`.
 
-* Send native tokens, ERC-20 tokens, SOL, or SPL tokens
-* Execute EVM contract calls through Alchemy smart wallets
-* Quote and execute EVM swaps and cross-chain bridges
-* Request gas or fee sponsorship with a Gas Manager policy
-* Check transaction, operation, and wallet session status in machine-readable JSON
-* Work from a terminal while you approve, fund, send from, or revoke the wallet in the Alchemy Dashboard
+## Capabilities
 
-## Capability matrix
-
-| Area | Current capability | How agents should discover it |
+| Area | Supported today | Discovery |
 |---|---|---|
-| Chains | EVM wallet operations on supported Alchemy wallet networks; Solana wallet operations on supported Solana networks. Swaps and bridges are EVM mainnet-only. | `alchemy evm network list`, `alchemy solana network list`, and `alchemy --json --no-interactive agent-prompt --scope wallet` |
-| EVM sends | Send native tokens or ERC-20 tokens with `alchemy evm send`. ENS recipients are supported where the selected network/client can resolve them. | `alchemy --json --no-interactive evm send --help` |
-| EVM contract writes | Execute state-changing functions with `alchemy evm contract call`, inline signatures, ABI files, JSON args, and optional ETH value. | `alchemy --json --no-interactive agent-prompt --scope wallet` |
-| EVM approvals | Approve, reset, or revoke ERC-20 allowances with `alchemy evm approve`. Unlimited approvals require explicit confirmation or `--yes`. | `alchemy evm approve --help` |
-| Swaps | Quote and execute same-chain EVM mainnet swaps with slippage controls and native-token sentinel support. | `alchemy evm swap quote --help` and `alchemy evm swap execute --help` |
-| Bridges | Quote and execute EVM mainnet bridges from `-n, --network` to `--to-network`. Source and destination networks must differ. | `alchemy xchain bridge quote --help` and `alchemy xchain bridge execute --help` |
-| Solana sends | Send SOL or SPL tokens with `alchemy solana send`, including dry runs, associated token account handling, and optional session signing. | `alchemy solana send --help` |
-| Status checks | Check EVM smart-wallet call IDs, EVM transaction hashes, and Solana signatures with `alchemy evm status` or `alchemy solana status`. | `alchemy evm status --help` and `alchemy solana status --help` |
-| Gas and fee sponsorship | EVM actions support `--gas-sponsored --gas-policy-id <id>`. Solana sends support `--fee-sponsored --fee-policy-id <id>`. Interactive CLI sessions can help select or create a policy. | `alchemy config status`, command help, and dashboard Gas Manager policies |
-| Session scopes | Session connections request explicit capabilities: `evm.signMessage`, `evm.signTypedData`, `evm.signAuthorization`, `evm.prepareCalls`, `evm.sendCalls`, and `solana.signTransaction`. | `alchemy --json --no-interactive wallet status --verify` |
-| Limits | Agent Wallet sessions are time bound and carry an `expiresAt`. The session signer does not support direct raw EVM transaction signing; use wallet commands that execute through Alchemy smart-wallet calls. Swaps and bridges are limited to EVM mainnets. | `wallet status --verify` plus the command-specific help |
-| Revocation | `alchemy wallet disconnect` revokes the current remote wallet sessions when the CLI is authenticated and clears local session state. You can also revoke sessions in the Dashboard. | `alchemy --json --no-interactive wallet disconnect` |
+| Chains | EVM wallet operations on supported Alchemy wallet networks. Solana sends on supported Solana networks. Swaps and bridges are EVM mainnet-only. | `alchemy evm network list`, `alchemy solana network list` |
+| EVM sends | Native token and ERC-20 sends with `alchemy evm send`. ENS recipients work where the selected network/client can resolve them. | `alchemy evm send --help` |
+| Contract writes | State-changing EVM calls with inline signatures, ABI files, JSON args, and optional ETH value. | `alchemy evm contract call --help` |
+| Approvals | ERC-20 approve, reset, and revoke flows. Unlimited approvals require confirmation or `--yes`. | `alchemy evm approve --help` |
+| Swaps | Same-chain EVM mainnet swap quotes and execution with slippage controls. | `alchemy evm swap quote --help`, `alchemy evm swap execute --help` |
+| Bridges | EVM mainnet bridge quotes and execution from `-n, --network` to `--to-network`. Source and destination networks must differ. | `alchemy xchain bridge quote --help`, `alchemy xchain bridge execute --help` |
+| Solana sends | SOL and SPL token sends, dry runs, associated token account handling, and optional session signing. | `alchemy solana send --help` |
+| Status | EVM smart-wallet call IDs, EVM transaction hashes, and Solana signatures. | `alchemy evm status --help`, `alchemy solana status --help` |
+| Sponsorship | EVM gas sponsorship with `--gas-sponsored --gas-policy-id <id>`. Solana fee sponsorship with `--fee-sponsored --fee-policy-id <id>`. | CLI help and Gas Manager policies in the Dashboard |
+| Session capabilities | `evm.signMessage`, `evm.signTypedData`, `evm.signAuthorization`, `evm.prepareCalls`, `evm.sendCalls`, and `solana.signTransaction`. | `alchemy --json --no-interactive wallet status --verify` |
+| Limits | The session signer does not support direct raw EVM transaction signing. Use CLI commands that execute through Alchemy smart-wallet calls. Gas and fee sponsorship policies are not wallet spend limits. | Command help and `wallet status --verify` |
+| Revocation | `alchemy wallet disconnect` clears local session state and revokes remote sessions when the CLI is authenticated. Dashboard revocation is also supported. | `alchemy --json --no-interactive wallet disconnect` |
 
-<Note>
-  Gas and fee sponsorship policies control whether Alchemy sponsors transaction costs. They are not general-purpose spend limits for the wallet session.
-</Note>
+## Connect a session
 
-## Connect an Agent Wallet session
-
-Install the latest CLI, log in, and connect a session wallet:
+Install the CLI, log in, and start a Dashboard approval flow:
 
 ```bash
 npm i -g @alchemy/cli@latest
@@ -48,46 +37,39 @@ alchemy wallet connect --mode session --instance-name codex-terminal
 alchemy wallet use session
 ```
 
-The CLI opens the Alchemy Dashboard approval flow. You approve the terminal session there, then the CLI stores a local session envelope and prints the approved wallet addresses, capabilities, and expiry.
-
-Verify the session from the backend before a state-changing workflow:
+Verify the approved session before running a state-changing workflow:
 
 ```bash
 alchemy --json --no-interactive wallet status --verify
 ```
 
-The JSON response includes `session.signerCapabilities`, `sessionsByChain`, `activeSigner`, `expiresAt`, and `remoteStatus`. Agents should inspect this before sending transactions.
+The response includes the active signer, session expiry, chain-specific session metadata, backend status, and enabled signer capabilities.
 
-## Run an end-to-end CLI workflow
+## End-to-end EVM example
 
-This example connects an Agent Wallet, checks funding, previews a send, broadcasts it, checks status, and revokes the session.
+This workflow checks funding, previews a send, broadcasts it, checks status, and revokes the session.
 
 ```bash
-# 1. Connect and approve the wallet session in the Dashboard.
 alchemy auth
 alchemy wallet connect --mode session --instance-name codex-terminal
 alchemy wallet use session
 
-# 2. Capture the active session EVM address.
 alchemy --json --no-interactive wallet address
-
-# 3. Check the sender's balance before spending.
 alchemy --json --no-interactive evm data balance <session_evm_address> -n base-mainnet
 
-# 4. Preview the exact call without signing or sending.
-alchemy --json --no-interactive evm send <recipient> 0.001 -n base-mainnet --dry-run
+alchemy --json --no-interactive evm send <recipient> 0.001 \
+  -n base-mainnet \
+  --dry-run
 
-# 5. Broadcast the transaction through the Agent Wallet session.
-alchemy --json --no-interactive evm send <recipient> 0.001 -n base-mainnet --signer session
+alchemy --json --no-interactive evm send <recipient> 0.001 \
+  -n base-mainnet \
+  --signer session
 
-# 6. Check the returned callId or txHash.
 alchemy --json --no-interactive evm status <call-id-or-tx-hash> -n base-mainnet
-
-# 7. Revoke the terminal session when the workflow is done.
 alchemy --json --no-interactive wallet disconnect
 ```
 
-For sponsored gas, add a Gas Manager policy:
+For sponsored gas, pass a Gas Manager policy:
 
 ```bash
 alchemy --json --no-interactive evm send <recipient> 0.001 \
@@ -97,7 +79,9 @@ alchemy --json --no-interactive evm send <recipient> 0.001 \
   --gas-policy-id <gas-policy-id>
 ```
 
-For Solana:
+## Solana example
+
+Use the same session signer for SOL or SPL token sends:
 
 ```bash
 alchemy --json --no-interactive solana send <recipient_pubkey> 0.01 \
@@ -105,24 +89,24 @@ alchemy --json --no-interactive solana send <recipient_pubkey> 0.01 \
   --signer session
 ```
 
-Add `--token <mint>` to send SPL tokens. Add `--fee-sponsored --fee-policy-id <fee-policy-id>` when you want a Solana fee policy to sponsor the transaction fee.
+Add `--token <mint>` for SPL tokens. Add `--fee-sponsored --fee-policy-id <fee-policy-id>` to request Solana fee sponsorship.
 
-## Let agents introspect the wallet surface
+## Machine-readable contract
 
-Agents should not infer wallet behavior from prose. Give them the live CLI contract:
+Use the live CLI output as the source of truth for agents and skills:
 
 ```bash
 npx -y @alchemy/cli@latest --json --no-interactive agent-prompt --scope wallet
 ```
 
-Use the output as the source of truth for command names, arguments, flags, auth requirements, examples, and error recovery. For a locally configured wallet, use the installed CLI instead:
+Use the installed CLI when the agent needs to inspect the current machine's configured wallet:
 
 ```bash
 alchemy --json --no-interactive agent-prompt --scope wallet
 alchemy --json --no-interactive wallet status --verify
 ```
 
-If you maintain an agent skill or system prompt, include this capability manifest alongside the CLI contract:
+You can also include this compact manifest in an agent skill or system prompt:
 
 ```json
 {
@@ -137,18 +121,16 @@ If you maintain an agent skill or system prompt, include this capability manifes
       "privateKeyExposure": "never_exposed_to_agent",
       "revocation": ["alchemy wallet disconnect", "dashboard"],
       "expiryField": "expiresAt",
-      "capabilities": {
-        "evm.signMessage": true,
-        "evm.signTypedData": true,
-        "evm.signAuthorization": true,
-        "evm.prepareCalls": true,
-        "evm.sendCalls": true,
-        "solana.signTransaction": true
-      }
+      "capabilities": [
+        "evm.signMessage",
+        "evm.signTypedData",
+        "evm.signAuthorization",
+        "evm.prepareCalls",
+        "evm.sendCalls",
+        "solana.signTransaction"
+      ]
     },
     "evm": {
-      "signingMode": "session_smart_wallet_calls",
-      "directRawTransactionSigning": false,
       "operations": [
         "native_send",
         "erc20_send",
@@ -160,33 +142,21 @@ If you maintain an agent skill or system prompt, include this capability manifes
         "bridge_execute",
         "status"
       ],
-      "sponsorship": {
-        "supported": true,
-        "flags": ["--gas-sponsored", "--gas-policy-id <id>"],
-        "policyType": "gas_sponsorship"
-      },
-      "limits": {
-        "swaps": "evm_mainnet_only",
-        "bridges": "evm_mainnet_only",
-        "spendingPolicies": "not_a_wallet_session_scope"
-      }
+      "sponsorshipFlags": ["--gas-sponsored", "--gas-policy-id <id>"],
+      "directRawTransactionSigning": false,
+      "limits": ["swaps_evm_mainnet_only", "bridges_evm_mainnet_only"]
     },
     "solana": {
-      "signingMode": "session_or_local",
       "operations": ["sol_send", "spl_token_send", "status"],
-      "sponsorship": {
-        "supported": true,
-        "flags": ["--fee-sponsored", "--fee-policy-id <id>"],
-        "policyType": "fee_sponsorship"
-      }
+      "sponsorshipFlags": ["--fee-sponsored", "--fee-policy-id <id>"]
     },
     "agentRules": [
-      "Always pass --json --no-interactive in automation.",
+      "Use --json --no-interactive in automation.",
       "Run wallet status --verify before state-changing wallet actions.",
-      "Run balance, allowance, or quote preflights before spending.",
+      "Run balance, allowance, or quote checks before spending.",
       "Use --dry-run where available before broadcast.",
-      "Treat gas sponsorship as fee payment control, not a wallet spend limit.",
-      "Disconnect or ask the operator to revoke the session after the workflow."
+      "Treat sponsorship policies as fee controls, not wallet spend limits.",
+      "Disconnect or revoke the session after the workflow."
     ]
   }
 }
@@ -194,27 +164,17 @@ If you maintain an agent skill or system prompt, include this capability manifes
 
 ## Dashboard controls
 
-Use the [Agent Wallets dashboard](https://dashboard.alchemy.com/products/agent-wallet/evm-wallet) to manage the wallet outside the CLI:
+Use the [Agent Wallets dashboard](https://dashboard.alchemy.com/products/agent-wallet/evm-wallet) to create wallets, approve terminal sessions, fund wallets through onramps, send from the wallet, and revoke sessions.
 
-* Create and view Agent Wallets
-* Approve terminal sessions opened by `alchemy wallet connect`
-* Fund wallets through onramps
-* Send from the wallet in the Dashboard
-* Revoke active or stale sessions
+## How sessions execute
 
-This gives you an operator control plane for agent workflows: the agent can propose and execute CLI actions, while you keep approval, funding, dashboard sends, and revocation in Alchemy.
+EVM session actions execute through Alchemy smart-wallet calls such as `wallet_prepareCalls` and `wallet_sendCalls`. The CLI uses those calls for nonce handling, preflight behavior, call IDs, status polling, batch-call support where the command uses it, and optional paymaster capabilities.
 
-## How Agent Wallet sessions work
-
-When you run `alchemy wallet connect --mode session`, the CLI creates a local session envelope and sends a connection request to Alchemy with the requested EVM and Solana capabilities. You approve that request in the Dashboard. After approval, the CLI can use the session for wallet-aware commands.
-
-For EVM, the session signer executes through Alchemy smart-wallet calls such as `wallet_prepareCalls` and `wallet_sendCalls`. This gives the CLI managed nonce handling, preflight behavior, call IDs, status polling, batch-call support where the command uses it, and optional paymaster capabilities for sponsored gas.
-
-For Solana, the session can sign Solana transactions for supported CLI flows such as SOL and SPL-token sends.
+Solana session actions sign transactions for supported CLI flows such as SOL and SPL token sends.
 
 ## Local wallet fallback
 
-Agent Wallet sessions are recommended for agents because the private key is not exposed to the agent. The CLI also supports local wallets for workflows where you explicitly want local key material:
+Use a local wallet only when you intentionally want local key material:
 
 ```bash
 alchemy wallet connect --mode local
@@ -222,7 +182,7 @@ alchemy wallet connect --mode local --import ./evm-private-key.txt
 alchemy wallet use local
 ```
 
-If both a session signer and a local EVM signer are configured, the CLI defaults to the session signer and warns once. Use `alchemy wallet use local` only when you intentionally want local signing.
+If both a session signer and a local EVM signer are configured, the CLI defaults to the session signer and prints a warning.
 
 ## Next steps
 

--- a/content/tutorials/build-with-ai/agent-wallets.mdx
+++ b/content/tutorials/build-with-ai/agent-wallets.mdx
@@ -91,7 +91,6 @@ Install the CLI, log in, and start a Dashboard approval flow:
 npm i -g @alchemy/cli@latest
 alchemy auth
 alchemy wallet connect --mode session --instance-name codex-terminal
-alchemy wallet use session
 ```
 
 Verify the approved session before running a state-changing workflow:
@@ -106,14 +105,10 @@ The response includes the active signer, session expiry, chain-specific session 
 
 <Tabs>
   <Tab title="EVM">
-    This workflow checks funding, previews a send, broadcasts it, checks status,
-    and revokes the session.
+    This workflow assumes you already approved a session. It checks funding,
+    previews a send, broadcasts it, and checks status.
 
     ```bash
-    alchemy auth
-    alchemy wallet connect --mode session --instance-name codex-terminal
-    alchemy wallet use session
-
     alchemy --json --no-interactive wallet address
     alchemy --json --no-interactive evm data balance <session_evm_address> -n base-mainnet
 
@@ -122,11 +117,9 @@ The response includes the active signer, session expiry, chain-specific session 
       --dry-run
 
     alchemy --json --no-interactive evm send <recipient> 0.001 \
-      -n base-mainnet \
-      --signer session
+      -n base-mainnet
 
     alchemy --json --no-interactive evm status <call-id-or-tx-hash> -n base-mainnet
-    alchemy --json --no-interactive wallet disconnect
     ```
 
     For sponsored gas, pass a Gas Manager policy:
@@ -134,25 +127,35 @@ The response includes the active signer, session expiry, chain-specific session 
     ```bash
     alchemy --json --no-interactive evm send <recipient> 0.001 \
       -n base-mainnet \
-      --signer session \
       --gas-sponsored \
       --gas-policy-id <gas-policy-id>
     ```
   </Tab>
 
   <Tab title="Solana">
-    Use the same session signer for SOL or SPL token sends.
+    This workflow assumes you already approved a session. It checks funding,
+    previews a send, broadcasts it, and checks status.
 
     ```bash
+    alchemy --json --no-interactive wallet address
+    alchemy --json --no-interactive solana rpc getBalance <session_solana_address> -n solana-mainnet
+
     alchemy --json --no-interactive solana send <recipient_pubkey> 0.01 \
       -n solana-mainnet \
-      --signer session
+      --dry-run
+
+    alchemy --json --no-interactive solana send <recipient_pubkey> 0.01 \
+      -n solana-mainnet
+
+    alchemy --json --no-interactive solana status <signature> -n solana-mainnet
     ```
 
     Add `--token <mint>` for SPL tokens. Add `--fee-sponsored
     --fee-policy-id <fee-policy-id>` to request Solana fee sponsorship.
   </Tab>
 </Tabs>
+
+Run `alchemy --json --no-interactive wallet disconnect` when the session is no longer needed.
 
 ## Machine-readable contract
 

--- a/content/tutorials/build-with-ai/agent-wallets.mdx
+++ b/content/tutorials/build-with-ai/agent-wallets.mdx
@@ -149,8 +149,16 @@ The response includes the active signer, session expiry, chain-specific session 
     alchemy --json --no-interactive solana status <signature> -n solana-mainnet
     ```
 
-    Add `--token <mint>` for SPL tokens. Add `--fee-sponsored
-    --fee-policy-id <fee-policy-id>` to request Solana fee sponsorship.
+    For sponsored fees, pass a Solana fee policy:
+
+    ```bash
+    alchemy --json --no-interactive solana send <recipient_pubkey> 0.01 \
+      -n solana-mainnet \
+      --fee-sponsored \
+      --fee-policy-id <fee-policy-id>
+    ```
+
+    Add `--token <mint>` for SPL tokens.
   </Tab>
 </Tabs>
 

--- a/content/tutorials/build-with-ai/agent-wallets.mdx
+++ b/content/tutorials/build-with-ai/agent-wallets.mdx
@@ -1,43 +1,232 @@
 ---
 title: Agent Wallets
-description: Give your AI agent a secure wallet it can use from the Alchemy CLI without exposing private keys.
-subtitle: Wallets that allow your agent to send tokens, swap, bridge, call contracts and check transaction status.
+description: Give your AI agent an Alchemy-managed wallet session for onchain actions through the Alchemy CLI, with dashboard approval, revocation, sponsorship, and machine-readable capability discovery.
+subtitle: Give your agent an approved wallet session for sending tokens, calling contracts, swapping, bridging, and checking transaction status from the Alchemy CLI.
 slug: docs/agent-wallets
 ---
 
-Agent Wallets give your AI agent a real onchain wallet it can use with the [Alchemy CLI](docs/alchemy-cli) to perform onchain actions.
+Agent Wallets let your AI agent execute onchain workflows through an approved Alchemy wallet session. The agent gets a scoped signing session for CLI actions; it does not receive or handle the wallet private key.
 
-Built with Privy embedded wallets, your agent will never see the wallet's private key. You approve wallet access, and you can revoke it at any time.
+Use Agent Wallets when your agent needs to:
 
-## Get Started
+* Send native tokens, ERC-20 tokens, SOL, or SPL tokens
+* Execute EVM contract calls through Alchemy smart wallets
+* Quote and execute EVM swaps and cross-chain bridges
+* Request gas or fee sponsorship with a Gas Manager policy
+* Check transaction, operation, and wallet session status in machine-readable JSON
+* Work from a terminal while you approve, fund, send from, or revoke the wallet in the Alchemy Dashboard
 
-Paste this prompt into your AI agent:
+## Capability matrix
+
+| Area | Current capability | How agents should discover it |
+|---|---|---|
+| Chains | EVM wallet operations on supported Alchemy wallet networks; Solana wallet operations on supported Solana networks. Swaps and bridges are EVM mainnet-only. | `alchemy evm network list`, `alchemy solana network list`, and `alchemy --json --no-interactive agent-prompt --scope wallet` |
+| EVM sends | Send native tokens or ERC-20 tokens with `alchemy evm send`. ENS recipients are supported where the selected network/client can resolve them. | `alchemy --json --no-interactive evm send --help` |
+| EVM contract writes | Execute state-changing functions with `alchemy evm contract call`, inline signatures, ABI files, JSON args, and optional ETH value. | `alchemy --json --no-interactive agent-prompt --scope wallet` |
+| EVM approvals | Approve, reset, or revoke ERC-20 allowances with `alchemy evm approve`. Unlimited approvals require explicit confirmation or `--yes`. | `alchemy evm approve --help` |
+| Swaps | Quote and execute same-chain EVM mainnet swaps with slippage controls and native-token sentinel support. | `alchemy evm swap quote --help` and `alchemy evm swap execute --help` |
+| Bridges | Quote and execute EVM mainnet bridges from `-n, --network` to `--to-network`. Source and destination networks must differ. | `alchemy xchain bridge quote --help` and `alchemy xchain bridge execute --help` |
+| Solana sends | Send SOL or SPL tokens with `alchemy solana send`, including dry runs, associated token account handling, and optional session signing. | `alchemy solana send --help` |
+| Status checks | Check EVM smart-wallet call IDs, EVM transaction hashes, and Solana signatures with `alchemy evm status` or `alchemy solana status`. | `alchemy evm status --help` and `alchemy solana status --help` |
+| Gas and fee sponsorship | EVM actions support `--gas-sponsored --gas-policy-id <id>`. Solana sends support `--fee-sponsored --fee-policy-id <id>`. Interactive CLI sessions can help select or create a policy. | `alchemy config status`, command help, and dashboard Gas Manager policies |
+| Session scopes | Session connections request explicit capabilities: `evm.signMessage`, `evm.signTypedData`, `evm.signAuthorization`, `evm.prepareCalls`, `evm.sendCalls`, and `solana.signTransaction`. | `alchemy --json --no-interactive wallet status --verify` |
+| Limits | Agent Wallet sessions are time bound and carry an `expiresAt`. The session signer does not support direct raw EVM transaction signing; use wallet commands that execute through Alchemy smart-wallet calls. Swaps and bridges are limited to EVM mainnets. | `wallet status --verify` plus the command-specific help |
+| Revocation | `alchemy wallet disconnect` revokes the current remote wallet sessions when the CLI is authenticated and clears local session state. You can also revoke sessions in the Dashboard. | `alchemy --json --no-interactive wallet disconnect` |
+
+<Note>
+  Gas and fee sponsorship policies control whether Alchemy sponsors transaction costs. They are not general-purpose spend limits for the wallet session.
+</Note>
+
+## Connect an Agent Wallet session
+
+Install the latest CLI, log in, and connect a session wallet:
 
 ```bash
-Install the latest Alchemy CLI with `npm i -g @alchemy/cli@latest`, then help me log in and create a wallet.
+npm i -g @alchemy/cli@latest
+alchemy auth
+alchemy wallet connect --mode session --instance-name codex-terminal
+alchemy wallet use session
 ```
 
-Your agent installs the CLI, authenticates, and connects an Agent Wallet.
+The CLI opens the Alchemy Dashboard approval flow. You approve the terminal session there, then the CLI stores a local session envelope and prints the approved wallet addresses, capabilities, and expiry.
 
-## Use cases
+Verify the session from the backend before a state-changing workflow:
 
-<CardGroup cols={2}>
-  <Card title="DeFi automation" icon="chart-line">
-    Check balances, quote and execute swaps, bridge to another chain, and deposit into a protocol — all in a single agent workflow.
-  </Card>
-  <Card title="Onchain development" icon="code">
-    Fund test wallets, deploy contracts, call contract methods, and automate repetitive dev tasks without leaving the CLI.
-  </Card>
-  <Card title="Treasury management" icon="wallet">
-    Send payments, move assets between wallets, and rebalance across chains as part of operational or finance workflows.
-  </Card>
-  <Card title="Multi-chain workflows" icon="arrow-right-arrow-left">
-    Bridge assets to where they're needed, then act — swap, deposit, or call contracts on the destination chain.
-  </Card>
-</CardGroup>
+```bash
+alchemy --json --no-interactive wallet status --verify
+```
+
+The JSON response includes `session.signerCapabilities`, `sessionsByChain`, `activeSigner`, `expiresAt`, and `remoteStatus`. Agents should inspect this before sending transactions.
+
+## Run an end-to-end CLI workflow
+
+This example connects an Agent Wallet, checks funding, previews a send, broadcasts it, checks status, and revokes the session.
+
+```bash
+# 1. Connect and approve the wallet session in the Dashboard.
+alchemy auth
+alchemy wallet connect --mode session --instance-name codex-terminal
+alchemy wallet use session
+
+# 2. Capture the active session EVM address.
+alchemy --json --no-interactive wallet address
+
+# 3. Check the sender's balance before spending.
+alchemy --json --no-interactive evm data balance <session_evm_address> -n base-mainnet
+
+# 4. Preview the exact call without signing or sending.
+alchemy --json --no-interactive evm send <recipient> 0.001 -n base-mainnet --dry-run
+
+# 5. Broadcast the transaction through the Agent Wallet session.
+alchemy --json --no-interactive evm send <recipient> 0.001 -n base-mainnet --signer session
+
+# 6. Check the returned callId or txHash.
+alchemy --json --no-interactive evm status <call-id-or-tx-hash> -n base-mainnet
+
+# 7. Revoke the terminal session when the workflow is done.
+alchemy --json --no-interactive wallet disconnect
+```
+
+For sponsored gas, add a Gas Manager policy:
+
+```bash
+alchemy --json --no-interactive evm send <recipient> 0.001 \
+  -n base-mainnet \
+  --signer session \
+  --gas-sponsored \
+  --gas-policy-id <gas-policy-id>
+```
+
+For Solana:
+
+```bash
+alchemy --json --no-interactive solana send <recipient_pubkey> 0.01 \
+  -n solana-mainnet \
+  --signer session
+```
+
+Add `--token <mint>` to send SPL tokens. Add `--fee-sponsored --fee-policy-id <fee-policy-id>` when you want a Solana fee policy to sponsor the transaction fee.
+
+## Let agents introspect the wallet surface
+
+Agents should not infer wallet behavior from prose. Give them the live CLI contract:
+
+```bash
+npx -y @alchemy/cli@latest --json --no-interactive agent-prompt --scope wallet
+```
+
+Use the output as the source of truth for command names, arguments, flags, auth requirements, examples, and error recovery. For a locally configured wallet, use the installed CLI instead:
+
+```bash
+alchemy --json --no-interactive agent-prompt --scope wallet
+alchemy --json --no-interactive wallet status --verify
+```
+
+If you maintain an agent skill or system prompt, include this capability manifest alongside the CLI contract:
+
+```json
+{
+  "alchemyAgentWallets": {
+    "sourceOfTruth": {
+      "latestCli": "npx -y @alchemy/cli@latest --json --no-interactive agent-prompt --scope wallet",
+      "installedCli": "alchemy --json --no-interactive agent-prompt --scope wallet",
+      "sessionStatus": "alchemy --json --no-interactive wallet status --verify"
+    },
+    "session": {
+      "approval": "dashboard",
+      "privateKeyExposure": "never_exposed_to_agent",
+      "revocation": ["alchemy wallet disconnect", "dashboard"],
+      "expiryField": "expiresAt",
+      "capabilities": {
+        "evm.signMessage": true,
+        "evm.signTypedData": true,
+        "evm.signAuthorization": true,
+        "evm.prepareCalls": true,
+        "evm.sendCalls": true,
+        "solana.signTransaction": true
+      }
+    },
+    "evm": {
+      "signingMode": "session_smart_wallet_calls",
+      "directRawTransactionSigning": false,
+      "operations": [
+        "native_send",
+        "erc20_send",
+        "contract_call",
+        "erc20_approve_reset_revoke",
+        "swap_quote",
+        "swap_execute",
+        "bridge_quote",
+        "bridge_execute",
+        "status"
+      ],
+      "sponsorship": {
+        "supported": true,
+        "flags": ["--gas-sponsored", "--gas-policy-id <id>"],
+        "policyType": "gas_sponsorship"
+      },
+      "limits": {
+        "swaps": "evm_mainnet_only",
+        "bridges": "evm_mainnet_only",
+        "spendingPolicies": "not_a_wallet_session_scope"
+      }
+    },
+    "solana": {
+      "signingMode": "session_or_local",
+      "operations": ["sol_send", "spl_token_send", "status"],
+      "sponsorship": {
+        "supported": true,
+        "flags": ["--fee-sponsored", "--fee-policy-id <id>"],
+        "policyType": "fee_sponsorship"
+      }
+    },
+    "agentRules": [
+      "Always pass --json --no-interactive in automation.",
+      "Run wallet status --verify before state-changing wallet actions.",
+      "Run balance, allowance, or quote preflights before spending.",
+      "Use --dry-run where available before broadcast.",
+      "Treat gas sponsorship as fee payment control, not a wallet spend limit.",
+      "Disconnect or ask the operator to revoke the session after the workflow."
+    ]
+  }
+}
+```
+
+## Dashboard controls
+
+Use the [Agent Wallets dashboard](https://dashboard.alchemy.com/products/agent-wallet/evm-wallet) to manage the wallet outside the CLI:
+
+* Create and view Agent Wallets
+* Approve terminal sessions opened by `alchemy wallet connect`
+* Fund wallets through onramps
+* Send from the wallet in the Dashboard
+* Revoke active or stale sessions
+
+This gives you an operator control plane for agent workflows: the agent can propose and execute CLI actions, while you keep approval, funding, dashboard sends, and revocation in Alchemy.
+
+## How Agent Wallet sessions work
+
+When you run `alchemy wallet connect --mode session`, the CLI creates a local session envelope and sends a connection request to Alchemy with the requested EVM and Solana capabilities. You approve that request in the Dashboard. After approval, the CLI can use the session for wallet-aware commands.
+
+For EVM, the session signer executes through Alchemy smart-wallet calls such as `wallet_prepareCalls` and `wallet_sendCalls`. This gives the CLI managed nonce handling, preflight behavior, call IDs, status polling, batch-call support where the command uses it, and optional paymaster capabilities for sponsored gas.
+
+For Solana, the session can sign Solana transactions for supported CLI flows such as SOL and SPL-token sends.
+
+## Local wallet fallback
+
+Agent Wallet sessions are recommended for agents because the private key is not exposed to the agent. The CLI also supports local wallets for workflows where you explicitly want local key material:
+
+```bash
+alchemy wallet connect --mode local
+alchemy wallet connect --mode local --import ./evm-private-key.txt
+alchemy wallet use local
+```
+
+If both a session signer and a local EVM signer are configured, the CLI defaults to the session signer and warns once. Use `alchemy wallet use local` only when you intentionally want local signing.
 
 ## Next steps
 
 * [Alchemy CLI](docs/alchemy-cli)
 * [Alchemy CLI wallets and signing](docs/alchemy-cli#wallets-and-signing)
+* [Alchemy Agent Skills](docs/alchemy-agent-skills)
 * [Alchemy Dashboard Agent Wallets](https://dashboard.alchemy.com/products/agent-wallet/evm-wallet)

--- a/content/tutorials/build-with-ai/alchemy-cli.mdx
+++ b/content/tutorials/build-with-ai/alchemy-cli.mdx
@@ -188,15 +188,15 @@ Most wallet-signed EVM commands accept `--signer session|local` to override the 
 
 ### Wallets and signing
 
-Use `alchemy wallet` to connect the signer used by onchain actions. EVM commands can use an [Agent Wallet session](docs/agent-wallets) approved through the Alchemy Dashboard or a local private key. The `session` signer refers to an Agent Wallet session, not an arbitrary browser wallet connection. Solana transaction commands currently use a local Solana wallet.
+Use `alchemy wallet` to connect the signer used by onchain actions. EVM commands can use an [Agent Wallet session](docs/agent-wallets) approved through the Alchemy Dashboard or a local private key. Solana send commands can use an Agent Wallet session or a local Solana wallet. The `session` signer refers to an Agent Wallet session, not an arbitrary browser wallet connection.
 
 Create, view, and revoke Agent Wallet sessions in the [Agent Wallets dashboard](https://dashboard.alchemy.com/products/agent-wallet/evm-wallet).
 
 | Command | Description |
 |---|---|
-| `alchemy wallet connect` | Connect a wallet. Use `--mode session` for an Agent Wallet session or `--mode local` for a local wallet. Local mode supports `--chain evm\|solana\|both` and defaults to both. |
-| `alchemy wallet connect --mode local --chain evm --import <path>` | Import a local EVM private key file |
-| `alchemy wallet connect --mode local --chain solana` | Create or configure a local Solana wallet |
+| `alchemy wallet connect` | Connect a wallet. Use `--mode session` for an Agent Wallet session or `--mode local` for local wallets. Session mode requests EVM and Solana capabilities. Local mode creates both EVM and Solana wallets. |
+| `alchemy wallet connect --mode session --instance-name <name>` | Name the CLI instance shown during Dashboard approval |
+| `alchemy wallet connect --mode local --import <path>` | Import a local EVM private key file |
 | `alchemy wallet status` | Show Agent Wallet session, local EVM, local Solana, and active signer status. Add `--verify` to check the backend session. |
 | `alchemy wallet address` | Display configured wallet addresses |
 | `alchemy wallet qr` | Display an EVM or Solana wallet address as a QR code |
@@ -205,17 +205,17 @@ Create, view, and revoke Agent Wallet sessions in the [Agent Wallets dashboard](
 
 ### Solana
 
-Solana transaction commands use a local Solana wallet. Use `--fee-sponsored` and `--fee-policy-id <id>` on supported Solana actions to request fee sponsorship.
+Solana send commands can use an Agent Wallet session or a local Solana wallet. Use `--fee-sponsored` and `--fee-policy-id <id>` on supported Solana actions to request fee sponsorship.
 
 ```bash
-alchemy wallet connect --mode local --chain solana
+alchemy wallet connect --mode session
 alchemy solana send <recipient> 0.1 -n solana-mainnet
 alchemy solana status <signature>
 ```
 
 | Command | Description |
 |---|---|
-| `alchemy solana send <to> <amount>` | Send native SOL. SPL token transfers are not yet supported. |
+| `alchemy solana send <to> <amount>` | Send native SOL. Add `--token <mint>` for SPL token transfers. |
 | `alchemy solana delegate approve --token-account <addr> --mint <addr> --delegate <addr> --amount <n> --decimals <n>` | Approve an SPL token delegate |
 | `alchemy solana delegate revoke --token-account <addr>` | Revoke an SPL token delegate |
 | `alchemy solana status [id]` | Check a Solana transaction signature; reads from stdin when omitted |


### PR DESCRIPTION
## What changed

- Rewrote the Agent Wallets page around concrete capabilities instead of high-level positioning.
- Removed the internal signer provider mention from the public docs.
- Added a capability matrix covering chains, operations, gas and fee sponsorship, session scopes, limits, and revocation behavior.
- Added end-to-end CLI examples for EVM and Solana Agent Wallet workflows.
- Added a machine-readable capability manifest for agents, skills, and system prompts.
- Updated the CLI docs to reflect current Agent Wallet session support for Solana sends and SPL token transfers.

## Why

The previous Agent Wallets page underrepresented the product and did not give agents a precise way to discover wallet capabilities. The new page documents the actual CLI surface, Dashboard control plane, and machine-readable discovery path via `agent-prompt --scope wallet`.

## Impact

Developers and AI agents get clearer guidance for connecting, verifying, using, sponsoring, and revoking Agent Wallet sessions. The page also avoids positioning Agent Wallets as a generic signing primitive and keeps current limitations explicit.

## Validation

- `pnpm exec prettier --check content/tutorials/build-with-ai/agent-wallets.mdx content/tutorials/build-with-ai/alchemy-cli.mdx`
- `pnpm exec eslint content/tutorials/build-with-ai/agent-wallets.mdx content/tutorials/build-with-ai/alchemy-cli.mdx`
- `git diff --check -- content/tutorials/build-with-ai/agent-wallets.mdx content/tutorials/build-with-ai/alchemy-cli.mdx`