### PR TITLE
Preview Rundler OpenRPC output

### DIFF
--- a/src/openrpc/alchemy/bundler/bundler.yaml
+++ b/src/openrpc/alchemy/bundler/bundler.yaml
@@ -3,720 +3,2167 @@
 $schema: https://meta.open-rpc.org/
 openrpc: 1.2.4
 info:
-  title: Alchemy Bundler API JSON-RPC Specification
-  description: A specification of the standard JSON-RPC methods for the Alchemy Bundler API.
+  title: Alchemy Rundler APIs JSON-RPC spec
+  description: A specification of the JSON-RPC methods exposed by Alchemy Rundler APIs.
   version: 0.0.0
 servers:
-  - url: https://eth-mainnet.g.alchemy.com/v2
-    name: Ethereum Mainnet
-  - url: https://eth-sepolia.g.alchemy.com/v2
-    name: Ethereum Sepolia
-  - url: https://anime-mainnet.g.alchemy.com/v2
-    name: Anime Mainnet
-  - url: https://anime-sepolia.g.alchemy.com/v2
-    name: Anime Sepolia
-  - url: https://apechain-mainnet.g.alchemy.com/v2
-    name: ApeChain Mainnet
-  - url: https://apechain-curtis.g.alchemy.com/v2
-    name: ApeChain Curtis
-  - url: https://arb-mainnet.g.alchemy.com/v2
-    name: Arbitrum Mainnet
-  - url: https://arb-sepolia.g.alchemy.com/v2
-    name: Arbitrum Sepolia
-  - url: https://arc-testnet.g.alchemy.com/v2
-    name: Arc Testnet
-  - url: https://base-mainnet.g.alchemy.com/v2
-    name: Base Mainnet
-  - url: https://base-sepolia.g.alchemy.com/v2
-    name: Base Sepolia
-  - url: https://berachain-mainnet.g.alchemy.com/v2
-    name: Berachain Mainnet
-  - url: https://bnb-mainnet.g.alchemy.com/v2
-    name: BNB Smart Chain Mainnet
-  - url: https://bnb-testnet.g.alchemy.com/v2
-    name: BNB Smart Chain Testnet
-  - url: https://celo-mainnet.g.alchemy.com/v2
-    name: Celo Mainnet
-  - url: https://celo-sepolia.g.alchemy.com/v2
-    name: Celo Sepolia
-  - url: https://frax-mainnet.g.alchemy.com/v2
-    name: Frax Mainnet
-  - url: https://gensyn-mainnet.g.alchemy.com/v2
-    name: Gensyn Mainnet
-  - url: https://gensyn-testnet.g.alchemy.com/v2
-    name: Gensyn Testnet
-  - url: https://hyperliquid-mainnet.g.alchemy.com/v2
-    name: Hyperliquid Mainnet
-  - url: https://hyperliquid-testnet.g.alchemy.com/v2
-    name: Hyperliquid Testnet
-  - url: https://ink-mainnet.g.alchemy.com/v2
-    name: Ink Mainnet
-  - url: https://ink-sepolia.g.alchemy.com/v2
-    name: Ink Sepolia
-  - url: https://polygon-mainnet.g.alchemy.com/v2
-    name: Polygon Mainnet
-  - url: https://polygon-amoy.g.alchemy.com/v2
-    name: Polygon Amoy
-  - url: https://megaeth-mainnet.g.alchemy.com/v2
-    name: MegaETH Mainnet
-  - url: https://megaeth-testnet.g.alchemy.com/v2
-    name: MegaETH Testnet
-  - url: https://monad-mainnet.g.alchemy.com/v2
-    name: Monad Mainnet
-  - url: https://monad-testnet.g.alchemy.com/v2
-    name: Monad Testnet
-  - url: https://mythos-mainnet.g.alchemy.com/v2
-    name: Mythos Mainnet
-  - url: https://opbnb-mainnet.g.alchemy.com/v2
-    name: opBNB Mainnet
-  - url: https://opbnb-testnet.g.alchemy.com/v2
-    name: opBNB Testnet
-  - url: https://opt-mainnet.g.alchemy.com/v2
-    name: OP Mainnet Mainnet
-  - url: https://opt-sepolia.g.alchemy.com/v2
-    name: OP Mainnet Sepolia
-  - url: https://plasma-mainnet.g.alchemy.com/v2
-    name: Plasma Mainnet
-  - url: https://plasma-testnet.g.alchemy.com/v2
-    name: Plasma Testnet
-  - url: https://rise-testnet.g.alchemy.com/v2
-    name: Rise Testnet
-  - url: https://robinhood-testnet.g.alchemy.com/v2
-    name: Robinhood Chain Testnet
-  - url: https://shape-mainnet.g.alchemy.com/v2
-    name: Shape Mainnet
-  - url: https://shape-sepolia.g.alchemy.com/v2
-    name: Shape Sepolia
-  - url: https://solana-mainnet.g.alchemy.com/v2
-    name: Solana Mainnet
-  - url: https://solana-devnet.g.alchemy.com/v2
-    name: Solana Devnet
-  - url: https://soneium-mainnet.g.alchemy.com/v2
-    name: Soneium Mainnet
-  - url: https://soneium-minato.g.alchemy.com/v2
-    name: Soneium Minato
-  - url: https://stable-mainnet.g.alchemy.com/v2
-    name: Stable Mainnet
-  - url: https://stable-testnet.g.alchemy.com/v2
-    name: Stable Testnet
-  - url: https://story-mainnet.g.alchemy.com/v2
-    name: Story Mainnet
-  - url: https://story-aeneid.g.alchemy.com/v2
-    name: Story Aeneid
-  - url: https://unichain-mainnet.g.alchemy.com/v2
-    name: Unichain Mainnet
-  - url: https://unichain-sepolia.g.alchemy.com/v2
-    name: Unichain Sepolia
-  - url: https://worldchain-mainnet.g.alchemy.com/v2
-    name: World Chain Mainnet
-  - url: https://worldchain-sepolia.g.alchemy.com/v2
-    name: World Chain Sepolia
-  - url: https://xlayer-mainnet.g.alchemy.com/v2
-    name: X Layer Mainnet
-  - url: https://xlayer-testnet.g.alchemy.com/v2
-    name: X Layer Testnet
-  - url: https://zora-mainnet.g.alchemy.com/v2
-    name: Zora Mainnet
-  - url: https://zora-sepolia.g.alchemy.com/v2
-    name: Zora Sepolia
+  - url: "https://eth-mainnet.g.alchemy.com/v2"
+    name: "Ethereum Mainnet"
+  - url: "https://eth-sepolia.g.alchemy.com/v2"
+    name: "Ethereum Sepolia"
+  - url: "https://anime-mainnet.g.alchemy.com/v2"
+    name: "Anime Mainnet"
+  - url: "https://anime-sepolia.g.alchemy.com/v2"
+    name: "Anime Sepolia"
+  - url: "https://apechain-mainnet.g.alchemy.com/v2"
+    name: "ApeChain Mainnet"
+  - url: "https://apechain-curtis.g.alchemy.com/v2"
+    name: "ApeChain Curtis"
+  - url: "https://arb-mainnet.g.alchemy.com/v2"
+    name: "Arbitrum Mainnet"
+  - url: "https://arb-sepolia.g.alchemy.com/v2"
+    name: "Arbitrum Sepolia"
+  - url: "https://arc-testnet.g.alchemy.com/v2"
+    name: "Arc Testnet"
+  - url: "https://base-mainnet.g.alchemy.com/v2"
+    name: "Base Mainnet"
+  - url: "https://base-sepolia.g.alchemy.com/v2"
+    name: "Base Sepolia"
+  - url: "https://berachain-mainnet.g.alchemy.com/v2"
+    name: "Berachain Mainnet"
+  - url: "https://bnb-mainnet.g.alchemy.com/v2"
+    name: "BNB Smart Chain Mainnet"
+  - url: "https://bnb-testnet.g.alchemy.com/v2"
+    name: "BNB Smart Chain Testnet"
+  - url: "https://celo-mainnet.g.alchemy.com/v2"
+    name: "Celo Mainnet"
+  - url: "https://celo-sepolia.g.alchemy.com/v2"
+    name: "Celo Sepolia"
+  - url: "https://gensyn-mainnet.g.alchemy.com/v2"
+    name: "Gensyn Mainnet"
+  - url: "https://gensyn-testnet.g.alchemy.com/v2"
+    name: "Gensyn Testnet"
+  - url: "https://hyperliquid-mainnet.g.alchemy.com/v2"
+    name: "Hyperliquid Mainnet"
+  - url: "https://hyperliquid-testnet.g.alchemy.com/v2"
+    name: "Hyperliquid Testnet"
+  - url: "https://ink-mainnet.g.alchemy.com/v2"
+    name: "Ink Mainnet"
+  - url: "https://ink-sepolia.g.alchemy.com/v2"
+    name: "Ink Sepolia"
+  - url: "https://megaeth-mainnet.g.alchemy.com/v2"
+    name: "MegaETH Mainnet"
+  - url: "https://megaeth-testnet.g.alchemy.com/v2"
+    name: "MegaETH Testnet"
+  - url: "https://monad-mainnet.g.alchemy.com/v2"
+    name: "Monad Mainnet"
+  - url: "https://monad-testnet.g.alchemy.com/v2"
+    name: "Monad Testnet"
+  - url: "https://mythos-mainnet.g.alchemy.com/v2"
+    name: "Mythos Mainnet"
+  - url: "https://opbnb-mainnet.g.alchemy.com/v2"
+    name: "opBNB Mainnet"
+  - url: "https://opbnb-testnet.g.alchemy.com/v2"
+    name: "opBNB Testnet"
+  - url: "https://opt-mainnet.g.alchemy.com/v2"
+    name: "OP Mainnet Mainnet"
+  - url: "https://opt-sepolia.g.alchemy.com/v2"
+    name: "OP Mainnet Sepolia"
+  - url: "https://plasma-mainnet.g.alchemy.com/v2"
+    name: "Plasma Mainnet"
+  - url: "https://plasma-testnet.g.alchemy.com/v2"
+    name: "Plasma Testnet"
+  - url: "https://polygon-mainnet.g.alchemy.com/v2"
+    name: "Polygon Mainnet"
+  - url: "https://polygon-amoy.g.alchemy.com/v2"
+    name: "Polygon Amoy"
+  - url: "https://robinhood-testnet.g.alchemy.com/v2"
+    name: "Robinhood Chain Testnet"
+  - url: "https://shape-mainnet.g.alchemy.com/v2"
+    name: "Shape Mainnet"
+  - url: "https://shape-sepolia.g.alchemy.com/v2"
+    name: "Shape Sepolia"
+  - url: "https://soneium-mainnet.g.alchemy.com/v2"
+    name: "Soneium Mainnet"
+  - url: "https://soneium-minato.g.alchemy.com/v2"
+    name: "Soneium Minato"
+  - url: "https://stable-mainnet.g.alchemy.com/v2"
+    name: "Stable Mainnet"
+  - url: "https://stable-testnet.g.alchemy.com/v2"
+    name: "Stable Testnet"
+  - url: "https://story-mainnet.g.alchemy.com/v2"
+    name: "Story Mainnet"
+  - url: "https://story-aeneid.g.alchemy.com/v2"
+    name: "Story Aeneid"
+  - url: "https://unichain-mainnet.g.alchemy.com/v2"
+    name: "Unichain Mainnet"
+  - url: "https://unichain-sepolia.g.alchemy.com/v2"
+    name: "Unichain Sepolia"
+  - url: "https://worldchain-mainnet.g.alchemy.com/v2"
+    name: "World Chain Mainnet"
+  - url: "https://worldchain-sepolia.g.alchemy.com/v2"
+    name: "World Chain Sepolia"
+  - url: "https://xlayer-mainnet.g.alchemy.com/v2"
+    name: "X Layer Mainnet"
+  - url: "https://xlayer-testnet.g.alchemy.com/v2"
+    name: "X Layer Testnet"
+  - url: "https://zora-mainnet.g.alchemy.com/v2"
+    name: "Zora Mainnet"
+  - url: "https://zora-sepolia.g.alchemy.com/v2"
+    name: "Zora Sepolia"
 methods:
