### PR TITLE
Document Usage API range limits

### DIFF
--- a/content/tutorials/build-with-ai/alchemy-cli.mdx
+++ b/content/tutorials/build-with-ai/alchemy-cli.mdx
@@ -286,6 +286,16 @@ alchemy usage timeseries --start-date 2026-06-01 --group-by network --metrics us
 
 `timeseries` accepts a date or time range, optional filters, and a single group-by dimension.
 
+Usage time-series ranges are limited by plan:
+
+| Plan | Maximum range |
+|---|---:|
+| Free | 1 day |
+| Pay as You Go | 7 days |
+| Longer ranges | [Contact sales](https://www.alchemy.com/contact-sales) |
+
+If you request a range longer than your plan supports, the Usage API returns results for the allowed range. The CLI shows the requested and returned ranges when this happens.
+
 | Flag | Description |
 |---|---|
 | `--start-date <date>` | Start date (`YYYY-MM-DD`). Required unless `--start-time` is set. |


### PR DESCRIPTION
## Description

Document the Usage API time-series range limits in the existing Alchemy CLI docs Usage section so users can understand why long requests may only return the allowed range.

## Related Issues

https://linear.app/alchemyapi/issue/AX-525/document-usage-api-date-range-limits

## Changes Made

- Added a Usage API plan-limit table for Free, Pay as You Go, and longer ranges.
- Linked longer-range users to the Alchemy contact sales page.
- Clarified that over-limit requests return the allowed range and that the CLI shows requested vs. returned ranges when this happens.

## Testing

- [x] I have tested these changes locally
- [ ] I have run the validation scripts (`pnpm run validate`)
- [ ] I have checked that the documentation builds correctly

Validation run:

- [x] `pnpm exec eslint content/tutorials/build-with-ai/alchemy-cli.mdx`
- [x] `pnpm exec prettier --check content/tutorials/build-with-ai/alchemy-cli.mdx`
- [x] `git diff --check`
- [ ] `pnpm run validate:docs-yml` could not complete because `scripts/validate-docs-yml.ts` fails at startup with `SyntaxError: The requested module 'ajv' does not provide an export named 'Ajv'`.

Created by Codex.
