### PR TITLE
Communicate July 1 as the Polygon zkEVM deprecation date

### DIFF
--- a/content/api-reference/node-api/node-supported-chains.mdx
+++ b/content/api-reference/node-api/node-supported-chains.mdx
@@ -218,8 +218,8 @@ Alchemy supports both EVM and non-EVM chains, view API references below:
 | Starknet | Starknet Mainnet | https://starknet-mainnet.g.alchemy.com/starknet/version/rpc/v0_10/API_KEY |
 | Starknet | Starknet Sepolia | https://starknet-sepolia.g.alchemy.com/starknet/version/rpc/v0_10/API_KEY |
 | Astar | Astar Mainnet | https://astar-mainnet.g.alchemy.com/v2/API_KEY |
-| Polygon zkEVM | Polygon zkEVM Mainnet (deprecating July 9, 2026 — [details](/docs/reference/polygon-zkevm-deprecation-notice)) | https://polygonzkevm-mainnet.g.alchemy.com/v2/API_KEY |
-| Polygon zkEVM | Polygon zkEVM Cardona (deprecating July 9, 2026 — [details](/docs/reference/polygon-zkevm-deprecation-notice)) | https://polygonzkevm-cardona.g.alchemy.com/v2/API_KEY |
+| Polygon zkEVM | Polygon zkEVM Mainnet (deprecating July 1, 2026 — [details](/docs/reference/polygon-zkevm-deprecation-notice)) | https://polygonzkevm-mainnet.g.alchemy.com/v2/API_KEY |
+| Polygon zkEVM | Polygon zkEVM Cardona (deprecating July 1, 2026 — [details](/docs/reference/polygon-zkevm-deprecation-notice)) | https://polygonzkevm-cardona.g.alchemy.com/v2/API_KEY |
 | ZetaChain | ZetaChain Mainnet | https://zetachain-mainnet.g.alchemy.com/v2/API_KEY |
 | ZetaChain | ZetaChain Testnet | https://zetachain-testnet.g.alchemy.com/v2/API_KEY |
 | Mantle | Mantle Mainnet | https://mantle-mainnet.g.alchemy.com/v2/API_KEY |

--- a/content/api-reference/polygon-zkevm/polygon-zkevm-api-quickstart.mdx
+++ b/content/api-reference/polygon-zkevm/polygon-zkevm-api-quickstart.mdx
@@ -6,7 +6,7 @@ slug: reference/polygon-zkevm-api-quickstart
 ---
 
 <Warning title="Polygon zkEVM deprecation">
-  Polygon Labs is [shutting down the Polygon zkEVM network on July 1, 2026](https://polygon.technology/polygon-zkevm). Alchemy will fully deprecate support for **Polygon zkEVM Mainnet** (`polygonzkevm-mainnet`) and the **Cardona** testnet (`polygonzkevm-cardona`) on **July 9, 2026**. See the [Polygon zkEVM Deprecation Notice](/docs/reference/polygon-zkevm-deprecation-notice) for details.
+  Polygon Labs is [shutting down the Polygon zkEVM network on July 1, 2026](https://polygon.technology/polygon-zkevm). Alchemy will fully deprecate support for **Polygon zkEVM Mainnet** (`polygonzkevm-mainnet`) and the **Cardona** testnet (`polygonzkevm-cardona`) on **July 1, 2026**. See the [Polygon zkEVM Deprecation Notice](/docs/reference/polygon-zkevm-deprecation-notice) for details.
 </Warning>
 
 <Tip title="Don't have an API key?" icon="star">

--- a/content/api-reference/polygon-zkevm/polygon-zkevm-deprecation-notice.mdx
+++ b/content/api-reference/polygon-zkevm/polygon-zkevm-deprecation-notice.mdx
@@ -6,13 +6,13 @@ slug: reference/polygon-zkevm-deprecation-notice
 
 ## ⚠️ Deprecation Notice
 
-**Alchemy will fully deprecate support for Polygon zkEVM Mainnet (`polygonzkevm-mainnet`) and the Polygon zkEVM Cardona testnet (`polygonzkevm-cardona`) on July 9, 2026.** After this date, requests to these endpoints will no longer be supported.
+**Alchemy will fully deprecate support for Polygon zkEVM Mainnet (`polygonzkevm-mainnet`) and the Polygon zkEVM Cardona testnet (`polygonzkevm-cardona`) on July 1, 2026.** After this date, requests to these endpoints will no longer be supported.
 
-Polygon zkEVM is being deprecated because [Polygon Labs is shutting down the Polygon zkEVM network on July 1, 2026](https://polygon.technology/polygon-zkevm). Both the mainnet and the Cardona testnet will be sunset by Polygon Labs, and Alchemy will spin down support shortly after.
+Polygon zkEVM is being deprecated because [Polygon Labs is shutting down the Polygon zkEVM network on July 1, 2026](https://polygon.technology/polygon-zkevm). Both the mainnet and the Cardona testnet will be sunset by Polygon Labs.
 
 ## What you need to do
 
-There is no migration path for Polygon zkEVM, as the network itself is being shut down. Before July 9, 2026:
+There is no migration path for Polygon zkEVM, as the network itself is being shut down. Before July 1, 2026:
 
 1. Remove any dependencies on Polygon zkEVM endpoints (`polygonzkevm-mainnet` and `polygonzkevm-cardona`) from your applications.
 2. If you are building on a Layer 2, explore Alchemy's other [supported chains](/docs/reference/node-supported-chains) for an alternative network that fits your needs.


### PR DESCRIPTION
## Summary
Follow-up to [#1397](https://github.com/alchemyplatform/docs/pull/1397). Updates the customer-facing Polygon zkEVM deprecation date from **July 9, 2026** to **July 1, 2026** to align with the network shutdown and avoid confusing customers with two different timelines.

Even though Alchemy continues supporting RPC through July 9, we communicate **July 1** (the network shutdown date) as the deprecation date.

Changes:
- **Deprecation notice page** — header date and "what you need to do" date updated to July 1; dropped the "spin down support shortly after" phrasing so there's a single timeline.
- **Polygon zkEVM API Quickstart** warning callout — updated to July 1, 2026.
- **Supported chains table** — both Mainnet and Cardona now read "deprecating July 1, 2026".

Made with [Cursor](https://cursor.com)