-  - name: rundler_maxPriorityFeePerGas
-    description: Returns a fee per gas that is an estimate of how much users should set as a priority fee in userOperations for Rundler endpoints.
+  - name: eth_sendUserOperation
+    description: "Sends a `UserOperation` to the given EVM network."
+    x-compute-units: 1000
+    x-rate-limit-cus: 100
+    x-compute-units-variants:
+      bso:
+        compute-units: 3000
+        rate-limit-cus: 100
+    params:
+      - name: "UserOperation"
+        required: true
+        description: "The UserOperation object. This can be a v0.6, v0.7, or v0.8 user operation, but MUST match the version of the entry point at the address of the second parameter."
+        schema:
+          anyOf:
+            - type: "object"
+              required:
+                - "sender"
+                - "nonce"
+                - "initCode"
+                - "callData"
+                - "callGasLimit"
+                - "verificationGasLimit"
+                - "preVerificationGas"
+                - "maxFeePerGas"
+                - "maxPriorityFeePerGas"
+                - "paymasterAndData"
+                - "signature"
+              properties:
+                sender:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "The account sending the userOperation."
+                nonce:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "Anti-replay parameter; also used as the salt for first-time account creation."
+                initCode:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "The initCode of the account (needed if and only if the account is not yet on-chain and needs to be created)."
+                callData:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "Encoded data for executing the primary function call or operation within the user's transaction, such as calling a smart contract function or transferring tokens. This data is passed to the sender's address during the execution of the userOperation."
+                callGasLimit:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "The amount of gas to allocate for the main execution call."
+                verificationGasLimit:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "The amount of gas to allocate for the verification step."
+                preVerificationGas:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "The amount of gas to compensate the bundler for pre-verification execution and calldata."
+                maxFeePerGas:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "The maximum fee per gas to pay for the execution of this operation (similar to EIP-1559 max_fee_per_gas)."
+                maxPriorityFeePerGas:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "Maximum priority fee per gas (similar to EIP-1559 max_priority_fee_per_gas)."
+                paymasterAndData:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "Address of paymaster sponsoring the transaction, followed by extra data to send to the paymaster (empty for self-sponsored transaction)."
+                signature:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "Data passed into the account along with the nonce during the verification step."
+                eip7702Auth:
+                  type: "object"
+                  required:
+                    - "chainId"
+                    - "nonce"
+                    - "address"
+                    - "yParity"
+                    - "r"
+                    - "s"
+                  properties:
+                    chainId:
+                      type: "string"
+                      pattern: "^(0x)[\\s\\S]{0,}$"
+                    nonce:
+                      type: "string"
+                      pattern: "^(0x)[\\s\\S]{0,}$"
+                    address:
+                      type: "string"
+                      pattern: "^(0x)[\\s\\S]{0,}$"
+                    yParity:
+                      type: "string"
+                      pattern: "^(0x)[\\s\\S]{0,}$"
+                    r:
+                      type: "string"
+                      pattern: "^(0x)[\\s\\S]{0,}$"
+                    s:
+                      type: "string"
+                      pattern: "^(0x)[\\s\\S]{0,}$"
+                  additionalProperties: {}
+                aggregator:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+              additionalProperties: {}
+            - type: "object"
+              required:
+                - "sender"
+                - "nonce"
+                - "callData"
+                - "callGasLimit"
+                - "verificationGasLimit"
+                - "preVerificationGas"
+                - "maxFeePerGas"
+                - "maxPriorityFeePerGas"
+                - "signature"
+              properties:
+                sender:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "The account sending the userOperation."
+                nonce:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "Anti-replay parameter; also used as the salt for first-time account creation."
+                factory:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "The account factory address (needed if and only if the account is not yet on-chain and needs to be created)."
+                factoryData:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "Data for the account factory (only if the account factory exists)."
+                callData:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "Encoded data for executing the primary function call or operation within the user's transaction, such as calling a smart contract function or transferring tokens. This data is passed to the sender's address during the execution of the userOperation."
+                callGasLimit:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "The amount of gas to allocate for the main execution call."
+                verificationGasLimit:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "The amount of gas to allocate for the verification step."
+                preVerificationGas:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "The amount of gas to compensate the bundler for pre-verification execution and calldata."
+                maxFeePerGas:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "The maximum fee per gas to pay for the execution of this operation (similar to EIP-1559 max_fee_per_gas)."
+                maxPriorityFeePerGas:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "Maximum priority fee per gas (similar to EIP-1559 max_priority_fee_per_gas)."
+                paymaster:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "Address of the paymaster contract (or empty, if the account pays for itself)."
+                paymasterVerificationGasLimit:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "The amount of gas to allocate for the paymaster validation code (only if a paymaster exists)."
+                paymasterPostOpGasLimit:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "The amount of gas to allocate for the paymaster post-op code (only if a paymaster exists)."
+                paymasterData:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "Data for the paymaster (only if the paymaster exists)."
+                signature:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "Data passed into the account along with the nonce during the verification step."
+                eip7702Auth:
+                  type: "object"
+                  required:
+                    - "chainId"
+                    - "nonce"
+                    - "address"
+                    - "yParity"
+                    - "r"
+                    - "s"
+                  properties:
+                    chainId:
+                      type: "string"
+                      pattern: "^(0x)[\\s\\S]{0,}$"
+                    nonce:
+                      type: "string"
+                      pattern: "^(0x)[\\s\\S]{0,}$"
+                    address:
+                      type: "string"
+                      pattern: "^(0x)[\\s\\S]{0,}$"
+                    yParity:
+                      type: "string"
+                      pattern: "^(0x)[\\s\\S]{0,}$"
+                    r:
+                      type: "string"
+                      pattern: "^(0x)[\\s\\S]{0,}$"
+                    s:
+                      type: "string"
+                      pattern: "^(0x)[\\s\\S]{0,}$"
+                  additionalProperties: {}
+                aggregator:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+              additionalProperties: {}
+
+      - name: "Entrypoint address"
+        required: true
+        description: "The EntryPoint address the request should be sent through. This MUST be one of the EntryPoints returned by the `supportedEntryPoints` RPC call."
+        schema:
+          type: "string"
+          pattern: "^(0x)[\\s\\S]{0,}$"
+
+    result:
+      name: "userOpHash"
+      description: "The calculated `userOpHash` for the `UserOperation`."
+      schema:
+        type: "string"
+        pattern: "^(0x)[\\s\\S]{0,}$"
+
+    examples:
+      - name: "eth_sendUserOperation example"
+        params:
+          - name: "param0"
+            value:
+              sender: "0x1111111111111111111111111111111111111111"
+              nonce: "0x1"
+              factory: "0x5555555555555555555555555555555555555555"
+              factoryData: "0x1234"
+              callData: "0x"
+              callGasLimit: "0x5208"
+              verificationGasLimit: "0x186a0"
+              preVerificationGas: "0x7530"
+              maxFeePerGas: "0x59682f00"
+              maxPriorityFeePerGas: "0x59682f"
+              paymaster: "0x0000000000000000000000000000000000000000"
+              paymasterVerificationGasLimit: "0x7530"
+              paymasterPostOpGasLimit: "0x5208"
+              paymasterData: "0x"
+              signature: "0x"
+          - name: "param1"
+            value: "0x0000000071727De22E5E9d8BAf0edAc6f37da032"
+        result:
+          name: "Response"
+          value: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+  - name: eth_estimateUserOperationGas
+    description: "Estimates the gas values for a `UserOperation`.\n\n<Note>\n  This endpoint requires a dummy signature in the `userOp`. Check our [FAQs](/docs/reference/bundler-faqs#what-is-a-dummy-signature) to learn what a dummy signature is.\n</Note>\n"
+    x-compute-units: 500
+    x-rate-limit-cus: 50
+    params:
+      - name: "UserOperation"
+        required: true
+        description: "Contains gas limits and prices (optional). This can be a v0.6, v0.7, or v0.8 userOperation but must match the version of the `EntryPoint` at the address of the second parameter."
+        schema:
+          anyOf:
+            - type: "object"
+              required:
+                - "sender"
+                - "nonce"
+                - "initCode"
+                - "callData"
+                - "paymasterAndData"
+                - "signature"
+              properties:
+                sender:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "The account sending the userOperation."
+                nonce:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "Anti-replay parameter; also used as the salt for first-time account creation."
+                initCode:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "The initCode of the account (needed if and only if the account is not yet on-chain and needs to be created)."
+                callData:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "Encoded data for executing the primary function call or operation within the user's transaction, such as calling a smart contract function or transferring tokens. This data is passed to the sender's address during the execution of the userOperation."
+                callGasLimit:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "The amount of gas to allocate for the main execution call."
+                verificationGasLimit:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "The amount of gas to allocate for the verification step."
+                preVerificationGas:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "The amount of gas to compensate the bundler for pre-verification execution and calldata."
+                maxFeePerGas:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "The maximum fee per gas to pay for the execution of this operation (similar to EIP-1559 max_fee_per_gas)."
+                maxPriorityFeePerGas:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "Maximum priority fee per gas (similar to EIP-1559 max_priority_fee_per_gas)."
+                paymasterAndData:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "Address of paymaster sponsoring the transaction, followed by extra data to send to the paymaster (empty for self-sponsored transaction)."
+                signature:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "Data passed into the account along with the nonce during the verification step."
+                eip7702Auth:
+                  type: "object"
+                  required:
+                    - "chainId"
+                    - "nonce"
+                    - "address"
+                    - "yParity"
+                    - "r"
+                    - "s"
+                  properties:
+                    chainId:
+                      type: "string"
+                      pattern: "^(0x)[\\s\\S]{0,}$"
+                    nonce:
+                      type: "string"
+                      pattern: "^(0x)[\\s\\S]{0,}$"
+                    address:
+                      type: "string"
+                      pattern: "^(0x)[\\s\\S]{0,}$"
+                    yParity:
+                      type: "string"
+                      pattern: "^(0x)[\\s\\S]{0,}$"
+                    r:
+                      type: "string"
+                      pattern: "^(0x)[\\s\\S]{0,}$"
+                    s:
+                      type: "string"
+                      pattern: "^(0x)[\\s\\S]{0,}$"
+                  additionalProperties: {}
+                aggregator:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+              additionalProperties: {}
+            - type: "object"
+              required:
+                - "sender"
+                - "nonce"
+                - "callData"
+                - "signature"
+              properties:
+                sender:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "The account sending the userOperation."
+                nonce:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "Anti-replay parameter; also used as the salt for first-time account creation."
+                factory:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "The account factory address (needed if and only if the account is not yet on-chain and needs to be created)."
+                factoryData:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "Data for the account factory (only if the account factory exists)."
+                callData:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "Encoded data for executing the primary function call or operation within the user's transaction, such as calling a smart contract function or transferring tokens. This data is passed to the sender's address during the execution of the userOperation."
+                callGasLimit:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "The amount of gas to allocate for the main execution call."
+                verificationGasLimit:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "The amount of gas to allocate for the verification step."
+                preVerificationGas:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "The amount of gas to compensate the bundler for pre-verification execution and calldata."
+                maxFeePerGas:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "The maximum fee per gas to pay for the execution of this operation (similar to EIP-1559 max_fee_per_gas)."
+                maxPriorityFeePerGas:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "Maximum priority fee per gas (similar to EIP-1559 max_priority_fee_per_gas)."
+                paymaster:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "Address of the paymaster contract (or empty, if the account pays for itself)."
+                paymasterVerificationGasLimit:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "The amount of gas to allocate for the paymaster validation code (only if a paymaster exists)."
+                paymasterPostOpGasLimit:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "The amount of gas to allocate for the paymaster post-op code (only if a paymaster exists)."
+                paymasterData:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "Data for the paymaster (only if the paymaster exists)."
+                signature:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "Data passed into the account along with the nonce during the verification step."
+                eip7702Auth:
+                  type: "object"
+                  required:
+                    - "chainId"
+                    - "nonce"
+                    - "address"
+                    - "yParity"
+                    - "r"
+                    - "s"
+                  properties:
+                    chainId:
+                      type: "string"
+                      pattern: "^(0x)[\\s\\S]{0,}$"
+                    nonce:
+                      type: "string"
+                      pattern: "^(0x)[\\s\\S]{0,}$"
+                    address:
+                      type: "string"
+                      pattern: "^(0x)[\\s\\S]{0,}$"
+                    yParity:
+                      type: "string"
+                      pattern: "^(0x)[\\s\\S]{0,}$"
+                    r:
+                      type: "string"
+                      pattern: "^(0x)[\\s\\S]{0,}$"
+                    s:
+                      type: "string"
+                      pattern: "^(0x)[\\s\\S]{0,}$"
+                  additionalProperties: {}
+                aggregator:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+              additionalProperties: {}
+
+      - name: "entryPoint"
+        required: true
+        description: "The address to which the request should be sent. This must be one of the `EntryPoint` returned by the `supportedEntryPoints` method and should match the version of the `userOp` in the first parameter."
+        schema:
+          type: "string"
+          pattern: "^(0x)[\\s\\S]{0,}$"
+
+      - name: "stateOverrideSet"
+        required: false
+        description: "Allows changes to the state of a contract before executing the call. For example, you can modify variable values (like balances or approvals) for that call without changing the contract itself on the blockchain.\n\nIn more technical terms, the state override set is an optional parameter that allows executing the call against a modified chain state. It is an address-to-state mapping, where each entry specifies some state to be overridden prior to executing the call."
+        schema:
+          type: "object"
+          additionalProperties:
+            type: "object"
+            properties:
+              balance:
+                type: "string"
+                pattern: "^(0x)[\\s\\S]{0,}$"
+                description: "Fake balance to set for the account before executing the call (<= 32 bytes)"
+              nonce:
+                type: "string"
+                pattern: "^(0x)[\\s\\S]{0,}$"
+                description: "Fake nonce to set for the account before executing the call (<= 8 bytes)."
+              code:
+                type: "string"
+                pattern: "^(0x)[\\s\\S]{0,}$"
+                description: "Fake EVM bytecode to inject into the account before executing the call."
+              state:
+                type: "object"
+                properties: {}
+                additionalProperties: {}
+                description: "Fake key-value mapping to override all slots in the account storage before executing the call."
+              stateDiff:
+                type: "object"
+                properties: {}
+                additionalProperties: {}
+                description: "Fake key-value mapping to override individual slots in the account storage before executing the call."
+            additionalProperties: {}
+          propertyNames:
+            type: "string"
+            pattern: "^(0x)[\\s\\S]{0,}$"
+
+    result:
+      name: "Gas estimation"
+      description: "Gas values estimated for the userOperation."
+      schema:
+        type: "object"
+        required:
+          - "preVerificationGas"
+          - "verificationGasLimit"
+          - "callGasLimit"
+        properties:
+          preVerificationGas:
+            type: "string"
+            pattern: "^(0x)[\\s\\S]{0,}$"
+            description: "Gas overhead of this userOperation."
+          verificationGasLimit:
+            type: "string"
+            pattern: "^(0x)[\\s\\S]{0,}$"
+            description: "Actual gas used by the validation of this userOperation."
+          callGasLimit:
+            type: "string"
+            pattern: "^(0x)[\\s\\S]{0,}$"
+            description: "Value used by inner account execution."
+          paymasterVerificationGasLimit:
+            type: "string"
+            pattern: "^(0x)[\\s\\S]{0,}$"
+            description: "Value used by the paymaster during verification."
+          paymasterPostOpGasLimit:
+            type: "string"
+            pattern: "^(0x)[\\s\\S]{0,}$"
+            description: "Value used by the paymaster during post-operation execution."
+        additionalProperties: {}
+
+    examples:
+      - name: "eth_estimateUserOperationGas example"
+        params:
+          - name: "param0"
+            value:
+              sender: "0x1111111111111111111111111111111111111111"
+              nonce: "0x1"
+              factory: "0x5555555555555555555555555555555555555555"
+              factoryData: "0x1234"
+              callData: "0x"
+              callGasLimit: "0x5208"
+              verificationGasLimit: "0x186a0"
+              preVerificationGas: "0x7530"
+              maxFeePerGas: "0x59682f00"
+              maxPriorityFeePerGas: "0x59682f"
+              paymaster: "0x0000000000000000000000000000000000000000"
+              paymasterVerificationGasLimit: "0x7530"
+              paymasterPostOpGasLimit: "0x5208"
+              paymasterData: "0x"
+              signature: "0x"
+          - name: "param1"
+            value: "0x0000000071727De22E5E9d8BAf0edAc6f37da032"
+        result:
+          name: "Response"
+          value:
+            preVerificationGas: "0x7530"
+            verificationGasLimit: "0x186a0"
+            callGasLimit: "0x5208"
+            paymasterVerificationGasLimit: "0x7530"
+            paymasterPostOpGasLimit: "0x5208"
+
+  - name: eth_getUserOperationByHash
+    description: "Return a `UserOperation` based on a `userOpHash`.\n\n<Note title=\"Limitations\">\n  This method retrieves and decodes userOperations from the logs of mined transactions by querying the node. If you attempt to fetch a userOperation from a distant past block, the request may be rejected by the node due to limitations on the block range size it can process.\n\n  The default range we support is 150 blocks, however the following networks have an unlimited range.\n\n  - Ethereum\n  - Polygon\n  - Base\n  - Optimism\n  - Worldchain\n  - Arbitrum\n</Note>\n"
+    x-compute-units: 20
+    params:
+      - name: "userOpHash"
+        required: true
+        description: "The `userOpHash` of the `UserOperation` to retrieve."
+        schema:
+          type: "string"
+          pattern: "^(0x)[\\s\\S]{0,}$"
+
+    result:
+      name: "UserOperation"
+      description: "The `UserOperation` object."
+      schema:
+        anyOf:
+          - type: "object"
+            required:
+              - "blockHash"
+              - "blockNumber"
+              - "entryPoint"
+              - "transactionHash"
+              - "userOperation"
+            properties:
+              blockHash:
+                type: "string"
+                pattern: "^(0x)[\\s\\S]{0,}$"
+                description: "Block hash of the block containing `UserOperation`."
+              blockNumber:
+                type: "string"
+                pattern: "^(0x)[\\s\\S]{0,}$"
+                description: "Block number in which `UserOperation` is included."
+              entryPoint:
+                type: "string"
+                pattern: "^(0x)[\\s\\S]{0,}$"
+                description: "Address of the EntryPoint contract."
+              transactionHash:
+                type: "string"
+                pattern: "^(0x)[\\s\\S]{0,}$"
+                description: "Transaction hash of the `UserOperation`."
+              userOperation:
+                anyOf:
+                  - type: "object"
+                    required:
+                      - "sender"
+                      - "nonce"
+                      - "callData"
+                      - "callGasLimit"
+                      - "verificationGasLimit"
+                      - "preVerificationGas"
+                      - "maxFeePerGas"
+                      - "maxPriorityFeePerGas"
+                      - "signature"
+                    properties:
+                      sender:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "The account sending the userOperation."
+                      nonce:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "Anti-replay parameter; also used as the salt for first-time account creation."
+                      initCode:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "The initCode of the account (needed if and only if the account is not yet on-chain and needs to be created)."
+                      callData:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "Encoded data for executing the primary function call or operation within the user's transaction, such as calling a smart contract function or transferring tokens. This data is passed to the sender's address during the execution of the userOperation."
+                      callGasLimit:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "The amount of gas to allocate for the main execution call."
+                      verificationGasLimit:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "The amount of gas to allocate for the verification step."
+                      preVerificationGas:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "The amount of gas to compensate the bundler for pre-verification execution and calldata."
+                      maxFeePerGas:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "The maximum fee per gas to pay for the execution of this operation (similar to EIP-1559 max_fee_per_gas)."
+                      maxPriorityFeePerGas:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "Maximum priority fee per gas (similar to EIP-1559 max_priority_fee_per_gas)."
+                      paymasterAndData:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "Address of paymaster sponsoring the transaction, followed by extra data to send to the paymaster (empty for self-sponsored transaction)."
+                      signature:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "Data passed into the account along with the nonce during the verification step."
+                      eip7702Auth:
+                        type: "object"
+                        required:
+                          - "chainId"
+                          - "nonce"
+                          - "address"
+                          - "yParity"
+                          - "r"
+                          - "s"
+                        properties:
+                          chainId:
+                            type: "string"
+                            pattern: "^(0x)[\\s\\S]{0,}$"
+                          nonce:
+                            type: "string"
+                            pattern: "^(0x)[\\s\\S]{0,}$"
+                          address:
+                            type: "string"
+                            pattern: "^(0x)[\\s\\S]{0,}$"
+                          yParity:
+                            type: "string"
+                            pattern: "^(0x)[\\s\\S]{0,}$"
+                          r:
+                            type: "string"
+                            pattern: "^(0x)[\\s\\S]{0,}$"
+                          s:
+                            type: "string"
+                            pattern: "^(0x)[\\s\\S]{0,}$"
+                        additionalProperties: {}
+                      aggregator:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                      entryPoint:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "Address of the EntryPoint contract."
+                      blockNumber:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "Block number in which `UserOperation` is included."
+                      blockHash:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "Block hash of the block containing `UserOperation`."
+                      transactionHash:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "Transaction hash of the `UserOperation`."
+                    additionalProperties: {}
+                    title: "Entrypoint v0.6 Response"
+                  - type: "object"
+                    required:
+                      - "sender"
+                      - "nonce"
+                      - "callData"
+                      - "callGasLimit"
+                      - "verificationGasLimit"
+                      - "preVerificationGas"
+                      - "maxFeePerGas"
+                      - "maxPriorityFeePerGas"
+                      - "signature"
+                    properties:
+                      sender:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "The account sending the userOperation."
+                      nonce:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "Anti-replay parameter; also used as the salt for first-time account creation."
+                      factory:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "The account factory address (needed if and only if the account is not yet on-chain and needs to be created)."
+                      factoryData:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "Data for the account factory (only if the account factory exists)."
+                      callData:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "Encoded data for executing the primary function call or operation within the user's transaction, such as calling a smart contract function or transferring tokens. This data is passed to the sender's address during the execution of the userOperation."
+                      callGasLimit:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "The amount of gas to allocate for the main execution call."
+                      verificationGasLimit:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "The amount of gas to allocate for the verification step."
+                      preVerificationGas:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "The amount of gas to compensate the bundler for pre-verification execution and calldata."
+                      maxFeePerGas:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "The maximum fee per gas to pay for the execution of this operation (similar to EIP-1559 max_fee_per_gas)."
+                      maxPriorityFeePerGas:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "Maximum priority fee per gas (similar to EIP-1559 max_priority_fee_per_gas)."
+                      paymaster:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "Address of the paymaster contract (or empty, if the account pays for itself)."
+                      paymasterVerificationGasLimit:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "The amount of gas to allocate for the paymaster validation code (only if a paymaster exists)."
+                      paymasterPostOpGasLimit:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "The amount of gas to allocate for the paymaster post-op code (only if a paymaster exists)."
+                      paymasterData:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "Data for the paymaster (only if the paymaster exists)."
+                      signature:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "Data passed into the account along with the nonce during the verification step."
+                      eip7702Auth:
+                        type: "object"
+                        required:
+                          - "chainId"
+                          - "nonce"
+                          - "address"
+                          - "yParity"
+                          - "r"
+                          - "s"
+                        properties:
+                          chainId:
+                            type: "string"
+                            pattern: "^(0x)[\\s\\S]{0,}$"
+                          nonce:
+                            type: "string"
+                            pattern: "^(0x)[\\s\\S]{0,}$"
+                          address:
+                            type: "string"
+                            pattern: "^(0x)[\\s\\S]{0,}$"
+                          yParity:
+                            type: "string"
+                            pattern: "^(0x)[\\s\\S]{0,}$"
+                          r:
+                            type: "string"
+                            pattern: "^(0x)[\\s\\S]{0,}$"
+                          s:
+                            type: "string"
+                            pattern: "^(0x)[\\s\\S]{0,}$"
+                        additionalProperties: {}
+                      aggregator:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                      entryPoint:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "Address of the EntryPoint contract."
+                      blockNumber:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "Block number in which `UserOperation` is included."
+                      blockHash:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "Block hash of the block containing `UserOperation`."
+                      transactionHash:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "Transaction hash of the `UserOperation`."
+                    additionalProperties: {}
+                    title: "Entrypoint v0.7 / v0.8 Response"
+                description: "The `UserOperation` object."
+            additionalProperties: {}
+          - type: "null"
+
+    examples:
+      - name: "eth_getUserOperationByHash example"
+        params:
+          - name: "param0"
+            value: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        result:
+          name: "Response"
+          value:
+            blockHash: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+            blockNumber: "0x12a3b4c"
+            entryPoint: "0x0000000071727De22E5E9d8BAf0edAc6f37da032"
+            transactionHash: "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+            userOperation:
+              sender: "0x1111111111111111111111111111111111111111"
+              nonce: "0x1"
+              factory: "0x5555555555555555555555555555555555555555"
+              factoryData: "0x1234"
+              callData: "0x"
+              callGasLimit: "0x5208"
+              verificationGasLimit: "0x186a0"
+              preVerificationGas: "0x7530"
+              maxFeePerGas: "0x59682f00"
+              maxPriorityFeePerGas: "0x59682f"
+              paymaster: "0x0000000000000000000000000000000000000000"
+              paymasterVerificationGasLimit: "0x7530"
+              paymasterPostOpGasLimit: "0x5208"
+              paymasterData: "0x"
+              signature: "0x"
+
+  - name: eth_getUserOperationReceipt
+    description: "Get the `UserOperationReceipt` based on the `userOpHash`.\n\n<Note title=\"Limitations\">\n  This method retrieves and decodes userOperations from the logs of mined transactions by querying the node. If you attempt to fetch a receipt for a transaction from a distant past block, the request may be rejected by the node due to limitations on the block range size it can process.\n\n  The default range we support is 150 blocks, however the following networks have an unlimited range.\n\n  - Ethereum\n  - Polygon\n  - Base\n  - Optimism\n  - Worldchain\n  - Arbitrum\n</Note>\n"
+    x-compute-units: 20
+    params:
+      - name: "userOpHash"
+        required: true
+        description: "The `userOpHash` of the `UserOperation` to get the receipt for (as returned by `eth_sendUserOperation`)."
+        schema:
+          type: "string"
+          pattern: "^(0x)[\\s\\S]{0,}$"
+
+      - name: "tag"
+        required: false
+        description: 'The blocktag for checking the UO status. "pending" or "latest". Defaults to "latest".'
+        schema:
+          type: "string"
+          enum:
+            - "pending"
+            - "latest"
+
+    result:
+      name: "UserOperationReceipt"
+      description: "`UserOperationReceipt` object representing the outcome of a `UserOperation`."
+      schema:
+        anyOf:
+          - type: "object"
+            required:
+              - "userOpHash"
+              - "entryPoint"
+              - "sender"
+              - "nonce"
+              - "actualGasCost"
+              - "actualGasUsed"
+              - "success"
+              - "logs"
+              - "receipt"
+            properties:
+              userOpHash:
+                type: "string"
+                pattern: "^(0x)[\\s\\S]{0,}$"
+                description: "The hash of the `UserOperation`."
+              entryPoint:
+                type: "string"
+                pattern: "^(0x)[\\s\\S]{0,}$"
+                description: "The EntryPoint address the request should be sent through. This MUST be one of the EntryPoints returned by the `supportedEntryPoints` RPC call."
+              sender:
+                type: "string"
+                pattern: "^(0x)[\\s\\S]{0,}$"
+                description: "The account initiating the `UserOperation`."
+              nonce:
+                type: "string"
+                pattern: "^(0x)[\\s\\S]{0,}$"
+                description: "The nonce used in the `UserOperation`."
+              paymaster:
+                type: "string"
+                pattern: "^(0x)[\\s\\S]{0,}$"
+                description: "The paymaster used for this `UserOperation` (or empty if self-sponsored)."
+              actualGasCost:
+                type: "string"
+                pattern: "^(0x)[\\s\\S]{0,}$"
+                description: "The actual amount paid (by account or paymaster) for this `UserOperation`."
+              actualGasUsed:
+                type: "string"
+                pattern: "^(0x)[\\s\\S]{0,}$"
+                description: "The total gas used by this `UserOperation` (including `preVerification`, `creation`, `validation`, and `execution`)."
+              success:
+                type: "boolean"
+                description: "Indicates whether the execution completed without reverting."
+              reason:
+                type: "string"
+                description: "In case of revert, this is the revert reason."
+              logs:
+                type: "array"
+                items:
+                  type: "object"
+                  required:
+                    - "address"
+                    - "topics"
+                    - "data"
+                  properties:
+                    address:
+                      type: "string"
+                      pattern: "^(0x)[\\s\\S]{0,}$"
+                      description: "20 Bytes - address from which this userOperation log originated."
+                    topics:
+                      type: "array"
+                      items:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                      description: "Array of indexed log argument topics for this userOperation log."
+                    data:
+                      type: "string"
+                      pattern: "^(0x)[\\s\\S]{0,}$"
+                      description: "Non-indexed log data for this userOperation."
+                  additionalProperties: {}
+                description: "The logs generated by this `UserOperation` (not including logs of other `UserOperations` in the same bundle)."
+              receipt:
+                type: "object"
+                required:
+                  - "blockHash"
+                  - "blockNumber"
+                  - "cumulativeGasUsed"
+                  - "effectiveGasPrice"
+                  - "from"
+                  - "gasUsed"
+                  - "logs"
+                  - "logsBloom"
+                  - "status"
+                  - "to"
+                  - "transactionHash"
+                  - "transactionIndex"
+                  - "type"
+                properties:
+                  type:
+                    anyOf:
+                      - type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                      - type: "string"
+                    description: "The type of the transaction."
+                  blockHash:
+                    type: "string"
+                    pattern: "^(0x)[\\s\\S]{0,}$"
+                    description: "32 Bytes - The hash of the block where the given transaction was included."
+                  blockNumber:
+                    type: "string"
+                    pattern: "^(0x)[\\s\\S]{0,}$"
+                    description: "The number of the block where the given transaction was included."
+                  contractAddress:
+                    anyOf:
+                      - type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                      - type: "null"
+                    description: "20 Bytes - The contract address created if the transaction was a contract creation, otherwise null."
+                  cumulativeGasUsed:
+                    type: "string"
+                    pattern: "^(0x)[\\s\\S]{0,}$"
+                    description: "The total amount of gas used when this transaction was executed in the block."
+                  effectiveGasPrice:
+                    type: "string"
+                    pattern: "^(0x)[\\s\\S]{0,}$"
+                    description: "The actual price per unit of gas paid by the sender."
+                  from:
+                    type: "string"
+                    pattern: "^(0x)[\\s\\S]{0,}$"
+                    description: "20 Bytes - address of the sender."
+                  gasUsed:
+                    type: "string"
+                    pattern: "^(0x)[\\s\\S]{0,}$"
+                    description: "The amount of gas used by this specific transaction alone."
+                  logs:
+                    type: "array"
+                    items:
+                      type: "object"
+                      required:
+                        - "address"
+                        - "blockHash"
+                        - "blockNumber"
+                        - "data"
+                        - "logIndex"
+                        - "removed"
+                        - "topics"
+                        - "transactionHash"
+                        - "transactionIndex"
+                      properties:
+                        address:
+                          type: "string"
+                          pattern: "^(0x)[\\s\\S]{0,}$"
+                          description: "20 Bytes - address from which this log originated."
+                        blockHash:
+                          type: "string"
+                          pattern: "^(0x)[\\s\\S]{0,}$"
+                          description: "The hash of the block where this log was included."
+                        blockNumber:
+                          type: "string"
+                          pattern: "^(0x)[\\s\\S]{0,}$"
+                          description: "The block number."
+                        data:
+                          type: "string"
+                          pattern: "^(0x)[\\s\\S]{0,}$"
+                          description: "Contains one or more 32 Bytes non-indexed arguments of the log."
+                        logIndex:
+                          type: "string"
+                          pattern: "^(0x)[\\s\\S]{0,}$"
+                          description: "The log index position in the block."
+                        removed:
+                          type: "boolean"
+                          description: "`true` when the log was removed due to a chain reorganization. `false` if it is a valid log."
+                        topics:
+                          type: "array"
+                          items:
+                            type: "string"
+                            pattern: "^(0x)[\\s\\S]{0,}$"
+                          description: "Array of zero to four 32 Bytes DATA values for indexed log arguments."
+                        transactionHash:
+                          type: "string"
+                          pattern: "^(0x)[\\s\\S]{0,}$"
+                          description: "The hash of the transaction this log was created from."
+                        transactionIndex:
+                          type: "string"
+                          pattern: "^(0x)[\\s\\S]{0,}$"
+                          description: "The transaction index position for the transaction that created this log."
+                      additionalProperties: {}
+                    description: "Array of `Log` objects."
+                  logsBloom:
+                    type: "string"
+                    pattern: "^(0x)[\\s\\S]{0,}$"
+                    description: "256 Bytes - Bloom filter for light clients to quickly retrieve related logs."
+                  status:
+                    type: "string"
+                    pattern: "^(0x)[\\s\\S]{0,}$"
+                    description: "Either `0x1` (success) or `0x0` (failure)."
+                  to:
+                    anyOf:
+                      - type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                      - type: "null"
+                    description: "20 Bytes - address of the receiver. Null when it is a contract creation transaction."
+                  transactionHash:
+                    type: "string"
+                    pattern: "^(0x)[\\s\\S]{0,}$"
+                    description: "32 Bytes - The hash of the transaction."
+                  transactionIndex:
+                    type: "string"
+                    pattern: "^(0x)[\\s\\S]{0,}$"
+                    description: "The index of the transaction in the block."
+                  blobGasPrice:
+                    type: "string"
+                    pattern: "^(0x)[\\s\\S]{0,}$"
+                  blobGasUsed:
+                    type: "string"
+                    pattern: "^(0x)[\\s\\S]{0,}$"
+                  blockTimestamp:
+                    type: "string"
+                    pattern: "^(0x)[\\s\\S]{0,}$"
+                  root:
+                    type: "string"
+                    pattern: "^(0x)[\\s\\S]{0,}$"
+                    description: "32 bytes of post-transaction state root (pre-Byzantium hard fork)."
+                additionalProperties: {}
+                description: "The `TransactionReceipt` object for the entire bundle, not only for this `UserOperation`."
+            additionalProperties: {}
+          - type: "null"
+
+    examples:
+      - name: "eth_getUserOperationReceipt example"
+        params:
+          - name: "param0"
+            value: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        result:
+          name: "Response"
+          value:
+            userOpHash: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            entryPoint: "0x0000000071727De22E5E9d8BAf0edAc6f37da032"
+            sender: "0x1111111111111111111111111111111111111111"
+            nonce: "0x1"
+            paymaster: "0x0000000000000000000000000000000000000000"
+            actualGasCost: "0x5208"
+            actualGasUsed: "0x5208"
+            success: true
+            reason: ""
+            logs:
+              - address: "0x0000000071727De22E5E9d8BAf0edAc6f37da032"
+                topics:
+                  - "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+                data: "0x"
+            receipt:
+              blockHash: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+              blockNumber: "0x12a3b4c"
+              contractAddress: null
+              cumulativeGasUsed: "0x5208"
+              effectiveGasPrice: "0x59682f00"
+              from: "0x3333333333333333333333333333333333333333"
+              gasUsed: "0x5208"
+              logs:
+                - address: "0x0000000071727De22E5E9d8BAf0edAc6f37da032"
+                  blockHash: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                  blockNumber: "0x12a3b4c"
+                  data: "0x"
+                  logIndex: "0x0"
+                  removed: false
+                  topics:
+                    - "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+                  transactionHash: "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                  transactionIndex: "0x0"
+              logsBloom: "0x00"
+              status: "0x1"
+              to: "0x4444444444444444444444444444444444444444"
+              transactionHash: "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+              transactionIndex: "0x0"
+              type: "0x2"
+
+  - name: eth_supportedEntryPoints
+    description: "Returns an array of the `entryPoint` addresses supported by the client."
     x-compute-units: 10
     params: []
     result:
-      name: Estimated priority fee
-      description: Returns the estimated priority fee per gas to be used in the userOperation for Rundler endpoints.
+      name: "Supported entryPoints"
+      description: "Array of supported `entryPoint` addresses."
       schema:
-        type: string
+        type: "array"
+        items:
+          type: "string"
+          pattern: "^(0x)[\\s\\S]{0,}$"
+
     examples:
-      - name: rundler_maxPriorityFeePerGas example
+      - name: "eth_supportedEntryPoints example"
         params: []
         result:
-          name: Estimated priority fee
-          value: "0xb1770efb14906e509893b6190359658208ae64d0c56e22f748a1b0869885559e"
+          name: "Response"
+          value:
+            - "0x0000000071727De22E5E9d8BAf0edAc6f37da032"
 
   - name: rundler_getUserOperationGasPrice
-    description: |
-      Returns gas price recommendations for setting fees in your user operations. The response includes current required fees and suggested fees with buffers for faster inclusion.
+    description: "Returns gas price recommendations for setting fees in your user operations. The response includes current required fees and suggested fees with buffers for faster inclusion."
     x-compute-units: 10
     params: []
     result:
-      name: Gas price recommendation
-      description: Gas price recommendation containing current fees and suggested fees with buffers.
+      name: "Gas price recommendation"
+      description: "Gas price recommendation containing current fees and suggested fees with buffers."
       schema:
