### PR TITLE
docs(katana): add Katana API quickstart and FAQ guides

### DIFF
--- a/content/api-reference/katana/katana-api-faq.mdx
+++ b/content/api-reference/katana/katana-api-faq.mdx
@@ -1,0 +1,33 @@
+---
+title: Katana API FAQ
+description: Frequently asked questions about the Katana API
+subtitle: Frequently asked questions about the Katana API
+slug: reference/katana-api-faq
+---
+
+## What is Katana?
+Katana is an EVM-compatible network purpose-built for DeFi, concentrating liquidity and directing chain-level yield back to users and applications to deliver deep, sustainable onchain markets.
+
+## How do I get started with Katana?
+See the [Katana API quickstart guide](/docs/reference/katana-api-quickstart) to start building on Katana.
+
+## What is the Katana API?
+The Katana API lets you interact with the Katana mainnet. You can execute transactions, query onchain data, and interact with the Katana network using the JSON-RPC standard.
+
+## Is Katana EVM compatible?
+Yes, Katana is EVM compatible.
+
+## What API does Katana use?
+Katana uses the JSON-RPC API standard. This API enables blockchain interaction on the Katana network, letting you read block and transaction data, query chain information, execute smart contracts, and store data onchain.
+
+## What methods are supported on Katana?
+Katana supports standard Ethereum JSON-RPC methods. Some chain-specific methods may vary. Check the Katana API endpoints documentation for a complete list.
+
+## What is a Katana API key?
+When you access the Katana network through a node provider like Alchemy, you use an API key to send transactions and retrieve data. We recommend you [sign up for a free API key](https://dashboard.alchemy.com/signup).
+
+## Which libraries support Katana?
+Common Ethereum libraries like [ethers.js](https://docs.ethers.org/v5/) are compatible with Katana, given its EVM nature.
+
+## Where can I get more help?
+If you have questions or feedback, contact us at support@alchemy.com or open a ticket in the [Alchemy Dashboard](https://dashboard.alchemy.com).

--- a/content/api-reference/katana/katana-api-quickstart.mdx
+++ b/content/api-reference/katana/katana-api-quickstart.mdx
@@ -1,0 +1,117 @@
+---
+title: Katana API Quickstart
+description: How to get started building on Katana and using the JSON-RPC API
+subtitle: How to get started building on Katana and using the JSON-RPC API
+slug: reference/katana-api-quickstart
+---
+
+*To use the Katana API, you need an Alchemy account. [Create a free account](https://dashboard.alchemy.com/signup) to get started.*
+
+## What is Katana?
+
+Katana is an EVM-compatible network purpose-built for DeFi, concentrating liquidity and directing chain-level yield back to users and applications to deliver deep, sustainable onchain markets.
+
+## What is the Katana API?
+
+The Katana API lets you interact with the Katana network through a set of JSON-RPC methods. If you've worked with Ethereum's JSON-RPC APIs, the interface will be familiar.
+
+## Get started
+
+### 1. Choose a package manager (npm or yarn)
+
+Pick a package manager for your project's dependencies.
+
+<CodeGroup>
+  ```shell npm
+  # Begin with npm by following the npm documentation
+  # https://docs.npmjs.com/downloading-and-installing-node-js-and-npm
+  ```
+
+  ```shell yarn
+  # For yarn, refer to yarn's installation guide
+  # https://classic.yarnpkg.com/lang/en/docs/install
+  ```
+</CodeGroup>
+
+### 2. Set up your project
+
+Run the following commands to create and initialize your project:
+
+<CodeGroup>
+  ```shell npm
+  mkdir katana-api-quickstart
+  cd katana-api-quickstart
+  npm init --yes
+  ```
+
+  ```shell yarn
+  mkdir katana-api-quickstart
+  cd katana-api-quickstart
+  yarn init --yes
+  ```
+</CodeGroup>
+
+This creates a new directory named `katana-api-quickstart` and initializes a Node.js project within it.
+
+### 3. Make your first request
+
+Install Axios to make API requests:
+
+<CodeGroup>
+  ```shell npm
+  npm install axios
+  ```
+
+  ```shell yarn
+  yarn add axios
+  ```
+</CodeGroup>
+
+Create an `index.js` file in your project directory and paste the following code:
+
+<CodeGroup>
+  ```javascript index.js
+  const axios = require('axios');
+
+  const url = 'https://katana-mainnet.g.alchemy.com/v2/your-api-key';
+
+  const payload = {
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'eth_blockNumber',
+    params: []
+  };
+
+  axios.post(url, payload)
+    .then(response => {
+      console.log('Latest Block:', response.data.result);
+    })
+    .catch(error => {
+      console.error(error);
+    });
+  ```
+</CodeGroup>
+
+Replace `your-api-key` with your actual Alchemy API key from the [Alchemy Dashboard](https://dashboard.alchemy.com/signup).
+
+### 4. Run your script
+
+Run your script to make a request to the Katana network:
+
+<CodeGroup>
+  ```shell shell
+  node index.js
+  ```
+</CodeGroup>
+
+You should see the latest block number from Katana in your console:
+
+<CodeGroup>
+  ```shell shell
+  Latest Block: 0x...
+  ```
+</CodeGroup>
+
+## Next steps
+
+You've made your first request to the Katana network. Explore the JSON-RPC methods available on Katana and start building your dApps.

--- a/content/docs.yml
+++ b/content/docs.yml
@@ -2294,6 +2294,10 @@ navigation:
 
       - section: Katana
         contents:
+          - page: Quickstart
+            path: api-reference/katana/katana-api-quickstart.mdx
+          - page: FAQ
+            path: api-reference/katana/katana-api-faq.mdx
           - page: Katana API Overview
             path: api-reference/katana/katana-api-overview.mdx
           - api: Katana API Endpoints


### PR DESCRIPTION
## Summary
- Added Katana API Quickstart and FAQ guides, generated via `pnpm run add-evm-chain` using the Mainnet RPC URL from [alchemy.com/rpc/katana](https://www.alchemy.com/rpc/katana) (`https://katana-mainnet.g.alchemy.com/v2`).
- Wired the new Quickstart and FAQ pages into the existing Katana section in `content/docs.yml` (the chain spec and overview were already present).
- Used a literal `your-api-key` placeholder in the quickstart sample URL (avoids the unbalanced `${...}` template syntax issue flagged on the Kaia PR).

## Changes
- New: `content/api-reference/katana/katana-api-quickstart.mdx`
- New: `content/api-reference/katana/katana-api-faq.mdx`
- Modified: `content/docs.yml` (Katana nav section now lists Quickstart → FAQ → Overview → API Endpoints)

Made with [Cursor](https://cursor.com)