### PR TITLE
Add Stellar Data API remote spec and navigation

### DIFF
--- a/content/api-reference/data/stellar-data-api/stellar-data-api-overview.mdx
+++ b/content/api-reference/data/stellar-data-api/stellar-data-api-overview.mdx
@@ -1,0 +1,22 @@
+---
+title: Stellar Data API Overview
+description: Learn about Alchemy's Stellar Data API.
+subtitle: Query indexed Stellar data including transfer history, account balances, and NFT holdings.
+slug: reference/stellar-data-api-overview
+---
+
+# Intro
+
+With the Stellar Data API, you can query indexed Stellar data across **native**, **classic**, and **Soroban** assets — including transfer history, account balances, and NFT holdings — without running your own indexer.
+
+Alchemy currently supports the following [Stellar Data API Endpoints](/docs/data/stellar-data-api/stellar-data-api-endpoints):
+
+* [`getStellarTransfers`](/docs/data/stellar-data-api/stellar-data-api-endpoints/get-stellar-transfers): Returns transfers (native, classic, and/or Soroban) matching the given filters, ordered by ledger.
+* [`getStellarBalances`](/docs/data/stellar-data-api/stellar-data-api-endpoints/get-stellar-balances): Returns the unified balance set for an account — native XLM, classic trustline assets, and Soroban contract tokens.
+* [`getStellarNfts`](/docs/data/stellar-data-api/stellar-data-api-endpoints/get-stellar-nfts): Returns NFTs held by an account, with filtering by contract or classic asset.
+
+Looking for Stellar JSON-RPC methods instead? Check out the [Stellar API Overview](/docs/stellar/stellar-api-overview).
+
+<Info>
+  All endpoints accept JSON request bodies, return results under a `data` envelope, and support pagination via opaque `pageKey` cursors.
+</Info>

--- a/content/api-reference/data/stellar-data-api/stellar-data-api-overview.mdx
+++ b/content/api-reference/data/stellar-data-api/stellar-data-api-overview.mdx
@@ -9,11 +9,7 @@ slug: reference/stellar-data-api-overview
 
 With the Stellar Data API, you can query indexed Stellar data across **native**, **classic**, and **Soroban** assets — including transfer history, account balances, and NFT holdings — without running your own indexer.
 
-Alchemy currently supports the following Stellar Data API endpoints:
-
-* [`getStellarTransfers`](/docs/data/stellar-data-api/stellar-data-api-endpoints/transfers/get-stellar-transfers): Returns transfers (native, classic, and/or Soroban) matching the given filters, ordered by ledger.
-* [`getStellarBalances`](/docs/data/stellar-data-api/stellar-data-api-endpoints/balances/get-stellar-balances): Returns the unified balance set for an account — native XLM, classic trustline assets, and Soroban contract tokens.
-* [`getStellarNfts`](/docs/data/stellar-data-api/stellar-data-api-endpoints/nfts/get-stellar-nfts): Returns NFTs held by an account, with filtering by contract or classic asset.
+Browse the **Stellar Data API Endpoints** in the sidebar for the full list of available methods and their request and response schemas.
 
 Looking for Stellar JSON-RPC methods instead? Check out the [Stellar API Overview](/docs/stellar/stellar-api-overview).
 

--- a/content/api-reference/data/stellar-data-api/stellar-data-api-overview.mdx
+++ b/content/api-reference/data/stellar-data-api/stellar-data-api-overview.mdx
@@ -9,11 +9,11 @@ slug: reference/stellar-data-api-overview
 
 With the Stellar Data API, you can query indexed Stellar data across **native**, **classic**, and **Soroban** assets — including transfer history, account balances, and NFT holdings — without running your own indexer.
 
-Alchemy currently supports the following [Stellar Data API Endpoints](/docs/data/stellar-data-api/stellar-data-api-endpoints):
+Alchemy currently supports the following Stellar Data API endpoints:
 