-        type: object
-        required: ["currentPriorityFee", "baseFee", "blockNumber", "suggested"]
+        type: "object"
+        required:
+          - "priorityFee"
+          - "baseFee"
+          - "blockNumber"
+          - "suggested"
         properties:
-          currentPriorityFee:
-            type: string
-            description: The current minimum priority fee required by the bundler (same as `rundler_maxPriorityFeePerGas`).
+          priorityFee:
+            type: "string"
+            pattern: "^(0x)[\\s\\S]{0,}$"
+            description: "The current minimum priority fee required by the bundler (same as `rundler_maxPriorityFeePerGas`)."
           baseFee:
-            type: string
-            description: The current pending base fee for the next block (without bundler overhead).
+            type: "string"
+            pattern: "^(0x)[\\s\\S]{0,}$"
+            description: "The current pending base fee for the next block (without bundler overhead)."
           blockNumber:
-            type: string
-            description: The block number this estimate is based on.
+            type: "string"
+            pattern: "^(0x)[\\s\\S]{0,}$"
+            description: "The block number this estimate is based on."
           suggested:
-            type: object
-            description: Suggested fees with configurable buffers for faster inclusion.
-            required: ["maxPriorityFeePerGas", "maxFeePerGas"]
+            type: "object"
+            required:
+              - "maxPriorityFeePerGas"
+              - "maxFeePerGas"
             properties:
               maxPriorityFeePerGas:
