### PR TITLE
Limit Claude plugin docs page to Claude Code

### DIFF
--- a/content/tutorials/build-with-ai/alchemy-claude-plugin.mdx
+++ b/content/tutorials/build-with-ai/alchemy-claude-plugin.mdx
@@ -1,11 +1,11 @@
 ---
 title: Alchemy Claude Plugin
-description: Query blockchain data across 100+ chains and manage Alchemy apps directly in Claude Code and Cowork with the official Alchemy plugin.
-subtitle: Query blockchain data across 100+ chains and manage Alchemy apps directly in Claude Code and Cowork with the official Alchemy plugin.
+description: Query blockchain data across 100+ chains and manage Alchemy apps directly in Claude Code with the official Alchemy plugin.
+subtitle: Query blockchain data across 100+ chains and manage Alchemy apps directly in Claude Code with the official Alchemy plugin.
 slug: docs/alchemy-claude-plugin
 ---
 
-The Alchemy plugin for [Claude Code](https://code.claude.com/) and Cowork bundles everything Claude needs to work with Alchemy in one install: the hosted [Alchemy MCP Server](docs/alchemy-mcp-server), slash commands for common workflows, and [Agent Skills](docs/alchemy-agent-skills) that teach Claude how to use Alchemy APIs in code.
+The Alchemy plugin for [Claude Code](https://code.claude.com/) bundles everything Claude needs to work with Alchemy in one install: the hosted [Alchemy MCP Server](docs/alchemy-mcp-server), slash commands for common workflows, and [Agent Skills](docs/alchemy-agent-skills) that teach Claude how to use Alchemy APIs in code.
 
 The plugin is open source at [alchemyplatform/alchemy-claude-plugin](https://github.com/alchemyplatform/alchemy-claude-plugin).
 
@@ -66,7 +66,7 @@ Networks default to `eth-mainnet` when you don't specify one.
 
 | | Best for |
 |---|---|
-| **Claude Plugin** | Claude Code and Cowork — one install that bundles the MCP server, slash commands, and skills |
+| **Claude Plugin** | Claude Code — one install that bundles the MCP server, slash commands, and skills |
 | **[MCP Server](docs/alchemy-mcp-server)** | Any MCP-compatible client (Cursor, Codex, Claude Desktop, VS Code Copilot) — live blockchain data as tool calls |
 | **[Agent Skills](docs/alchemy-agent-skills)** | Any agent that writes code against Alchemy APIs — endpoint knowledge without tool calls |
 


### PR DESCRIPTION
## Summary

- Follow-up to #1370: removes "Cowork" wording from the Alchemy Claude Plugin page — the plugin has only been tested on Claude Code, and the directory submission lists Claude Code as the sole supported platform.


Made with [Cursor](https://cursor.com)