-* [`getStellarTransfers`](/docs/data/stellar-data-api/stellar-data-api-endpoints/get-stellar-transfers): Returns transfers (native, classic, and/or Soroban) matching the given filters, ordered by ledger.
-* [`getStellarBalances`](/docs/data/stellar-data-api/stellar-data-api-endpoints/get-stellar-balances): Returns the unified balance set for an account — native XLM, classic trustline assets, and Soroban contract tokens.
-* [`getStellarNfts`](/docs/data/stellar-data-api/stellar-data-api-endpoints/get-stellar-nfts): Returns NFTs held by an account, with filtering by contract or classic asset.
+* [`getStellarTransfers`](/docs/data/stellar-data-api/stellar-data-api-endpoints/transfers/get-stellar-transfers): Returns transfers (native, classic, and/or Soroban) matching the given filters, ordered by ledger.
+* [`getStellarBalances`](/docs/data/stellar-data-api/stellar-data-api-endpoints/balances/get-stellar-balances): Returns the unified balance set for an account — native XLM, classic trustline assets, and Soroban contract tokens.
+* [`getStellarNfts`](/docs/data/stellar-data-api/stellar-data-api-endpoints/nfts/get-stellar-nfts): Returns NFTs held by an account, with filtering by contract or classic asset.
 
 Looking for Stellar JSON-RPC methods instead? Check out the [Stellar API Overview](/docs/stellar/stellar-api-overview).
 

--- a/content/docs.yml
+++ b/content/docs.yml
@@ -2112,6 +2112,8 @@ navigation:
             path: api-reference/stellar/stellar-api-overview.mdx
           - api: Stellar API Endpoints
             api-name: stellar
+          - link: Stellar Data API
+            href: /docs/data/stellar-data-api
         slug: stellar
 
       - section: Story

--- a/content/docs.yml
+++ b/content/docs.yml
@@ -2117,7 +2117,7 @@ navigation:
           - api: Stellar API Endpoints
             api-name: stellar
           - link: Stellar Data API
-            href: /docs/data/stellar-data-api
+            href: /docs/reference/stellar-data-api-overview
         slug: stellar
 
       - section: Story

--- a/content/docs.yml
+++ b/content/docs.yml
@@ -844,6 +844,11 @@ navigation:
           - api: Transactions Receipts Endpoints
             api-name: transactions-receipt
         slug: utility-apis
+      - section: Stellar Data API
+        contents:
+          - api: Stellar Data API Endpoints
+            api-name: stellar-data-api
+        slug: stellar-data-api
       - section: Subgraphs
         contents:
           - page: Alchemy Subgraphs Deprecation Notice

--- a/content/docs.yml
+++ b/content/docs.yml
@@ -846,6 +846,8 @@ navigation:
         slug: utility-apis
       - section: Stellar Data API
         contents:
+          - page: Stellar Data API Overview
+            path: api-reference/data/stellar-data-api/stellar-data-api-overview.mdx
           - api: Stellar Data API Endpoints
             api-name: stellar-data-api
         slug: stellar-data-api

--- a/content/remote-specs.json
+++ b/content/remote-specs.json
@@ -17,5 +17,10 @@
     "name": "gas-manager-coverage",
     "url": "https://txe-api-specs.docs.alchemy.com/paymaster/openrpc.yaml",
     "type": "openrpc"
+  },
+  {
+    "name": "stellar-data-api",
+    "url": "https://data-api.docs.alchemy.com/stellar/openapi.yaml",
+    "type": "openapi"
   }
 ]

--- a/content/remote-specs.json
+++ b/content/remote-specs.json
@@ -20,7 +20,7 @@
   },
   {
     "name": "stellar-data-api",
-    "url": "https://data-api.docs.alchemy.com/stellar/openapi.yaml",
+    "url": "https://data-api-specs.docs.alchemy.com/stellar/openapi.yaml",
     "type": "openapi"
   }
 ]


### PR DESCRIPTION
## Summary
- Registers `stellar-data-api` in `content/remote-specs.json` pointing to `https://data-api.docs.alchemy.com/stellar/openapi.yaml`
- Adds a **Stellar Data API** section to the `data` tab in `content/docs.yml` (after Utility API)

## Test plan
- [ ] CI fetches and lints the spec from `https://data-api.docs.alchemy.com/stellar/openapi.yaml` without errors
- [ ] Stellar Data API section appears in the data tab navigation
- [ ] API endpoints render correctly from the remote spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)