### PR TITLE
docs(dashboard): document Activity Log + webhook subscriptions (OCSF mapping)

### DIFF
--- a/content/docs.yml
+++ b/content/docs.yml
@@ -113,6 +113,8 @@ navigation:
             path: tutorials/getting-started/developer-best-practices/dashboard-alerts.mdx
           - page: Request Logs
             path: tutorials/getting-started/dashboard/request-logs.mdx
+          - page: Activity Log
+            path: tutorials/getting-started/dashboard/activity-log.mdx
           - page: Roles
             path: tutorials/getting-started/dashboard/dashboard-roles.mdx
           - page: Single Sign-On (SSO)
@@ -127,6 +129,13 @@ navigation:
               - api: Admin API Endpoints
                 api-name: admin-api
                 flattened: true
+          - section: Activity Log Webhooks
+            hidden: true
+            contents:
+              - page: Webhook Subscriptions
+                path: tutorials/getting-started/dashboard/activity-log-webhook-subscriptions.mdx
+              - page: OCSF Mapping
+                path: tutorials/getting-started/dashboard/activity-log-ocsf-mapping.mdx
       - section: Tutorials
         contents:
           - section: Transactions

--- a/content/docs.yml
+++ b/content/docs.yml
@@ -113,8 +113,6 @@ navigation:
             path: tutorials/getting-started/developer-best-practices/dashboard-alerts.mdx
           - page: Request Logs
             path: tutorials/getting-started/dashboard/request-logs.mdx
-          - page: Activity Log
-            path: tutorials/getting-started/dashboard/activity-log.mdx
           - page: Roles
             path: tutorials/getting-started/dashboard/dashboard-roles.mdx
           - page: Single Sign-On (SSO)
@@ -129,9 +127,11 @@ navigation:
               - api: Admin API Endpoints
                 api-name: admin-api
                 flattened: true
-          - section: Activity Log Webhooks
+          - section: Activity Log
             hidden: true
             contents:
+              - page: Overview
+                path: tutorials/getting-started/dashboard/activity-log.mdx
               - page: Webhook Subscriptions
                 path: tutorials/getting-started/dashboard/activity-log-webhook-subscriptions.mdx
               - page: OCSF Mapping

--- a/content/tutorials/getting-started/dashboard/activity-log-ocsf-mapping.mdx
+++ b/content/tutorials/getting-started/dashboard/activity-log-ocsf-mapping.mdx
@@ -1,7 +1,7 @@
 ---
 title: OCSF Mapping
 subtitle: Suggested mapping from Alchemy activity actions to OCSF event classes.