-                type: string
-                description: Priority fee with buffer above the current minimum (default 30% buffer).
+                type: "string"
+                pattern: "^(0x)[\\s\\S]{0,}$"
+                description: "Priority fee with buffer above the current minimum (default 30% buffer)."
               maxFeePerGas:
-                type: string
-                description: Bundler-inflated base fee with buffer plus suggested priority fee (default 50% base fee buffer).
+                type: "string"
+                pattern: "^(0x)[\\s\\S]{0,}$"
+                description: "Bundler-inflated base fee with buffer plus suggested priority fee (default 50% base fee buffer)."
+            additionalProperties: {}
+            description: "Suggested fees with configurable buffers for faster inclusion."
+        additionalProperties: {}
+
     examples:
-      - name: rundler_getUserOperationGasPrice example
+      - name: "rundler_getUserOperationGasPrice example"
         params: []
         result:
-          name: Gas price recommendation
+          name: "Response"
           value:
-            currentPriorityFee: "0x59682f00"
+            priorityFee: "0x59682f00"
             baseFee: "0x165a0bc00"
             blockNumber: "0x12a3b4c"
             suggested:
               maxPriorityFeePerGas: "0x746a5280"
-              maxFeePerGas: "0x28CDB6C80"
+              maxFeePerGas: "0x1dcd65000"
 
-  - name: eth_getUserOperationReceipt
-    description: |
-      Get the `UserOperationReceipt` based on the `userOpHash`.
-
-      <Note title="Limitations">
-        This method retrieves and decodes userOperations from the logs of mined transactions by querying the node. If you attempt to fetch a receipt for a transaction from a distant past block, the request may be rejected by the node due to limitations on the block range size it can process.
-
-        The default range we support is 150 blocks, however the following networks have an unlimited range.
-
-        - Ethereum
-        - Polygon
-        - Base
-        - Optimism
-        - Worldchain
-        - Arbitrum
-      </Note>
-    x-compute-units: 20
-    params:
-      - name: userOpHash
-        required: true
-        description: The `userOpHash` of the `UserOperation` to get the receipt for (as returned by `eth_sendUserOperation`).
-        schema:
-          $ref: "../_shared_wallets/components.yaml#/components/schemas/hash32"
-      - name: tag
-        required: false
-        description: The blocktag for checking the UO status. \"pending\" or \"latest\". Defaults to \"latest\".".
-        schema:
-          type: string
-          enum: ["pending", "latest"]
-    result:
-      name: UserOperationReceipt
-      description: "`UserOperationReceipt` object representing the outcome of a `UserOperation`."
-      schema:
-        type: object
-        required:
-          [
-            "userOpHash",
-            "entryPoint",
-            "sender",
-            "nonce",
-            "paymaster",
-            "actualGasCost",
-            "actualGasUsed",
-            "success",
-            "reason",
-            "logs",
-            "receipt",
-            "status",
-          ]
-        properties:
-          userOpHash:
-            type: string
-            description: The hash of the `UserOperation`.
-          entryPoint:
-            type: string
-            description: The EntryPoint address the request should be sent through. This MUST be one of the EntryPoints returned by the `supportedEntryPoints` RPC call.
-          sender:
-            type: string
-            description: The account initiating the `UserOperation`.
-          nonce:
-            type: string
-            description: The nonce used in the `UserOperation`.
-          paymaster:
-            type: string
-            description: The paymaster used for this `UserOperation` (or empty if self-sponsored).
-          actualGasCost:
-            type: string
-            description: The actual amount paid (by account or paymaster) for this `UserOperation`.
-          actualGasUsed:
-            type: string
-            description: The total gas used by this `UserOperation` (including `preVerification`, `creation`, `validation`, and `execution`).
-          success:
-            type: boolean
-            description: Indicates whether the execution completed without reverting.
-          reason:
-            type: string
-            description: In case of revert, this is the revert reason.
-          logs:
-            type: array
-            description: The logs generated by this `UserOperation` (not including logs of other `UserOperations` in the same bundle).
-            items:
-              type: string
-          receipt:
-            type: object
-            description: The `TransactionReceipt` object for the entire bundle, not only for this `UserOperation`.
-            required:
-              [
-                "blockHash",
-                "blockNumber",
-                "transactionIndex",
-                "transactionHash",
-                "from",
-                "to",
-                "cumulativeGasUsed",
-                "gasUsed",
-                "contractAddress",
-                "logs",
-                "logsBloom",
-                "root",
-                "status",
-                "effectiveGasPrice",
-                "type",
-              ]
-            properties:
-              blockHash:
-                type: string
-                description: 32 Bytes - The hash of the block where the given transaction was included.
-              blockNumber:
-                type: string
-                description: The number of the block where the given transaction was included.
-              transactionIndex:
-                type: string
-                description: The index of the transaction in the block.
-              transactionHash:
-                type: string
-                description: 32 Bytes - The hash of the transaction.
-              from:
-                type: string
-                description: 20 Bytes - address of the sender.
-              to:
-                type: string
-                description: 20 Bytes - address of the receiver. Null when its a contract creation transaction.
-              cumulativeGasUsed:
-                type: string
-                description: The total amount of gas used when this transaction was executed in the block.
-              gasUsed:
-                type: string
-                description: The amount of gas used by this specific transaction alone.
-              contractAddress:
-                type: string
-                description: 20 Bytes - The contract address created, if the transaction was a contract creation, otherwise null.
-              logs:
-                type: array
-                description: Array of `Log` objects.
-                required:
-                  [
-                    "blockHash",
-                    "blockNumber",
-                    "transactionIndex",
-                    "address",
-                    "logIndex",
-                    "data",
-                    "removed",
-                    "topics",
-                    "transactionHash",
-                  ]
-                items:
-                  type: object
-                  properties:
-                    blockHash:
-                      type: string
-                      description: hash of the block where this log was in. `null` when its pending log.
-                    blockNumber:
-                      type: string
-                      description: The block num.
-                    transactionIndex:
-                      type: integer
-                      description: Integer of the transactions index position log was created from. null when its pending log.
-                    address:
-                      type: string
-                      description: 20 Bytes - address from which this log originated.
-                    logIndex:
-                      type: integer
-                      description: Integer of the log index position in the block. null when its pending log.
-                    data:
-                      type: string
-                      description: Contains one or more 32 Bytes non-indexed arguments of the log.
-                    removed:
-                      type: boolean
-                      description: "`true` when the log was removed, due to a chain reorganization. `false` if its a valid log."
-                    topics:
-                      type: array
-                      description: "Array of zero to four 32 Bytes `DATA` of indexed log arguments. In solidity: The first topic is the hash of the signature of the event (e.g. `Deposit(address,bytes32,uint256)`), except you declare the event with the anonymous specifier."
-                      items:
-                        type: string
-                    transactionHash:
-                      type: string
-                      description: Hash of the transactions this log was created from. null when its pending log.
-              logsBloom:
-                type: string
-                description: 256 Bytes - Bloom filter for light clients to quickly retrieve related logs.
-              root:
-                type: string
-                description: 32 bytes of post-transaction stateroot. (pre Byzantium hard fork at block 4,370,000).
-              status:
-                type: integer
-                description: Either `1` (success) or `0` (failure). (post Byzantium hard fork at block 4,370,000).
-              effectiveGasPrice:
-                type: string
-                description: The actual price per unit of gas paid by the sender.
-              type:
-                type: string
-                description: The type of the transaction.
-          status:
-            type: string
-            description: The status of the `UserOperation`. Could be \"Mined\" or \"Preconfirmed\"."
-    examples:
-      - name: eth_getUserOperationReceipt example
-        params:
-          - name: userOpHash
-            value: "0x93c06f3f5909cc2b192713ed9bf93e3e1fde4b22fcd2466304fa404f9b80ff90"
-        result:
-          name: UserOperationReceipt
-          value:
-            userOpHash: "0x77c0b560eb0b042902abc5613f768d2a6b2d67481247e9663bf4d68dec0ca122"
-            entryPoint: "0xc944E90C64B2c07662A292be6244BDf05Cda44a7"
-            sender: "0x742d35Cc6634C0532925a3b844Bc454e4438f44e"
-            nonce: 42
-            paymaster: "0x7A0A0d159218E6a2f407B99173A2b12A6DDfC2a6"
-            actualGasCost: 21000
-            actualGasUsed: 314159
-            success: true
-            reason: ""
-            logs: []
-            receipt:
-              transactionHash: "0x8fc90a6c3ee3001cdcbbb685b4fbe67b1fa2bec575b15b0395fea5540d0901ae"
-              blockHash: "0x58a945e1558810523df00490ff28cbe111b37851c44679ce5be1eeaebb4b4907"
-              blockNumber: "0xeb8822"
-              transactionIndex: "0x4e"
-            status: "Mined"
-
-  - name: eth_supportedEntryPoints
-    description: |
-      Returns an array of the `entryPoint` addresses supported by the client.
+  - name: rundler_maxPriorityFeePerGas
+    description: "Returns a fee per gas that is an estimate of how much users should set as a priority fee in userOperations for Rundler endpoints."
     x-compute-units: 10
     params: []
     result:
-      name: Supported entryPoints
-      description: Array of supported `entryPoint` addresses.
+      name: "Estimated priority fee"
+      description: "Returns the estimated priority fee per gas to be used in the userOperation for Rundler endpoints."
       schema:
-        type: array
-        items:
-          $ref: "../_shared_wallets/components.yaml#/components/schemas/address"
+        type: "string"
+        pattern: "^(0x)[\\s\\S]{0,}$"
+
     examples:
