### PR TITLE
docs(cli): document device-code login for headless environments

### DIFF
--- a/content/tutorials/build-with-ai/alchemy-cli.mdx
+++ b/content/tutorials/build-with-ai/alchemy-cli.mdx
@@ -32,6 +32,18 @@ Sign in via browser. The CLI saves a token and prompts you to pick an app, then 
 alchemy auth
 ```
 
+### Headless and remote environments
+
+If the CLI runs where a browser can't reach it — GitHub Codespaces, SSH sessions, sandboxes, CI — use the device authorization flow. The CLI prints a short code and a verification link; open the link in a browser on any device, check the code matches the one in your terminal, and approve.
+
+```bash
+alchemy auth login --device-code
+```
+
+Plain `alchemy auth` also auto-detects remote and non-interactive environments and switches to this flow on its own, so remote sessions usually don't need the flag.
+
+### Selecting an app
+
 To change the selected app later, list your apps and select one:
 
 ```bash
@@ -318,6 +330,7 @@ Filters are optional and combined with AND. `--group-by` accepts at most one dim
 | Command | Description |
 |---|---|
 | `alchemy auth` | Sign in via browser. Use `alchemy auth login --force` to re-authenticate and `-y` to skip the confirmation prompt. |
+| `alchemy auth login --device-code` | Sign in from headless or remote environments (Codespaces, sandboxes, SSH, CI) by approving a short code in a browser on any device. Auto-detected for remote and non-interactive sessions. |
 | `alchemy auth status` | Show whether you're signed in |
 | `alchemy auth logout` | Clear the saved authentication token |
 | `alchemy doctor` | Run setup checks and print remediation commands |

--- a/content/tutorials/build-with-ai/alchemy-cli.mdx
+++ b/content/tutorials/build-with-ai/alchemy-cli.mdx
@@ -34,13 +34,19 @@ alchemy auth
 
 ### Headless and remote environments
 
-If the CLI runs somewhere a browser can't reach it, like GitHub Codespaces, SSH sessions, sandboxes, or CI, use the device authorization flow. The CLI prints a short code and a verification link. Open the link in a browser on any device, check the code matches the one in your terminal, and approve.
+If the CLI runs somewhere a browser can't reach it, use the device authorization flow. The CLI prints a short code and a verification link. Open the link in a browser on any device, check the code matches the one in your terminal, and approve.
 
 ```bash
 alchemy auth login --device-code
 ```
 
-Plain `alchemy auth` also auto-detects remote and non-interactive environments and switches to this flow on its own, so remote sessions usually don't need the flag.
+The flag works in every environment. Plain `alchemy auth` also switches to this flow on its own when it detects one of the following, so these don't need the flag:
+
+* GitHub Codespaces, Gitpod, Replit, Google Cloud Shell, and Coder workspaces
+* SSH sessions
+* Non-interactive sessions like CI and piped output, where the browser flow can't prompt
+
+If auto-detection misses your environment, the browser login times out after two minutes and its error points you to the same command.
 
 ### Selecting an app
 

--- a/content/tutorials/build-with-ai/alchemy-cli.mdx
+++ b/content/tutorials/build-with-ai/alchemy-cli.mdx
@@ -34,7 +34,7 @@ alchemy auth
 
 ### Headless and remote environments
 
-If the CLI runs where a browser can't reach it — GitHub Codespaces, SSH sessions, sandboxes, CI — use the device authorization flow. The CLI prints a short code and a verification link; open the link in a browser on any device, check the code matches the one in your terminal, and approve.
+If the CLI runs somewhere a browser can't reach it, like GitHub Codespaces, SSH sessions, sandboxes, or CI, use the device authorization flow. The CLI prints a short code and a verification link. Open the link in a browser on any device, check the code matches the one in your terminal, and approve.
 
 ```bash
 alchemy auth login --device-code


### PR DESCRIPTION
## What

`@alchemy/cli` 0.18.0 added an OAuth 2.0 Device Authorization Grant (RFC 8628) login flow so `alchemy auth` works in headless and remote environments (GitHub Codespaces, sandboxes, SSH, CI) where the browser cannot reach the CLI's localhost callback.

This documents it on the Alchemy CLI page:
- New **Headless and remote environments** subsection under **Authenticate** with the `alchemy auth login --device-code` command and a note that plain `alchemy auth` auto-detects remote/non-interactive sessions
- New row in the **Auth and config** command reference table

## Context

CLI side: OMGWINNING/alchemy-cli#99 (released as 0.18.0). Server side: OMGWINNING/authchemy#546-#548, live in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)