### PR TITLE
Add Polygon zkEVM deprecation notice

### DIFF
--- a/content/api-reference/node-api/node-supported-chains.mdx
+++ b/content/api-reference/node-api/node-supported-chains.mdx
@@ -218,8 +218,8 @@ Alchemy supports both EVM and non-EVM chains, view API references below:
 | Starknet | Starknet Mainnet | https://starknet-mainnet.g.alchemy.com/starknet/version/rpc/v0_10/API_KEY |
 | Starknet | Starknet Sepolia | https://starknet-sepolia.g.alchemy.com/starknet/version/rpc/v0_10/API_KEY |
 | Astar | Astar Mainnet | https://astar-mainnet.g.alchemy.com/v2/API_KEY |
-| Polygon zkEVM | Polygon zkEVM Mainnet | https://polygonzkevm-mainnet.g.alchemy.com/v2/API_KEY |
-| Polygon zkEVM | Polygon zkEVM Cardona | https://polygonzkevm-cardona.g.alchemy.com/v2/API_KEY |
+| Polygon zkEVM | Polygon zkEVM Mainnet (deprecating July 9, 2026 — [details](/docs/reference/polygon-zkevm-deprecation-notice)) | https://polygonzkevm-mainnet.g.alchemy.com/v2/API_KEY |
+| Polygon zkEVM | Polygon zkEVM Cardona (deprecating July 9, 2026 — [details](/docs/reference/polygon-zkevm-deprecation-notice)) | https://polygonzkevm-cardona.g.alchemy.com/v2/API_KEY |
 | ZetaChain | ZetaChain Mainnet | https://zetachain-mainnet.g.alchemy.com/v2/API_KEY |
 | ZetaChain | ZetaChain Testnet | https://zetachain-testnet.g.alchemy.com/v2/API_KEY |
 | Mantle | Mantle Mainnet | https://mantle-mainnet.g.alchemy.com/v2/API_KEY |

--- a/content/api-reference/polygon-zkevm/polygon-zkevm-api-quickstart.mdx
+++ b/content/api-reference/polygon-zkevm/polygon-zkevm-api-quickstart.mdx
@@ -5,6 +5,10 @@ subtitle: How to get started building on Polygon zkEVM using Alchemy
 slug: reference/polygon-zkevm-api-quickstart
 ---
 
+<Warning title="Polygon zkEVM deprecation">
+  Polygon Labs is [shutting down the Polygon zkEVM network on July 1, 2026](https://polygon.technology/polygon-zkevm). Alchemy will fully deprecate support for **Polygon zkEVM Mainnet** (`polygonzkevm-mainnet`) and the **Cardona** testnet (`polygonzkevm-cardona`) on **July 9, 2026**. See the [Polygon zkEVM Deprecation Notice](/docs/reference/polygon-zkevm-deprecation-notice) for details.
+</Warning>
+
 <Tip title="Don't have an API key?" icon="star">
   Build faster with production-ready APIs, smart wallets and rollup infrastructure across 70+ chains. Create your free Alchemy API key and{" "}
   <a href="https://dashboard.alchemy.com/signup">get started today</a>.

--- a/content/api-reference/polygon-zkevm/polygon-zkevm-deprecation-notice.mdx
+++ b/content/api-reference/polygon-zkevm/polygon-zkevm-deprecation-notice.mdx
@@ -1,0 +1,22 @@
+---
+title: Polygon zkEVM Deprecation Notice
+description: Important notice regarding the deprecation of Polygon zkEVM Mainnet and the Cardona testnet
+slug: reference/polygon-zkevm-deprecation-notice
+---
+
+## ⚠️ Deprecation Notice
+
+**Alchemy will fully deprecate support for Polygon zkEVM Mainnet (`polygonzkevm-mainnet`) and the Polygon zkEVM Cardona testnet (`polygonzkevm-cardona`) on July 9, 2026.** After this date, requests to these endpoints will no longer be supported.
+
+Polygon zkEVM is being deprecated because [Polygon Labs is shutting down the Polygon zkEVM network on July 1, 2026](https://polygon.technology/polygon-zkevm). Both the mainnet and the Cardona testnet will be sunset by Polygon Labs, and Alchemy will spin down support shortly after.
+
+## What you need to do
+
+There is no migration path for Polygon zkEVM, as the network itself is being shut down. Before July 9, 2026:
+
+1. Remove any dependencies on Polygon zkEVM endpoints (`polygonzkevm-mainnet` and `polygonzkevm-cardona`) from your applications.
+2. If you are building on a Layer 2, explore Alchemy's other [supported chains](/docs/reference/node-supported-chains) for an alternative network that fits your needs.
+
+## Need help?
+
+If you have any questions or need assistance, contact us at support@alchemy.com or open a ticket in the [Alchemy Dashboard](https://dashboard.alchemy.com/).

--- a/content/docs.yml
+++ b/content/docs.yml
@@ -1952,6 +1952,8 @@ navigation:
             slug: polygon-zkevm-api-faq
           - page: Polygon zkEVM API Overview
             path: api-reference/polygon-zkevm/polygon-zkevm-api-overview.mdx
+          - page: Polygon zkEVM Deprecation Notice
+            path: api-reference/polygon-zkevm/polygon-zkevm-deprecation-notice.mdx
           - api: Polygon zkEVM API Endpoints
             api-name: polygon-zkevm
             # Pin the slug: the auto-generated kebab-case of "Polygon zkEVM API


### PR DESCRIPTION
## Summary
- Kicks off the docs side of the [Polygon zkEVM deprecation](https://app.notion.com/p/Polygon-zkEVM-mainnet-testnet-384069f200668011ac07fb1ae8a53e75). Polygon Labs is [shutting down the Polygon zkEVM network on July 1, 2026](https://polygon.technology/polygon-zkevm); Alchemy spins down support for **Polygon zkEVM Mainnet** and the **Cardona** testnet on **July 9, 2026**.
- Adds a dedicated **Polygon zkEVM Deprecation Notice** page (no migration path, since the network itself is sunsetting) and links it in the Polygon zkEVM nav.
- Surfaces a `<Warning>` callout at the top of the **Polygon zkEVM API Quickstart**.
- Marks **Polygon zkEVM Mainnet** and **Polygon zkEVM Cardona** as deprecating in the supported chains table with a link to the notice.

Made with [Cursor](https://cursor.com)