-      - name: eth_supportedEntryPoints example
+      - name: "rundler_maxPriorityFeePerGas example"
         params: []
         result:
-          name: Supported entryPoints
-          value:
-            - "0xcd01C8aa8995A59eB7B2627E69b40e0524B5ecf8"
-            - "0x7A0A0d159218E6a2f407B99173A2b12A6DDfC2a6"
+          name: "Response"
+          value: "0x59682f"
 
-  - name: eth_getUserOperationByHash
-    description: |
-      Return a `UserOperation` based on a `userOpHash`.
-
-      <Note title="Limitations">
-        This method method retrieves and decodes userOperations from the logs of mined transactions by querying the node. If you attempt to fetch a userOperation from a distant past block, the request may be rejected by the node due to limitations on the block range size it can process.
-
-        The default range we support is 150 blocks, however the following networks have an unlimited range.
-
-        - Ethereum
-        - Polygon
-        - Base
-        - Optimism
-        - Worldchain
-        - Arbitrum
-      </Note>
-    x-compute-units: 20
+  - name: rundler_getUserOperationStatus
+    description: "Returns the current status and related details for a `UserOperation`."
+    x-compute-units: 50
     params:
-      - name: userOpHash
+      - name: "userOpHash"
         required: true
-        description: The `userOpHash` of the `UserOperation` to retrieve.
+        description: "The `userOpHash` of the `UserOperation` to check."
         schema:
-          $ref: "../_shared_wallets/components.yaml#/components/schemas/hash32"
-    result:
-      name: UserOperation
-      description: The `UserOperation` object.
-      schema:
-        type: object
-        required: ["entrypointV06Response", "entrypointV07Response"]
-        properties:
-          entrypointV06Response:
-            title: "Entrypoint v0.6 Response"
-            type: "object"
-            properties:
-              sender:
-                type: "string"
-                description: The account sending the userOperation.
-              nonce:
-                type: "string"
-                description: Anti-replay parameter; also used as the salt for first-time account creation.
-              initCode:
-                type: "string"
-                description: The initCode of the account (needed if and only if the account is not yet on-chain and needs to be created).
-              callData:
-                type: "string"
-                description: Encoded data for executing the primary function call or operation within the user's transaction, such as calling a smart contract function or transferring tokens. This data is passed to the sender's address during the execution of the userOperation.
-              callGasLimit:
-                type: "string"
-                description: The amount of gas to allocate for the main execution call.
-              verificationGasLimit:
-                type: "string"
-                description: The amount of gas to allocate for the verification step.
-              preVerificationGas:
-                type: "string"
-                description: The amount of gas to compensate the bundler for pre-verification execution and calldata.
-              maxFeePerGas:
-                type: "string"
-                description: The maximum fee per gas to pay for the execution of this operation (similar to EIP-1559 max_fee_per_gas).
-              maxPriorityFeePerGas:
-                type: "string"
-                description: Maximum priority fee per gas (similar to EIP-1559 max_priority_fee_per_gas).
-              signature:
-                type: "string"
-                description: Data passed into the account along with the nonce during the verification step.
-              paymasterAndData:
-                type: "string"
-                description: Address of paymaster sponsoring the transaction, followed by extra data to send to the paymaster (empty for self-sponsored transaction).
-              entryPoint:
-                type: "string"
-                description: Address of the EntryPoint contract.
-              blockNumber:
-                type: "string"
-                description: Block number in which `UserOperation` is included.
-              blockHash:
-                type: "string"
-                description: Block hash of the block containing `UserOperation`.
-              transactionHash:
-                type: "string"
-                description: Transaction hash of the `UserOperation`.
-          entrypointV07Response:
-            title: "Entrypoint v0.7 / v0.8 Response"
-            type: "object"
-            properties:
-              sender:
-                type: "string"
-                description: The account sending the userOperation.
-              nonce:
-                type: "string"
-                description: Anti-replay parameter; also used as the salt for first-time account creation.
-              factory:
-                type: "string"
-                description: The account factory address (needed if and only if the account is not yet on-chain and needs to be created).
-              factoryData:
-                type: "string"
-                description: Data for the account factory (only if the account factory exists).
-              callData:
-                type: "string"
-                description: Encoded data for executing the primary function call or operation within the user's transaction, such as calling a smart contract function or transferring tokens. This data is passed to the sender's address during the execution of the userOperation.
-              callGasLimit:
-                type: "string"
-                description: The amount of gas to allocate for the main execution call.
-              verificationGasLimit:
-                type: "string"
-                description: The amount of gas to allocate for the verification step.
-              preVerificationGas:
-                type: "string"
-                description: The amount of gas to compensate the bundler for pre-verification execution and calldata.
-              maxFeePerGas:
-                type: "string"
-                description: The maximum fee per gas to pay for the execution of this operation (similar to EIP-1559 max_fee_per_gas).
-              maxPriorityFeePerGas:
-                type: "string"
-                description: Maximum priority fee per gas (similar to EIP-1559 max_priority_fee_per_gas).
-              paymasterVerificationGasLimit:
-                type: "string"
-                description: The amount of gas to allocate for the paymaster validation code (only if a paymaster exists).
-              paymasterPostOpGasLimit:
-                type: "string"
-                description: The amount of gas to allocate for the paymaster post-op code (only if a paymaster exists).
-              signature:
-                type: "string"
-                description: Data passed into the account along with the nonce during the verification step.
-              paymaster:
-                type: "string"
-                description: Address of the paymaster contract (or empty, if the account pays for itself).
-              paymasterData:
-                type: "string"
-                description: Data for the paymaster (only if the paymaster exists).
-              entryPoint:
-                type: "string"
-                description: Address of the EntryPoint contract.
-              blockNumber:
-                type: "string"
-                description: Block number in which `UserOperation` is included.
-              blockHash:
-                type: "string"
-                description: Block hash of the block containing `UserOperation`.
-              transactionHash:
-                type: "string"
-                description: Transaction hash of the `UserOperation`.
-    examples:
-      - name: eth_getUserOperationByHash example
-        params:
-          - name: userOpHash
-            value: "0x77c0b560eb0b042902abc5613f768d2a6b2d67481247e9663bf4d68dec0ca122"
-        result:
-          name: UserOperation
-          value:
-            sender: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
-            nonce: 1
-            initCode: "0x"
-            callData: "0x"
-            callGasLimit: "0x0"
-            verificationGasLimit: "0x0"
-            preVerificationGas: "0x0"
-            maxFeePerGas: "0x0"
-            maxPriorityFeePerGas: "0x0"
-            paymasterAndData: "0x"
-            signature: "0x"
-            entryPoint: "0x"
-            blockNumber: "0x"
-            blockHash: "0x"
-            transactionHash: "0x"
+          type: "string"
+          pattern: "^(0x)[\\s\\S]{0,}$"
 
