### PR TITLE
docs(pricing): add cu:auto markers to Compute Unit Costs tables

### DIFF
--- a/content/api-reference/pricing-resources/pricing/compute-unit-costs.mdx
+++ b/content/api-reference/pricing-resources/pricing/compute-unit-costs.mdx
@@ -14,6 +14,7 @@ For more details, check out the [Compute Units](/docs/reference/compute-units#wh
 
 # EVM: Standard JSON-RPC Methods
 
+{/* cu:auto product="evm" */}
 | Method                                   | CU                          | Throughput CU |
 | ---------------------------------------- | --------------------------- | ------------- |
 | net\_version                             | 0                           |               |
@@ -80,11 +81,13 @@ For more details, check out the [Compute Units](/docs/reference/compute-units#wh
 | eth\_getBlockReceipts                    | 20                          | 500           |
 | eth\_submitWork                          | 20                          |               |
 | batch                                    | CU of method # times called |               |
+{/* cu:auto end */}
 
 * To view the batch request breakdown in the Alchemy Dashboard, click on "raw request"
 
 # Solana: Standard JSON-RPC Methods
 
+{/* cu:auto product="solana" */}
 | Method                            | CU                          | Throughput CU |
 | --------------------------------- | --------------------------- | ------------- |
 | getLeaderSchedule                 | 20                          |               |
@@ -141,11 +144,13 @@ For more details, check out the [Compute Units](/docs/reference/compute-units#wh
 | getSupply                         | 160                         |               |
 | getLargestAccounts                | 3000                        |               |
 | batch\*                           | CU of method # times called |               |
+{/* cu:auto end */}
 
 * To view the batch request breakdown in the Alchemy Dashboard, click on "raw request"
 
 # Solana: DAS APIs (NFT/Token)
 
+{/* cu:auto product="solana-das" */}
 | Method               | CU  | Throughput CU |
 | -------------------- | --- | ------------- |
 | getAsset             | 80  | 200           |
@@ -160,9 +165,11 @@ For more details, check out the [Compute Units](/docs/reference/compute-units#wh
 | getAssetSignatures   | 160 | 200           |
 | getNftEditions       | 160 | 200           |
 | getTokenAccounts     | 160 | 200           |
+{/* cu:auto end */}
 
 # Solana: Photon APIs (ZK Compression)
 
+{/* cu:auto product="solana-photon" */}
 | Method                                | CU   | Throughput CU |
 | ------------------------------------- | ---- | ------------- |
 | getCompressedAccount                  | 120  | 100           |
@@ -191,6 +198,7 @@ For more details, check out the [Compute Units](/docs/reference/compute-units#wh
 | getTransactionWithCompressionInfo     | 120  | 100           |
 | getValidityProof                      | 1200 | 500           |
 | getValidityProofV2                    | 1200 | 500           |
+{/* cu:auto end */}
 
 # Solana: Yellowstone gRPC
 
@@ -212,6 +220,7 @@ For more details, check out the [Compute Units](/docs/reference/compute-units#wh
 
 # Debug API
 
+{/* cu:auto product="debug" */}
 | Method                    | CU | Throughput CU |
 | ------------------------- | -- | ------------- |
 | debug\_traceTransaction   | 40 | 1000          |
@@ -223,22 +232,26 @@ For more details, check out the [Compute Units](/docs/reference/compute-units#wh
 | debug\_getRawHeader       | 40 | 1000          |
 | debug\_getRawReceipts     | 40 | 1000          |
 | debug\_storageRangeAt     | 40 | 1000          |
+{/* cu:auto end */}
 
 # Embedded Account APIs
 
 Similar to the [NFT API](/docs/reference/compute-unit-costs#nft-api), the Embedded Account APIs implement "Throughput CU" to count separately toward your applications' throughput!
 
+{/* cu:auto product="signer" */}
 | Method               | CU   | Throughput CU |
 | -------------------- | ---- | ------------- |
 | /signer/auth         | 100  | 50            |
 | /signer/lookup       | 20   | 50            |
 | /signer/sign-payload | 6000 | 300           |
 | /signer/whoami       | 100  | 20            |
+{/* cu:auto end */}
 
 # Gas Manager & Bundler APIs
 
 Similar to the [NFT API](/docs/reference/compute-unit-costs#nft-api), the Gas Manager & Bundler APIs implement "Throughput CU" to count separately toward your applications' throughput!
 
+{/* cu:auto product="gas-manager-bundler" */}
 | Method                                     | CU   | Throughput CU |
 | ------------------------------------------ | ---- | ------------- |
 | eth\_sendUserOperation                     | 1000 | 100           |
@@ -251,6 +264,7 @@ Similar to the [NFT API](/docs/reference/compute-unit-costs#nft-api), the Gas Ma
 | alchemy\_requestPaymasterAndData           | 1000 | 100           |
 | alchemy\_requestGasAndPaymasterAndData     | 1250 | 125           |
 | alchemy\_requestFeePayer                   | 1000 | 100           |
+{/* cu:auto end */}
 
 * When `eth_sendUserOperation` is called with a valid bundler sponsorship header (`x-alchemy-policy-id`), the CU cost is 3000 instead of the standard 1000.
 * When `alchemy_requestFeePayer` is called with `prefundRent = true`, the CU cost is 1250 instead of the standard 1000.
@@ -259,6 +273,7 @@ Similar to the [NFT API](/docs/reference/compute-unit-costs#nft-api), the Gas Ma
 
 We want builders to be able to use as much of the NFT API as they need without worrying about throughput. Because of that, we have discounted how NFT API requests count towards your applications’ guaranteed throughput by 6-10x. This means you can make more concurrent NFT API requests, and use the “Throughput CU” below to calculate how much you can use!
 
+{/* cu:auto product="nft" */}
 | Method                   | CU   | Throughput CU |
 | ------------------------ | ---- | ------------- |
 | getNFTMetadata           | 80   | 10            |
@@ -284,9 +299,11 @@ We want builders to be able to use as much of the NFT API as they need without w
 | invalidateContract       | 80   | 80            |
 | refreshNftMetadata       | 40   | 10            |
 | reportSpam               | 0    | 10            |
+{/* cu:auto end */}
 
 # Portfolio API
 
+{/* cu:auto product="portfolio" */}
 | Method                            | CU   |
 | --------------------------------- | ---- |
 | assets/nfts/by-address            | 1000 |
@@ -294,25 +311,31 @@ We want builders to be able to use as much of the NFT API as they need without w
 | assets/tokens/by-address          | 360  |
 | assets/tokens/balances/by-address | 200  |
 | /transactions/history/by-address  | 1000 |
+{/* cu:auto end */}
 
 # Prices API
 
+{/* cu:auto product="prices" */}
 | Method            | CU |
 | ----------------- | -- |
 | tokens/by-symbol  | 40 |
 | tokens/by-address | 40 |
 | tokens/historical | 40 |
+{/* cu:auto end */}
 
 # Token API
 
+{/* cu:auto product="token" */}
 | Method                     | CU  |
 | -------------------------- | --- |
 | alchemy\_getTokenBalances  | 20  |
 | alchemy\_getTokenMetadata  | 10  |
 | alchemy\_getTokenAllowance | 20  |
+{/* cu:auto end */}
 
 # Trace API
 
+{/* cu:auto product="trace" */}
 | Method                         | CU | Throughput CU |
 | ------------------------------ | -- | ------------- |
 | trace\_get                     | 20 | 20            |
@@ -324,9 +347,11 @@ We want builders to be able to use as much of the NFT API as they need without w
 | trace\_filter                  | 40 | 40            |
 | trace\_replayTransaction       | 80 | 3000          |
 | trace\_replayBlockTransactions | 80 | 3000          |
+{/* cu:auto end */}
 
 # Arbitrum Trace API
 
+{/* cu:auto product="arbtrace" */}
 | Method                            | CU | Throughput CU |
 | --------------------------------- | -- | ------------- |
 | arbtrace\_get                     | 20 | 20            |
@@ -337,30 +362,38 @@ We want builders to be able to use as much of the NFT API as they need without w
 | arbtrace\_filter                  | 40 | 40            |
 | arbtrace\_replayTransaction       | 80 | 3000          |
 | arbtrace\_replayBlockTransactions | 80 | 3000          |
+{/* cu:auto end */}
 
 # Transact
 
+{/* cu:auto product="transact" */}
 | Method                                    | CU   |
 | ----------------------------------------- | ---- |
 | alchemy\_simulateAssetChanges             | 2500 |
 | alchemy\_simulateExecution                | 2500 |
+{/* cu:auto end */}
 
 # Transfers API
 
+{/* cu:auto product="transfers" */}
 | Method                     | CU  |
 | -------------------------- | --- |
 | alchemy\_getAssetTransfers | 120 |
+{/* cu:auto end */}
 
 # Utility API
 
+{/* cu:auto product="utility" */}
 | Method                          | CU  |
 | ------------------------------- | --- |
 | alchemy\_getTransactionReceipts | 250 |
+{/* cu:auto end */}
 
 # Wallet APIs
 
 Similar to the [NFT API](/docs/reference/compute-unit-costs#nft-api), the Wallet APIs implement "Throughput CU" to count separately toward your applications' throughput!
 
+{/* cu:auto product="wallet" */}
 | Method                                     | CU   | Throughput CU |
 | ------------------------------------------ | ---- | ------------- |
 | wallet_requestAccount                      | 50   | -             |
@@ -376,6 +409,7 @@ Similar to the [NFT API](/docs/reference/compute-unit-costs#nft-api), the Wallet
 | wallet_getCrossChainStatus_v0              | 40   | -             |
 | wallet_prepareSign                         | 15   | -             |
 | wallet_requestQuote_v0                     | 800  | -             |
+{/* cu:auto end */}
 
 # Webhooks and Subscription APIs
 
@@ -391,6 +425,7 @@ On average, a typical byte-priced webhook or WebSocket subscription event is abo
 
 # Polygon PoS: Specific Methods
 
+{/* cu:auto product="polygon-pos" */}
 | Method                    | CU |
 | ------------------------- | -- |
 | bor\_getAuthor            | 10 |
@@ -398,9 +433,11 @@ On average, a typical byte-priced webhook or WebSocket subscription event is abo
 | bor\_getCurrentValidators | 10 |
 | bor\_getRootHash          | 10 |
 | bor\_getSignersAtHash     | 10 |
+{/* cu:auto end */}
 
 # Polygon zkEVM: Specific Methods
 
+{/* cu:auto product="polygon-zkevm" */}
 | Method                          | CU |
 | ------------------------------- | -- |
 | zkevm\_batchNumber              | 10 |
@@ -414,9 +451,11 @@ On average, a typical byte-priced webhook or WebSocket subscription event is abo
 | zkevm\_virtualBatchNumber       | 10 |
 | zkevm\_estimateFee              | 40 |
 | zkevm\_estimateGasPrice         | 40 |
+{/* cu:auto end */}
 
 # Starknet: Standard JSON-RPC Methods
 
+{/* cu:auto product="starknet" */}
 | Method                                    | CU   |
 | ----------------------------------------- | ---- |
 | starknet\_getBlockWithTxHashes            | 20   |
@@ -452,9 +491,11 @@ On average, a typical byte-priced webhook or WebSocket subscription event is abo
 | starknet\_getMessagesStatus              | 20   |
 | starknet\_getStorageProof                | 20   |
 | starknet\_traceTransaction               | 20   |
+{/* cu:auto end */}
 
 # zkSync Era: Specific Methods
 
+{/* cu:auto product="zksync" */}
 | Method                                          | CU |
 | ----------------------------------------------- | -- |
 | zks\_estimateFee                                | 10 |
@@ -481,9 +522,11 @@ On average, a typical byte-priced webhook or WebSocket subscription event is abo
 | zks\_L1BatchNumber                              | 10 |
 | zks\_L1ChainId                                  | 10 |
 | zks\_sendRawTransactionWithDetailedOutput       | 20 |
+{/* cu:auto end */}
 
 # Ethereum Beacon: Standard HTTP API Methods
 
+{/* cu:auto product="eth-beacon" */}
 | Method                                                         | CU  |
 | -------------------------------------------------------------- | --- |
 | /eth/v2/beacon/blocks/\{block\_id}/attestations                | 20  |
@@ -526,9 +569,11 @@ On average, a typical byte-priced webhook or WebSocket subscription event is abo
 | /eth/v1/beacon/states/\{state\_id}/proposer\_lookahead         | 20  |
 | /eth/v1/beacon/states/\{state\_id}/randao                      | 20  |
 | /eth/v1/beacon/states/\{state\_id}/validator\_identities       | 20  |
+{/* cu:auto end */}
 
 # Aptos: Standard REST API Methods
 
+{/* cu:auto product="aptos" */}
 | Method                                                         | CU  |
 | -------------------------------------------------------------- | --- |
 | /v1/                                                           | 20  |
@@ -555,9 +600,11 @@ On average, a typical byte-priced webhook or WebSocket subscription event is abo
 | /v1/transactions/encode\_submission                            | 20  |
 | /v1/transactions/simulate                                      | 20  |
 | /v1/view                                                       | 20  |
+{/* cu:auto end */}
 
 # Bitcoin: Standard JSON-RPC Methods
 
+{/* cu:auto product="bitcoin" */}
 | Method                                                    | CU  |
 | --------------------------------------------------------- | --- |
 | getbestblockhash                                          | 10  |
@@ -590,9 +637,11 @@ On average, a typical byte-priced webhook or WebSocket subscription event is abo
 | testmempoolaccept                                         | 10  |
 | sendrawtransaction                                        | 10  |
 | submitpackage                                             | 10  |
+{/* cu:auto end */}
 
 # UTXO REST API Methods
 
+{/* cu:auto product="utxo" */}
 | Method                                                    | CU  |
 | --------------------------------------------------------- | --- |
 | /api/v2/block-index/\{block\_height}                      | 20  |
@@ -607,9 +656,11 @@ On average, a typical byte-priced webhook or WebSocket subscription event is abo
 | /api/v2/tickers-list                                      | 20  |
 | /api/v2/tickers                                           | 20  |
 | /api/v2/balancehistory/\{address}                         | 20  |
+{/* cu:auto end */}
 
 # Celestia Bridge: Standard RPC Methods
 
+{/* cu:auto product="celestia" */}
 | Method                                                    | CU  |
 | --------------------------------------------------------- | --  |
 | blob.Get                                                  | 20  |
@@ -641,9 +692,11 @@ On average, a typical byte-priced webhook or WebSocket subscription event is abo
 | da.Submit                                                 | 20  |
 | da.Get                                                    | 20  |
 | fraud.Get                                                 | 20  |
+{/* cu:auto end */}
 
 # Citrea: Specific Methods
 
+{/* cu:auto product="citrea" */}
 | Method                                      | CU |
 | ------------------------------------------- | -- |
 | citrea\_getL2StatusHeightsByL1Height        | 20 |
@@ -663,23 +716,29 @@ On average, a typical byte-priced webhook or WebSocket subscription event is abo
 | ledger\_getSequencerCommitmentsOnSlotByHash | 20 |
 | ledger\_getSequencerCommitmentsOnSlotByNumber | 20 |
 | ledger\_getVerifiedBatchProofsBySlotHeight  | 20 |
+{/* cu:auto end */}
 
 # Linea: Specific Methods
 
+{/* cu:auto product="linea" */}
 | Method                                        | CU |
 | --------------------------------------------- | -- |
 | linea\_estimateGas                            | 20 |
 | linea\_getProof                               | 20 |
 | linea\_getTransactionExclusionStatusV1        | 20 |
+{/* cu:auto end */}
 
 # MegaETH: Specific Methods
 
+{/* cu:auto product="megaeth" */}
 | Method                    | CU |
 | ------------------------- | -- |
 | eth\_getWithdrawalProof   | 20 |
+{/* cu:auto end */}
 
 # Stellar: Standard Methods
 
+{/* cu:auto product="stellar" */}
 | Method               | CU |
 | -------------------- | -- |
 | getEvents            | 20 |
@@ -694,9 +753,11 @@ On average, a typical byte-priced webhook or WebSocket subscription event is abo
 | getVersionInfo       | 20 |
 | sendTransaction      | 20 |
 | simulateTransaction  | 20 |
+{/* cu:auto end */}
 
 # Sui: Standard Methods
 
+{/* cu:auto product="sui" */}
 | Method                                   | CU |
 | ---------------------------------------- | -- |
 | sui\_devInspectTransactionBlock           | 20 |
@@ -751,9 +812,11 @@ On average, a typical byte-priced webhook or WebSocket subscription event is abo
 | unsafe\_splitCoinEqual                   | 20 |
 | unsafe\_transferObject                   | 20 |
 | unsafe\_transferSui                      | 20 |
+{/* cu:auto end */}
 
 # Tron: Standard HTTP Methods
 
+{/* cu:auto product="tron" */}
 | Method                                                    | CU  |
 | --------------------------------------------------------- | --- |
 | /wallet/accountpermissionupdate                           | 20  |
@@ -844,9 +907,11 @@ On average, a typical byte-priced webhook or WebSocket subscription event is abo
 | /wallet/updatesetting                                     | 20  |
 | /wallet/votewitnessaccount                                | 20  |
 | /wallet/withdrawexpireunfreeze                            | 20  |
+{/* cu:auto end */}
 
 # Tron: Solidity HTTP Methods
 
+{/* cu:auto product="tron-solidity" */}
 | Method                                                    | CU  |
 | --------------------------------------------------------- | --- |
 | /walletsolidity/estimateenergy                            | 20  |
@@ -879,6 +944,7 @@ On average, a typical byte-priced webhook or WebSocket subscription event is abo
 | /walletsolidity/scanshieldedtrc20notesbyivk               | 20  |
 | /walletsolidity/scanshieldedtrc20notesbyovk               | 20  |
 | /walletsolidity/triggerconstantcontract                   | 20  |
+{/* cu:auto end */}
 
 # Compute unit cost for error codes
 


### PR DESCRIPTION
## Description

One-time setup for automating the [Compute Unit Costs](https://www.alchemy.com/docs/reference/compute-unit-costs) pricing page from Daikon topconfig (DX-3112). Dynamic CU pricing means customers are billed updated prices immediately after a chain-config update, so this hand-maintained page needs to regenerate automatically.

This PR wraps each generated CU table in `{/* cu:auto product="<tag>" */}` … `{/* cu:auto end */}` markers — MDX comments that do not render. The new `UpdateComputeUnitCostsFromDaikonWorkflow` in the dashboard repo (companion PR: OMGWINNING/dashboard#8087) rewrites only the table rows between markers on a daily cron; all prose, headers, and footnotes outside markers stay hand-written and are never touched. The `product` tag is the stable key the automation matches on — not the header text — so renaming a header or moving a whole block (markers included) is safe.

## Summary

- Wrap all 33 per-method CU tables in `cu:auto` markers (marker insertion only — zero changes to table content in this PR)
- Bandwidth-priced and rules sections intentionally have NO markers and stay fully manual: Solana Yellowstone gRPC, Solana WebSocket Subscriptions, Webhooks and Subscription APIs, and the error-codes table
- Conditional-pricing footnotes (e.g. sponsored `eth_sendUserOperation`, `alchemy_requestFeePayer` with `prefundRent`) live outside markers and persist across regenerations

## Test Plan

- [x] `prettier --check` passes on the page
- [x] Simulated the workflow's full regeneration against this marked-up page + real topconfig: markers parse, regeneration is idempotent, output is prettier-clean
- [x] Markers are MDX comments — verified they do not render

LINEAR TASK: https://linear.app/alchemyapi/issue/DX-3112/automate-the-compute-unit-costs-pricing-page-from-daikon-topconfig