### PR TITLE
Clarify Alchemy Signer signup sunset

### DIFF
--- a/content/wallets/shared/v4-signer-banner.mdx
+++ b/content/wallets/shared/v4-signer-banner.mdx
@@ -1,1 +1,1 @@
-<Warning>The Alchemy signer is being sunset. For new projects, we recommend using [`@alchemy/wallet-apis`](/docs/wallets/quickstart) with [Privy as your signer](/docs/wallets/third-party/signers/privy).</Warning>
+<Warning>Alchemy Signer APIs are being sunset. As of June 16, 2026, Alchemy Signer no longer supports new user signups. Existing users can still log in to be migrated. For new users, use [Privy](/docs/wallets/third-party/signers/privy) with [Wallet APIs](/docs/wallets/quickstart).</Warning>

--- a/src/openapi/accounts/accounts.yaml
+++ b/src/openapi/accounts/accounts.yaml
@@ -11,9 +11,10 @@ security:
 paths:
   /signup:
     post:
-      summary: Create Wallet
+      summary: Create Wallet (deprecated)
+      deprecated: true
       description: >
-        Enables the creation of a Smart Wallet using Alchemy Signer. It allows applications to authenticate users and facilitate signature operations on their behalf. A Smart Wallet is either an on-chain Modular Account with Alchemy Signer as the owner, a standalone EOA signer managed through Alchemy Signer, or a standalone Solana Wallet managed through the Alchemy Signer.
+        Alchemy Signer APIs are being sunset. As of June 16, 2026, Alchemy Signer no longer supports new user signups. Existing users can still log in to be migrated. For new users, use [Privy](/docs/wallets/third-party/signers/privy) with [Wallet APIs](/docs/wallets/quickstart).
       security:
         - apiKey: []
       x-readme:
@@ -311,7 +312,7 @@ paths:
     post:
       summary: Authenticate with JWT
       description: >
-        Authenticates a user using a JSON Web Token (JWT) for secure access to their Smart Wallet functionalities. This endpoint validates the provided JWT token and can be used for authenticating an existing user or to pregenerate a wallet.
+        Authenticates an existing user using a JSON Web Token (JWT) for secure access to their Smart Wallet functionality. New user signup and wallet pregeneration are no longer supported as of June 16, 2026 because Alchemy Signer APIs are being sunset.
       security:
         - apiKey: []
       x-readme:
@@ -367,7 +368,7 @@ paths:
                 properties:
                   isSignup:
                     type: boolean
-                    description: If true, indicates a new wallet was created.
+                    description: Deprecated. New signups are no longer supported.
                     default: false
                   orgId:
                     $ref: "#/components/schemas/orgId"


### PR DESCRIPTION
## Description

Clarifies that Alchemy Signer APIs are being sunset and no longer support new user signups as of June 16, 2026.

## Related Issues

None.

## Changes Made

- Updated the shared v4 signer banner with the signup sunset warning and Privy/Wallet APIs migration path.
- Marked the Signer `/signup` endpoint deprecated and updated JWT auth docs to avoid implying wallet pregeneration is still supported.

## Testing

- `ruby -e 'require "yaml"; YAML.load_file("src/openapi/accounts/accounts.yaml"); puts "accounts.yaml parsed"'`
- `pnpm run validate:rest` could not run because `node_modules` is missing and the workspace shell is using Node 18 instead of the repo-required Node 22.

* [x] I have tested these changes locally
* [ ] I have run the validation scripts (`pnpm run validate`)
* [ ] I have checked that the documentation builds correctly