-  - name: eth_sendUserOperation
-    description: |
-      Sends a `UserOperation` to the given EVM network.
+    result:
+      name: "UserOperation status"
+      description: "Status information for a `UserOperation`, including receipt and pending bundle details when available."
+      schema:
+        type: "object"
+        required:
+          - "status"
+          - "receipt"
+          - "userOperation"
+          - "addedAtBlock"
+          - "validUntil"
+          - "validAfter"
+          - "pendingBundle"
+        properties:
+          status:
+            type: "string"
+            enum:
+              - "unknown"
+              - "pending"
+              - "pendingBundle"
+              - "mined"
+              - "preconfirmed"
+            description: "The current status of the `UserOperation`."
+          receipt:
+            anyOf:
+              - type: "object"
+                required:
+                  - "userOpHash"
+                  - "entryPoint"
+                  - "sender"
+                  - "nonce"
+                  - "actualGasCost"
+                  - "actualGasUsed"
+                  - "success"
+                  - "logs"
+                  - "receipt"
+                properties:
+                  userOpHash:
+                    type: "string"
+                    pattern: "^(0x)[\\s\\S]{0,}$"
+                    description: "The hash of the `UserOperation`."
+                  entryPoint:
+                    type: "string"
+                    pattern: "^(0x)[\\s\\S]{0,}$"
+                    description: "The EntryPoint address the request should be sent through. This MUST be one of the EntryPoints returned by the `supportedEntryPoints` RPC call."
+                  sender:
+                    type: "string"
+                    pattern: "^(0x)[\\s\\S]{0,}$"
+                    description: "The account initiating the `UserOperation`."
+                  nonce:
+                    type: "string"
+                    pattern: "^(0x)[\\s\\S]{0,}$"
+                    description: "The nonce used in the `UserOperation`."
+                  paymaster:
+                    type: "string"
+                    pattern: "^(0x)[\\s\\S]{0,}$"
+                    description: "The paymaster used for this `UserOperation` (or empty if self-sponsored)."
+                  actualGasCost:
+                    type: "string"
+                    pattern: "^(0x)[\\s\\S]{0,}$"
+                    description: "The actual amount paid (by account or paymaster) for this `UserOperation`."
+                  actualGasUsed:
+                    type: "string"
+                    pattern: "^(0x)[\\s\\S]{0,}$"
+                    description: "The total gas used by this `UserOperation` (including `preVerification`, `creation`, `validation`, and `execution`)."
+                  success:
+                    type: "boolean"
+                    description: "Indicates whether the execution completed without reverting."
+                  reason:
+                    type: "string"
+                    description: "In case of revert, this is the revert reason."
+                  logs:
+                    type: "array"
+                    items:
+                      type: "object"
+                      required:
+                        - "address"
+                        - "topics"
+                        - "data"
+                      properties:
+                        address:
+                          type: "string"
+                          pattern: "^(0x)[\\s\\S]{0,}$"
+                          description: "20 Bytes - address from which this userOperation log originated."
+                        topics:
+                          type: "array"
+                          items:
+                            type: "string"
+                            pattern: "^(0x)[\\s\\S]{0,}$"
+                          description: "Array of indexed log argument topics for this userOperation log."
+                        data:
+                          type: "string"
+                          pattern: "^(0x)[\\s\\S]{0,}$"
+                          description: "Non-indexed log data for this userOperation."
+                      additionalProperties: {}
+                    description: "The logs generated by this `UserOperation` (not including logs of other `UserOperations` in the same bundle)."
+                  receipt:
+                    type: "object"
+                    required:
+                      - "blockHash"
+                      - "blockNumber"
+                      - "cumulativeGasUsed"
+                      - "effectiveGasPrice"
+                      - "from"
+                      - "gasUsed"
+                      - "logs"
+                      - "logsBloom"
+                      - "status"
+                      - "to"
+                      - "transactionHash"
+                      - "transactionIndex"
+                      - "type"
+                    properties:
+                      type:
+                        anyOf:
+                          - type: "string"
+                            pattern: "^(0x)[\\s\\S]{0,}$"
+                          - type: "string"
+                        description: "The type of the transaction."
+                      blockHash:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "32 Bytes - The hash of the block where the given transaction was included."
+                      blockNumber:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "The number of the block where the given transaction was included."
+                      contractAddress:
+                        anyOf:
+                          - type: "string"
+                            pattern: "^(0x)[\\s\\S]{0,}$"
+                          - type: "null"
+                        description: "20 Bytes - The contract address created if the transaction was a contract creation, otherwise null."
+                      cumulativeGasUsed:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "The total amount of gas used when this transaction was executed in the block."
+                      effectiveGasPrice:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "The actual price per unit of gas paid by the sender."
+                      from:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "20 Bytes - address of the sender."
+                      gasUsed:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "The amount of gas used by this specific transaction alone."
+                      logs:
+                        type: "array"
+                        items:
+                          type: "object"
+                          required:
+                            - "address"
+                            - "blockHash"
+                            - "blockNumber"
+                            - "data"
+                            - "logIndex"
+                            - "removed"
+                            - "topics"
+                            - "transactionHash"
+                            - "transactionIndex"
+                          properties:
+                            address:
+                              type: "string"
+                              pattern: "^(0x)[\\s\\S]{0,}$"
+                              description: "20 Bytes - address from which this log originated."
+                            blockHash:
+                              type: "string"
+                              pattern: "^(0x)[\\s\\S]{0,}$"
+                              description: "The hash of the block where this log was included."
+                            blockNumber:
+                              type: "string"
+                              pattern: "^(0x)[\\s\\S]{0,}$"
+                              description: "The block number."
+                            data:
+                              type: "string"
+                              pattern: "^(0x)[\\s\\S]{0,}$"
+                              description: "Contains one or more 32 Bytes non-indexed arguments of the log."
+                            logIndex:
+                              type: "string"
+                              pattern: "^(0x)[\\s\\S]{0,}$"
+                              description: "The log index position in the block."
+                            removed:
+                              type: "boolean"
+                              description: "`true` when the log was removed due to a chain reorganization. `false` if it is a valid log."
+                            topics:
+                              type: "array"
+                              items:
+                                type: "string"
+                                pattern: "^(0x)[\\s\\S]{0,}$"
+                              description: "Array of zero to four 32 Bytes DATA values for indexed log arguments."
+                            transactionHash:
+                              type: "string"
+                              pattern: "^(0x)[\\s\\S]{0,}$"
+                              description: "The hash of the transaction this log was created from."
+                            transactionIndex:
+                              type: "string"
+                              pattern: "^(0x)[\\s\\S]{0,}$"
+                              description: "The transaction index position for the transaction that created this log."
+                          additionalProperties: {}
+                        description: "Array of `Log` objects."
+                      logsBloom:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "256 Bytes - Bloom filter for light clients to quickly retrieve related logs."
+                      status:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "Either `0x1` (success) or `0x0` (failure)."
+                      to:
+                        anyOf:
+                          - type: "string"
+                            pattern: "^(0x)[\\s\\S]{0,}$"
+                          - type: "null"
+                        description: "20 Bytes - address of the receiver. Null when it is a contract creation transaction."
+                      transactionHash:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "32 Bytes - The hash of the transaction."
+                      transactionIndex:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "The index of the transaction in the block."
+                      blobGasPrice:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                      blobGasUsed:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                      blockTimestamp:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                      root:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "32 bytes of post-transaction state root (pre-Byzantium hard fork)."
+                    additionalProperties: {}
+                    description: "The `TransactionReceipt` object for the entire bundle, not only for this `UserOperation`."
+                additionalProperties: {}
+              - type: "null"
+            description: "The receipt for completed userOperations, or null when no receipt is available."
+          userOperation:
+            anyOf:
+              - anyOf:
+                  - type: "object"
+                    required:
+                      - "sender"
+                      - "nonce"
+                      - "callData"
+                      - "callGasLimit"
+                      - "verificationGasLimit"
+                      - "preVerificationGas"
+                      - "maxFeePerGas"
+                      - "maxPriorityFeePerGas"
+                      - "signature"
+                    properties:
+                      sender:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "The account sending the userOperation."
+                      nonce:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "Anti-replay parameter; also used as the salt for first-time account creation."
+                      initCode:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "The initCode of the account (needed if and only if the account is not yet on-chain and needs to be created)."
+                      callData:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "Encoded data for executing the primary function call or operation within the user's transaction, such as calling a smart contract function or transferring tokens. This data is passed to the sender's address during the execution of the userOperation."
+                      callGasLimit:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "The amount of gas to allocate for the main execution call."
+                      verificationGasLimit:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "The amount of gas to allocate for the verification step."
+                      preVerificationGas:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "The amount of gas to compensate the bundler for pre-verification execution and calldata."
+                      maxFeePerGas:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "The maximum fee per gas to pay for the execution of this operation (similar to EIP-1559 max_fee_per_gas)."
+                      maxPriorityFeePerGas:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "Maximum priority fee per gas (similar to EIP-1559 max_priority_fee_per_gas)."
+                      paymasterAndData:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "Address of paymaster sponsoring the transaction, followed by extra data to send to the paymaster (empty for self-sponsored transaction)."
+                      signature:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "Data passed into the account along with the nonce during the verification step."
+                      eip7702Auth:
+                        type: "object"
+                        required:
+                          - "chainId"
+                          - "nonce"
+                          - "address"
+                          - "yParity"
+                          - "r"
+                          - "s"
+                        properties:
+                          chainId:
+                            type: "string"
+                            pattern: "^(0x)[\\s\\S]{0,}$"
+                          nonce:
+                            type: "string"
+                            pattern: "^(0x)[\\s\\S]{0,}$"
+                          address:
+                            type: "string"
+                            pattern: "^(0x)[\\s\\S]{0,}$"
+                          yParity:
+                            type: "string"
+                            pattern: "^(0x)[\\s\\S]{0,}$"
+                          r:
+                            type: "string"
+                            pattern: "^(0x)[\\s\\S]{0,}$"
+                          s:
+                            type: "string"
+                            pattern: "^(0x)[\\s\\S]{0,}$"
+                        additionalProperties: {}
+                      aggregator:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                      entryPoint:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "Address of the EntryPoint contract."
+                      blockNumber:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "Block number in which `UserOperation` is included."
+                      blockHash:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "Block hash of the block containing `UserOperation`."
+                      transactionHash:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "Transaction hash of the `UserOperation`."
+                    additionalProperties: {}
+                    title: "Entrypoint v0.6 Response"
+                  - type: "object"
+                    required:
+                      - "sender"
+                      - "nonce"
+                      - "callData"
+                      - "callGasLimit"
+                      - "verificationGasLimit"
+                      - "preVerificationGas"
+                      - "maxFeePerGas"
+                      - "maxPriorityFeePerGas"
+                      - "signature"
+                    properties:
+                      sender:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "The account sending the userOperation."
+                      nonce:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "Anti-replay parameter; also used as the salt for first-time account creation."
+                      factory:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "The account factory address (needed if and only if the account is not yet on-chain and needs to be created)."
+                      factoryData:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "Data for the account factory (only if the account factory exists)."
+                      callData:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "Encoded data for executing the primary function call or operation within the user's transaction, such as calling a smart contract function or transferring tokens. This data is passed to the sender's address during the execution of the userOperation."
+                      callGasLimit:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "The amount of gas to allocate for the main execution call."
+                      verificationGasLimit:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "The amount of gas to allocate for the verification step."
+                      preVerificationGas:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "The amount of gas to compensate the bundler for pre-verification execution and calldata."
+                      maxFeePerGas:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "The maximum fee per gas to pay for the execution of this operation (similar to EIP-1559 max_fee_per_gas)."
+                      maxPriorityFeePerGas:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "Maximum priority fee per gas (similar to EIP-1559 max_priority_fee_per_gas)."
+                      paymaster:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "Address of the paymaster contract (or empty, if the account pays for itself)."
+                      paymasterVerificationGasLimit:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "The amount of gas to allocate for the paymaster validation code (only if a paymaster exists)."
+                      paymasterPostOpGasLimit:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "The amount of gas to allocate for the paymaster post-op code (only if a paymaster exists)."
+                      paymasterData:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "Data for the paymaster (only if the paymaster exists)."
+                      signature:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "Data passed into the account along with the nonce during the verification step."
+                      eip7702Auth:
+                        type: "object"
+                        required:
+                          - "chainId"
+                          - "nonce"
+                          - "address"
+                          - "yParity"
+                          - "r"
+                          - "s"
+                        properties:
+                          chainId:
+                            type: "string"
+                            pattern: "^(0x)[\\s\\S]{0,}$"
+                          nonce:
+                            type: "string"
+                            pattern: "^(0x)[\\s\\S]{0,}$"
+                          address:
+                            type: "string"
+                            pattern: "^(0x)[\\s\\S]{0,}$"
+                          yParity:
+                            type: "string"
+                            pattern: "^(0x)[\\s\\S]{0,}$"
+                          r:
+                            type: "string"
+                            pattern: "^(0x)[\\s\\S]{0,}$"
+                          s:
+                            type: "string"
+                            pattern: "^(0x)[\\s\\S]{0,}$"
+                        additionalProperties: {}
+                      aggregator:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                      entryPoint:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "Address of the EntryPoint contract."
+                      blockNumber:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "Block number in which `UserOperation` is included."
+                      blockHash:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "Block hash of the block containing `UserOperation`."
+                      transactionHash:
+                        type: "string"
+                        pattern: "^(0x)[\\s\\S]{0,}$"
+                        description: "Transaction hash of the `UserOperation`."
+                    additionalProperties: {}
+                    title: "Entrypoint v0.7 / v0.8 Response"
+              - type: "null"
+            description: "The userOperation payload when available."
+          addedAtBlock:
+            anyOf:
+              - type: "string"
+                pattern: "^(0x)[\\s\\S]{0,}$"
+              - type: "null"
+            description: "The block number when the userOperation was added, or null when unavailable."
+          validUntil:
+            anyOf:
+              - type: "string"
+                pattern: "^(0x)[\\s\\S]{0,}$"
+              - type: "null"
+            description: "The last block or timestamp for which the userOperation is valid, or null when unavailable."
+          validAfter:
+            anyOf:
+              - type: "string"
+                pattern: "^(0x)[\\s\\S]{0,}$"
+              - type: "null"
+            description: "The first block or timestamp for which the userOperation is valid, or null when unavailable."
+          pendingBundle:
+            anyOf:
+              - type: "object"
+                required:
+                  - "txHash"
+                  - "sentAtBlock"
+                  - "bundlerAddress"
+                properties:
+                  txHash:
+                    type: "string"
+                    pattern: "^(0x)[\\s\\S]{0,}$"
+                    description: "The transaction hash for the pending bundle."
+                  sentAtBlock:
+                    type: "string"
+                    pattern: "^(0x)[\\s\\S]{0,}$"
+                    description: "The block number when the bundle was sent."
+                  bundlerAddress:
+                    type: "string"
+                    pattern: "^(0x)[\\s\\S]{0,}$"
+                    description: "The bundler address that sent the bundle."
+                additionalProperties: {}
+              - type: "null"
+            description: "Pending bundle details, or null when the userOperation is not in a pending bundle."
+        additionalProperties: {}
+
+    examples:
+      - name: "rundler_getUserOperationStatus example"
+        params:
+          - name: "param0"
+            value: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        result:
+          name: "Response"
+          value:
+            status: "pendingBundle"
+            receipt: null
+            userOperation:
+              sender: "0x1111111111111111111111111111111111111111"
+              nonce: "0x1"
+              factory: "0x5555555555555555555555555555555555555555"
+              factoryData: "0x1234"
+              callData: "0x"
+              callGasLimit: "0x5208"
+              verificationGasLimit: "0x186a0"
+              preVerificationGas: "0x7530"
+              maxFeePerGas: "0x59682f00"
+              maxPriorityFeePerGas: "0x59682f"
+              paymaster: "0x0000000000000000000000000000000000000000"
+              paymasterVerificationGasLimit: "0x7530"
+              paymasterPostOpGasLimit: "0x5208"
+              paymasterData: "0x"
+              signature: "0x"
+            addedAtBlock: "0x12a3b4c"
+            validUntil: "0x68f00000"
+            validAfter: "0x0"
+            pendingBundle:
+              txHash: "0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+              sentAtBlock: "0x12a3b4d"
+              bundlerAddress: "0x2222222222222222222222222222222222222222"
+
+  - name: rundler_dropLocalUserOperation
+    description: "Drops a local userOperation from the bundler mempool when it has not yet been bundled."
     x-compute-units: 1000
-    x-rate-limit-cus: 100
-
     params:
-      - name: UserOperation
+      - name: "UserOperation"
         required: true
-        description: The UserOperation object. This can be a v0.6, v0.7, or v0.8 user operation, but MUST match the version of the entry point at the address of the second parameter.
+        description: "The UserOperation object. This can be a v0.6, v0.7, or v0.8 user operation, but MUST match the version of the entry point at the address of the second parameter."
         schema:
