### PR TITLE
Clean up July 2 weekly changelog: remove non-public chains, add release links

### DIFF
--- a/content/changelog/2026-07-02.md
+++ b/content/changelog/2026-07-02.md
@@ -10,23 +10,11 @@
 
 * Bob Mainnet: op-reth v2.3.3
 * Eth Hoodi: lighthouse [v8.2.0](https://github.com/sigp/lighthouse/releases/tag/v8.2.0)
-* Etherlink Mainnet: etherlink octez-evm-node-v0.62-pre1
-* Etherlink Testnet: etherlink octez-evm-node-v0.60
-* Hedera Mainnet: relay 0.78.0
-* Hedera Testnet: relay 0.78.0
-* Hemi Sepolia: op-node a22bfa0
-* Jovay Mainnet: jovay 0.14.0-rc1
-* Jovay Testnet: jovay 0.14.0-rc1
-* Lens Mainnet: zksync-en v31.0.0
-* Lisk Mainnet: op-reth v2.3.3, op-node v1.19.1
-* Neox Mainnet: neox-geth v1.17.4
-* Neox Testnet: neox-geth v1.17.4
+* Jovay Mainnet: jovay [0.14.0-rc1](https://github.com/jovaynetwork/jovay-releases/releases/tag/v0.14.0-rc1)
+* Jovay Testnet: jovay [0.14.0-rc1](https://github.com/jovaynetwork/jovay-releases/releases/tag/v0.14.0-rc1)
+* Lens Mainnet: zksync-en [v31.0.0](https://github.com/matter-labs/zksync-era/releases/tag/core-v31.0.0)
 * Rise Testnet: rise-node sha-bb10092, op-node sha-b1f242d
-* Robinhood Testnet: nitro-node v3.11.1-8512b8c
+* Robinhood Testnet: nitro-node [v3.11.1-8512b8c](https://github.com/OffchainLabs/nitro/releases/tag/v3.11.1)
 * Shape Mainnet: op-reth v2.3.2
-* Taiko Mainnet: taiko-client taiko-alethia-client-v2.3.1
-* Taiko Testnet: taiko-client taiko-alethia-client-v2.5.0
-* Tempo Mainnet: tempo 1.10.1
-* Tempo Moderato: tempo 1.10.1
-* Xdc Mainnet: xdc-node [v2.7.1](https://github.com/xinfinorg/xdposchain/releases/tag/v2.7.1)
-* Xdc Testnet: xdc-node [v2.7.1](https://github.com/xinfinorg/xdposchain/releases/tag/v2.7.1)
+* Tempo Mainnet: tempo [1.10.1](https://github.com/tempoxyz/tempo/releases/tag/v1.10.1)
+* Tempo Moderato: tempo [1.10.1](https://github.com/tempoxyz/tempo/releases/tag/v1.10.1)


### PR DESCRIPTION
## Summary
- Cross-checked every network in `content/changelog/2026-07-02.md` against `dashboard/networks/prod/<NETWORK>.yml` in OMGWINNING/chain-config and removed entries whose `availability` is not `PUBLIC`:
  - Etherlink Mainnet/Testnet, Hedera Mainnet/Testnet, Hemi Sepolia, Lisk Mainnet, Neox Mainnet/Testnet, Taiko Mainnet/Testnet (Hoodi), Xdc Mainnet/Testnet (all `PRERELEASE`)
- Added missing upstream GitHub release links:
  - Jovay Mainnet/Testnet → `jovaynetwork/jovay-releases` tag `v0.14.0-rc1`
  - Lens Mainnet (zksync-en) → `matter-labs/zksync-era` tag `core-v31.0.0`
  - Robinhood Testnet (nitro-node) → `OffchainLabs/nitro` tag `v3.11.1` (nearest release to the build-suffixed `v3.11.1-8512b8c`)
  - Tempo Mainnet/Moderato → `tempoxyz/tempo` tag `v1.10.1`
- Left the following unlinked since no canonical upstream release exists:
  - Bob Mainnet / Shape Mainnet `op-reth` patch versions (reth only tags minors)
  - Rise Testnet `rise-node`/`op-node` sha-pinned builds

## Test plan
- [x] Verified each removed network's `availability` field in `dashboard/networks/prod/` via GitHub API
- [x] Verified each added release link resolves via GitHub releases API