-slug: docs/activity-log-ocsf-mapping
+slug: activity-log-ocsf-mapping
 ---
 
 When you stream Activity Log events to a SIEM via [webhook subscriptions](/docs/activity-log-webhook-subscriptions), each event carries an `action` field (e.g. `APP_APP_CREATED`). Many SIEMs normalize events into the [Open Cybersecurity Schema Framework (OCSF)](https://schema.ocsf.io). This page provides a **suggested** mapping from each Alchemy `action` value to an OCSF event class, plus the complete list of actions Alchemy emits.

--- a/content/tutorials/getting-started/dashboard/activity-log-ocsf-mapping.mdx
+++ b/content/tutorials/getting-started/dashboard/activity-log-ocsf-mapping.mdx
@@ -1,0 +1,171 @@
+---
+title: OCSF Mapping
+subtitle: Suggested mapping from Alchemy activity actions to OCSF event classes.
+slug: docs/activity-log-ocsf-mapping
+---
+
+When you stream Activity Log events to a SIEM via [webhook subscriptions](/docs/activity-log-webhook-subscriptions), each event carries an `action` field (e.g. `APP_APP_CREATED`). Many SIEMs normalize events into the [Open Cybersecurity Schema Framework (OCSF)](https://schema.ocsf.io). This page provides a **suggested** mapping from each Alchemy `action` value to an OCSF event class, plus the complete list of actions Alchemy emits.
+
+<Info>
+  This is a **suggested reference mapping**, not a contract. OCSF classes evolve and your detection model may differ — adapt the mapping to your environment. Alchemy delivers its own payload shape (see [Webhook Subscriptions → Payload](/docs/activity-log-webhook-subscriptions#payload)); the mapping is applied in your SIEM's ingest pipeline.
+</Info>
+
+***
+
+## How to use this mapping
+
+1. Read the `action` field from each webhook event.
+2. Look it up in the tables below to find the suggested OCSF class and `class_uid`.
+3. In your SIEM ingest pipeline, set the OCSF `class_uid` (and a sensible `activity_id`) accordingly, and map the Alchemy fields onto OCSF attributes — for example:
+
+| Alchemy field | OCSF attribute |
+| --- | --- |
+| `timestamp` | `time` |
+| `actor.id` / `actor.display_name` | `actor.user.uid` / `actor.user.name` |
+| `source_ip` | `src_endpoint.ip` |
+| `message` | `message` |
+| `action` | `metadata.product.feature.name` (or a custom field) |
+| `request_id` | `metadata.correlation_uid` |
+
+### OCSF classes used below
+
+| OCSF class | `class_uid` |
+| --- | --- |
+| Authentication | 3002 |
+| Account Change | 3001 |
+| User Access Management | 3005 |
+| Entity Management | 3004 |
+| API Activity | 6003 |
+
+***
+
+## Authentication → Authentication (3002)
+
+| `action` | Description |
+| --- | --- |
+| `AUTH_LOGIN_SUCCESS` | Login success |
+| `AUTH_LOGIN_FAILED` | Login failed |
+
+## Credential & account lifecycle → Account Change (3001)
+
+| `action` | Description |
+| --- | --- |
+| `AUTH_PASSWORD_RESET_REQUESTED` | Password reset requested |
+| `AUTH_PASSWORD_RESET_COMPLETED` | Password reset completed |
+| `ACCOUNT_TEAM_NAME_UPDATED` | Team name updated |
+| `ACCOUNT_TEAM_USER_INVITE_SENT` | User invited to team |
+| `ACCOUNT_TEAM_USER_INVITE_ACCEPTED` | User accepted team invite |
+| `ACCOUNT_TEAM_USER_REMOVED` | User removed from team |
+| `ACCOUNT_TEAM_USER_DETAILS_UPDATED` | User details updated |
+| `ACCOUNT_TEAM_USER_ADDED` | User invited to team (legacy) |
+| `ACCOUNT_TEAM_ONBOARDING_NETWORK_UPDATED` | Onboarding network updated |
+
+## Role changes → User Access Management (3005)
+
+| `action` | Description |
+| --- | --- |
+| `ACCOUNT_TEAM_USER_ROLE_UPDATED` | User role updated |
+
+## Apps, keys & app configuration → Entity Management (3004)
+
+| `action` | Description |
+| --- | --- |
+| `APP_APP_CREATED` | App created |
+| `APP_APP_DELETED` | App deleted |
+| `APP_APP_NAME_UPDATED` | App name updated |
+| `APP_APP_DESCRIPTION_UPDATED` | App description updated |
+| `APP_APP_KEY_ROTATED` | API key rotated |
+| `APP_API_KEY_ACCESS_UPDATED` | API key access updated |
+| `APP_JWT_CREATED` | JWT created |
+| `APP_JWT_DELETED` | JWT deleted |
+| `ACCOUNT_ACCESS_KEY_CREATED` | Access key created |
+| `ACCOUNT_ACCESS_KEY_DELETED` | Access key deleted |
+| `APP_ALERT_CREATED` | Alert created |
+| `APP_ALERT_UPDATED` | Alert updated |
+| `APP_ALERT_DELETED` | Alert deleted |
+| `APP_ALERT_ENABLED` | Alert enabled |
+| `APP_ALERT_DISABLED` | Alert disabled |
+| `APP_INITIALIZE_GAS_POLICY` | Gas policy initialized |
+| `APP_INITIALIZE_WALLET_CONFIG` | Wallet config initialized |
+| `APP_GAS_POLICY_CREATED` | Gas policy created |
+| `APP_GAS_POLICY_UPDATED` | Gas policy updated |
+| `APP_GAS_POLICY_DELETED` | Gas policy deleted |
+| `APP_GAS_POLICY_ACTIVATED` | Gas policy activated |
+| `APP_GAS_POLICY_DEACTIVATED` | Gas policy deactivated |
+| `APP_GAS_PUMP_PROGRAM_CREATED` | Gas program created |
+| `APP_GAS_PUMP_PROGRAM_UPDATED` | Gas program updated |
+| `APP_GAS_PUMP_PROGRAM_DELETED` | Gas program deleted |
+| `APP_GAS_PUMP_PROGRAM_BUILDER_APPROVED` | Gas program builder approved |
+| `APP_GAS_PUMP_PROGRAM_BUILDER_REJECTED` | Gas program builder rejected |
+| `WALLET_KEY_QUORUM_CREATED` | Wallet key quorum created |
+| `WALLET_KEY_QUORUM_UPDATED` | Wallet key quorum updated |
+| `WALLET_KEY_QUORUM_DELETED` | Wallet key quorum deleted |
+
+## Network & security configuration → Entity Management (3004)
+
+These are security-relevant configuration changes. Some teams prefer to route them to a dedicated "configuration change" detection pipeline.
+
+| `action` | Description |
+| --- | --- |
+| `APP_NETWORK_ENABLED` | Network enabled |
+| `APP_NETWORK_DISABLED` | Network disabled |
+| `APP_NETWORK_ALL_ENABLED` | All networks enabled |
+| `APP_NETWORK_ALL_DISABLED` | All networks disabled |
+| `APP_ALLOWLIST_RESTRICTED_ADDRESS_ADDED` | Allowlist restricted address added |
+| `APP_ALLOWLIST_RESTRICTED_ADDRESS_REMOVED` | Allowlist restricted address removed |
+| `APP_ALLOWLIST_RESTRICTED_DOMAIN_ADDED` | Allowlist restricted domain added |
+| `APP_ALLOWLIST_RESTRICTED_DOMAIN_REMOVED` | Allowlist restricted domain removed |
+| `APP_ALLOWLIST_RESTRICTED_IP_ADDED` | Allowlist restricted IP added |
+| `APP_ALLOWLIST_RESTRICTED_IP_REMOVED` | Allowlist restricted IP removed |
+| `ACCOUNT_TEAM_IP_ALLOWLIST_IP_ADDED` | IP allowlist address added |
+| `ACCOUNT_TEAM_IP_ALLOWLIST_IP_REMOVED` | IP allowlist address removed |
+| `ACCOUNT_TEAM_IP_ALLOWLIST_IP_UPDATED` | IP allowlist address updated |
+
+## Billing & account administration → Account Change (3001)
+
+| `action` | Description |
+| --- | --- |
+| `BILLING_PLAN_UPDATED` | Billing plan updated |
+| `BILLING_PLAN_SPEND_LIMIT_UPDATED` | Spend limit updated |
+| `BILLING_USAGE_LIMIT_UPDATED` | Usage limit updated |
+| `BILLING_USAGE_LIMIT_BY_APP_UPDATED` | App usage limit updated |
+| `BILLING_PAYMENT_METHOD_ADDED` | Payment method added |
+| `BILLING_PAYMENT_METHOD_REMOVED` | Payment method removed |
+| `BILLING_PAYMENT_METHOD_UPDATED` | Payment method updated (legacy) |
+| `BILLING_INVOICE_EMAIL_ADDED` | Invoice email added |
+| `BILLING_INVOICE_EMAIL_REMOVED` | Invoice email removed |
+| `BILLING_INVOICE_EMAIL_UPDATED` | Invoice email updated (legacy) |
+| `BILLING_PAYMENT_ADDRESS_UPDATED` | Payment address updated |
+| `BILLING_TAX_DETAILS_UPDATED` | Tax details updated |
+| `BILLING_APP_USAGE_CAP_CREATED` | Usage cap created |
+| `BILLING_APP_USAGE_CAP_UPDATED` | Usage cap updated |
+| `BILLING_APP_USAGE_CAP_DELETED` | Usage cap deleted |
+| `BILLING_USAGE_AUTOSCALE_ENABLED` | Autoscale enabled |
+| `BILLING_USAGE_AUTOSCALE_DISABLED` | Autoscale disabled |
+| `ACCOUNT_ACTIVITY_LOG_EXPORTED` | Activity log exported |
+| `ACCOUNT_ACTIVITY_LOG_WEBHOOK_SUBSCRIPTION_CREATED` | Webhook subscription created |
+| `ACCOUNT_ACTIVITY_LOG_WEBHOOK_SUBSCRIPTION_UPDATED` | Webhook subscription updated |
+| `ACCOUNT_ACTIVITY_LOG_WEBHOOK_SUBSCRIPTION_DELETED` | Webhook subscription deleted |
+
+## Wallet activity → Authentication (3002) / API Activity (6003)
+
+Smart-wallet events are product-specific. Map session lifecycle to **Authentication (3002)** and signing/sync activity to **API Activity (6003)**, or to a custom class that fits your detection model.
+
+| `action` | Description | Suggested class |
+| --- | --- | --- |
+| `WALLET_SESSION_CREATED` | Wallet session created | Authentication (3002) |
+| `WALLET_SESSION_DISCONNECTED` | Wallet session disconnected | Authentication (3002) |
+| `WALLET_SESSION_APPROVED` | Wallet session approved | Authentication (3002) |
+| `WALLET_SESSION_DENIED` | Wallet session denied | Authentication (3002) |
+| `WALLET_SESSION_REVOKED` | Wallet session revoked | Authentication (3002) |
+| `WALLET_SIGNATURE_REQUESTED` | Wallet signature requested | API Activity (6003) |
+| `WALLET_SIGNATURE_COMPLETED` | Wallet signature completed | API Activity (6003) |
+| `WALLET_SIGNATURE_REJECTED` | Wallet signature rejected | API Activity (6003) |
+| `WALLET_SYNCED` | Wallet synced | API Activity (6003) |
+
+***
+
+## Notes
+
+* New `action` values may be added over time. Handle unknown actions gracefully in your pipeline (e.g. fall back to a generic OCSF class such as **API Activity (6003)**) rather than dropping the event.
+* Actions marked *(legacy)* are retained for backward compatibility and may appear in historical data.

--- a/content/tutorials/getting-started/dashboard/activity-log-ocsf-mapping.mdx
+++ b/content/tutorials/getting-started/dashboard/activity-log-ocsf-mapping.mdx
@@ -7,7 +7,7 @@ slug: docs/activity-log-ocsf-mapping
 When you stream Activity Log events to a SIEM via [webhook subscriptions](/docs/activity-log-webhook-subscriptions), each event carries an `action` field (e.g. `APP_APP_CREATED`). Many SIEMs normalize events into the [Open Cybersecurity Schema Framework (OCSF)](https://schema.ocsf.io). This page provides a **suggested** mapping from each Alchemy `action` value to an OCSF event class, plus the complete list of actions Alchemy emits.
 
 <Info>
-  This is a **suggested reference mapping**, not a contract. OCSF classes evolve and your detection model may differ — adapt the mapping to your environment. Alchemy delivers its own payload shape (see [Webhook Subscriptions → Payload](/docs/activity-log-webhook-subscriptions#payload)); the mapping is applied in your SIEM's ingest pipeline.
+  This is a **suggested reference mapping**, not a contract. OCSF classes evolve and your detection model may differ, so adapt the mapping to your environment. Alchemy delivers its own payload shape (see [Webhook Subscriptions → Payload](/docs/activity-log-webhook-subscriptions#payload)); the mapping is applied in your SIEM's ingest pipeline.
 </Info>
 
 ***
@@ -16,7 +16,7 @@ When you stream Activity Log events to a SIEM via [webhook subscriptions](/docs/
 
 1. Read the `action` field from each webhook event.
 2. Look it up in the tables below to find the suggested OCSF class and `class_uid`.
-3. In your SIEM ingest pipeline, set the OCSF `class_uid` (and a sensible `activity_id`) accordingly, and map the Alchemy fields onto OCSF attributes — for example:
+3. In your SIEM ingest pipeline, set the OCSF `class_uid` (and a sensible `activity_id`) accordingly, and map the Alchemy fields onto OCSF attributes, for example:
 
 | Alchemy field | OCSF attribute |
 | --- | --- |

--- a/content/tutorials/getting-started/dashboard/activity-log-webhook-subscriptions.mdx
+++ b/content/tutorials/getting-started/dashboard/activity-log-webhook-subscriptions.mdx
@@ -1,7 +1,7 @@
 ---
 title: Activity Log Webhook Subscriptions
 subtitle: Stream your team's activity events to a SIEM or log destination over HTTPS.
-slug: docs/activity-log-webhook-subscriptions
+slug: activity-log-webhook-subscriptions
 ---
 
 Activity Log webhook subscriptions forward your team's [Activity Log](/docs/activity-log) events to an endpoint you control, typically a SIEM (Splunk, Datadog, Panther, Microsoft Sentinel, etc.) or a log pipeline. Each time a matching event occurs, Alchemy sends an HTTPS `POST` with a JSON body to your endpoint, usually within a minute of the event.

--- a/content/tutorials/getting-started/dashboard/activity-log-webhook-subscriptions.mdx
+++ b/content/tutorials/getting-started/dashboard/activity-log-webhook-subscriptions.mdx
@@ -6,10 +6,6 @@ slug: docs/activity-log-webhook-subscriptions
 
 Activity Log webhook subscriptions forward your team's [Activity Log](/docs/activity-log) events to an endpoint you control, typically a SIEM (Splunk, Datadog, Panther, Microsoft Sentinel, etc.) or a log pipeline. Each time a matching event occurs, Alchemy sends an HTTPS `POST` with a JSON body to your endpoint, usually within a minute of the event.
 
-<Info>
-  Webhook subscriptions are available to **select teams** and are enabled by Alchemy on request. If you don't see the **Webhook subscriptions** tab on the Activity Log page, contact your Alchemy account team to have it enabled. The [Activity Log](/docs/activity-log) and webhook subscriptions are enabled together.
-</Info>
-
 ![](https://alchemyapi-res.cloudinary.com/image/upload/v1780953373/docs/log-webhooks.png)
 
 ***
@@ -50,7 +46,7 @@ Alchemy attaches the credential you configure as a header on every request to yo
 | --- | --- | --- |
 | **Bearer token** | `Authorization: Bearer <token>` | Standard token-based authentication. |
 | **Basic** | `Authorization: Basic <base64(username:password)>` | Authenticates with a username and password. |
-| **Custom header** | `<name>: <value>` | Used when your endpoint requires a custom header name for authentication, for example Splunk HEC (`Authorization: Splunk <token>`) or Datadog (`DD-API-KEY: <key>`). |
+| **Custom header** | `<name>: <value>` | Used when your endpoint requires a custom header name for authentication. |
 
 ***
 

--- a/content/tutorials/getting-started/dashboard/activity-log-webhook-subscriptions.mdx
+++ b/content/tutorials/getting-started/dashboard/activity-log-webhook-subscriptions.mdx
@@ -140,7 +140,8 @@ Each subscription card shows its recent delivery health, including the last succ
 ## Delivery & reliability
 
 * Deliveries are made per team and are isolated from other teams.
-* Alchemy automatically **retries failed deliveries** with backoff. Transient errors on your endpoint generally recover without intervention.
+* Alchemy automatically **retries failed deliveries** with backoff, at least 3 times over the span of an hour. Transient errors on your endpoint generally recover without intervention.
+* If all retry attempts are exhausted, the event is **dropped** and Alchemy sends an **email notification** to let you know about the failure.
 * If an endpoint **keeps failing**, the subscription is flagged in the dashboard with a *"failing delivery"* warning and its last failure reason. Fix your endpoint to resume delivery; a persistently failing subscription may be paused.
 * Because events stream in near real-time, your endpoint should respond quickly (return `2xx` as soon as you've accepted the event) and do heavier processing asynchronously.
 

--- a/content/tutorials/getting-started/dashboard/activity-log-webhook-subscriptions.mdx
+++ b/content/tutorials/getting-started/dashboard/activity-log-webhook-subscriptions.mdx
@@ -60,19 +60,24 @@ Each delivery is a single JSON event sent with `Content-Type: application/json`.
 
 ```json
 {
-  "id": "aa_log_a7b1fcc6114820b7e15f",
-  "timestamp": "2026-06-08T21:32:29.413Z",
-  "action": "AUTH_LOGIN_SUCCESS",
-  "action_display_name": "Login success",
+  "id": "aa_log_d73851bd5c5f004bffc5",
+  "timestamp": "2026-06-08T21:42:29.600Z",
+  "action": "APP_APP_NAME_UPDATED",
+  "action_display_name": "App name updated",
   "actor": {
     "id": "u_JDR4PP",
     "display_name": "Jane Doe",
     "type": "user"
   },
-  "message": "User logged in successfully.",
-  "source_ip": "2a09:bac0:1000:318::4d0:4b",
+  "message": "App name set to \"hien test 3\"",
+  "source_ip": "104.22.20.200",
   "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36 Edg/148.0.0.0",
-  "request_id": "de66c060-79ae-4063-b8c3-479ae9a8dc89"
+  "request_id": "dd645159-3192-4f69-99e9-d9fc031d02ec",
+  "target": {
+    "kind": "app",
+    "id": "ia2pyqvxzriqfebf",
+    "name": "hien test 3"
+  }
 }
 ```
 

--- a/content/tutorials/getting-started/dashboard/activity-log-webhook-subscriptions.mdx
+++ b/content/tutorials/getting-started/dashboard/activity-log-webhook-subscriptions.mdx
@@ -7,7 +7,7 @@ slug: docs/activity-log-webhook-subscriptions
 Activity Log webhook subscriptions forward your team's [Activity Log](/docs/account-activity-log) events to an endpoint you control — typically a SIEM (Splunk, Datadog, Panther, Microsoft Sentinel, etc.) or a log pipeline. Each time a matching event occurs, Alchemy sends an HTTPS `POST` with a JSON body to your endpoint, usually within a minute of the event.
 
 <Info>
-  Webhook subscriptions are available to **select teams** and are enabled by Alchemy on request. If you don't see the **Webhook subscriptions** tab on the Activity Log page, contact your Alchemy account team to have it enabled. The [Activity Log](/docs/account-activity-log) itself is available to all accounts.
+  Webhook subscriptions are available to **select teams** and are enabled by Alchemy on request. If you don't see the **Webhook subscriptions** tab on the Activity Log page, contact your Alchemy account team to have it enabled. The [Activity Log](/docs/account-activity-log) and webhook subscriptions are enabled together.
 </Info>
 
 {/* SCREENSHOT: Activity Log page with the "Webhook subscriptions" tab selected, showing one or two subscription cards. Suggested filename: activity-log-webhooks-list.png */}

--- a/content/tutorials/getting-started/dashboard/activity-log-webhook-subscriptions.mdx
+++ b/content/tutorials/getting-started/dashboard/activity-log-webhook-subscriptions.mdx
@@ -97,7 +97,7 @@ Each delivery is a single JSON event sent with `Content-Type: application/json`.
 | `target.name` | string | The target's display name. |
 
 <Tip>
-  The payload shape is stable, so build your ingest pipeline against these field names. Map the `action` value to your SIEM's schema using the [OCSF Mapping](/docs/activity-log-ocsf-mapping) reference.
+  The payload shape is stable, so build your ingest pipeline against these field names. The fields won't change, but new `action` values may be added as new features ship, so handle unrecognized actions gracefully rather than dropping the event. Map the `action` value to your SIEM's schema using the [OCSF Mapping](/docs/activity-log-ocsf-mapping) reference.
 </Tip>
 
 ***

--- a/content/tutorials/getting-started/dashboard/activity-log-webhook-subscriptions.mdx
+++ b/content/tutorials/getting-started/dashboard/activity-log-webhook-subscriptions.mdx
@@ -70,7 +70,7 @@ Each delivery is a single JSON event sent with `Content-Type: application/json`.
     "type": "user"
   },
   "message": "App name set to \"Demo App\"",
-  "source_ip": "104.22.20.200",
+  "source_ip": "203.0.113.42",
   "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36 Edg/148.0.0.0",
   "request_id": "dd645159-3192-4f69-99e9-d9fc031d02ec",
   "target": {

--- a/content/tutorials/getting-started/dashboard/activity-log-webhook-subscriptions.mdx
+++ b/content/tutorials/getting-started/dashboard/activity-log-webhook-subscriptions.mdx
@@ -1,0 +1,166 @@
+---
+title: Activity Log Webhook Subscriptions
+subtitle: Stream your team's activity events to a SIEM or log destination over HTTPS.
+slug: docs/activity-log-webhook-subscriptions
+---
+
+Activity Log webhook subscriptions forward your team's [Activity Log](/docs/account-activity-log) events to an endpoint you control — typically a SIEM (Splunk, Datadog, Panther, Microsoft Sentinel, etc.) or a log pipeline. Each time a matching event occurs, Alchemy sends an HTTPS `POST` with a JSON body to your endpoint, usually within a minute of the event.
+
+<Info>
+  Webhook subscriptions are available to **select teams** and are enabled by Alchemy on request. If you don't see the **Webhook subscriptions** tab on the Activity Log page, contact your Alchemy account team to have it enabled. The [Activity Log](/docs/account-activity-log) itself is available to all accounts.
+</Info>
+
+{/* SCREENSHOT: Activity Log page with the "Webhook subscriptions" tab selected, showing one or two subscription cards. Suggested filename: activity-log-webhooks-list.png */}
+
+***
+
+## How it works
+
+* Activity events for your team are matched against your subscriptions' event-type filters.
+* For each matching subscription, Alchemy sends an HTTPS `POST` with a JSON payload (see [Payload](#payload)) to your configured **Endpoint URL**.
+* Alchemy authenticates **to your endpoint** using the credential you configure on the subscription (a Bearer token, Basic auth, or a custom header). See [Authentication](#authentication).
+
+<Info>
+  Managing webhook subscriptions requires an **Admin** or **Owner** role on the team.
+</Info>
+
+***
+
+## Create a subscription
+
+1. Open the [Alchemy Dashboard](https://dashboard.alchemy.com) and go to **Activity Log** → **Webhook subscriptions** tab.
+2. Click **New subscription**.
+3. Fill in the form:
+   * **Name** — a label to identify this subscription (up to 100 characters). You can create multiple subscriptions, e.g. one for security events and one for billing events.
+   * **Endpoint URL** — the HTTPS URL Alchemy will `POST` events to. Must use `https://`.
+   * **Authentication** — how Alchemy authenticates to your endpoint. See [Authentication](#authentication).
+   * **Event types** — which actions to forward. All event types are selected by default; narrow this to only the events you care about. At least one must be selected.
+4. Click **Test event** to send a synthetic event to your endpoint. You must receive a successful (`2xx`) response before you can create the subscription — see [Testing](#testing-your-endpoint).
+5. Click **Create**.
+
+{/* SCREENSHOT: The "New webhook subscription" modal showing Name, Endpoint URL, Authentication selector, and Event types, with the Test event and Create buttons. Suggested filename: activity-log-webhooks-create-modal.png */}
+
+***
+
+## Authentication
+
+Alchemy attaches the credential you configure as a header on every request to your endpoint. Choose the method your destination expects:
+
+| Method | Header Alchemy sends | Typical use |
+| --- | --- | --- |
+| **Bearer token** | `Authorization: Bearer <token>` | Generic; most log pipelines and transform layers. |
+| **Basic** | `Authorization: Basic <base64(username:password)>` | Generic; endpoints behind basic auth. |
+| **Custom header** | `<name>: <value>` | Splunk HEC (`Authorization: Splunk <token>`), Datadog (`DD-API-KEY: <key>`), and other proprietary destinations. |
+
+<Warning>
+  **Payloads are not signed.** Alchemy does not add an HMAC or signature header to webhook deliveries. Authenticity is established by the auth header you configure above, so:
+
+  * Always use an `https://` endpoint.
+  * Treat the configured credential as a shared secret: have your endpoint reject any request that does not present it.
+  * Rotate the credential by editing the subscription if it's ever exposed.
+</Warning>
+
+***
+
+## Payload
+
+Each delivery is a single JSON event sent with `Content-Type: application/json`. Field names are `snake_case`. Every identifier is an external ID (SID); internal numeric IDs are never exposed.
+
+```json
+{
+  "id": "aa_log_3f9c8b2a",
+  "timestamp": "2026-05-27T21:00:00.000Z",
+  "action": "APP_APP_CREATED",
+  "action_display_name": "App created",
+  "actor": {
+    "id": "usr_8a21f0c4",
+    "display_name": "Jane Doe",
+    "type": "user"
+  },
+  "message": "Created app \"Mainnet Production\"",
+  "source_ip": "203.0.113.42",
+  "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) ...",
+  "request_id": "req_b1c2d3e4",
+  "target": {
+    "kind": "app",
+    "id": "app_9d4f7a10",
+    "name": "Mainnet Production"
+  }
+}
+```
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `id` | string | Unique event ID. |
+| `timestamp` | string | ISO 8601 UTC timestamp of when the event occurred. |
+| `action` | string | The action type, e.g. `APP_APP_CREATED`. See the full list in [OCSF Mapping](/docs/activity-log-ocsf-mapping). |
+| `action_display_name` | string | Human-readable label for the action, e.g. `App created`. |
+| `actor` | object \| null | Who performed the action. May be absent for some system events. |
+| `actor.id` | string | The actor's external ID. |
+| `actor.display_name` | string | The actor's display name. |
+| `actor.type` | string | One of `user`, `system`, or `access-key`. |
+| `message` | string | Human-readable description of the event. |
+| `source_ip` | string | Source IP address the action came from. |
+| `user_agent` | string | User agent of the originating request. |
+| `request_id` | string | Correlation ID for the originating request. |
+| `target` | object \| null | The entity the action acted on. May be absent. |
+| `target.kind` | string | The target entity type, e.g. `app`. |
+| `target.id` | string | The target's external ID. |
+| `target.name` | string | The target's display name. |
+
+<Tip>
+  The payload shape is stable — build your ingest pipeline against these field names. Map the `action` value to your SIEM's schema using the [OCSF Mapping](/docs/activity-log-ocsf-mapping) reference.
+</Tip>
+
+***
+
+## Filtering events
+
+Use the **Event types** selector to forward only the actions you need. For example, route authentication and access-key events to your security SIEM, and billing events to a separate destination. You can change the filter at any time by editing the subscription.
+
+***
+
+## Testing your endpoint
+
+The **Test event** button sends a **synthetic** event to your endpoint using the same payload shape and the auth header you've configured.
+
+* You must receive a successful (`2xx`) response before the **Create** button is enabled. Changing the URL or auth fields requires re-testing.
+* The dashboard reports the HTTP status your endpoint returned (e.g. *"Endpoint reachable! Your server returned HTTP 200"*), or a timeout/connection error.
+* There is a short cooldown between tests, and test requests time out after a few seconds.
+* Test events are **not** real activity and do **not** appear in your Activity Log.
+
+{/* SCREENSHOT: The form after a successful test, showing the success message and the now-enabled Create button. Suggested filename: activity-log-webhooks-test-success.png */}
+
+***
+
+## Managing subscriptions
+
+From the **Webhook subscriptions** tab you can:
+
+* **Edit** a subscription's name, URL, authentication, or event filter.
+* **Pause / resume** delivery without deleting the subscription.
+* **Delete** a subscription.
+* **Test** the endpoint again at any time.
+
+Each subscription card shows its recent delivery health, including the last successful and last failed delivery.
+
+{/* SCREENSHOT: A subscription card showing status (last success/last failure). Suggested filename: activity-log-webhooks-card-status.png */}
+
+***
+
+## Delivery & reliability
+
+* Deliveries are made per team and are isolated from other teams.
+* Alchemy automatically **retries failed deliveries** with backoff. Transient errors on your endpoint generally recover without intervention.
+* If an endpoint **keeps failing**, the subscription is flagged in the dashboard with a *"failing delivery"* warning and its last failure reason. Fix your endpoint to resume delivery; a persistently failing subscription may be paused.
+* Because events stream in near real-time, your endpoint should respond quickly (return `2xx` as soon as you've accepted the event) and do heavier processing asynchronously.
+
+<Note>
+  Activity Log entries are retained for 30 days regardless of webhook delivery, so you can still export missed events from the [Activity Log](/docs/account-activity-log) within that window.
+</Note>
+
+***
+
+## Next steps
+
+* [OCSF Mapping](/docs/activity-log-ocsf-mapping) — map the `action` field to OCSF event classes for your SIEM, plus the full list of action values.

--- a/content/tutorials/getting-started/dashboard/activity-log-webhook-subscriptions.mdx
+++ b/content/tutorials/getting-started/dashboard/activity-log-webhook-subscriptions.mdx
@@ -69,14 +69,14 @@ Each delivery is a single JSON event sent with `Content-Type: application/json`.
     "display_name": "Jane Doe",
     "type": "user"
   },
-  "message": "App name set to \"hien test 3\"",
+  "message": "App name set to \"Demo App\"",
   "source_ip": "104.22.20.200",
   "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36 Edg/148.0.0.0",
   "request_id": "dd645159-3192-4f69-99e9-d9fc031d02ec",
   "target": {
     "kind": "app",
     "id": "ia2pyqvxzriqfebf",
-    "name": "hien test 3"
+    "name": "Demo App"
   }
 }
 ```

--- a/content/tutorials/getting-started/dashboard/activity-log-webhook-subscriptions.mdx
+++ b/content/tutorials/getting-started/dashboard/activity-log-webhook-subscriptions.mdx
@@ -10,7 +10,7 @@ Activity Log webhook subscriptions forward your team's [Activity Log](/docs/acti
   Webhook subscriptions are available to **select teams** and are enabled by Alchemy on request. If you don't see the **Webhook subscriptions** tab on the Activity Log page, contact your Alchemy account team to have it enabled. The [Activity Log](/docs/activity-log) and webhook subscriptions are enabled together.
 </Info>
 
-{/* SCREENSHOT: Activity Log page with the "Webhook subscriptions" tab selected, showing one or two subscription cards. Suggested filename: activity-log-webhooks-list.png */}
+![](https://alchemyapi-res.cloudinary.com/image/upload/v1780953373/docs/log-webhooks.png)
 
 ***
 
@@ -38,7 +38,7 @@ Activity Log webhook subscriptions forward your team's [Activity Log](/docs/acti
 4. Click **Test event** to send a synthetic event to your endpoint. You must receive a successful (`2xx`) response before you can create the subscription. See [Testing](#testing-your-endpoint).
 5. Click **Create**.
 
-{/* SCREENSHOT: The "New webhook subscription" modal showing Name, Endpoint URL, Authentication selector, and Event types, with the Test event and Create buttons. Suggested filename: activity-log-webhooks-create-modal.png */}
+![](https://alchemyapi-res.cloudinary.com/image/upload/v1780953373/docs/new-subscription.png)
 
 ***
 
@@ -129,7 +129,7 @@ The **Test event** button sends a **synthetic** event to your endpoint using the
 * There is a short cooldown between tests, and test requests time out after a few seconds.
 * Test events are **not** real activity and do **not** appear in your Activity Log.
 
-{/* SCREENSHOT: The form after a successful test, showing the success message and the now-enabled Create button. Suggested filename: activity-log-webhooks-test-success.png */}
+![](https://alchemyapi-res.cloudinary.com/image/upload/v1780953373/docs/test-webhook.png)
 
 ***
 
@@ -143,8 +143,6 @@ From the **Webhook subscriptions** tab you can:
 * **Test** the endpoint again at any time.
 
 Each subscription card shows its recent delivery health, including the last successful and last failed delivery.
-
-{/* SCREENSHOT: A subscription card showing status (last success/last failure). Suggested filename: activity-log-webhooks-card-status.png */}
 
 ***
 

--- a/content/tutorials/getting-started/dashboard/activity-log-webhook-subscriptions.mdx
+++ b/content/tutorials/getting-started/dashboard/activity-log-webhook-subscriptions.mdx
@@ -48,44 +48,31 @@ Alchemy attaches the credential you configure as a header on every request to yo
 
 | Method | Header Alchemy sends | Typical use |
 | --- | --- | --- |
-| **Bearer token** | `Authorization: Bearer <token>` | Generic; most log pipelines and transform layers. |
-| **Basic** | `Authorization: Basic <base64(username:password)>` | Generic; endpoints behind basic auth. |
-| **Custom header** | `<name>: <value>` | Splunk HEC (`Authorization: Splunk <token>`), Datadog (`DD-API-KEY: <key>`), and other proprietary destinations. |
-
-<Warning>
-  **Payloads are not signed.** Alchemy does not add an HMAC or signature header to webhook deliveries. Authenticity is established by the auth header you configure above, so:
-
-  * Always use an `https://` endpoint.
-  * Treat the configured credential as a shared secret: have your endpoint reject any request that does not present it.
-  * Rotate the credential by editing the subscription if it's ever exposed.
-</Warning>
+| **Bearer token** | `Authorization: Bearer <token>` | Standard token-based authentication. |
+| **Basic** | `Authorization: Basic <base64(username:password)>` | Authenticates with a username and password. |
+| **Custom header** | `<name>: <value>` | Used when your endpoint requires a custom header name for authentication, for example Splunk HEC (`Authorization: Splunk <token>`) or Datadog (`DD-API-KEY: <key>`). |
 
 ***
 
 ## Payload
 
-Each delivery is a single JSON event sent with `Content-Type: application/json`. Field names are `snake_case`. Every identifier is an external ID (SID); internal numeric IDs are never exposed.
+Each delivery is a single JSON event sent with `Content-Type: application/json`.
 
 ```json
 {
-  "id": "aa_log_3f9c8b2a",
-  "timestamp": "2026-05-27T21:00:00.000Z",
-  "action": "APP_APP_CREATED",
-  "action_display_name": "App created",
+  "id": "aa_log_a7b1fcc6114820b7e15f",
+  "timestamp": "2026-06-08T21:32:29.413Z",
+  "action": "AUTH_LOGIN_SUCCESS",
+  "action_display_name": "Login success",
   "actor": {
-    "id": "usr_8a21f0c4",
+    "id": "u_JDR4PP",
     "display_name": "Jane Doe",
     "type": "user"
   },
-  "message": "Created app \"Mainnet Production\"",
-  "source_ip": "203.0.113.42",
-  "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) ...",
-  "request_id": "req_b1c2d3e4",
-  "target": {
-    "kind": "app",
-    "id": "app_9d4f7a10",
-    "name": "Mainnet Production"
-  }
+  "message": "User logged in successfully.",
+  "source_ip": "2a09:bac0:1000:318::4d0:4b",
+  "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36 Edg/148.0.0.0",
+  "request_id": "de66c060-79ae-4063-b8c3-479ae9a8dc89"
 }
 ```
 
@@ -116,7 +103,7 @@ Each delivery is a single JSON event sent with `Content-Type: application/json`.
 
 ## Filtering events
 
-Use the **Event types** selector to forward only the actions you need. For example, route authentication and access-key events to your security SIEM, and billing events to a separate destination. You can change the filter at any time by editing the subscription.
+Use the **Event types** selector to forward only the actions you need. For example, route authentication and access-key events to your security SIEM, and billing events to a separate destination. The event filter is set when you create the subscription; to change it, create a new subscription with the updated filter and delete the old one.
 
 ***
 
@@ -135,14 +122,17 @@ The **Test event** button sends a **synthetic** event to your endpoint using the
 
 ## Managing subscriptions
 
-From the **Webhook subscriptions** tab you can:
+A subscription's settings (name, URL, authentication, and event filter) are fixed once it's created. From the **Webhook subscriptions** tab you can:
 
-* **Edit** a subscription's name, URL, authentication, or event filter.
 * **Pause / resume** delivery without deleting the subscription.
 * **Delete** a subscription.
 * **Test** the endpoint again at any time.
 
 Each subscription card shows its recent delivery health, including the last successful and last failed delivery.
+
+<Note>
+  Subscriptions can't be edited after they're created. To change a subscription's name, URL, authentication, or event filter, create a new subscription with the updated settings and delete the old one.
+</Note>
 
 ***
 

--- a/content/tutorials/getting-started/dashboard/activity-log-webhook-subscriptions.mdx
+++ b/content/tutorials/getting-started/dashboard/activity-log-webhook-subscriptions.mdx
@@ -4,10 +4,10 @@ subtitle: Stream your team's activity events to a SIEM or log destination over H
 slug: docs/activity-log-webhook-subscriptions
 ---
 
-Activity Log webhook subscriptions forward your team's [Activity Log](/docs/account-activity-log) events to an endpoint you control — typically a SIEM (Splunk, Datadog, Panther, Microsoft Sentinel, etc.) or a log pipeline. Each time a matching event occurs, Alchemy sends an HTTPS `POST` with a JSON body to your endpoint, usually within a minute of the event.
+Activity Log webhook subscriptions forward your team's [Activity Log](/docs/activity-log) events to an endpoint you control — typically a SIEM (Splunk, Datadog, Panther, Microsoft Sentinel, etc.) or a log pipeline. Each time a matching event occurs, Alchemy sends an HTTPS `POST` with a JSON body to your endpoint, usually within a minute of the event.
 
 <Info>
-  Webhook subscriptions are available to **select teams** and are enabled by Alchemy on request. If you don't see the **Webhook subscriptions** tab on the Activity Log page, contact your Alchemy account team to have it enabled. The [Activity Log](/docs/account-activity-log) and webhook subscriptions are enabled together.
+  Webhook subscriptions are available to **select teams** and are enabled by Alchemy on request. If you don't see the **Webhook subscriptions** tab on the Activity Log page, contact your Alchemy account team to have it enabled. The [Activity Log](/docs/activity-log) and webhook subscriptions are enabled together.
 </Info>
 
 {/* SCREENSHOT: Activity Log page with the "Webhook subscriptions" tab selected, showing one or two subscription cards. Suggested filename: activity-log-webhooks-list.png */}
@@ -156,7 +156,7 @@ Each subscription card shows its recent delivery health, including the last succ
 * Because events stream in near real-time, your endpoint should respond quickly (return `2xx` as soon as you've accepted the event) and do heavier processing asynchronously.
 
 <Note>
-  Activity Log entries are retained for 30 days regardless of webhook delivery, so you can still export missed events from the [Activity Log](/docs/account-activity-log) within that window.
+  Activity Log entries are retained for 30 days regardless of webhook delivery, so you can still export missed events from the [Activity Log](/docs/activity-log) within that window.
 </Note>
 
 ***

--- a/content/tutorials/getting-started/dashboard/activity-log-webhook-subscriptions.mdx
+++ b/content/tutorials/getting-started/dashboard/activity-log-webhook-subscriptions.mdx
@@ -28,7 +28,7 @@ Activity Log webhook subscriptions forward your team's [Activity Log](/docs/acti
 
 ## Create a subscription
 
-1. Open the [Alchemy Dashboard](https://dashboard.alchemy.com) and go to **Activity Log** → **Webhook subscriptions** tab.
+1. Open the [Alchemy Dashboard](https://dashboard.alchemy.com) and go to [Activity Log](https://dashboard.alchemy.com/activity-log) → [Webhook subscriptions](https://dashboard.alchemy.com/activity-log/webhook-subscriptions) tab.
 2. Click **New subscription**.
 3. Fill in the form:
    * **Name**: a label to identify this subscription (up to 100 characters). You can create multiple subscriptions, e.g. one for security events and one for billing events.

--- a/content/tutorials/getting-started/dashboard/activity-log-webhook-subscriptions.mdx
+++ b/content/tutorials/getting-started/dashboard/activity-log-webhook-subscriptions.mdx
@@ -4,7 +4,7 @@ subtitle: Stream your team's activity events to a SIEM or log destination over H
 slug: docs/activity-log-webhook-subscriptions
 ---
 
-Activity Log webhook subscriptions forward your team's [Activity Log](/docs/activity-log) events to an endpoint you control — typically a SIEM (Splunk, Datadog, Panther, Microsoft Sentinel, etc.) or a log pipeline. Each time a matching event occurs, Alchemy sends an HTTPS `POST` with a JSON body to your endpoint, usually within a minute of the event.
+Activity Log webhook subscriptions forward your team's [Activity Log](/docs/activity-log) events to an endpoint you control, typically a SIEM (Splunk, Datadog, Panther, Microsoft Sentinel, etc.) or a log pipeline. Each time a matching event occurs, Alchemy sends an HTTPS `POST` with a JSON body to your endpoint, usually within a minute of the event.
 
 <Info>
   Webhook subscriptions are available to **select teams** and are enabled by Alchemy on request. If you don't see the **Webhook subscriptions** tab on the Activity Log page, contact your Alchemy account team to have it enabled. The [Activity Log](/docs/activity-log) and webhook subscriptions are enabled together.
@@ -31,11 +31,11 @@ Activity Log webhook subscriptions forward your team's [Activity Log](/docs/acti
 1. Open the [Alchemy Dashboard](https://dashboard.alchemy.com) and go to **Activity Log** → **Webhook subscriptions** tab.
 2. Click **New subscription**.
 3. Fill in the form:
-   * **Name** — a label to identify this subscription (up to 100 characters). You can create multiple subscriptions, e.g. one for security events and one for billing events.
-   * **Endpoint URL** — the HTTPS URL Alchemy will `POST` events to. Must use `https://`.
-   * **Authentication** — how Alchemy authenticates to your endpoint. See [Authentication](#authentication).
-   * **Event types** — which actions to forward. All event types are selected by default; narrow this to only the events you care about. At least one must be selected.
-4. Click **Test event** to send a synthetic event to your endpoint. You must receive a successful (`2xx`) response before you can create the subscription — see [Testing](#testing-your-endpoint).
+   * **Name**: a label to identify this subscription (up to 100 characters). You can create multiple subscriptions, e.g. one for security events and one for billing events.
+   * **Endpoint URL**: the HTTPS URL Alchemy will `POST` events to. Must use `https://`.
+   * **Authentication**: how Alchemy authenticates to your endpoint. See [Authentication](#authentication).
+   * **Event types**: which actions to forward. All event types are selected by default; narrow this to only the events you care about. At least one must be selected.
+4. Click **Test event** to send a synthetic event to your endpoint. You must receive a successful (`2xx`) response before you can create the subscription. See [Testing](#testing-your-endpoint).
 5. Click **Create**.
 
 {/* SCREENSHOT: The "New webhook subscription" modal showing Name, Endpoint URL, Authentication selector, and Event types, with the Test event and Create buttons. Suggested filename: activity-log-webhooks-create-modal.png */}
@@ -109,7 +109,7 @@ Each delivery is a single JSON event sent with `Content-Type: application/json`.
 | `target.name` | string | The target's display name. |
 
 <Tip>
-  The payload shape is stable — build your ingest pipeline against these field names. Map the `action` value to your SIEM's schema using the [OCSF Mapping](/docs/activity-log-ocsf-mapping) reference.
+  The payload shape is stable, so build your ingest pipeline against these field names. Map the `action` value to your SIEM's schema using the [OCSF Mapping](/docs/activity-log-ocsf-mapping) reference.
 </Tip>
 
 ***
@@ -163,4 +163,4 @@ Each subscription card shows its recent delivery health, including the last succ
 
 ## Next steps
 
-* [OCSF Mapping](/docs/activity-log-ocsf-mapping) — map the `action` field to OCSF event classes for your SIEM, plus the full list of action values.
+* [OCSF Mapping](/docs/activity-log-ocsf-mapping): map the `action` field to OCSF event classes for your SIEM, plus the full list of action values.

--- a/content/tutorials/getting-started/dashboard/activity-log.mdx
+++ b/content/tutorials/getting-started/dashboard/activity-log.mdx
@@ -64,7 +64,7 @@ The Activity Log captures account- and app-level changes across several categori
 
 To pull the log into a spreadsheet or share it with your security team, click **Export** in the top-right of the page. Alchemy generates a CSV (`activity-log.csv`) containing the **Timestamp**, **Action**, **User**, **App**, **Details**, and **IP Address** for the entries in view.
 
-![](https://alchemyapi-res.cloudinary.com/image/upload/v1780953373/docs/export-activity-log.png)
+![](https://alchemyapi-res.cloudinary.com/image/upload/v1780956922/docs/export-button_riuon1.png)
 
 ***
 

--- a/content/tutorials/getting-started/dashboard/activity-log.mdx
+++ b/content/tutorials/getting-started/dashboard/activity-log.mdx
@@ -4,15 +4,15 @@ subtitle: Track and audit changes made across your Alchemy account.
 slug: docs/activity-log
 ---
 
-The Activity Log is an audit trail of important changes made across your Alchemy account. It records who did what, when, and from where — so you can answer questions like "who deleted this app?", "when was this access key created?", or "which member changed our billing plan?".
+The Activity Log is an audit trail of important changes made across your Alchemy account. It records who did what, when, and from where, so you can answer questions like "who deleted this app?", "when was this access key created?", or "which member changed our billing plan?".
 
 It lives in the [Alchemy Dashboard](https://dashboard.alchemy.com/activity-log).
 
-{/* SCREENSHOT: Activity Log page — full view showing the table with a few rows and the Export button in the top-right. Suggested filename: activity-log-overview.png */}
+{/* SCREENSHOT: Activity Log page, full view showing the table with a few rows and the Export button in the top-right. Suggested filename: activity-log-overview.png */}
 
 ### Why it matters
 
-* **Security & audit**: Maintain a record of security-relevant changes — logins, access key creation, allowlist edits, and role changes — for incident response and compliance reviews.
+* **Security & audit**: Maintain a record of security-relevant changes (logins, access key creation, allowlist edits, and role changes) for incident response and compliance reviews.
 * **Accountability**: See which team member (or access key) made a change, and from which IP address.
 * **Troubleshooting**: Correlate a configuration change with a change in your app's behavior.
 
@@ -46,11 +46,11 @@ Each entry includes the following columns:
 
 The Activity Log captures account- and app-level changes across several categories, including:
 
-* **Apps** — creating, deleting, renaming apps; rotating API keys; managing JWTs and allowlists; enabling/disabling networks.
-* **Team & access** — inviting and removing members, role changes, access key creation/deletion, and IP allowlist changes.
-* **Authentication** — login success/failure and password resets.
-* **Billing** — plan changes, payment methods, usage limits, and usage caps.
-* **Alerts, gas policies, and wallet activity** — creating and updating alerts, gas policies/programs, and smart-wallet sessions and signatures.
+* **Apps**: creating, deleting, renaming apps; rotating API keys; managing JWTs and allowlists; enabling/disabling networks.
+* **Team & access**: inviting and removing members, role changes, access key creation/deletion, and IP allowlist changes.
+* **Authentication**: login success/failure and password resets.
+* **Billing**: plan changes, payment methods, usage limits, and usage caps.
+* **Alerts, gas policies, and wallet activity**: creating and updating alerts, gas policies/programs, and smart-wallet sessions and signatures.
 
 <Tip>
   For the complete, authoritative list of every logged action, see the action reference in the [OCSF Mapping](/docs/activity-log-ocsf-mapping) table, which lists each action alongside its description.
@@ -60,7 +60,7 @@ The Activity Log captures account- and app-level changes across several categori
 
 ## Filtering and searching
 
-Use the controls above the table to narrow down entries — for example by time range — so you can quickly find the events you care about. The most recent events appear first.
+Use the controls above the table to narrow down entries, for example by time range, so you can quickly find the events you care about. The most recent events appear first.
 
 {/* SCREENSHOT: Activity Log filters/search controls above the table. Suggested filename: activity-log-filters.png */}
 

--- a/content/tutorials/getting-started/dashboard/activity-log.mdx
+++ b/content/tutorials/getting-started/dashboard/activity-log.mdx
@@ -1,0 +1,83 @@
+---
+title: Activity Log
+subtitle: Track and audit changes made across your Alchemy team.
+slug: docs/account-activity-log
+---
+
+The Activity Log is an audit trail of important changes made across your Alchemy team. It records who did what, when, and from where — so you can answer questions like "who deleted this app?", "when was this access key created?", or "which member changed our billing plan?".
+
+It's available on all Alchemy accounts and lives in the [Alchemy Dashboard](https://dashboard.alchemy.com/activity-log).
+
+{/* SCREENSHOT: Activity Log page — full view showing the table with a few rows and the Export button in the top-right. Suggested filename: activity-log-overview.png */}
+
+### Why it matters
+
+* **Security & audit**: Maintain a record of security-relevant changes — logins, access key creation, allowlist edits, and role changes — for incident response and compliance reviews.
+* **Accountability**: See which team member (or access key) made a change, and from which IP address.
+* **Troubleshooting**: Correlate a configuration change with a change in your app's behavior.
+
+***
+
+## Accessing the Activity Log
+
+1. Open the [Alchemy Dashboard](https://dashboard.alchemy.com).
+2. Navigate to **Activity Log** (`https://dashboard.alchemy.com/activity-log`).
+
+<Info>
+  Viewing the Activity Log requires an **Admin** or **Owner** role on the team. Members with a Viewer or Developer role won't see it.
+</Info>
+
+***
+
+## What's in the log
+
+Each entry includes the following columns:
+
+| Column | Description |
+| --- | --- |
+| **Timestamp** | When the action occurred (your local time). |
+| **Action** | A human-readable description of what happened (e.g. *App created*, *Login success*). |
+| **Actor** | The team member, access key, or system that performed the action. |
+| **App** | The app the action relates to, if any. Links to the app when it still exists. |
+| **Details** | Additional context about the change. |
+| **IP Address** | The source IP address the action came from. |
+
+### What gets logged
+
+The Activity Log captures account- and app-level changes across several categories, including:
+
+* **Apps** — creating, deleting, renaming apps; rotating API keys; managing JWTs and allowlists; enabling/disabling networks.
+* **Team & access** — inviting and removing members, role changes, access key creation/deletion, and IP allowlist changes.
+* **Authentication** — login success/failure and password resets.
+* **Billing** — plan changes, payment methods, usage limits, and usage caps.
+* **Alerts, gas policies, and wallet activity** — creating and updating alerts, gas policies/programs, and smart-wallet sessions and signatures.
+
+<Tip>
+  For the complete, authoritative list of every logged action, see the action reference in the [OCSF Mapping](/docs/activity-log-ocsf-mapping) table, which lists each action alongside its description.
+</Tip>
+
+***
+
+## Filtering and searching
+
+Use the controls above the table to narrow down entries — for example by time range — so you can quickly find the events you care about. The most recent events appear first.
+
+{/* SCREENSHOT: Activity Log filters/search controls above the table. Suggested filename: activity-log-filters.png */}
+
+***
+
+## Exporting to CSV
+
+To pull the log into a spreadsheet or share it with your security team, click **Export** in the top-right of the page. Alchemy generates a CSV (`activity-log.csv`) containing the **Timestamp**, **Action**, **User**, **App**, **Details**, and **IP Address** for the entries in view.
+
+{/* SCREENSHOT: The Export button highlighted in the top-right of the Activity Log page. Suggested filename: activity-log-export.png */}
+
+***
+
+## Retention
+
+Activity Log entries are retained for **30 days**. Export regularly, or stream events to your own systems, if you need to keep a longer history.
+
+<Note>
+  Need activity events delivered to your SIEM or log pipeline in real time? Streaming activity events over HTTPS webhooks is available to select teams — reach out to your Alchemy account team to learn more.
+</Note>

--- a/content/tutorials/getting-started/dashboard/activity-log.mdx
+++ b/content/tutorials/getting-started/dashboard/activity-log.mdx
@@ -1,7 +1,7 @@
 ---
 title: Activity Log
 subtitle: Track and audit changes made across your Alchemy account.
-slug: docs/account-activity-log
+slug: docs/activity-log
 ---
 
 The Activity Log is an audit trail of important changes made across your Alchemy account. It records who did what, when, and from where — so you can answer questions like "who deleted this app?", "when was this access key created?", or "which member changed our billing plan?".

--- a/content/tutorials/getting-started/dashboard/activity-log.mdx
+++ b/content/tutorials/getting-started/dashboard/activity-log.mdx
@@ -6,7 +6,11 @@ slug: docs/account-activity-log
 
 The Activity Log is an audit trail of important changes made across your Alchemy account. It records who did what, when, and from where — so you can answer questions like "who deleted this app?", "when was this access key created?", or "which member changed our billing plan?".
 
-It's available on all Alchemy accounts and lives in the [Alchemy Dashboard](https://dashboard.alchemy.com/activity-log).
+It lives in the [Alchemy Dashboard](https://dashboard.alchemy.com/activity-log).
+
+<Info>
+  The Activity Log is enabled by Alchemy for select accounts. If you don't see it in your dashboard, reach out to your Alchemy account team.
+</Info>
 
 {/* SCREENSHOT: Activity Log page — full view showing the table with a few rows and the Export button in the top-right. Suggested filename: activity-log-overview.png */}
 
@@ -79,5 +83,5 @@ To pull the log into a spreadsheet or share it with your security team, click **
 Activity Log entries are retained for **30 days**. Export regularly, or stream events to your own systems, if you need to keep a longer history.
 
 <Note>
-  Need activity events delivered to your SIEM or log pipeline in real time? Streaming activity events over HTTPS webhooks is available to select teams — reach out to your Alchemy account team to learn more.
+  Need activity events delivered to your SIEM or log pipeline in real time? See [Webhook Subscriptions](/docs/activity-log-webhook-subscriptions) to stream events over HTTPS.
 </Note>

--- a/content/tutorials/getting-started/dashboard/activity-log.mdx
+++ b/content/tutorials/getting-started/dashboard/activity-log.mdx
@@ -21,10 +21,10 @@ It lives in the [Alchemy Dashboard](https://dashboard.alchemy.com/activity-log).
 ## Accessing the Activity Log
 
 1. Open the [Alchemy Dashboard](https://dashboard.alchemy.com).
-2. Navigate to **Activity Log** (`https://dashboard.alchemy.com/activity-log`).
+2. Navigate to [Activity Log](https://dashboard.alchemy.com/activity-log).
 
 <Info>
-  Viewing the Activity Log requires an **Admin** or **Owner** role on the team. Members with a Viewer or Developer role won't see it.
+  Viewing the Activity Log requires an **Admin** or **Owner** [role](/docs/dashboard-roles) on the team. Members with a Viewer or Developer role won't see it.
 </Info>
 
 ***

--- a/content/tutorials/getting-started/dashboard/activity-log.mdx
+++ b/content/tutorials/getting-started/dashboard/activity-log.mdx
@@ -8,10 +8,6 @@ The Activity Log is an audit trail of important changes made across your Alchemy
 
 It lives in the [Alchemy Dashboard](https://dashboard.alchemy.com/activity-log).
 
-<Info>
-  The Activity Log is enabled by Alchemy for select accounts. If you don't see it in your dashboard, reach out to your Alchemy account team.
-</Info>
-
 {/* SCREENSHOT: Activity Log page — full view showing the table with a few rows and the Export button in the top-right. Suggested filename: activity-log-overview.png */}
 
 ### Why it matters

--- a/content/tutorials/getting-started/dashboard/activity-log.mdx
+++ b/content/tutorials/getting-started/dashboard/activity-log.mdx
@@ -1,10 +1,10 @@
 ---
 title: Activity Log
-subtitle: Track and audit changes made across your Alchemy team.
+subtitle: Track and audit changes made across your Alchemy account.
 slug: docs/account-activity-log
 ---
 
-The Activity Log is an audit trail of important changes made across your Alchemy team. It records who did what, when, and from where — so you can answer questions like "who deleted this app?", "when was this access key created?", or "which member changed our billing plan?".
+The Activity Log is an audit trail of important changes made across your Alchemy account. It records who did what, when, and from where — so you can answer questions like "who deleted this app?", "when was this access key created?", or "which member changed our billing plan?".
 
 It's available on all Alchemy accounts and lives in the [Alchemy Dashboard](https://dashboard.alchemy.com/activity-log).
 

--- a/content/tutorials/getting-started/dashboard/activity-log.mdx
+++ b/content/tutorials/getting-started/dashboard/activity-log.mdx
@@ -1,7 +1,7 @@
 ---
 title: Activity Log
 subtitle: Track and audit changes made across your Alchemy account.
-slug: docs/activity-log
+slug: activity-log
 ---
 
 The Activity Log is an audit trail of important changes made across your Alchemy account. It records who did what, when, and from where, so you can answer questions like "who deleted this app?", "when was this access key created?", or "which member changed our billing plan?".

--- a/content/tutorials/getting-started/dashboard/activity-log.mdx
+++ b/content/tutorials/getting-started/dashboard/activity-log.mdx
@@ -24,8 +24,10 @@ It lives in the [Alchemy Dashboard](https://dashboard.alchemy.com/activity-log).
 2. Navigate to [Activity Log](https://dashboard.alchemy.com/activity-log).
 
 <Info>
-  Viewing the Activity Log requires an **Admin** or **Owner** [role](/docs/dashboard-roles) on the team. Members with a Viewer or Developer role won't see it.
+	Viewing the Activity Log requires an **Admin** or **Owner** [role](/docs/dashboard-roles) on the team. Members with a Viewer or Developer role won't see it.
 </Info>
+
+![](https://alchemyapi-res.cloudinary.com/image/upload/v1780953374/docs/activity-logs-2.png)
 
 ***
 
@@ -53,16 +55,8 @@ The Activity Log captures account- and app-level changes across several categori
 * **Alerts, gas policies, and wallet activity**: creating and updating alerts, gas policies/programs, and smart-wallet sessions and signatures.
 
 <Tip>
-  For the complete, authoritative list of every logged action, see the action reference in the [OCSF Mapping](/docs/activity-log-ocsf-mapping) table, which lists each action alongside its description.
+	For the complete, authoritative list of every logged action, see the action reference in the [OCSF Mapping](/docs/activity-log-ocsf-mapping) table, which lists each action alongside its description.
 </Tip>
-
-***
-
-## Filtering and searching
-
-Use the controls above the table to narrow down entries, for example by time range, so you can quickly find the events you care about. The most recent events appear first.
-
-{/* SCREENSHOT: Activity Log filters/search controls above the table. Suggested filename: activity-log-filters.png */}
 
 ***
 
@@ -70,7 +64,7 @@ Use the controls above the table to narrow down entries, for example by time ran
 
 To pull the log into a spreadsheet or share it with your security team, click **Export** in the top-right of the page. Alchemy generates a CSV (`activity-log.csv`) containing the **Timestamp**, **Action**, **User**, **App**, **Details**, and **IP Address** for the entries in view.
 
-{/* SCREENSHOT: The Export button highlighted in the top-right of the Activity Log page. Suggested filename: activity-log-export.png */}
+![](https://alchemyapi-res.cloudinary.com/image/upload/v1780953373/docs/export-activity-log.png)
 
 ***
 
@@ -79,5 +73,5 @@ To pull the log into a spreadsheet or share it with your security team, click **
 Activity Log entries are retained for **30 days**. Export regularly, or stream events to your own systems, if you need to keep a longer history.
 
 <Note>
-  Need activity events delivered to your SIEM or log pipeline in real time? See [Webhook Subscriptions](/docs/activity-log-webhook-subscriptions) to stream events over HTTPS.
+	Need activity events delivered to your SIEM or log pipeline in real time? See [Webhook Subscriptions](/docs/activity-log-webhook-subscriptions) to stream events over HTTPS.
 </Note>


### PR DESCRIPTION
## What

Adds documentation for the dashboard **Activity Log** and its feature-flagged **Webhook Subscriptions**.

**Nav (`content/docs.yml`, Tools section):**
- **Activity Log** — new **visible** page.
- **Activity Log Webhooks** — new **hidden** section (`hidden: true`, accessible only by direct URL, same mechanism as the Admin API docs) containing **Webhook Subscriptions** and **OCSF Mapping**.

**Pages:**
| Page | Visibility | URL |
| --- | --- | --- |
| Activity Log | Visible | `/docs/account-activity-log` |
| Webhook Subscriptions | Hidden (URL-only) | `/docs/activity-log-webhook-subscriptions` |
| OCSF Mapping | Hidden (URL-only) | `/docs/activity-log-ocsf-mapping` |

## Why

The Activity Log had no docs. Webhook subscriptions are limited to teams we enable via feature flag, so — following the Admin API precedent — those pages are hidden from the public nav and reachable only by direct URL.

## Notes
- **Authentication is documented accurately:** Alchemy sends only the auth header you configure (Bearer / Basic / custom). There is **no Alchemy-generated payload signature** in v1. (Companion fix to the dashboard's "signed" UI copy: OMGWINNING/dashboard#7943.)
- **OCSF mapping** is framed as a *suggested reference*, not a contract, and covers every `ActivityType` value.
- **Screenshots:** `{/* SCREENSHOT ... */}` placeholders mark suggested spots; images are Cloudinary-hosted (no local image dir in this repo).
- Hidden pages use `docs/`-prefixed slugs so in-content cross-links match the proven sibling pattern and pass the lychee link-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)