### PR TITLE
docs(kaia): add Kaia API quickstart and FAQ guides

### DIFF
--- a/content/api-reference/kaia/kaia-api-faq.mdx
+++ b/content/api-reference/kaia/kaia-api-faq.mdx
@@ -1,0 +1,33 @@
+---
+title: Kaia API FAQ
+description: Frequently asked questions about the Kaia API
+subtitle: Frequently asked questions about the Kaia API
+slug: reference/kaia-api-faq
+---
+
+## What is Kaia?
+Kaia is a public, EVM-compatible Layer 1 blockchain created from the merger of Klaytn and Finschia, designed for high performance with one-second block times, low transaction fees, and instant finality to power large-scale Web3 and stablecoin applications.
+
+## How do I get started with Kaia?
+See the [Kaia API quickstart guide](/docs/reference/kaia-api-quickstart) to start building on Kaia.
+
+## What is the Kaia API?
+The Kaia API lets you interact with the Kaia mainnet. You can execute transactions, query onchain data, and interact with the Kaia network using the JSON-RPC standard.
+
+## Is Kaia EVM compatible?
+Yes, Kaia is EVM compatible.
+
+## What API does Kaia use?
+Kaia uses the JSON-RPC API standard. This API enables blockchain interaction on the Kaia network, letting you read block and transaction data, query chain information, execute smart contracts, and store data onchain.
+
+## What methods are supported on Kaia?
+Kaia supports standard Ethereum JSON-RPC methods. Some chain-specific methods may vary. Check the Kaia API endpoints documentation for a complete list.
+
+## What is a Kaia API key?
+When you access the Kaia network through a node provider like Alchemy, you use an API key to send transactions and retrieve data. We recommend you [sign up for a free API key](https://dashboard.alchemy.com/signup).
+
+## Which libraries support Kaia?
+Common Ethereum libraries like [ethers.js](https://docs.ethers.org/v5/) are compatible with Kaia, given its EVM nature.
+
+## Where can I get more help?
+If you have questions or feedback, contact us at support@alchemy.com or open a ticket in the [Alchemy Dashboard](https://dashboard.alchemy.com).

--- a/content/api-reference/kaia/kaia-api-quickstart.mdx
+++ b/content/api-reference/kaia/kaia-api-quickstart.mdx
@@ -1,0 +1,117 @@
+---
+title: Kaia API Quickstart
+description: How to get started building on Kaia and using the JSON-RPC API
+subtitle: How to get started building on Kaia and using the JSON-RPC API
+slug: reference/kaia-api-quickstart
+---
+
+*To use the Kaia API, you need an Alchemy account. [Create a free account](https://dashboard.alchemy.com/signup) to get started.*
+
+## What is Kaia?
+
+Kaia is a public, EVM-compatible Layer 1 blockchain created from the merger of Klaytn and Finschia, designed for high performance with one-second block times, low transaction fees, and instant finality to power large-scale Web3 and stablecoin applications.
+
+## What is the Kaia API?
+
+The Kaia API lets you interact with the Kaia network through a set of JSON-RPC methods. If you've worked with Ethereum's JSON-RPC APIs, the interface will be familiar.
+
+## Get started
+
+### 1. Choose a package manager (npm or yarn)
+
+Pick a package manager for your project's dependencies.
+
+<CodeGroup>
+  ```shell npm
+  # Begin with npm by following the npm documentation
+  # https://docs.npmjs.com/downloading-and-installing-node-js-and-npm
+  ```
+
+  ```shell yarn
+  # For yarn, refer to yarn's installation guide
+  # https://classic.yarnpkg.com/lang/en/docs/install
+  ```
+</CodeGroup>
+
+### 2. Set up your project
+
+Run the following commands to create and initialize your project:
+
+<CodeGroup>
+  ```shell npm
+  mkdir kaia-api-quickstart
+  cd kaia-api-quickstart
+  npm init --yes
+  ```
+
+  ```shell yarn
+  mkdir kaia-api-quickstart
+  cd kaia-api-quickstart
+  yarn init --yes
+  ```
+</CodeGroup>
+
+This creates a new directory named `kaia-api-quickstart` and initializes a Node.js project within it.
+
+### 3. Make your first request
+
+Install Axios to make API requests:
+
+<CodeGroup>
+  ```shell npm
+  npm install axios
+  ```
+
+  ```shell yarn
+  yarn add axios
+  ```
+</CodeGroup>
+
+Create an `index.js` file in your project directory and paste the following code:
+
+<CodeGroup>
+  ```javascript index.js
+  const axios = require('axios');
+
+  const url = 'https://kaia-mainnet.g.alchemy.com/v2/${your-api-key}';
+
+  const payload = {
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'eth_blockNumber',
+    params: []
+  };
+
+  axios.post(url, payload)
+    .then(response => {
+      console.log('Latest Block:', response.data.result);
+    })
+    .catch(error => {
+      console.error(error);
+    });
+  ```
+</CodeGroup>
+
+Replace `your-api-key` with your actual Alchemy API key from the [Alchemy Dashboard](https://dashboard.alchemy.com/signup).
+
+### 4. Run your script
+
+Run your script to make a request to the Kaia network:
+
+<CodeGroup>
+  ```shell shell
+  node index.js
+  ```
+</CodeGroup>
+
+You should see the latest block number from Kaia in your console:
+
+<CodeGroup>
+  ```shell shell
+  Latest Block: 0x...
+  ```
+</CodeGroup>
+
+## Next steps
+
+You've made your first request to the Kaia network. Explore the JSON-RPC methods available on Kaia and start building your dApps.

--- a/content/api-reference/kaia/kaia-api-quickstart.mdx
+++ b/content/api-reference/kaia/kaia-api-quickstart.mdx
@@ -73,7 +73,7 @@ Create an `index.js` file in your project directory and paste the following code
   ```javascript index.js
   const axios = require('axios');
 
-  const url = 'https://kaia-mainnet.g.alchemy.com/v2/${your-api-key}';
+  const url = 'https://kaia-mainnet.g.alchemy.com/v2/your-api-key';
 
   const payload = {
     jsonrpc: '2.0',

--- a/content/docs.yml
+++ b/content/docs.yml
@@ -2309,6 +2309,10 @@ navigation:
 
       - section: Kaia
         contents:
+          - page: Quickstart
+            path: api-reference/kaia/kaia-api-quickstart.mdx
+          - page: FAQ
+            path: api-reference/kaia/kaia-api-faq.mdx
           - page: Kaia API Overview
             path: api-reference/kaia/kaia-api-overview.mdx
           - api: Kaia API Endpoints


### PR DESCRIPTION
## Summary
- Added Kaia API Quickstart and FAQ guides, generated via `pnpm run add-evm-chain` using the Mainnet RPC URL from [alchemy.com/rpc/kaia](https://www.alchemy.com/rpc/kaia) (`https://kaia-mainnet.g.alchemy.com/v2`).
- Wired the new Quickstart and FAQ pages into the existing Kaia section in `content/docs.yml` (the chain spec and overview were already present).

## Changes
- New: `content/api-reference/kaia/kaia-api-quickstart.mdx`
- New: `content/api-reference/kaia/kaia-api-faq.mdx`
- Modified: `content/docs.yml` (Kaia nav section now lists Quickstart → FAQ → Overview → API Endpoints)

Made with [Cursor](https://cursor.com)