### PR TITLE
Fix Yellowstone API overview links copying URL instead of navigating

### DIFF
--- a/content/api-reference/yellowstone/api-reference-overview.mdx
+++ b/content/api-reference/yellowstone/api-reference-overview.mdx
@@ -11,23 +11,23 @@ Yellowstone gRPC provides real-time streaming of Solana blockchain data through 
 ## Subscription types
 
 <CardGroup>
-  <Card title="Subscribe Request" icon="gear" href="/docs/reference/yellowstone-grpc-subscribe-request">
+  <Card title="Subscribe Request" href="/docs/reference/yellowstone-grpc-subscribe-request">
     The base structure for all subscriptions. Defines filters, commitment levels, and combines multiple subscription types in a single request.
   </Card>
 
-  <Card title="Subscribe to Slots" icon="clock" href="/docs/reference/yellowstone-grpc-subscribe-slots">
+  <Card title="Subscribe to Slots" href="/docs/reference/yellowstone-grpc-subscribe-slots">
     Track slot progression and chain state. Essential for understanding confirmations and synchronizing with blockchain time.
   </Card>
 
-  <Card title="Subscribe to Transactions" icon="arrow-right-arrow-left" href="/docs/reference/yellowstone-grpc-subscribe-transactions">
+  <Card title="Subscribe to Transactions" href="/docs/reference/yellowstone-grpc-subscribe-transactions">
     Stream transactions with filters for accounts, vote/non-vote, and success/failure status.
   </Card>
 
-  <Card title="Subscribe to Accounts" icon="user" href="/docs/reference/yellowstone-grpc-subscribe-accounts">
+  <Card title="Subscribe to Accounts" href="/docs/reference/yellowstone-grpc-subscribe-accounts">
     Monitor account changes with filters for addresses, owners, data patterns, and balances.
   </Card>
 
-  <Card title="Subscribe to Blocks" icon="cube" href="/docs/reference/yellowstone-grpc-subscribe-blocks">
+  <Card title="Subscribe to Blocks" href="/docs/reference/yellowstone-grpc-subscribe-blocks">
     Stream complete blocks with all transactions and metadata.
   </Card>
 </CardGroup>

--- a/content/api-reference/yellowstone/api-reference-overview.mdx
+++ b/content/api-reference/yellowstone/api-reference-overview.mdx
@@ -10,17 +10,24 @@ Yellowstone gRPC provides real-time streaming of Solana blockchain data through 
 
 ## Subscription types
 
-### [Subscribe Request](/docs/reference/yellowstone-grpc-subscribe-request)
-The base structure for all subscriptions. Defines filters, commitment levels, and combines multiple subscription types in a single request.
+<CardGroup>
+  <Card title="Subscribe Request" icon="gear" href="/docs/reference/yellowstone-grpc-subscribe-request">
+    The base structure for all subscriptions. Defines filters, commitment levels, and combines multiple subscription types in a single request.
+  </Card>
 
-### [Subscribe to Slots](/docs/reference/yellowstone-grpc-subscribe-slots)
-Track slot progression and chain state. Essential for understanding confirmations and synchronizing with blockchain time.
+  <Card title="Subscribe to Slots" icon="clock" href="/docs/reference/yellowstone-grpc-subscribe-slots">
+    Track slot progression and chain state. Essential for understanding confirmations and synchronizing with blockchain time.
+  </Card>
 
-### [Subscribe to Transactions](/docs/reference/yellowstone-grpc-subscribe-transactions)
-Stream transactions with filters for accounts, vote/non-vote, and success/failure status.
+  <Card title="Subscribe to Transactions" icon="arrow-right-arrow-left" href="/docs/reference/yellowstone-grpc-subscribe-transactions">
+    Stream transactions with filters for accounts, vote/non-vote, and success/failure status.
+  </Card>
 
-### [Subscribe to Accounts](/docs/reference/yellowstone-grpc-subscribe-accounts)
-Monitor account changes with filters for addresses, owners, data patterns, and balances.
+  <Card title="Subscribe to Accounts" icon="user" href="/docs/reference/yellowstone-grpc-subscribe-accounts">
+    Monitor account changes with filters for addresses, owners, data patterns, and balances.
+  </Card>
 
-### [Subscribe to Blocks](/docs/reference/yellowstone-grpc-subscribe-blocks)
-Stream complete blocks with all transactions and metadata.
+  <Card title="Subscribe to Blocks" icon="cube" href="/docs/reference/yellowstone-grpc-subscribe-blocks">
+    Stream complete blocks with all transactions and metadata.
+  </Card>
+</CardGroup>


### PR DESCRIPTION
## Summary

On the [Yellowstone gRPC API Reference Overview](https://www.alchemy.com/docs/reference/yellowstone-grpc-api-overview) page, clicking a "Subscription types" entry copied the page's section anchor (e.g. `…#subscribe-to-slots`) to the clipboard instead of navigating to the linked subpage.

**Root cause:** each entry was authored as a *heading that is also a link* — `### [Subscribe to Slots](/docs/reference/yellowstone-grpc-subscribe-slots)`. Fern auto-generates a section anchor id for every heading and attaches a "copy link to this section" click handler. That handler intercepted the click and won over the embedded `<a href>`, so the click copied the current page's anchor rather than following the link.

**Fix:** convert the five entries into a `<CardGroup>` of `<Card>`s (the pattern already used elsewhere in the docs, e.g. `solana-api-quickstart.mdx`). Cards navigate via `href` with no heading-anchor interference, and the section reads as a cleaner navigation index.

## Test plan

- [x] Verify in a docs preview that clicking each card navigates to the corresponding subpage:
  - Subscribe Request → `/docs/reference/yellowstone-grpc-subscribe-request`
  - Subscribe to Slots → `/docs/reference/yellowstone-grpc-subscribe-slots`
  - Subscribe to Transactions → `/docs/reference/yellowstone-grpc-subscribe-transactions`
  - Subscribe to Accounts → `/docs/reference/yellowstone-grpc-subscribe-accounts`
  - Subscribe to Blocks → `/docs/reference/yellowstone-grpc-subscribe-blocks`

🤖 Generated with [Claude Code](https://claude.com/claude-code)