-          oneOf:
-            - $ref: "../_shared_wallets/components.yaml#/components/schemas/UserOperationV06"
-            - $ref: "../_shared_wallets/components.yaml#/components/schemas/UserOperationV07"
-      - name: Entrypoint address
+          anyOf:
+            - type: "object"
+              required:
+                - "sender"
+                - "nonce"
+                - "initCode"
+                - "callData"
+                - "callGasLimit"
+                - "verificationGasLimit"
+                - "preVerificationGas"
+                - "maxFeePerGas"
+                - "maxPriorityFeePerGas"
+                - "paymasterAndData"
+                - "signature"
+              properties:
+                sender:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "The account sending the userOperation."
+                nonce:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "Anti-replay parameter; also used as the salt for first-time account creation."
+                initCode:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "The initCode of the account (needed if and only if the account is not yet on-chain and needs to be created)."
+                callData:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "Encoded data for executing the primary function call or operation within the user's transaction, such as calling a smart contract function or transferring tokens. This data is passed to the sender's address during the execution of the userOperation."
+                callGasLimit:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "The amount of gas to allocate for the main execution call."
+                verificationGasLimit:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "The amount of gas to allocate for the verification step."
+                preVerificationGas:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "The amount of gas to compensate the bundler for pre-verification execution and calldata."
+                maxFeePerGas:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "The maximum fee per gas to pay for the execution of this operation (similar to EIP-1559 max_fee_per_gas)."
+                maxPriorityFeePerGas:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "Maximum priority fee per gas (similar to EIP-1559 max_priority_fee_per_gas)."
+                paymasterAndData:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "Address of paymaster sponsoring the transaction, followed by extra data to send to the paymaster (empty for self-sponsored transaction)."
+                signature:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "Data passed into the account along with the nonce during the verification step."
+                eip7702Auth:
+                  type: "object"
+                  required:
+                    - "chainId"
+                    - "nonce"
+                    - "address"
+                    - "yParity"
+                    - "r"
+                    - "s"
+                  properties:
+                    chainId:
+                      type: "string"
+                      pattern: "^(0x)[\\s\\S]{0,}$"
+                    nonce:
+                      type: "string"
+                      pattern: "^(0x)[\\s\\S]{0,}$"
+                    address:
+                      type: "string"
+                      pattern: "^(0x)[\\s\\S]{0,}$"
+                    yParity:
+                      type: "string"
+                      pattern: "^(0x)[\\s\\S]{0,}$"
+                    r:
+                      type: "string"
+                      pattern: "^(0x)[\\s\\S]{0,}$"
+                    s:
+                      type: "string"
+                      pattern: "^(0x)[\\s\\S]{0,}$"
+                  additionalProperties: {}
+                aggregator:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+              additionalProperties: {}
+            - type: "object"
+              required:
+                - "sender"
+                - "nonce"
+                - "callData"
+                - "callGasLimit"
+                - "verificationGasLimit"
+                - "preVerificationGas"
+                - "maxFeePerGas"
+                - "maxPriorityFeePerGas"
+                - "signature"
+              properties:
+                sender:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "The account sending the userOperation."
+                nonce:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "Anti-replay parameter; also used as the salt for first-time account creation."
+                factory:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "The account factory address (needed if and only if the account is not yet on-chain and needs to be created)."
+                factoryData:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "Data for the account factory (only if the account factory exists)."
+                callData:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "Encoded data for executing the primary function call or operation within the user's transaction, such as calling a smart contract function or transferring tokens. This data is passed to the sender's address during the execution of the userOperation."
+                callGasLimit:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "The amount of gas to allocate for the main execution call."
+                verificationGasLimit:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "The amount of gas to allocate for the verification step."
+                preVerificationGas:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "The amount of gas to compensate the bundler for pre-verification execution and calldata."
+                maxFeePerGas:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "The maximum fee per gas to pay for the execution of this operation (similar to EIP-1559 max_fee_per_gas)."
+                maxPriorityFeePerGas:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "Maximum priority fee per gas (similar to EIP-1559 max_priority_fee_per_gas)."
+                paymaster:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "Address of the paymaster contract (or empty, if the account pays for itself)."
+                paymasterVerificationGasLimit:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "The amount of gas to allocate for the paymaster validation code (only if a paymaster exists)."
+                paymasterPostOpGasLimit:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "The amount of gas to allocate for the paymaster post-op code (only if a paymaster exists)."
+                paymasterData:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "Data for the paymaster (only if the paymaster exists)."
+                signature:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+                  description: "Data passed into the account along with the nonce during the verification step."
+                eip7702Auth:
+                  type: "object"
+                  required:
+                    - "chainId"
+                    - "nonce"
+                    - "address"
+                    - "yParity"
+                    - "r"
+                    - "s"
+                  properties:
+                    chainId:
+                      type: "string"
+                      pattern: "^(0x)[\\s\\S]{0,}$"
+                    nonce:
+                      type: "string"
+                      pattern: "^(0x)[\\s\\S]{0,}$"
+                    address:
+                      type: "string"
+                      pattern: "^(0x)[\\s\\S]{0,}$"
+                    yParity:
+                      type: "string"
+                      pattern: "^(0x)[\\s\\S]{0,}$"
+                    r:
+                      type: "string"
+                      pattern: "^(0x)[\\s\\S]{0,}$"
+                    s:
+                      type: "string"
+                      pattern: "^(0x)[\\s\\S]{0,}$"
+                  additionalProperties: {}
+                aggregator:
+                  type: "string"
+                  pattern: "^(0x)[\\s\\S]{0,}$"
+              additionalProperties: {}
+
+      - name: "entryPoint"
         required: true
-        description: The EntryPoint address the request should be sent through. This MUST be one of the EntryPoints returned by the `supportedEntryPoints` RPC call.
+        description: "The EntryPoint address the request should be sent through. This MUST be one of the EntryPoints returned by the `supportedEntryPoints` RPC call."
         schema:
-          $ref: "../_shared_wallets/components.yaml#/components/schemas/address"
+          type: "string"
+          pattern: "^(0x)[\\s\\S]{0,}$"
+
     result:
-      name: userOpHash
-      description: The calculated `userOpHash` for the `UserOperation`.
+      name: "Dropped userOperation hash"
+      description: "The dropped `userOpHash`, or null if no matching local userOperation was dropped."
       schema:
-        type: string
-        format: "hex"
+        anyOf:
+          - type: "string"
+            pattern: "^(0x)[\\s\\S]{0,}$"
+          - type: "null"
+
     examples:
-      - name: eth_sendUserOperation example
+      - name: "rundler_dropLocalUserOperation example"
         params:
-          - name: UserOperation
-            value: { sender: "0x...", nonce: "0x...", callData: "0x..." }
-          - name: Entrypoint address
-            value: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789"
+          - name: "param0"
+            value:
+              sender: "0x1111111111111111111111111111111111111111"
+              nonce: "0x1"
+              factory: "0x5555555555555555555555555555555555555555"
+              factoryData: "0x1234"
+              callData: "0x"
+              callGasLimit: "0x5208"
+              verificationGasLimit: "0x186a0"
+              preVerificationGas: "0x7530"
+              maxFeePerGas: "0x59682f00"
+              maxPriorityFeePerGas: "0x59682f"
+              paymaster: "0x0000000000000000000000000000000000000000"
+              paymasterVerificationGasLimit: "0x7530"
+              paymasterPostOpGasLimit: "0x5208"
+              paymasterData: "0x"
+              signature: "0x"
+          - name: "param1"
+            value: "0x0000000071727De22E5E9d8BAf0edAc6f37da032"
         result:
-          name: userOpHash
-          value:
-            result: "0x1234...5678"
-
-  - name: eth_estimateUserOperationGas
-    description: |
-      Estimates the gas values for a `UserOperation`.
-
-      <Note>
-        This endpoint requires a dummy signature in the `userOp`. Check our [FAQs](/docs/reference/bundler-faqs#what-is-a-dummy-signature) to learn what a dummy signature is.
-      </Note>
-    x-compute-units: 500
-    x-rate-limit-cus: 50
-    params:
-      - name: UserOperation
-        required: true
-        description: Contains gas limits and prices (optional). This can be a v0.6, v0.7, or v0.8 userOperation but must match the version of the `EntryPoint` at the address of the second parameter.
-        schema:
-          oneOf:
-            - $ref: "../_shared_wallets/components.yaml#/components/schemas/UserOperationV06"
-            - $ref: "../_shared_wallets/components.yaml#/components/schemas/UserOperationV07"
-      - name: entryPoint
-        required: true
-        description: The address to which the request should be sent. This must be one of the `EntryPoint` returned by the `supportedEntryPoints` method and should match the version of the `userOp` in the first parameter.
-        schema:
-          $ref: "../_shared_wallets/components.yaml#/components/schemas/address"
-      - name: "stateOverrideSet"
-        required: false
-        description: |
-          Allows changes to the state of a contract before executing the call. For example, you can modify variable values (like balances or approvals) for that call without changing the contract itself on the blockchain. 
-
-          In more technical terms, the state override set is an optional parameter that allows executing the call against a modified chain state. It is an address-to-state mapping, where each entry specifies some state to be overridden prior to executing the call.
-        schema:
-          type: "object"
-          properties:
-            balance:
-              type: "string"
-              description: "Fake balance to set for the account before executing the call (<= 32 bytes)"
-            nonce:
-              type: "string"
-              description: Fake nonce to set for the account before executing the call (<= 8 bytes).
-            code:
-              type: "string"
-              description: "Fake EVM bytecode to inject into the account before executing the call."
-            state:
-              type: "object"
-              description: "Fake key-value mapping to override all slots in the account storage before executing the call."
-            stateDiff:
-              type: "object"
-              description: "Fake key-value mapping to override individual slots in the account storage before executing the call."
-    result:
-      name: Gas estimation
-      description: Gas values estimated for the userOperation.
-      schema:
-        type: object
-        required: ["entrypointV06Response", "entrypointV07Response"]
-        properties:
-          entrypointV06Response:
-            type: object
-            title: Entrypoint v0.6 Response
-            properties:
-              preVerificationGas:
-                $ref: "../_shared_wallets/components.yaml#/components/schemas/uint256"
-                description: Gas overhead of this userOperation.
-              verificationGasLimit:
-                $ref: "../_shared_wallets/components.yaml#/components/schemas/uint256"
-                description: Actual gas used by the validation of this userOperation.
-              callGasLimit:
-                $ref: "../_shared_wallets/components.yaml#/components/schemas/uint256"
-                description: Value used by inner account execution.
-          entrypointV07Response:
-            type: object
-            title: Entrypoint v0.7 / v0.8 Response
-            properties:
-              preVerificationGas:
-                $ref: "../_shared_wallets/components.yaml#/components/schemas/uint256"
-                description: Gas overhead of this userOperation.
-              verificationGasLimit:
-                $ref: "../_shared_wallets/components.yaml#/components/schemas/uint256"
-                description: Actual gas used by the validation of this userOperation.
-              callGasLimit:
-                $ref: "../_shared_wallets/components.yaml#/components/schemas/uint256"
-                description: Value used by inner account execution.
-              paymasterVerificationGasLimit:
-                $ref: "../_shared_wallets/components.yaml#/components/schemas/uint256"
-                description: Value used by the paymaster during verification.
-    examples:
-      - name: eth_estimateUserOperationGas example
-        params:
-          - name: UserOperation
-            value: { sender: "0x...", nonce: "0x...", callData: "0x..." }
-          - name: Entrypoint address
-            value: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789"
-        result:
-          name: Gas estimation
-          value:
-            preVerificationGas: "0x1"
-            verificationGasLimit: "0x1"
-            callGasLimit: "0x1"
-            paymasterVerificationGasLimit: "0x1"
+          name: "Response"
+          value: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"


### PR DESCRIPTION
## Description

Replaces the local Bundler API OpenRPC source with the generated Rundler YAML output from wallet-server so the docs preview can be checked before publishing.

## Related Issues

Linear ticket not linked: I could not find a local Linear integration, Linear token, or ticket ID in the workspace. This PR is for preview validation before publishing.

## Changes Made

- Replaced `src/openrpc/alchemy/bundler/bundler.yaml` with wallet-server `openrpc/rundler.yaml` output.
- Keeps the existing docs spec path so the Bundler API preview route continues to use the current navigation target.
- Adds generated schema coverage for `rundler_getUserOperationStatus` and `rundler_dropLocalUserOperation` in the Bundler/Rundler spec.

## Testing

- [x] `pnpm run generate:rpc`
- [x] `pnpm run validate:rpc`
- [x] `pnpm exec prettier --check src/openrpc/alchemy/bundler/bundler.yaml`
- [x] `git diff --check`
- [ ] I have run the validation scripts (`pnpm run validate`)
- [ ] I have checked that the documentation builds correctly