### PR TITLE
docs(pricing): first generated Compute Unit Costs update (drift audit)

### DIFF
--- a/content/api-reference/pricing-resources/pricing/compute-unit-costs.mdx
+++ b/content/api-reference/pricing-resources/pricing/compute-unit-costs.mdx
@@ -17,69 +17,76 @@ For more details, check out the [Compute Units](/docs/reference/compute-units#wh
 {/* cu:auto product="evm" */}
 | Method                                   | CU                          | Throughput CU |
 | ---------------------------------------- | --------------------------- | ------------- |
-| net\_version                             | 0                           |               |
-| eth\_chainId                             | 0                           |               |
-| eth\_syncing                             | 0                           |               |
-| eth\_protocolVersion                     | 0                           |               |
-| net\_listening                           | 0                           |               |
-| eth\_uninstallFilter                     | 10                          |               |
+| eth\_chainId                             | 0                           | 5             |
+| eth\_protocolVersion                     | 0                           | 5             |
+| eth\_syncing                             | 0                           | 5             |
+| net\_listening                           | 0                           | 5             |
+| net\_peerCount                           | 0                           | 5             |
+| net\_version                             | 0                           | 5             |
 | eth\_accounts                            | 10                          |               |
-| eth\_blockNumber                         | 10                          |               |
-| eth\_subscribe                           | 10                          |               |
-| eth\_unsubscribe                         | 10                          |               |
-| eth\_feeHistory                          | 10                          |               |
 | eth\_baseFee                             | 10                          |               |
-| eth\_maxPriorityFeePerGas                | 10                          |               |
 | eth\_blobBaseFee                         | 10                          |               |
+| eth\_blockNumber                         | 10                          |               |
 | eth\_createAccessList                    | 10                          |               |
-| eth\_getTransactionReceipt               | 20                          |               |
-| eth\_getUncleByBlockHashAndIndex         | 20                          |               |
-| eth\_getUncleByBlockNumberAndIndex       | 20                          |               |
-| eth\_getTransactionByBlockHashAndIndex   | 20                          |               |
-| eth\_getTransactionByBlockNumberAndIndex | 20                          |               |
-| eth\_getUncleCountByBlockHash            | 20                          |               |
-| eth\_getUncleCountByBlockNumber          | 20                          |               |
-| web3\_clientVersion                      | 20                          |               |
-| web3\_sha3                               | 20                          |               |
-| eth\_getBlockByNumber                    | 20                          |               |
-| eth\_getStorageAt                        | 20                          |               |
-| eth\_getTransactionByHash                | 20                          |               |
-| eth\_getRawTransactionByHash             | 20                          |               |
-| eth\_gasPrice                            | 20                          |               |
-| eth\_getBalance                          | 20                          |               |
-| eth\_getCode                             | 20                          |               |
-| eth\_getBlobSidecars                     | 20                          |               |
-| eth\_getFinalizedHeader                  | 20                          |               |
-| eth\_getFilterChanges                    | 20                          |               |
-| eth\_newBlockFilter                      | 20                          |               |
-| eth\_newFilter                           | 20                          |               |
-| eth\_simulateV1                          | 40                          |               |
-| eth\_newPendingTransactionFilter         | 20                          |               |
-| eth\_getBlockTransactionCountByHash      | 20                          |               |
-| eth\_getBlockTransactionCountByNumber    | 20                          |               |
-| eth\_getProof                            | 20                          |               |
-| eth\_getBlockByHash                      | 20                          |               |
-| eth\_getAccount                          | 20                          |               |
-| eth\_getRootHash                         | 20                          |               |
-| eth\_fillTransaction                     | 20                          |               |
+| eth\_feeHistory                          | 10                          |               |
+| eth\_getAssetBalance                     | 10                          |               |
+| eth\_getChainConfig                      | 10                          |               |
+| eth\_maxPriorityFeePerGas                | 10                          |               |
+| eth\_subscribe                           | 10                          |               |
+| eth\_uninstallFilter                     | 10                          |               |
+| eth\_unsubscribe                         | 10                          |               |
 | erigon\_forks                            | 20                          |               |
 | erigon\_getHeaderByHash                  | 20                          |               |
 | erigon\_getHeaderByNumber                | 20                          |               |
 | erigon\_getLogsByHash                    | 20                          |               |
 | erigon\_issuance                         | 20                          |               |
+| eth\_callMany                            | 20                          |               |
+| eth\_estimateGas                         | 20                          |               |
+| eth\_fillTransaction                     | 20                          |               |
+| eth\_gasPrice                            | 20                          |               |
+| eth\_getAccount                          | 20                          |               |
+| eth\_getBalance                          | 20                          |               |
+| eth\_getBlobSidecars                     | 20                          |               |
+| eth\_getBlockByHash                      | 20                          |               |
+| eth\_getBlockByNumber                    | 20                          |               |
+| eth\_getBlockReceipts                    | 20                          | 500           |
+| eth\_getBlockTransactionCountByHash      | 20                          |               |
+| eth\_getBlockTransactionCountByNumber    | 20                          |               |
+| eth\_getCode                             | 20                          |               |
+| eth\_getFilterChanges                    | 20                          |               |
+| eth\_getFinalizedHeader                  | 20                          |               |
+| eth\_getProof                            | 20                          |               |
+| eth\_getRawTransactionByHash             | 20                          |               |
+| eth\_getRootHash                         | 20                          |               |
+| eth\_getStorageAt                        | 20                          |               |
+| eth\_getTdByNumber                       | 20                          |               |
+| eth\_getTransactionByBlockHashAndIndex   | 20                          |               |
+| eth\_getTransactionByBlockNumberAndIndex | 20                          |               |
+| eth\_getTransactionByHash                | 20                          |               |
 | eth\_getTransactionCount                 | 20                          |               |
-| eth\_getTdByNumber                        | 20                          |               |
+| eth\_getTransactionReceipt               | 20                          |               |
+| eth\_getTransactionReceiptsByBlock       | 20                          | 1500          |
+| eth\_getUncleByBlockHashAndIndex         | 20                          |               |
+| eth\_getUncleByBlockNumberAndIndex       | 20                          |               |
+| eth\_getUncleCountByBlockHash            | 20                          |               |
+| eth\_getUncleCountByBlockNumber          | 20                          |               |
+| eth\_newBlockFilter                      | 20                          |               |
+| eth\_newFilter                           | 20                          |               |
+| eth\_newPendingTransactionFilter         | 20                          |               |
+| eth\_submitWork                          | 20                          |               |
+| parlia\_getSnapshot                      | 20                          |               |
+| web3\_clientVersion                      | 20                          |               |
+| web3\_sha3                               | 20                          |               |
 | eth\_call                                | 26                          |               |
 | eth\_callBundle                          | 40                          |               |
-| eth\_callMany                            | 20                          |               |
+| eth\_sendRawTransaction                  | 40                          | 50            |
+| eth\_sendRawTransactionSync              | 40                          | 125           |
+| eth\_simulateV1                          | 40                          |               |
+| realtime\_sendRawTransaction             | 40                          |               |
 | eth\_getAccountInfo                      | 60                          |               |
 | eth\_getFilterLogs                       | 60                          |               |
 | eth\_getLogs                             | 60                          |               |
-| eth\_estimateGas                         | 20                          |               |
-| eth\_sendRawTransaction                  | 40                          | 250           |
-| eth\_sendRawTransactionSync              | 40                          | 250           |
-| eth\_getBlockReceipts                    | 20                          | 500           |
-| eth\_submitWork                          | 20                          |               |
+| txpool\_content                          | 500                         |               |
 | batch                                    | CU of method # times called |               |
 {/* cu:auto end */}
 
@@ -90,58 +97,61 @@ For more details, check out the [Compute Units](/docs/reference/compute-units#wh
 {/* cu:auto product="solana" */}
 | Method                            | CU                          | Throughput CU |
 | --------------------------------- | --------------------------- | ------------- |
-| getLeaderSchedule                 | 20                          |               |
-| requestAirdrop                    | 20                          |               |
-| getVoteAccounts                   | 20                          |               |
-| getBlockCommitment                | 20                          |               |
-| getBlocksWithLimit                | 20                          |               |
-| getHealth                         | 20                          |               |
-| getIdentity                       | 20                          |               |
-| getLatestBlockhash                | 20                          |               |
-| getSlot                           | 20                          |               |
-| getInflationRate                  | 20                          |               |
-| getMaxRetransmitSlot              | 20                          |               |
-| getRecentPerformanceSamples       | 20                          |               |
-| getRecentPrioritizationFees       | 10                          |               |
-| getEpochInfo                      | 20                          |               |
-| getTokenAccountBalance            | 20                          |               |
-| getBlockTime                      | 20                          |               |
-| getHighestSnapshotSlot            | 20                          |               |
-| sendTransaction                   | 20                          |               |
-| getEpochSchedule                  | 20                          |               |
-| getStakeActivation                | 20                          |               |
-| getMaxShredInsertSlot             | 20                          |               |
-| getVersion                        | 20                          |               |
-| isBlockhashValid                  | 20                          |               |
 | getAccountInfo                    | 10                          |               |
-| getFeeForMessage                  | 20                          |               |
-| getTokenLargestAccounts           | 20                          |               |
-| getInflationGovernor              | 20                          |               |
-| getSlotLeader                     | 20                          |               |
-| getMultipleAccounts               | 20                          |               |
-| minimumLedgerSlot                 | 20                          |               |
-| getBlockHeight                    | 20                          |               |
-| simulateTransaction               | 20                          |               |
-| simulateBundle                    | 20                          |               |
-| getSignatureStatuses              | 20                          |               |
-| getBlocks                         | 10                          |               |
-| getTokenAccountsByOwner           | 10                          |               |
-| getMinimumBalanceForRentExemption | 10                          |               |
 | getBalance                        | 10                          |               |
-| getGenesisHash                    | 10                          |               |
 | getBlockProduction                | 10                          |               |
+| getBlocks                         | 10                          |               |
+| getGenesisHash                    | 10                          |               |
+| getMinimumBalanceForRentExemption | 10                          |               |
+| getPriorityFeeEstimate            | 10                          | 20            |
+| getRecentPrioritizationFees       | 10                          |               |
+| getTokenAccountsByDelegate        | 10                          |               |
+| getTokenAccountsByOwner           | 10                          |               |
+| getBlockCommitment                | 20                          |               |
+| getBlockHeight                    | 20                          |               |
+| getBlocksWithLimit                | 20                          |               |
+| getBlockTime                      | 20                          |               |
+| getClusterNodes                   | 20                          |               |
+| getEpochInfo                      | 20                          |               |
+| getEpochSchedule                  | 20                          |               |
+| getFeeForMessage                  | 20                          |               |
+| getHealth                         | 20                          |               |
+| getHighestSnapshotSlot            | 20                          |               |
+| getIdentity                       | 20                          |               |
+| getInflationGovernor              | 20                          |               |
+| getInflationRate                  | 20                          |               |
+| getLatestBlockhash                | 20                          |               |
+| getLeaderSchedule                 | 20                          |               |
+| getMaxRetransmitSlot              | 20                          |               |
+| getMaxShredInsertSlot             | 20                          |               |
+| getMultipleAccounts               | 20                          |               |
+| getProgramAccounts                | 20                          | 117           |
+| getRecentPerformanceSamples       | 20                          |               |
+| getSignatureStatuses              | 20                          |               |
+| getSlot                           | 20                          |               |
+| getSlotLeader                     | 20                          |               |
+| getSlotLeaders                    | 20                          |               |
+| getStakeActivation                | 20                          |               |
+| getTokenAccountBalance            | 20                          |               |
+| getTokenLargestAccounts           | 20                          |               |
 | getTokenSupply                    | 20                          |               |
 | getTransactionCount               | 20                          |               |
-| getSlotLeaders                    | 20                          |               |
-| getClusterNodes                   | 20                          |               |
-| getSignaturesForAddress           | 40                          |               |
-| getFirstAvailableBlock            | 40                          |               |
-| getTransaction                    | 40                          |               |
+| getVersion                        | 20                          |               |
+| getVoteAccounts                   | 20                          |               |
+| isBlockhashValid                  | 20                          |               |
+| minimumLedgerSlot                 | 20                          |               |
+| requestAirdrop                    | 20                          |               |
+| sendStakedTransaction             | 20                          |               |
+| sendTransaction                   | 20                          |               |
+| simulateBundle                    | 20                          |               |
+| simulateTransaction               | 20                          |               |
 | getBlock                          | 40                          |               |
-| getProgramAccounts                | 20                          |               |
-| getInflationReward                | 40                          |               |
-| getPriorityFeeEstimate            | 10                          | 20            |
-| getSupply                         | 160                         |               |
+| getFirstAvailableBlock            | 40                          |               |
+| getInflationReward                | 40                          | 300           |
+| getSignaturesForAddress           | 40                          |               |
+| getTransaction                    | 40                          |               |
+| getTransactionsForAddress         | 100                         |               |
+| getSupply                         | 160                         | 800           |
 | getLargestAccounts                | 3000                        |               |
 | batch\*                           | CU of method # times called |               |
 {/* cu:auto end */}
@@ -154,17 +164,17 @@ For more details, check out the [Compute Units](/docs/reference/compute-units#wh
 | Method               | CU  | Throughput CU |
 | -------------------- | --- | ------------- |
 | getAsset             | 80  | 200           |
-| getAssets            | 480 | 200           |
 | getAssetProof        | 160 | 200           |
-| getAssetProofs       | 480 | 200           |
-| getAssetsByAuthority | 480 | 200           |
-| getAssetsByOwner     | 480 | 200           |
-| getAssetsByGroup     | 480 | 200           |
-| getAssetsByCreator   | 480 | 200           |
-| searchAssets         | 480 | 200           |
 | getAssetSignatures   | 160 | 200           |
 | getNftEditions       | 160 | 200           |
 | getTokenAccounts     | 160 | 200           |
+| getAssetProofs       | 480 | 200           |
+| getAssets            | 480 | 200           |
+| getAssetsByAuthority | 480 | 200           |
+| getAssetsByCreator   | 480 | 200           |
+| getAssetsByGroup     | 480 | 200           |
+| getAssetsByOwner     | 480 | 200           |
+| searchAssets         | 480 | 200           |
 {/* cu:auto end */}
 
 # Solana: Photon APIs (ZK Compression)
@@ -221,17 +231,24 @@ For more details, check out the [Compute Units](/docs/reference/compute-units#wh
 # Debug API
 
 {/* cu:auto product="debug" */}
-| Method                    | CU | Throughput CU |
-| ------------------------- | -- | ------------- |
-| debug\_traceTransaction   | 40 | 1000          |
-| debug\_traceCall          | 40 | 1000          |
-| debug\_traceCallMany      | 40 | 1000          |
-| debug\_traceBlockByHash   | 40 | 1000          |
-| debug\_traceBlockByNumber | 40 | 1000          |
-| debug\_getBadBlocks       | 40 | 1000          |
-| debug\_getRawHeader       | 40 | 1000          |
-| debug\_getRawReceipts     | 40 | 1000          |
-| debug\_storageRangeAt     | 40 | 1000          |
+| Method                        | CU | Throughput CU |
+| ----------------------------- | -- | ------------- |
+| debug\_dbAncient              | 40 | 1000          |
+| debug\_dbAncients             | 40 | 1000          |
+| debug\_dbGet                  | 40 | 1000          |
+| debug\_executionWitness       | 40 | 1000          |
+| debug\_executionWitnessByHash | 40 | 1000          |
+| debug\_getBadBlocks           | 40 | 1000          |
+| debug\_getRawBlock            | 40 | 1000          |
+| debug\_getRawHeader           | 40 | 1000          |
+| debug\_getRawReceipts         | 40 | 1000          |
+| debug\_getTrieFlushInterval   | 40 | 1000          |
+| debug\_storageRangeAt         | 40 | 1000          |
+| debug\_traceBlockByHash       | 40 | 1000          |
+| debug\_traceBlockByNumber     | 40 | 1000          |
+| debug\_traceCall              | 40 | 1000          |
+| debug\_traceCallMany          | 40 | 1000          |
+| debug\_traceTransaction       | 40 | 1000          |
 {/* cu:auto end */}
 
 # Embedded Account APIs
@@ -239,12 +256,42 @@ For more details, check out the [Compute Units](/docs/reference/compute-units#wh
 Similar to the [NFT API](/docs/reference/compute-unit-costs#nft-api), the Embedded Account APIs implement "Throughput CU" to count separately toward your applications' throughput!
 
 {/* cu:auto product="signer" */}
-| Method               | CU   | Throughput CU |
-| -------------------- | ---- | ------------- |
-| /signer/auth         | 100  | 50            |
-| /signer/lookup       | 20   | 50            |
-| /signer/sign-payload | 6000 | 300           |
-| /signer/whoami       | 100  | 20            |
+| Method                                 | CU   | Throughput CU |
+| -------------------------------------- | ---- | ------------- |
+| /signer/auth-get-multi-factor          | 10   | 50            |
+| /signer/auth-list-multi-factors        | 10   | 50            |
+| /signer/auth-validate-multi-factors    | 10   | 50            |
+| /signer/multi-owner-prepare-add        | 10   |               |
+| /signer/multi-owner-prepare-delete     | 10   |               |
+| /signer/multi-owner-sign-raw-payload   | 10   |               |
+| /signer/multi-owner-update-root-quorum | 10   |               |
+| /signer/multi-sig-prepare-add          | 10   |               |
+| /signer/prepare-oauth                  | 10   | 50            |
+| /signer/signer-config                  | 10   |               |
+| /signer/track-key-export               | 10   | 50            |
+| /signer/auth-delete-multi-factors      | 20   | 50            |
+| /signer/auth-request-multi-factor      | 20   | 50            |
+| /signer/auth-verify-multi-factor       | 20   | 50            |
+| /signer/lookup                         | 20   | 50            |
+| /signer/add-oauth-provider             | 100  | 50            |
+| /signer/auth                           | 100  | 50            |
+| /signer/init-otp                       | 100  | 50            |
+| /signer/list-auth-methods              | 100  | 50            |
+| /signer/otp                            | 100  | 50            |
+| /signer/remove-oauth-provider          | 100  | 50            |
+| /signer/update-email-auth              | 100  | 50            |
+| /signer/update-phone-auth              | 100  | 50            |
+| /signer/verify-otp                     | 100  | 50            |
+| /signer/whoami                         | 100  | 20            |
+| /signer/multi-owner-add                | 250  | 50            |
+| /signer/multi-owner-delete             | 250  | 50            |
+| /signer/multi-sig-add                  | 250  | 50            |
+| /signer/auth-jwt                       | 400  | 300           |
+| /signer/oauth                          | 400  | 300           |
+| /signer/multi-owner-create             | 1000 | 300           |
+| /signer/multi-sig-create               | 1000 | 300           |
+| /signer/signup                         | 1000 | 300           |
+| /signer/sign-payload                   | 6000 | 300           |
 {/* cu:auto end */}
 
 # Gas Manager & Bundler APIs
@@ -254,16 +301,31 @@ Similar to the [NFT API](/docs/reference/compute-unit-costs#nft-api), the Gas Ma
 {/* cu:auto product="gas-manager-bundler" */}
 | Method                                     | CU   | Throughput CU |
 | ------------------------------------------ | ---- | ------------- |
-| eth\_sendUserOperation                     | 1000 | 100           |
+| debug\_bundler\_clearMempool               | 10   |               |
+| debug\_bundler\_clearState                 | 10   |               |
+| debug\_bundler\_dumpMempool                | 10   |               |
+| debug\_bundler\_dumpPaymasterBalances      | 10   |               |
+| debug\_bundler\_dumpReputation             | 10   |               |
+| debug\_bundler\_getStakeStatus             | 10   |               |
+| debug\_bundler\_sendBundleNow              | 10   |               |
+| debug\_bundler\_setBundlingMode            | 10   |               |
+| debug\_bundler\_setReputation              | 10   |               |
+| eth\_supportedEntryPoints                  | 10   |               |
+| rundler\_getUserOperationGasPrice          | 10   |               |
+| rundler\_maxPriorityFeePerGas              | 10   |               |
+| eth\_getUserOperationByHash                | 20   |               |
+| eth\_getUserOperationReceipt               | 20   |               |
+| rundler\_getUserOperationStatus            | 50   |               |
+| pm\_getPaymasterStubData                   | 250  | 100           |
 | eth\_estimateUserOperationGas              | 500  | 50            |
-| eth\_getUserOperationByHash                | 20   | 17            |
-| eth\_getUserOperationReceipt               | 20   | 15            |
-| eth\_supportedEntryPoints                  | 10   | 5             |
-| rundler\_maxPriorityFeePerGas              | 10   | 10            |
-| alchemy\_simulateUserOperationAssetChanges | 2500 | 2500          |
-| alchemy\_requestPaymasterAndData           | 1000 | 100           |
-| alchemy\_requestGasAndPaymasterAndData     | 1250 | 125           |
 | alchemy\_requestFeePayer                   | 1000 | 100           |
+| alchemy\_requestPaymasterAndData           | 1000 | 100           |
+| alchemy\_requestPaymasterTokenQuote        | 1000 | 100           |
+| eth\_sendUserOperation                     | 1000 | 100           |
+| pm\_getPaymasterData                       | 1000 | 100           |
+| rundler\_dropLocalUserOperation            | 1000 |               |
+| alchemy\_requestGasAndPaymasterAndData     | 1250 | 125           |
+| alchemy\_simulateUserOperationAssetChanges | 2500 |               |
 {/* cu:auto end */}
 
 * When `eth_sendUserOperation` is called with a valid bundler sponsorship header (`x-alchemy-policy-id`), the CU cost is 3000 instead of the standard 1000.
@@ -274,63 +336,68 @@ Similar to the [NFT API](/docs/reference/compute-unit-costs#nft-api), the Gas Ma
 We want builders to be able to use as much of the NFT API as they need without worrying about throughput. Because of that, we have discounted how NFT API requests count towards your applications’ guaranteed throughput by 6-10x. This means you can make more concurrent NFT API requests, and use the “Throughput CU” below to calculate how much you can use!
 
 {/* cu:auto product="nft" */}
-| Method                   | CU   | Throughput CU |
-| ------------------------ | ---- | ------------- |
-| getNFTMetadata           | 80   | 10            |
-| getContractMetadata      | 160  | 10            |
-| getCollectionMetadata    | 240  | 10            |
-| getNFTsForOwner          | 480  | 100           |
-| getContractsForOwner     | 320  | 100           |
-| getCollectionsForOwner   | 360  | 100           |
-| getNFTsForContract       | 600  | 50            |
-| getOwnersForNFT          | 80   | 10            |
-| getOwnersForContract     | 480  | 20            |
-| getFloorPrice            | 80   | 10            |
-| getNFTSales              | 160  | 10            |
-| computeRarity            | 80   | 10            |
-| summarizeNFTAttributes   | 80   | 10            |
-| isHolderOfContract       | 80   | 10            |
-| searchContractMetadata   | 480  | 50            |
-| getNFTMetadataBatch      | 480  | 100           |
-| getContractMetadataBatch | 480  | 100           |
-| getSpamContracts         | 480  | 10            |
-| isSpamContract           | 80   | 10            |
-| isAirdropNFT             | 80   | 10            |
-| invalidateContract       | 80   | 80            |
-| refreshNftMetadata       | 40   | 10            |
-| reportSpam               | 0    | 10            |
+| Method                   | CU  | Throughput CU |
+| ------------------------ | --- | ------------- |
+| reportSpam               | 0   | 10            |
+| refreshNftMetadata       | 40  | 10            |
+| computeRarity            | 80  | 10            |
+| getFloorPrice            | 80  | 10            |
+| getNFTMetadata           | 80  | 10            |
+| getOwnersForNFT          | 80  | 10            |
+| invalidateContract       | 80  |               |
+| isAirdropNFT             | 80  | 10            |
+| isHolderOfContract       | 80  | 10            |
+| isSpamContract           | 80  | 10            |
+| summarizeNFTAttributes   | 80  | 10            |
+| getContractMetadata      | 160 | 10            |
+| getNFTSales              | 160 | 10            |
+| getCollectionMetadata    | 240 | 10            |
+| getContractsForOwner     | 320 | 100           |
+| getCollectionsForOwner   | 360 | 100           |
+| getContractMetadataBatch | 480 | 100           |
+| getNFTMetadataBatch      | 480 | 100           |
+| getNFTsForOwner          | 480 | 100           |
+| getOwnersForContract     | 480 | 20            |
+| getSpamContracts         | 480 | 10            |
+| searchContractMetadata   | 480 | 50            |
+| getNFTsForContract       | 600 | 100           |
 {/* cu:auto end */}
 
 # Portfolio API
 
 {/* cu:auto product="portfolio" */}
-| Method                            | CU   |
-| --------------------------------- | ---- |
-| assets/nfts/by-address            | 1000 |
-| assets/nfts/contracts/by-address  | 600  |
-| assets/tokens/by-address          | 360  |
-| assets/tokens/balances/by-address | 200  |
-| /transactions/history/by-address  | 1000 |
+| Method                            | CU   | Throughput CU |
+| --------------------------------- | ---- | ------------- |
+| utility/blocks/by-timestamp       | 10   | 1             |
+| stellar/balances                  | 40   |               |
+| stellar/nfts                      | 40   |               |
+| stellar/transfers                 | 40   |               |
+| assets/tokens/balances/by-address | 200  | 1             |
+| tokens/balances/by-address        | 200  | 1             |
+| assets/tokens/by-address          | 360  | 1             |
+| assets/nfts/contracts/by-address  | 600  | 1             |
+| assets/nfts/by-address            | 1000 | 1             |
+| transactions/history/by-address   | 1000 | 100           |
 {/* cu:auto end */}
 
 # Prices API
 
 {/* cu:auto product="prices" */}
-| Method            | CU |
-| ----------------- | -- |
-| tokens/by-symbol  | 40 |
-| tokens/by-address | 40 |
-| tokens/historical | 40 |
+| Method            | CU | Throughput CU |
+| ----------------- | -- | ------------- |
+| tokens/by-address | 40 | 20            |
+| tokens/by-symbol  | 40 | 20            |
+| tokens/historical | 40 | 20            |
 {/* cu:auto end */}
 
 # Token API
 
 {/* cu:auto product="token" */}
-| Method                     | CU  |
-| -------------------------- | --- |
-| alchemy\_getTokenBalances  | 20  |
-| alchemy\_getTokenMetadata  | 10  |
-| alchemy\_getTokenAllowance | 20  |
+| Method                     | CU |
+| -------------------------- | -- |
+| alchemy\_getTokenMetadata  | 10 |
+| alchemy\_getTokenAllowance | 20 |
+| alchemy\_getTokenBalances  | 20 |
 {/* cu:auto end */}
 
 # Trace API
@@ -338,15 +405,15 @@ We want builders to be able to use as much of the NFT API as they need without w
 {/* cu:auto product="trace" */}
 | Method                         | CU | Throughput CU |
 | ------------------------------ | -- | ------------- |
-| trace\_get                     | 20 | 20            |
-| trace\_block                   | 20 | 20            |
-| trace\_transaction             | 40 | 40            |
-| trace\_call                    | 40 | 40            |
+| trace\_block                   | 20 |               |
+| trace\_get                     | 20 |               |
+| trace\_call                    | 40 |               |
+| trace\_filter                  | 40 |               |
+| trace\_rawTransaction          | 40 |               |
+| trace\_transaction             | 40 |               |
 | trace\_callMany                | 80 | 3000          |
-| trace\_rawTransaction          | 40 | 40            |
-| trace\_filter                  | 40 | 40            |
-| trace\_replayTransaction       | 80 | 3000          |
 | trace\_replayBlockTransactions | 80 | 3000          |
+| trace\_replayTransaction       | 80 | 3000          |
 {/* cu:auto end */}
 
 # Arbitrum Trace API
@@ -354,23 +421,25 @@ We want builders to be able to use as much of the NFT API as they need without w
 {/* cu:auto product="arbtrace" */}
 | Method                            | CU | Throughput CU |
 | --------------------------------- | -- | ------------- |
-| arbtrace\_get                     | 20 | 20            |
-| arbtrace\_block                   | 20 | 20            |
-| arbtrace\_transaction             | 40 | 40            |
-| arbtrace\_call                    | 40 | 40            |
-| arbtrace\_callMany                | 80 | 80            |
-| arbtrace\_filter                  | 40 | 40            |
-| arbtrace\_replayTransaction       | 80 | 3000          |
+| arbtrace\_block                   | 20 | 1000          |
+| arbtrace\_get                     | 20 | 1000          |
+| arbtrace\_call                    | 40 | 1000          |
+| arbtrace\_filter                  | 40 | 1000          |
+| arbtrace\_transaction             | 40 |               |
+| arbtrace\_callMany                | 80 | 1000          |
 | arbtrace\_replayBlockTransactions | 80 | 3000          |
+| arbtrace\_replayTransaction       | 80 | 3000          |
 {/* cu:auto end */}
 
 # Transact
 
 {/* cu:auto product="transact" */}
-| Method                                    | CU   |
-| ----------------------------------------- | ---- |
-| alchemy\_simulateAssetChanges             | 2500 |
-| alchemy\_simulateExecution                | 2500 |
+| Method                              | CU   |
+| ----------------------------------- | ---- |
+| alchemy\_simulateAssetChanges       | 2500 |
+| alchemy\_simulateExecution          | 2500 |
+| alchemy\_simulateAssetChangesBundle | 4500 |
+| alchemy\_simulateExecutionBundle    | 4500 |
 {/* cu:auto end */}
 
 # Transfers API
@@ -394,21 +463,21 @@ We want builders to be able to use as much of the NFT API as they need without w
 Similar to the [NFT API](/docs/reference/compute-unit-costs#nft-api), the Wallet APIs implement "Throughput CU" to count separately toward your applications' throughput!
 
 {/* cu:auto product="wallet" */}
-| Method                                     | CU   | Throughput CU |
-| ------------------------------------------ | ---- | ------------- |
-| wallet_requestAccount                      | 50   | -             |
-| wallet_prepareCalls                        | 1750 | 50            |
-| wallet_sendPreparedCalls                   | 3000 | 100           |
-| wallet_createAccount                       | 50   | -             |
-| wallet_createSession                       | 50   | -             |
-| wallet_getCallsStatus                      | 20   | -             |
-| wallet_listAccounts                        | 10   | -             |
-| wallet_formatSign                          | 15   | -             |
-| wallet_getAssets                           | 200  | -             |
-| wallet_getCapabilities                     | 10   | -             |
-| wallet_getCrossChainStatus_v0              | 40   | -             |
-| wallet_prepareSign                         | 15   | -             |
-| wallet_requestQuote_v0                     | 800  | -             |
+| Method                          | CU   | Throughput CU |
+| ------------------------------- | ---- | ------------- |
+| wallet\_getCapabilities         | 10   |               |
+| wallet\_listAccounts            | 10   |               |
+| wallet\_formatSign              | 15   |               |
+| wallet\_prepareSign             | 15   |               |
+| wallet\_getCallsStatus          | 20   |               |
+| wallet\_getCrossChainStatus\_v0 | 40   |               |
+| wallet\_createAccount           | 50   |               |
+| wallet\_createSession           | 50   |               |
+| wallet\_requestAccount          | 50   |               |
+| wallet\_getAssets               | 200  |               |
+| wallet\_requestQuote\_v0        | 800  | 50            |
+| wallet\_prepareCalls            | 1750 | 50            |
+| wallet\_sendPreparedCalls       | 3000 | 100           |
 {/* cu:auto end */}
 
 # Webhooks and Subscription APIs
@@ -440,6 +509,7 @@ On average, a typical byte-priced webhook or WebSocket subscription event is abo
 {/* cu:auto product="polygon-zkevm" */}
 | Method                          | CU |
 | ------------------------------- | -- |
+| eth\_getCompilers               | 10 |
 | zkevm\_batchNumber              | 10 |
 | zkevm\_batchNumberByBlockNumber | 10 |
 | zkevm\_consolidatedBlockNumber  | 10 |
@@ -456,494 +526,714 @@ On average, a typical byte-priced webhook or WebSocket subscription event is abo
 # Starknet: Standard JSON-RPC Methods
 
 {/* cu:auto product="starknet" */}
-| Method                                    | CU   |
-| ----------------------------------------- | ---- |
-| starknet\_getBlockWithTxHashes            | 20   |
-| starknet\_getBlockWithTxs                 | 20   |
-| starknet\_getStateUpdate                  | 20   |
-| starknet\_getStorageAt                    | 20   |
-| starknet\_getTransactionByHash            | 20   |
-| starknet\_getTransactionByBlockIdAndIndex | 20   |
-| starknet\_getTransactionReceipt           | 20   |
-| starknet\_getClass                        | 20   |
-| starknet\_getClassHashAt                  | 20   |
-| starknet\_getClassAt                      | 20   |
-| starknet\_getBlockTransactionCount        | 20   |
-| starknet\_call                            | 20   |
-| starknet\_blockNumber                     | 20   |
-| starknet\_blockHashAndNumber              | 20   |
-| starknet\_chainId                         | 0    |
-| starknet\_pendingTransactions             | 20   |
-| starknet\_syncing                         | 0    |
-| starknet\_getNonce                        | 20   |
-| starknet\_getEvents                       | 20   |
-| starknet\_estimateFee                     | 20   |
-| starknet\_addInvokeTransaction            | 160  |
-| starknet\_addDeclareTransaction           | 160  |
-| starknet\_addDeployAccountTransaction     | 160  |
-| starknet\_estimateMessageFee              | 20   |
-| starknet\_getBlockWithReceipts            | 20   |
-| starknet\_traceBlockTransactions          | 80   |
-| starknet\_specVersion                     | 10   |
-| starknet\_getTransactionStatus            | 20   |
-| starknet\_simulateTransactions            | 20   |
-| starknet\_getCompiledCasm                | 20   |
-| starknet\_getMessagesStatus              | 20   |
-| starknet\_getStorageProof                | 20   |
-| starknet\_traceTransaction               | 20   |
+| Method                                       | CU  | Throughput CU |
+| -------------------------------------------- | --- | ------------- |
+| starknet\_chainId                            | 0   | 5             |
+| starknet\_syncing                            | 0   | 5             |
+| starknet\_blockHashAndNumber                 | 10  |               |
+| starknet\_blockNumber                        | 10  |               |
+| starknet\_specVersion                        | 10  |               |
+| pathfinder\_getTransactionStatus             | 20  |               |
+| pathfinder\_lastL1AcceptedBlockHashAndNumber | 20  |               |
+| starknet\_call                               | 20  |               |
+| starknet\_estimateFee                        | 20  |               |
+| starknet\_estimateMessageFee                 | 20  |               |
+| starknet\_getBlockTransactionCount           | 20  |               |
+| starknet\_getBlockWithReceipts               | 20  | 500           |
+| starknet\_getBlockWithTxHashes               | 20  |               |
+| starknet\_getBlockWithTxs                    | 20  |               |
+| starknet\_getClass                           | 20  |               |
+| starknet\_getClassAt                         | 20  |               |
+| starknet\_getClassHashAt                     | 20  |               |
+| starknet\_getCompiledCasm                    | 20  |               |
+| starknet\_getEvents                          | 20  |               |
+| starknet\_getMessagesStatus                  | 20  |               |
+| starknet\_getNonce                           | 20  |               |
+| starknet\_getStateUpdate                     | 20  |               |
+| starknet\_getStorageAt                       | 20  |               |
+| starknet\_getStorageProof                    | 20  |               |
+| starknet\_getTransactionByBlockIdAndIndex    | 20  |               |
+| starknet\_getTransactionByHash               | 20  |               |
+| starknet\_getTransactionReceipt              | 20  |               |
+| starknet\_getTransactionStatus               | 20  |               |
+| starknet\_pendingTransactions                | 20  |               |
+| starknet\_simulateTransactions               | 20  |               |
+| starknet\_traceTransaction                   | 20  |               |
+| starknet\_traceBlockTransactions             | 80  | 3000          |
+| starknet\_addDeclareTransaction              | 160 |               |
+| starknet\_addDeployAccountTransaction        | 160 |               |
+| starknet\_addInvokeTransaction               | 160 |               |
 {/* cu:auto end */}
 
 # zkSync Era: Specific Methods
 
 {/* cu:auto product="zksync" */}
-| Method                                          | CU |
-| ----------------------------------------------- | -- |
-| zks\_estimateFee                                | 10 |
-| zks\_estimateGasL1ToL2                          | 10 |
-| zks\_gasPerPubdata                              | 10 |
-| zks\_getAllAccountBalances                       | 10 |
-| zks\_getBaseTokenL1Address                      | 10 |
-| zks\_getBlockDetails                            | 10 |
-| zks\_getBridgeContracts                         | 10 |
-| zks\_getBridgehubContract                       | 10 |
-| zks\_getBytecodeByHash                          | 10 |
-| zks\_getConfirmedTokens                         | 10 |
-| zks\_getFeeParams                               | 10 |
-| zks\_getL1BatchBlockRange                       | 10 |
-| zks\_getL1BatchDetails                          | 10 |
-| zks\_getL1GasPrice                              | 10 |
-| zks\_getL2ToL1LogProof                          | 10 |
-| zks\_getL2ToL1MsgProof                          | 10 |
-| zks\_getMainContract                            | 10 |
-| zks\_getProtocolVersion                         | 10 |
-| zks\_getRawBlockTransactions                    | 10 |
-| zks\_getTestnetPaymaster                        | 10 |
-| zks\_getTransactionDetails                      | 10 |
-| zks\_L1BatchNumber                              | 10 |
-| zks\_L1ChainId                                  | 10 |
-| zks\_sendRawTransactionWithDetailedOutput       | 20 |
+| Method                                    | CU |
+| ----------------------------------------- | -- |
+| zks\_estimateFee                          | 10 |
+| zks\_estimateGasL1ToL2                    | 10 |
+| zks\_gasPerPubdata                        | 10 |
+| zks\_getAllAccountBalances                | 10 |
+| zks\_getBaseTokenL1Address                | 10 |
+| zks\_getBlockDetails                      | 10 |
+| zks\_getBridgeContracts                   | 10 |
+| zks\_getBridgehubContract                 | 10 |
+| zks\_getBytecodeByHash                    | 10 |
+| zks\_getConfirmedTokens                   | 10 |
+| zks\_getFeeParams                         | 10 |
+| zks\_getL1BatchBlockRange                 | 10 |
+| zks\_getL1BatchDetails                    | 10 |
+| zks\_getL1GasPrice                        | 10 |
+| zks\_getL2ToL1LogProof                    | 10 |
+| zks\_getL2ToL1MsgProof                    | 10 |
+| zks\_getMainContract                      | 10 |
+| zks\_getProof                             | 10 |
+| zks\_getProtocolVersion                   | 10 |
+| zks\_getRawBlockTransactions              | 10 |
+| zks\_getTestnetPaymaster                  | 10 |
+| zks\_getTransactionDetails                | 10 |
+| zks\_L1BatchNumber                        | 10 |
+| zks\_L1ChainId                            | 10 |
+| zks\_sendRawTransactionWithDetailedOutput | 20 |
 {/* cu:auto end */}
 
 # Ethereum Beacon: Standard HTTP API Methods
 
 {/* cu:auto product="eth-beacon" */}
-| Method                                                         | CU  |
-| -------------------------------------------------------------- | --- |
-| /eth/v2/beacon/blocks/\{block\_id}/attestations                | 20  |
-| /eth/v1/beacon/blocks/\{block\_id}/root                        | 20  |
-| /eth/v1/beacon/blinded\_blocks/\{slot}                         | 20  |
-| /eth/v1/beacon/blob\_sidecars/\{block\_id}                     | 20  |
-| /eth/v1/beacon/genesis                                         | 20  |
-| /eth/v1/beacon/headers                                         | 20  |
-| /eth/v1/beacon/headers/\{block\_id}                            | 20  |
-| /eth/v1/beacon/pool/voluntary\_exits                           | 20  |
-| /eth/v1/beacon/states/\{state\_id}/committees                  | 20  |
-| /eth/v1/beacon/states/\{state\_id}/finality\_checkpoints       | 20  |
-| /eth/v1/beacon/states/\{state\_id}/fork                        | 20  |
-| /eth/v1/beacon/states/\{state\_id}/pending\_consolidations     | 20  |
-| /eth/v1/beacon/states/\{state\_id}/pending\_partial\_withdrawals | 20  |
-| /eth/v1/beacon/states/\{state\_id}/root                        | 20  |
-| /eth/v1/beacon/states/\{state\_id}/sync\_committees            | 20  |
-| /eth/v1/beacon/states/\{state\_id}/validator\_balances         | 20  |
-| /eth/v1/beacon/states/\{state\_id}/validators                  | 20  |
-| /eth/v1/beacon/states/\{state\_id}/validators/\{validator\_id} | 20  |
-| /eth/v1/beacon/rewards/sync\_committee/\{block\_id}            | 20  |
-| /eth/v1/beacon/rewards/blocks/\{block\_id}                     | 20  |
-| /eth/v1/beacon/rewards/attestations/\{epoch}                   | 20  |
-| /eth/v1/config/deposit\_contract                               | 20  |
-| /eth/v1/config/fork\_schedule                                  | 20  |
-| /eth/v1/config/spec                                            | 20  |
-| /eth/v1/node/peer\_count                                       | 20  |
-| /eth/v1/node/peers                                             | 20  |
-| /eth/v1/node/syncing                                           | 20  |
-| /eth/v1/node/version                                           | 20  |
-| /eth/v2/validator/aggregate\_attestation                       | 20  |
-| /eth/v1/validator/duties/attester/\{epoch}                     | 20  |
-| /eth/v1/validator/duties/proposer/\{epoch}                     | 20  |
-| /eth/v1/validator/duties/sync/\{epoch}                         | 20  |
-| /eth/v1/validator/sync\_committee\_contribution                | 20  |
-| /eth/v2/beacon/blocks/\{block\_id}                             | 20  |
-| /eth/v1/beacon/blinded\_blocks/\{block\_id}                    | 20  |
-| /eth/v1/beacon/blobs/\{block\_id}                              | 20  |
-| /eth/v1/beacon/states/\{state\_id}/pending\_deposits           | 20  |
-| /eth/v1/beacon/states/\{state\_id}/proposer\_lookahead         | 20  |
-| /eth/v1/beacon/states/\{state\_id}/randao                      | 20  |
-| /eth/v1/beacon/states/\{state\_id}/validator\_identities       | 20  |
+| Method                                                           | CU |
+| ---------------------------------------------------------------- | -- |
+| /eth/v1/beacon/blinded\_blocks/\{block\_id}                      | 20 |
+| /eth/v1/beacon/blinded\_blocks/\{slot}                           | 20 |
+| /eth/v1/beacon/blob\_sidecars/\{block\_id}                       | 20 |
+| /eth/v1/beacon/blobs/\{block\_id}                                | 20 |
+| /eth/v1/beacon/blocks/\{block\_id}/root                          | 20 |
+| /eth/v1/beacon/genesis                                           | 20 |
+| /eth/v1/beacon/headers                                           | 20 |
+| /eth/v1/beacon/headers/\{block\_id}                              | 20 |
+| /eth/v1/beacon/pool/voluntary\_exits                             | 20 |
+| /eth/v1/beacon/rewards/attestations/\{epoch}                     | 20 |
+| /eth/v1/beacon/rewards/blocks/\{block\_id}                       | 20 |
+| /eth/v1/beacon/rewards/sync\_committee/\{block\_id}              | 20 |
+| /eth/v1/beacon/states/\{state\_id}/committees                    | 20 |
+| /eth/v1/beacon/states/\{state\_id}/finality\_checkpoints         | 20 |
+| /eth/v1/beacon/states/\{state\_id}/fork                          | 20 |
+| /eth/v1/beacon/states/\{state\_id}/pending\_consolidations       | 20 |
+| /eth/v1/beacon/states/\{state\_id}/pending\_deposits             | 20 |
+| /eth/v1/beacon/states/\{state\_id}/pending\_partial\_withdrawals | 20 |
+| /eth/v1/beacon/states/\{state\_id}/proposer\_lookahead           | 20 |
+| /eth/v1/beacon/states/\{state\_id}/randao                        | 20 |
+| /eth/v1/beacon/states/\{state\_id}/root                          | 20 |
+| /eth/v1/beacon/states/\{state\_id}/sync\_committees              | 20 |
+| /eth/v1/beacon/states/\{state\_id}/validator\_balances           | 20 |
+| /eth/v1/beacon/states/\{state\_id}/validator\_identities         | 20 |
+| /eth/v1/beacon/states/\{state\_id}/validators                    | 20 |
+| /eth/v1/beacon/states/\{state\_id}/validators/\{validator\_id}   | 20 |
+| /eth/v1/config/deposit\_contract                                 | 20 |
+| /eth/v1/config/fork\_schedule                                    | 20 |
+| /eth/v1/config/spec                                              | 20 |
+| /eth/v1/debug/beacon/data\_column\_sidecars/\{block\_id}         | 20 |
+| /eth/v1/debug/fork\_choice                                       | 20 |
+| /eth/v1/node/identity                                            | 20 |
+| /eth/v1/node/peer\_count                                         | 20 |
+| /eth/v1/node/peers                                               | 20 |
+| /eth/v1/node/syncing                                             | 20 |
+| /eth/v1/node/version                                             | 20 |
+| /eth/v1/validator/attestation\_data                              | 20 |
+| /eth/v1/validator/contribution\_and\_proofs                      | 20 |
+| /eth/v1/validator/duties/attester/\{epoch}                       | 20 |
+| /eth/v1/validator/duties/proposer/\{epoch}                       | 20 |
+| /eth/v1/validator/duties/sync/\{epoch}                           | 20 |
+| /eth/v1/validator/sync\_committee\_contribution                  | 20 |
+| /eth/v2/beacon/blocks/\{block\_id}                               | 20 |
+| /eth/v2/beacon/blocks/\{block\_id}/attestations                  | 20 |
+| /eth/v2/beacon/pool/attestations                                 | 20 |
+| /eth/v2/debug/beacon/states/\{state\_id}                         | 20 |
+| /eth/v2/validator/aggregate\_attestation                         | 20 |
+| /eth/v3/validator/blocks/\{slot}                                 | 20 |
 {/* cu:auto end */}
 
 # Aptos: Standard REST API Methods
 
 {/* cu:auto product="aptos" */}
-| Method                                                         | CU  |
-| -------------------------------------------------------------- | --- |
-| /v1/                                                           | 20  |
-| /v1/accounts/\{address}                                        | 20  |
-| /v1/accounts/\{address}/balance/\{asset\_type}                 | 20  |
-| /v1/accounts/\{address}/events/\{creation\_number}             | 20  |
-| /v1/accounts/\{address}/events/\{event\_handle}/\{field\_name} | 20  |
-| /v1/accounts/\{address}/module/\{module\_name}                 | 20  |
-| /v1/accounts/\{address}/modules                                | 20  |
-| /v1/accounts/\{address}/resource/\{resource\_type}             | 20  |
-| /v1/accounts/\{address}/resources                              | 20  |
-| /v1/accounts/\{address}/transactions                           | 20  |
-| /v1/blocks/by\_height/\{block\_height}                         | 20  |
-| /v1/blocks/by\_version/\{version}                              | 20  |
-| /v1/estimate\_gas\_price                                       | 20  |
-| /v1/-/healthy                                                  | 20  |
-| /v1/spec                                                       | 20  |
-| /v1/tables/\{table\_handle}/item                               | 20  |
-| /v1/tables/\{table\_handle}/raw\_item                          | 20  |
-| /v1/transactions                                               | 20  |
-| /v1/transactions/batch                                         | 20  |
-| /v1/transactions/by\_hash/\{txn\_hash}                         | 20  |
-| /v1/transactions/by\_version/\{txn\_version}                   | 20  |
-| /v1/transactions/encode\_submission                            | 20  |
-| /v1/transactions/simulate                                      | 20  |
-| /v1/view                                                       | 20  |
+| Method                                                         | CU |
+| -------------------------------------------------------------- | -- |
+| /v1                                                            | 20 |
+| /v1/                                                           | 20 |
+| /v1/-/healthy                                                  | 20 |
+| /v1/accounts/\{address}                                        | 20 |
+| /v1/accounts/\{address}/balance/\{asset\_type}                 | 20 |
+| /v1/accounts/\{address}/events/\{creation\_number}             | 20 |
+| /v1/accounts/\{address}/events/\{event\_handle}/\{field\_name} | 20 |
+| /v1/accounts/\{address}/module/\{module\_name}                 | 20 |
+| /v1/accounts/\{address}/modules                                | 20 |
+| /v1/accounts/\{address}/resource/\{resource\_type}             | 20 |
+| /v1/accounts/\{address}/resources                              | 20 |
+| /v1/accounts/\{address}/transaction\_summaries                 | 20 |
+| /v1/accounts/\{address}/transactions                           | 20 |
+| /v1/blocks/by\_height/\{block\_height}                         | 20 |
+| /v1/blocks/by\_version/\{version}                              | 20 |
+| /v1/estimate\_gas\_price                                       | 20 |
+| /v1/spec                                                       | 20 |
+| /v1/tables/\{table\_handle}/item                               | 20 |
+| /v1/tables/\{table\_handle}/raw\_item                          | 20 |
+| /v1/transactions                                               | 20 |
+| /v1/transactions/auxiliary\_info                               | 20 |
+| /v1/transactions/batch                                         | 20 |
+| /v1/transactions/by\_hash/\{txn\_hash}                         | 20 |
+| /v1/transactions/by\_version/\{txn\_version}                   | 20 |
+| /v1/transactions/encode\_submission                            | 20 |
+| /v1/transactions/simulate                                      | 20 |
+| /v1/transactions/wait\_by\_hash/\{txn\_hash}                   | 20 |
+| /v1/view                                                       | 20 |
 {/* cu:auto end */}
 
 # Bitcoin: Standard JSON-RPC Methods
 
 {/* cu:auto product="bitcoin" */}
-| Method                                                    | CU  |
-| --------------------------------------------------------- | --- |
-| getbestblockhash                                          | 10  |
-| getblock                                                  | 10  |
-| getblockchaininfo                                         | 10  |
-| getblockcount                                             | 10  |
-| getblockhash                                              | 10  |
-| getblockheader                                            | 10  |
-| getblockstats                                             | 10  |
-| getdifficulty                                             | 10  |
-| getmempoolancestors                                       | 10  |
-| getmempooldescendants                                     | 10  |
-| getmempoolinfo                                            | 10  |
-| getrawmempool                                             | 10  |
-| gettxout                                                  | 10  |
-| gettxoutproof                                             | 10  |
-| getchaintips                                              | 10  |
-| getchaintxstats                                           | 10  |
-| getblocktemplate                                          | 10  |
-| submitblock                                               | 10  |
-| decoderawtransaction                                      | 10  |
-| decodescript                                              | 10  |
-| estimatesmartfee                                          | 10  |
-| getconnectioncount                                        | 10  |
-| getindexinfo                                              | 10  |
-| getmemoryinfo                                             | 10  |
-| validateaddress                                           | 10  |
-| verifymessage                                             | 10  |
-| gettxoutsetinfo                                           | 10  |
-| testmempoolaccept                                         | 10  |
-| sendrawtransaction                                        | 10  |
-| submitpackage                                             | 10  |
+| Method                | CU |
+| --------------------- | -- |
+| createrawtransaction  | 10 |
+| decoderawtransaction  | 10 |
+| decodescript          | 10 |
+| estimatesmartfee      | 10 |
+| getbestblockhash      | 10 |
+| getblock              | 10 |
+| getblockchaininfo     | 10 |
+| getblockcount         | 10 |
+| getblockfilter        | 10 |
+| getblockhash          | 10 |
+| getblockheader        | 10 |
+| getblockstats         | 10 |
+| getblocktemplate      | 10 |
+| getchaintips          | 10 |
+| getchaintxstats       | 10 |
+| getconnectioncount    | 10 |
+| getdifficulty         | 10 |
+| getindexinfo          | 10 |
+| getmemoryinfo         | 10 |
+| getmempoolancestors   | 10 |
+| getmempooldescendants | 10 |
+| getmempoolinfo        | 10 |
+| getnetworkhashps      | 10 |
+| getnetworkinfo        | 10 |
+| getrawmempool         | 10 |
+| getrawtransaction     | 10 |
+| gettxout              | 10 |
+| gettxoutproof         | 10 |
+| gettxoutsetinfo       | 10 |
+| sendrawtransaction    | 10 |
+| submitblock           | 10 |
+| submitheader          | 10 |
+| submitpackage         | 10 |
+| testmempoolaccept     | 10 |
+| validateaddress       | 10 |
+| verifymessage         | 10 |
 {/* cu:auto end */}
 
 # UTXO REST API Methods
 
 {/* cu:auto product="utxo" */}
-| Method                                                    | CU  |
-| --------------------------------------------------------- | --- |
-| /api/v2/block-index/\{block\_height}                      | 20  |
-| /api/v2/tx/\{txid}                                        | 20  |
-| /api/v2/tx-specific/\{txid}                               | 20  |
-| /api/v2/address/\{address}                                | 20  |
-| /api/v2/xpub/\{xpub}                                      | 20  |
-| /api/v2/utxo/\{descriptor}                                | 20  |
-| /api/v2/block/\{block}                                    | 20  |
-| /api/v2/sendtx/\{hex}                                     | 20  |
-| /api/v2/sendtx                                            | 20  |
-| /api/v2/tickers-list                                      | 20  |
-| /api/v2/tickers                                           | 20  |
-| /api/v2/balancehistory/\{address}                         | 20  |
+| Method                               | CU |
+| ------------------------------------ | -- |
+| /api/v2/address/\{address}           | 20 |
+| /api/v2/balancehistory/\{address}    | 20 |
+| /api/v2/block-index/\{block\_height} | 20 |
+| /api/v2/block/\{block}               | 20 |
+| /api/v2/sendtx                       | 20 |
+| /api/v2/sendtx/\{hex}                | 20 |
+| /api/v2/tickers                      | 20 |
+| /api/v2/tickers-list                 | 20 |
+| /api/v2/tx-specific/\{txid}          | 20 |
+| /api/v2/tx/\{txid}                   | 20 |
+| /api/v2/utxo/\{descriptor}           | 20 |
+| /api/v2/xpub/\{xpub}                 | 20 |
 {/* cu:auto end */}
 
 # Celestia Bridge: Standard RPC Methods
 
 {/* cu:auto product="celestia" */}
-| Method                                                    | CU  |
-| --------------------------------------------------------- | --  |
-| blob.Get                                                  | 20  |
-| blob.GetAll                                               | 20  |
-| blob.Submit                                               | 20  |
-| blob.GetCommitmentProof                                   | 20  |
-| blob.GetProof                                             | 20  |
-| blob.Included                                             | 20  |
-| state.AccountAddress                                      | 20  |
-| state.Balance                                             | 20  |
-| state.BalanceForAddress                                   | 20  |
-| state.SubmitPayForBlob                                    | 20  |
-| state.Transfer                                            | 20  |
-| header.GetByHash                                          | 20  |
-| header.GetByHeight                                        | 20  |
-| header.GetRangeByHeight                                   | 20  |
-| header.LocalHead                                          | 20  |
-| header.NetworkHead                                        | 20  |
-| header.SyncState                                          | 20  |
-| header.SyncWait                                           | 20  |
-| header.WaitForHeight                                      | 20  |
-| share.GetEDS                                              | 20  |
-| share.GetNamespaceData                                    | 20  |
-| share.GetRange                                            | 20  |
-| share.GetRow                                              | 20  |
-| share.GetSamples                                          | 20  |
-| share.SharesAvailable                                     | 20  |
-| blobstream.GetDataRootTupleInclusionProof                 | 20  |
-| da.Submit                                                 | 20  |
-| da.Get                                                    | 20  |
-| fraud.Get                                                 | 20  |
+| Method                                    | CU |
+| ----------------------------------------- | -- |
+| blob.Get                                  | 20 |
+| blob.GetAll                               | 20 |
+| blob.GetCommitmentProof                   | 20 |
+| blob.GetProof                             | 20 |
+| blob.Included                             | 20 |
+| blob.Submit                               | 20 |
+| blobstream.GetDataRootTupleInclusionProof | 20 |
+| da.Get                                    | 20 |
+| da.Submit                                 | 20 |
+| fraud.Get                                 | 20 |
+| header.GetByHash                          | 20 |
+| header.GetByHeight                        | 20 |
+| header.GetRangeByHeight                   | 20 |
+| header.LocalHead                          | 20 |
+| header.NetworkHead                        | 20 |
+| header.SyncState                          | 20 |
+| header.SyncWait                           | 20 |
+| header.WaitForHeight                      | 20 |
+| share.GetEDS                              | 20 |
+| share.GetNamespaceData                    | 20 |
+| share.GetRange                            | 20 |
+| share.GetRow                              | 20 |
+| share.GetSamples                          | 20 |
+| share.GetShare                            | 20 |
+| share.SharesAvailable                     | 20 |
+| state.AccountAddress                      | 20 |
+| state.Balance                             | 20 |
+| state.BalanceForAddress                   | 20 |
+| state.SubmitPayForBlob                    | 20 |
+| state.Transfer                            | 20 |
 {/* cu:auto end */}
 
 # Citrea: Specific Methods
 
 {/* cu:auto product="citrea" */}
-| Method                                      | CU |
-| ------------------------------------------- | -- |
-| citrea\_getL2StatusHeightsByL1Height        | 20 |
-| citrea\_getLastCommittedL2Height            | 20 |
-| citrea\_getLastProvenL2Height               | 20 |
-| citrea\_sendRawDepositTransaction           | 20 |
-| citrea\_syncStatus                          | 20 |
-| ledger\_getHeadL2Block                      | 20 |
-| ledger\_getHeadL2BlockHeight                | 20 |
-| ledger\_getL2BlockByHash                    | 20 |
-| ledger\_getL2BlockByNumber                  | 20 |
-| ledger\_getL2BlockRange                     | 20 |
-| ledger\_getL2GenesisStateRoot               | 20 |
-| ledger\_getLastScannedL1Height              | 20 |
-| ledger\_getLastVerifiedBatchProof           | 20 |
-| ledger\_getSequencerCommitmentByIndex       | 20 |
-| ledger\_getSequencerCommitmentsOnSlotByHash | 20 |
+| Method                                        | CU |
+| --------------------------------------------- | -- |
+| citrea\_getL2StatusHeightsByL1Height          | 20 |
+| citrea\_getLastCommittedL2Height              | 20 |
+| citrea\_getLastProvenL2Height                 | 20 |
+| citrea\_sendRawDepositTransaction             | 20 |
+| citrea\_syncStatus                            | 20 |
+| eth\_estimateDiffSize                         | 20 |
+| ledger\_getHeadL2Block                        | 20 |
+| ledger\_getHeadL2BlockHeight                  | 20 |
+| ledger\_getL2BlockByHash                      | 20 |
+| ledger\_getL2BlockByNumber                    | 20 |
+| ledger\_getL2BlockRange                       | 20 |
+| ledger\_getL2GenesisStateRoot                 | 20 |
+| ledger\_getLastScannedL1Height                | 20 |
+| ledger\_getLastVerifiedBatchProof             | 20 |
+| ledger\_getSequencerCommitmentByIndex         | 20 |
+| ledger\_getSequencerCommitmentsOnSlotByHash   | 20 |
 | ledger\_getSequencerCommitmentsOnSlotByNumber | 20 |
-| ledger\_getVerifiedBatchProofsBySlotHeight  | 20 |
+| ledger\_getVerifiedBatchProofsBySlotHeight    | 20 |
 {/* cu:auto end */}
 
 # Linea: Specific Methods
 
 {/* cu:auto product="linea" */}
-| Method                                        | CU |
-| --------------------------------------------- | -- |
-| linea\_estimateGas                            | 20 |
-| linea\_getProof                               | 20 |
-| linea\_getTransactionExclusionStatusV1        | 20 |
+| Method                                 | CU |
+| -------------------------------------- | -- |
+| linea\_estimateGas                     | 20 |
+| linea\_getProof                        | 20 |
+| linea\_getTransactionExclusionStatusV1 | 20 |
 {/* cu:auto end */}
 
 # MegaETH: Specific Methods
 
 {/* cu:auto product="megaeth" */}
-| Method                    | CU |
-| ------------------------- | -- |
-| eth\_getWithdrawalProof   | 20 |
+| Method                  | CU |
+| ----------------------- | -- |
+| eth\_getWithdrawalProof | 20 |
 {/* cu:auto end */}
 
 # Stellar: Standard Methods
 
 {/* cu:auto product="stellar" */}
-| Method               | CU |
-| -------------------- | -- |
-| getEvents            | 20 |
-| getFeeStats          | 20 |
-| getHealth            | 20 |
-| getLatestLedger      | 20 |
-| getLedgerEntries     | 20 |
-| getLedgers           | 50 |
-| getNetwork           | 20 |
-| getTransaction       | 40 |
-| getTransactions      | 50 |
-| getVersionInfo       | 20 |
-| sendTransaction      | 20 |
-| simulateTransaction  | 20 |
+| Method                                                      | CU |
+| ----------------------------------------------------------- | -- |
+| /accounts                                                   | 20 |
+| /accounts/\{account\_id}                                    | 20 |
+| /accounts/\{account\_id}/data/\{key}                        | 20 |
+| /accounts/\{account\_id}/effects                            | 20 |
+| /accounts/\{account\_id}/offers                             | 20 |
+| /accounts/\{account\_id}/operations                         | 20 |
+| /accounts/\{account\_id}/payments                           | 20 |
+| /accounts/\{account\_id}/trades                             | 20 |
+| /accounts/\{account\_id}/transactions                       | 20 |
+| /assets                                                     | 20 |
+| /claimable\_balances                                        | 20 |
+| /claimable\_balances/\{claimable\_balance\_id}              | 20 |
+| /claimable\_balances/\{claimable\_balance\_id}/operations   | 20 |
+| /claimable\_balances/\{claimable\_balance\_id}/transactions | 20 |
+| /effects                                                    | 20 |
+| /fee\_stats                                                 | 20 |
+| /ledgers                                                    | 20 |
+| /ledgers/\{sequence}                                        | 20 |
+| /ledgers/\{sequence}/effects                                | 20 |
+| /ledgers/\{sequence}/operations                             | 20 |
+| /ledgers/\{sequence}/payments                               | 20 |
+| /ledgers/\{sequence}/transactions                           | 20 |
+| /liquidity\_pools                                           | 20 |
+| /liquidity\_pools/\{liquidity\_pool\_id}                    | 20 |
+| /liquidity\_pools/\{liquidity\_pool\_id}/effects            | 20 |
+| /liquidity\_pools/\{liquidity\_pool\_id}/operations         | 20 |
+| /liquidity\_pools/\{liquidity\_pool\_id}/trades             | 20 |
+| /liquidity\_pools/\{liquidity\_pool\_id}/transactions       | 20 |
+| /offers                                                     | 20 |
+| /offers/\{offer\_id}                                        | 20 |
+| /offers/\{offer\_id}/trades                                 | 20 |
+| /operations                                                 | 20 |
+| /operations/\{operation\_id}                                | 20 |
+| /operations/\{operation\_id}/effects                        | 20 |
+| /order\_book                                                | 20 |
+| /paths                                                      | 20 |
+| /paths/strict-receive                                       | 20 |
+| /paths/strict-send                                          | 20 |
+| /payments                                                   | 20 |
+| /trade\_aggregations                                        | 20 |
+| /trades                                                     | 20 |
+| /transactions                                               | 20 |
+| /transactions\_async                                        | 20 |
+| /transactions/\{transaction\_id}                            | 20 |
+| /transactions/\{transaction\_id}/effects                    | 20 |
+| /transactions/\{transaction\_id}/operations                 | 20 |
+| /transactions/\{transaction\_id}/payments                   | 20 |
+| getEvents                                                   | 20 |
+| getFeeStats                                                 | 20 |
+| getHealth                                                   | 20 |
+| getLatestLedger                                             | 20 |
+| getLedgerEntries                                            | 20 |
+| getNetwork                                                  | 20 |
+| getVersionInfo                                              | 20 |
+| sendTransaction                                             | 20 |
+| simulateTransaction                                         | 20 |
+| getTransaction                                              | 40 |
+| getLedgers                                                  | 50 |
+| getTransactions                                             | 50 |
 {/* cu:auto end */}
 
 # Sui: Standard Methods
 
 {/* cu:auto product="sui" */}
-| Method                                   | CU |
-| ---------------------------------------- | -- |
-| sui\_devInspectTransactionBlock           | 20 |
-| sui\_dryRunTransactionBlock              | 20 |
-| sui\_executeTransactionBlock             | 20 |
-| sui\_getChainIdentifier                  | 20 |
-| sui\_getCheckpoint                       | 20 |
-| sui\_getCheckpoints                      | 20 |
-| sui\_getEvents                           | 20 |
-| sui\_getLatestCheckpointSequenceNumber   | 20 |
-| sui\_getMoveFunctionArgTypes             | 20 |
-| sui\_getNormalizedMoveFunction           | 20 |
-| sui\_getNormalizedMoveModule             | 20 |
-| sui\_getNormalizedMoveModulesByPackage   | 20 |
-| sui\_getNormalizedMoveStruct             | 20 |
-| sui\_getObject                           | 20 |
-| sui\_getProtocolConfig                   | 20 |
-| sui\_getTotalTransactionBlocks           | 20 |
-| sui\_getTransactionBlock                 | 20 |
-| sui\_multiGetObjects                     | 20 |
-| sui\_multiGetTransactionBlocks           | 20 |
-| sui\_tryGetPastObject                    | 20 |
-| sui\_tryMultiGetPastObjects              | 20 |
-| suix\_getAllBalances                      | 20 |
-| suix\_getAllCoins                         | 20 |
-| suix\_getBalance                         | 20 |
-| suix\_getCoinMetadata                    | 20 |
-| suix\_getCoins                           | 20 |
-| suix\_getCommitteeInfo                   | 20 |
-| suix\_getDynamicFieldObject              | 20 |
-| suix\_getDynamicFields                   | 20 |
-| suix\_getLatestBridge                    | 20 |
-| suix\_getLatestSuiSystemState            | 20 |
-| suix\_getOwnedObjects                    | 20 |
-| suix\_getReferenceGasPrice               | 20 |
-| suix\_getStakes                          | 20 |
-| suix\_getStakesByIds                     | 20 |
-| suix\_getTotalSupply                     | 20 |
-| suix\_queryEvents                        | 20 |
-| suix\_queryTransactionBlocks             | 20 |
-| suix\_resolveNameServiceAddress          | 20 |
-| unsafe\_batchTransaction                 | 20 |
-| unsafe\_mergeCoins                       | 20 |
-| unsafe\_moveCall                         | 20 |
-| unsafe\_pay                              | 20 |
-| unsafe\_payAllSui                        | 20 |
-| unsafe\_paySui                           | 20 |
-| unsafe\_publish                          | 20 |
-| unsafe\_requestAddStake                  | 20 |
-| unsafe\_requestWithdrawStake             | 20 |
-| unsafe\_splitCoin                        | 20 |
-| unsafe\_splitCoinEqual                   | 20 |
-| unsafe\_transferObject                   | 20 |
-| unsafe\_transferSui                      | 20 |
+| Method                                 | CU |
+| -------------------------------------- | -- |
+| sui\_devInspectTransactionBlock        | 20 |
+| sui\_dryRunTransactionBlock            | 20 |
+| sui\_executeTransactionBlock           | 20 |
+| sui\_getChainIdentifier                | 20 |
+| sui\_getCheckpoint                     | 20 |
+| sui\_getCheckpoints                    | 20 |
+| sui\_getEvents                         | 20 |
+| sui\_getLatestCheckpointSequenceNumber | 20 |
+| sui\_getMoveFunctionArgTypes           | 20 |
+| sui\_getNormalizedMoveFunction         | 20 |
+| sui\_getNormalizedMoveModule           | 20 |
+| sui\_getNormalizedMoveModulesByPackage | 20 |
+| sui\_getNormalizedMoveStruct           | 20 |
+| sui\_getObject                         | 20 |
+| sui\_getProtocolConfig                 | 20 |
+| sui\_getTotalTransactionBlocks         | 20 |
+| sui\_getTransactionBlock               | 20 |
+| sui\_multiGetObjects                   | 20 |
+| sui\_multiGetTransactionBlocks         | 20 |
+| sui\_tryGetPastObject                  | 20 |
+| sui\_tryMultiGetPastObjects            | 20 |
+| suix\_getAllBalances                   | 20 |
+| suix\_getAllCoins                      | 20 |
+| suix\_getBalance                       | 20 |
+| suix\_getCoinMetadata                  | 20 |
+| suix\_getCoins                         | 20 |
+| suix\_getCommitteeInfo                 | 20 |
+| suix\_getDynamicFieldObject            | 20 |
+| suix\_getDynamicFields                 | 20 |
+| suix\_getLatestSuiSystemState          | 20 |
+| suix\_getOwnedObjects                  | 20 |
+| suix\_getReferenceGasPrice             | 20 |
+| suix\_getStakes                        | 20 |
+| suix\_getStakesByIds                   | 20 |
+| suix\_getTotalSupply                   | 20 |
+| suix\_queryEvents                      | 20 |
+| suix\_queryTransactionBlocks           | 20 |
+| suix\_resolveNameServiceAddress        | 20 |
+| unsafe\_batchTransaction               | 20 |
+| unsafe\_mergeCoins                     | 20 |
+| unsafe\_moveCall                       | 20 |
+| unsafe\_pay                            | 20 |
+| unsafe\_payAllSui                      | 20 |
+| unsafe\_paySui                         | 20 |
+| unsafe\_publish                        | 20 |
+| unsafe\_requestAddStake                | 20 |
+| unsafe\_requestWithdrawStake           | 20 |
+| unsafe\_splitCoin                      | 20 |
+| unsafe\_splitCoinEqual                 | 20 |
+| unsafe\_transferObject                 | 20 |
+| unsafe\_transferSui                    | 20 |
 {/* cu:auto end */}
 
 # Tron: Standard HTTP Methods
 
 {/* cu:auto product="tron" */}
-| Method                                                    | CU  |
-| --------------------------------------------------------- | --- |
-| /wallet/accountpermissionupdate                           | 20  |
-| /wallet/broadcasthex                                      | 20  |
-| /wallet/broadcasttransaction                              | 20  |
-| /wallet/clearabi                                          | 20  |
-| /wallet/createaccount                                     | 20  |
-| /wallet/createassetissue                                  | 20  |
-| /wallet/createtransaction                                 | 20  |
-| /wallet/deploycontract                                    | 20  |
-| /wallet/estimateenergy                                    | 20  |
-| /wallet/freezebalance                                     | 20  |
-| /wallet/freezebalancev2                                   | 20  |
-| /wallet/getaccount                                        | 20  |
-| /wallet/getaccountbalance                                 | 20  |
-| /wallet/getaccountnet                                     | 20  |
-| /wallet/getaccountresource                                | 20  |
-| /wallet/getassetissuebyid                                 | 20  |
-| /wallet/getassetissuebyname                               | 20  |
-| /wallet/getblock                                          | 20  |
-| /wallet/getblockbynum                                     | 20  |
-| /wallet/getblockbyid                                      | 20  |
-| /wallet/getblockbylatestnum                               | 20  |
-| /wallet/getblockbylimitnext                               | 20  |
-| /wallet/getburntrx                                        | 20  |
-| /wallet/getchainparameters                                | 20  |
-| /wallet/getcontract                                       | 20  |
-| /wallet/getcontractinfo                                   | 20  |
-| /wallet/getdelegatedresource                              | 20  |
-| /wallet/getdelegatedresourceaccountindex                  | 20  |
-| /wallet/getdiversifier                                    | 20  |
-| /wallet/getenergyprices                                   | 20  |
-| /wallet/getexchangebyid                                   | 20  |
-| /wallet/getincomingviewingkey                             | 20  |
-| /wallet/getnewshieldedaddress                             | 20  |
-| /wallet/getnodeinfo                                       | 20  |
-| /wallet/getnowblock                                       | 20  |
-| /wallet/getpaginatedassetissuelist                        | 20  |
-| /wallet/getproposalbyid                                   | 20  |
-| /wallet/gettransactionbyid                                | 20  |
-| /wallet/gettransactioninfobyid                            | 20  |
-| /wallet/gettransactionlistfrompending                     | 20  |
-| /wallet/triggersmartcontract                              | 20  |
-| /wallet/triggerconstantcontract                           | 20  |
-| /wallet/transferasset                                     | 20  |
-| /wallet/unfreezebalance                                   | 20  |
-| /wallet/unfreezebalancev2                                 | 20  |
-| /wallet/unfreezeasset                                     | 20  |
-| /wallet/updateaccount                                     | 20  |
-| /wallet/validateaddress                                   | 20  |
-| /wallet/createshieldedcontractparameters                  | 20  |
-| /wallet/createspendauthsig                                | 20  |
-| /wallet/delegateresource                                  | 20  |
-| /wallet/exchangecreate                                    | 20  |
-| /wallet/exchangeinject                                    | 20  |
-| /wallet/exchangetransaction                               | 20  |
-| /wallet/exchangewithdraw                                  | 20  |
-| /wallet/getakfromask                                      | 20  |
-| /wallet/getassetissuebyaccount                            | 20  |
-| /wallet/getassetissuelist                                 | 20  |
-| /wallet/getassetissuelistbyname                           | 20  |
-| /wallet/getavailableunfreezecount                         | 20  |
-| /wallet/getbandwidthprices                                | 20  |
-| /wallet/getblockbalance                                   | 20  |
-| /wallet/getcandelegatedmaxsize                            | 20  |
-| /wallet/getcanwithdrawunfreezeamount                      | 20  |
-| /wallet/getdelegatedresourceaccountindexv2                | 20  |
-| /wallet/getdelegatedresourcev2                            | 20  |
-| /wallet/getexpandedspendingkey                            | 20  |
-| /wallet/getnkfromnsk                                      | 20  |
-| /wallet/getpendingsize                                    | 20  |
-| /wallet/getspendingkey                                    | 20  |
-| /wallet/gettransactionfrompending                         | 20  |
-| /wallet/gettransactioninfobyblocknum                      | 20  |
-| /wallet/gettriggerinputforshieldedtrc20contract           | 20  |
-| /wallet/getzenpaymentaddress                              | 20  |
-| /wallet/isshieldedtrc20contractnotespent                  | 20  |
-| /wallet/listexchanges                                     | 20  |
-| /wallet/listproposals                                     | 20  |
-| /wallet/participateassetissue                             | 20  |
-| /wallet/proposalapprove                                   | 20  |
-| /wallet/proposaldelete                                    | 20  |
-| /wallet/scanshieldedtrc20notesbyivk                       | 20  |
-| /wallet/scanshieldedtrc20notesbyovk                       | 20  |
-| /wallet/undelegateresource                                | 20  |
-| /wallet/updateasset                                       | 20  |
-| /wallet/updateenergylimit                                 | 20  |
-| /wallet/updatesetting                                     | 20  |
-| /wallet/votewitnessaccount                                | 20  |
-| /wallet/withdrawexpireunfreeze                            | 20  |
+| Method                                          | CU |
+| ----------------------------------------------- | -- |
+| /wallet/accountpermissionupdate                 | 20 |
+| /wallet/broadcasthex                            | 20 |
+| /wallet/broadcasttransaction                    | 20 |
+| /wallet/clearabi                                | 20 |
+| /wallet/createaccount                           | 20 |
+| /wallet/createassetissue                        | 20 |
+| /wallet/createshieldedcontractparameters        | 20 |
+| /wallet/createspendauthsig                      | 20 |
+| /wallet/createtransaction                       | 20 |
+| /wallet/delegateresource                        | 20 |
+| /wallet/deploycontract                          | 20 |
+| /wallet/estimateenergy                          | 20 |
+| /wallet/exchangecreate                          | 20 |
+| /wallet/exchangeinject                          | 20 |
+| /wallet/exchangetransaction                     | 20 |
+| /wallet/exchangewithdraw                        | 20 |
+| /wallet/freezebalance                           | 20 |
+| /wallet/freezebalancev2                         | 20 |
+| /wallet/getaccount                              | 20 |
+| /wallet/getaccountbalance                       | 20 |
+| /wallet/getaccountnet                           | 20 |
+| /wallet/getaccountresource                      | 20 |
+| /wallet/getakfromask                            | 20 |
+| /wallet/getassetissuebyaccount                  | 20 |
+| /wallet/getassetissuebyid                       | 20 |
+| /wallet/getassetissuebyname                     | 20 |
+| /wallet/getassetissuelist                       | 20 |
+| /wallet/getassetissuelistbyname                 | 20 |
+| /wallet/getavailableunfreezecount               | 20 |
+| /wallet/getbandwidthprices                      | 20 |
+| /wallet/getblock                                | 20 |
+| /wallet/getblockbalance                         | 20 |
+| /wallet/getblockbyid                            | 20 |
+| /wallet/getblockbylatestnum                     | 20 |
+| /wallet/getblockbylimitnext                     | 20 |
+| /wallet/getblockbynum                           | 20 |
+| /wallet/getburntrx                              | 20 |
+| /wallet/getcandelegatedmaxsize                  | 20 |
+| /wallet/getcanwithdrawunfreezeamount            | 20 |
+| /wallet/getchainparameters                      | 20 |
+| /wallet/getcontract                             | 20 |
+| /wallet/getcontractinfo                         | 20 |
+| /wallet/getdelegatedresource                    | 20 |
+| /wallet/getdelegatedresourceaccountindex        | 20 |
+| /wallet/getdelegatedresourceaccountindexv2      | 20 |
+| /wallet/getdelegatedresourcev2                  | 20 |
+| /wallet/getdiversifier                          | 20 |
+| /wallet/getenergyprices                         | 20 |
+| /wallet/getexchangebyid                         | 20 |
+| /wallet/getexpandedspendingkey                  | 20 |
+| /wallet/getincomingviewingkey                   | 20 |
+| /wallet/getnewshieldedaddress                   | 20 |
+| /wallet/getnkfromnsk                            | 20 |
+| /wallet/getnodeinfo                             | 20 |
+| /wallet/getnowblock                             | 20 |
+| /wallet/getpaginatedassetissuelist              | 20 |
+| /wallet/getpendingsize                          | 20 |
+| /wallet/getproposalbyid                         | 20 |
+| /wallet/getsignweight                           | 20 |
+| /wallet/getspendingkey                          | 20 |
+| /wallet/gettransactionbyid                      | 20 |
+| /wallet/gettransactionfrompending               | 20 |
+| /wallet/gettransactioninfobyblocknum            | 20 |
+| /wallet/gettransactioninfobyid                  | 20 |
+| /wallet/gettransactionlistfrompending           | 20 |
+| /wallet/gettriggerinputforshieldedtrc20contract | 20 |
+| /wallet/getzenpaymentaddress                    | 20 |
+| /wallet/isshieldedtrc20contractnotespent        | 20 |
+| /wallet/listexchanges                           | 20 |
+| /wallet/listproposals                           | 20 |
+| /wallet/participateassetissue                   | 20 |
+| /wallet/proposalapprove                         | 20 |
+| /wallet/proposaldelete                          | 20 |
+| /wallet/scanshieldedtrc20notesbyivk             | 20 |
+| /wallet/scanshieldedtrc20notesbyovk             | 20 |
+| /wallet/transferasset                           | 20 |
+| /wallet/triggerconstantcontract                 | 20 |
+| /wallet/triggersmartcontract                    | 20 |
+| /wallet/undelegateresource                      | 20 |
+| /wallet/unfreezeasset                           | 20 |
+| /wallet/unfreezebalance                         | 20 |
+| /wallet/unfreezebalancev2                       | 20 |
+| /wallet/updateaccount                           | 20 |
+| /wallet/updateasset                             | 20 |
+| /wallet/updateenergylimit                       | 20 |
+| /wallet/updatesetting                           | 20 |
+| /wallet/validateaddress                         | 20 |
+| /wallet/votewitnessaccount                      | 20 |
+| /wallet/withdrawexpireunfreeze                  | 20 |
 {/* cu:auto end */}
 
 # Tron: Solidity HTTP Methods
 
 {/* cu:auto product="tron-solidity" */}
-| Method                                                    | CU  |
-| --------------------------------------------------------- | --- |
-| /walletsolidity/estimateenergy                            | 20  |
-| /walletsolidity/getaccount                                | 20  |
-| /walletsolidity/getassetissuebyid                         | 20  |
-| /walletsolidity/getassetissuebyname                       | 20  |
-| /walletsolidity/getassetissuelist                         | 20  |
-| /walletsolidity/getassetissuelistbyname                   | 20  |
-| /walletsolidity/getavailableunfreezecount                 | 20  |
-| /walletsolidity/getblock                                  | 20  |
-| /walletsolidity/getblockbyid                              | 20  |
-| /walletsolidity/getblockbylatestnum                       | 20  |
-| /walletsolidity/getblockbylimitnext                       | 20  |
-| /walletsolidity/getblockbynum                             | 20  |
-| /walletsolidity/getburntrx                                | 20  |
-| /walletsolidity/getcandelegatedmaxsize                    | 20  |
-| /walletsolidity/getcanwithdrawunfreezeamount              | 20  |
-| /walletsolidity/getdelegatedresource                      | 20  |
-| /walletsolidity/getdelegatedresourceaccountindex          | 20  |
-| /walletsolidity/getdelegatedresourceaccountindexv2        | 20  |
-| /walletsolidity/getexchangebyid                           | 20  |
-| /walletsolidity/getnowblock                               | 20  |
-| /walletsolidity/getpaginatedassetissuelist                | 20  |
-| /walletsolidity/gettransactionbyid                        | 20  |
-| /walletsolidity/gettransactioncountbyblocknum             | 20  |
-| /walletsolidity/gettransactioninfobyblocknum              | 20  |
-| /walletsolidity/gettransactioninfobyid                    | 20  |
-| /walletsolidity/isshieldedtrc20contractnotespent          | 20  |
-| /walletsolidity/listexchanges                             | 20  |
-| /walletsolidity/scanshieldedtrc20notesbyivk               | 20  |
-| /walletsolidity/scanshieldedtrc20notesbyovk               | 20  |
-| /walletsolidity/triggerconstantcontract                   | 20  |
+| Method                                             | CU |
+| -------------------------------------------------- | -- |
+| /walletsolidity/estimateenergy                     | 20 |
+| /walletsolidity/getaccount                         | 20 |
+| /walletsolidity/getassetissuebyid                  | 20 |
+| /walletsolidity/getassetissuebyname                | 20 |
+| /walletsolidity/getassetissuelist                  | 20 |
+| /walletsolidity/getassetissuelistbyname            | 20 |
+| /walletsolidity/getavailableunfreezecount          | 20 |
+| /walletsolidity/getblock                           | 20 |
+| /walletsolidity/getblockbyid                       | 20 |
+| /walletsolidity/getblockbylatestnum                | 20 |
+| /walletsolidity/getblockbylimitnext                | 20 |
+| /walletsolidity/getblockbynum                      | 20 |
+| /walletsolidity/getburntrx                         | 20 |
+| /walletsolidity/getcandelegatedmaxsize             | 20 |
+| /walletsolidity/getcanwithdrawunfreezeamount       | 20 |
+| /walletsolidity/getdelegatedresource               | 20 |
+| /walletsolidity/getdelegatedresourceaccountindex   | 20 |
+| /walletsolidity/getdelegatedresourceaccountindexv2 | 20 |
+| /walletsolidity/getexchangebyid                    | 20 |
+| /walletsolidity/getnowblock                        | 20 |
+| /walletsolidity/getpaginatedassetissuelist         | 20 |
+| /walletsolidity/gettransactionbyid                 | 20 |
+| /walletsolidity/gettransactioncountbyblocknum      | 20 |
+| /walletsolidity/gettransactioninfobyblocknum       | 20 |
+| /walletsolidity/gettransactioninfobyid             | 20 |
+| /walletsolidity/isshieldedtrc20contractnotespent   | 20 |
+| /walletsolidity/listexchanges                      | 20 |
+| /walletsolidity/scanshieldedtrc20notesbyivk        | 20 |
+| /walletsolidity/scanshieldedtrc20notesbyovk        | 20 |
+| /walletsolidity/triggerconstantcontract            | 20 |
+{/* cu:auto end */}
+
+# Astar: Specific Methods
+
+{/* cu:auto product="astar" */}
+| Method                  | CU |
+| ----------------------- | -- |
+| chain\_getFinalizedHead | 10 |
+| chain\_getHeader        | 10 |
+{/* cu:auto end */}
+
+# Bitcoin: Indexer REST API Methods
+
+{/* cu:auto product="bitcoin-indexer" */}
+| Method                                            | CU |
+| ------------------------------------------------- | -- |
+| /address-prefix/\{prefix}                         | 20 |
+| /address/\{address}                               | 20 |
+| /address/\{address}/txs                           | 20 |
+| /address/\{address}/txs/chain/\{last\_seen\_txid} | 20 |
+| /address/\{address}/txs/mempool                   | 20 |
+| /address/\{address}/utxo                          | 20 |
+| /block-height/\{height}                           | 20 |
+| /block/\{hash}                                    | 20 |
+| /block/\{hash}/header                             | 20 |
+| /block/\{hash}/raw                                | 20 |
+| /block/\{hash}/status                             | 20 |
+| /block/\{hash}/txid/\{index}                      | 20 |
+| /block/\{hash}/txids                              | 20 |
+| /block/\{hash}/txs/\{start\_index}                | 20 |
+| /blocks/\{start\_height}                          | 20 |
+| /blocks/tip/hash                                  | 20 |
+| /blocks/tip/height                                | 20 |
+| /fee-estimates                                    | 20 |
+| /mempool                                          | 20 |
+| /mempool/recent                                   | 20 |
+| /mempool/txids                                    | 20 |
+| /scripthash/\{hash}                               | 20 |
+| /scripthash/\{hash}/txs                           | 20 |
+| /scripthash/\{hash}/txs/chain/\{last\_seen\_txid} | 20 |
+| /scripthash/\{hash}/txs/mempool                   | 20 |
+| /scripthash/\{hash}/utxo                          | 20 |
+| /tx/\{txid}                                       | 20 |
+| /tx/\{txid}/hex                                   | 20 |
+| /tx/\{txid}/merkle-proof                          | 20 |
+| /tx/\{txid}/merkleblock-proof                     | 20 |
+| /tx/\{txid}/outspend/\{vout}                      | 20 |
+| /tx/\{txid}/outspends                             | 20 |
+| /tx/\{txid}/raw                                   | 20 |
+| /tx/\{txid}/status                                | 20 |
+| /txs/package                                      | 20 |
+{/* cu:auto end */}
+
+# HyperEVM: Specific Methods
+
+{/* cu:auto product="hyperevm" */}
+| Method                            | CU |
+| --------------------------------- | -- |
+| eth\_bigBlockGasPrice             | 20 |
+| eth\_getBlockReceiptsWithSystemTx | 20 |
+| eth\_getSystemTxsByBlockHash      | 20 |
+| eth\_getSystemTxsByBlockNumber    | 20 |
+| eth\_usingBigBlocks               | 20 |
+{/* cu:auto end */}
+
+# Optimism: Specific Methods
+
+{/* cu:auto product="optimism" */}
+| Method                  | CU |
+| ----------------------- | -- |
+| optimism\_outputAtBlock | 10 |
+| optimism\_rollupConfig  | 10 |
+| optimism\_syncStatus    | 10 |
+| optimism\_version       | 10 |
+{/* cu:auto end */}
+
+# Avalanche P-Chain: Standard Methods
+
+{/* cu:auto product="pchain" */}
+| Method                         | CU |
+| ------------------------------ | -- |
+| platform.getAllValidatorsAt    | 20 |
+| platform.getBalance            | 20 |
+| platform.getBlockchains        | 20 |
+| platform.getBlockchainStatus   | 20 |
+| platform.getCurrentSupply      | 20 |
+| platform.getCurrentValidators  | 20 |
+| platform.getFeeConfig          | 20 |
+| platform.getFeeState           | 20 |
+| platform.getHeight             | 20 |
+| platform.getMinStake           | 20 |
+| platform.getRewardUTXOs        | 20 |
+| platform.getStake              | 20 |
+| platform.getStakingAssetID     | 20 |
+| platform.getSubnets            | 20 |
+| platform.getTimestamp          | 20 |
+| platform.getTotalStake         | 20 |
+| platform.getTx                 | 20 |
+| platform.getTxStatus           | 20 |
+| platform.getUTXOs              | 20 |
+| platform.getValidatorFeeConfig | 20 |
+| platform.getValidatorFeeState  | 20 |
+| platform.getValidatorsAt       | 20 |
+| platform.issueTx               | 20 |
+| platform.sampleValidators      | 20 |
+| platform.validatedBy           | 20 |
+| platform.validates             | 20 |
+{/* cu:auto end */}
+
+# Sui: gRPC Methods
+
+{/* cu:auto product="sui-grpc" */}
+| Method                                                     | CU |
+| ---------------------------------------------------------- | -- |
+| sui.rpc.v2.LedgerService/GetServiceInfo                    | 10 |
+| sui.rpc.v2.SubscriptionService/SubscribeCheckpoints        | 10 |
+| sui.rpc.v2.LedgerService/BatchGetObjects                   | 20 |
+| sui.rpc.v2.LedgerService/BatchGetTransactions              | 20 |
+| sui.rpc.v2.LedgerService/GetCheckpoint                     | 20 |
+| sui.rpc.v2.LedgerService/GetEpoch                          | 20 |
+| sui.rpc.v2.LedgerService/GetObject                         | 20 |
+| sui.rpc.v2.LedgerService/GetTransaction                    | 20 |
+| sui.rpc.v2.MovePackageService/GetDatatype                  | 20 |
+| sui.rpc.v2.MovePackageService/GetFunction                  | 20 |
+| sui.rpc.v2.MovePackageService/GetPackage                   | 20 |
+| sui.rpc.v2.MovePackageService/ListPackageVersions          | 20 |
+| sui.rpc.v2.NameService/LookupName                          | 20 |
+| sui.rpc.v2.NameService/ReverseLookupName                   | 20 |
+| sui.rpc.v2.SignatureVerificationService/VerifySignature    | 20 |
+| sui.rpc.v2.StateService/GetBalance                         | 20 |
+| sui.rpc.v2.StateService/GetCoinInfo                        | 20 |
+| sui.rpc.v2.StateService/ListBalances                       | 20 |
+| sui.rpc.v2.StateService/ListDynamicFields                  | 20 |
+| sui.rpc.v2.StateService/ListOwnedObjects                   | 20 |
+| sui.rpc.v2.TransactionExecutionService/ExecuteTransaction  | 20 |
+| sui.rpc.v2.TransactionExecutionService/SimulateTransaction | 20 |
+{/* cu:auto end */}
+
+# Solana: Yellowstone gRPC Unary Methods
+
+{/* cu:auto product="yellowstone-grpc" */}
+| Method                            | CU |
+| --------------------------------- | -- |
+| geyser.Geyser/GetBlockHeight      | 10 |
+| geyser.Geyser/GetLatestBlockhash  | 10 |
+| geyser.Geyser/GetSlot             | 10 |
+| geyser.Geyser/GetVersion          | 10 |
+| geyser.Geyser/IsBlockhashValid    | 10 |
+| geyser.Geyser/Ping                | 10 |
+| geyser.Geyser/SubscribeReplayInfo | 10 |
 {/* cu:auto end */}
 
 # Compute unit cost for error codes


### PR DESCRIPTION
## Description

**Stacked on #1424** (the marker PR) — merge that first; this PR's diff then shows exactly what the automation changes.

This is the first generated output of `UpdateComputeUnitCostsFromDaikonWorkflow` (OMGWINNING/dashboard#8087), produced by running the workflow's generator locally against the latest `chain-config` topconfig (1100 methods). It serves as the **drift audit** from the ticket's acceptance criteria: every diff against the hand-maintained tables is a pre-existing inaccuracy or omission that the daily automation will keep fixed. Once the workflow is deployed and scheduled, PRs identical to this one arrive automatically on `bot/daikon-cu-costs-update`.

## Drift audit summary

**Coverage: 658 → 899 table rows.** 243 billed methods were missing from the page entirely, 53 rows had wrong values, 1 row is removed. Per team review, methods that exist only on non-public networks (TON, Tendermint, Celestia consensus gRPC, Arc mainnet — all PRERELEASE in the dashboard network config) are excluded; their sections auto-create with a Slack alert if those networks ever go public.

**7 new sections auto-created** (inferred titles — please review naming/placement; renaming headers or moving blocks is safe, the marker carries the key):
- Avalanche P-Chain (26 methods), Astar substrate methods (2), Optimism-specific (4), HyperEVM (5)
- Bitcoin Indexer REST (35, Esplora-style `indexer` group), Sui gRPC (22), Solana Yellowstone gRPC unary (7)
- Previously previewed TON/Tendermint/Celestia-gRPC/Arc sections and the internal `all` group are excluded (non-public networks / internal billing keys)

**Notable value corrections** (topconfig is the billing source of truth):
- `eth_sendRawTransaction` Throughput CU 250 → 50, `eth_sendRawTransactionSync` 250 → 125
- `starknet_blockNumber`/`starknet_blockHashAndNumber` CU 20 → 10
- `getNFTsForContract` Throughput CU 50 → 100
- Solana `getSupply`/`getProgramAccounts`/`getInflationReward` gained real throughput values (800/117/300)
- Prices API rows gained Throughput CU 20; Portfolio rows gained their (oddly low) explicit values of 1
- Trace/Arbtrace/Gas-Manager rows that showed Throughput CU equal to CU are now blank per the rule "only show when explicitly set AND differing" (`rateLimitComputeUnits` defaults to `computeUnits`, so equal values carry no information)

**Removals** (both verified intentional):
- `suix_getLatestBridge` — marked `METHOD_PRERELEASE` in topconfig; the page only lists public methods
- Portfolio's `/transactions/history/by-address` is a rename to `transactions/history/by-address` (path normalization), not a removal

**Formatting normalization**: uniform `\_` escaping (the Wallet section was inconsistent), deterministic row sort (CU ascending, then name), NFT/signer/prices/portfolio rows keep their public display names via the workflow's display-name map.

**Flagged, not on the page**: `/tx` (custom method shared by Celestia consensus + Bitcoin) resolves to no product tag — the workflow Slack-alerts this; it needs a manual override decision.

**Found in the process**: likely topconfig typo `aarbtrace_rawTransaction` (double "a") — appears as a new Arbtrace row here; should be fixed in Daikon.

## Test Plan

- [x] Output produced by the exact generator code in OMGWINNING/dashboard#8087 (232 unit tests passing there)
- [x] `prettier --check` passes
- [x] Regeneration over this output is idempotent (second run produces zero diff)
- [x] All content outside `cu:auto` markers verified byte-identical to the marker PR
- [x] Human review of auto-created section titles/placement

LINEAR TASK: https://linear.app/alchemyapi/issue/DX-3112/automate-the-compute-unit-costs-pricing-page-from-daikon-topconfig
