### PR TITLE
fix(docs): correct the Tron spend authorization endpoint

### DIFF
--- a/src/openapi/tron-http/tron-http.yaml
+++ b/src/openapi/tron-http/tron-http.yaml
@@ -3154,7 +3154,7 @@ paths:
               example:
                 parameter: "contract_param"
 
-  /wallet/createspendsauthsig:
+  /wallet/createspendauthsig:
     post:
       summary: Create spend authorization signature
       description: Creates a spend authorization signature for a shielded transaction using a secret key and message data.

--- a/src/openapi/tron-http/tron-http.yaml
+++ b/src/openapi/tron-http/tron-http.yaml
@@ -3157,7 +3157,7 @@ paths:
   /wallet/createspendauthsig:
     post:
       summary: Create spend authorization signature
-      description: Creates a spend authorization signature for a shielded transaction using a secret key and message data.
+      description: Creates a spend authorization signature for a shielded transaction from the spend authorizing key, the transaction hash, and the random scalar alpha.
       tags:
         - Tron HTTP API Endpoints
       requestBody:
@@ -3167,20 +3167,23 @@ paths:
             schema:
               type: object
               properties:
-                sk:
+                ask:
                   type: string
-                data:
+                tx_hash:
+                  type: string
+                alpha:
                   type: string
             example:
-              sk: "secret_key"
-              data: "message_to_sign"
+              ask: "spend_authorizing_key"
+              tx_hash: "transaction_hash"
+              alpha: "random_scalar"
       responses:
         "200":
           description: Spend authorization signature created
           content:
             application/json:
               example:
-                signature: "signed_data"
+                value: "signature_bytes"
 
   /wallet/gettriggerinputforshieldedtrc20contract:
     post:


### PR DESCRIPTION
## Description

The generated Feature Support data and revalidation wiring previously carried by this stacked PR have been removed because docs-site now resolves the matrix directly from Daikon. The remaining diff is the OpenAPI correction discovered during the original drift audit.

## Summary

- Corrects the Tron spend-authorization endpoint from `/wallet/createspendsauthsig` to `/wallet/createspendauthsig`.
- Updates its request schema to `ask`, `tx_hash`, and `alpha`.
- Updates the example response to the documented `value` field.
- Removes `content/feature-support.json` and Feature Support revalidation workflow changes from this PR.

## Test Plan

- Final diff against the stacked base contains only `src/openapi/tron-http/tron-http.yaml`.
- Docs TypeScript typecheck passed after dependency install.
- YAML diff was reviewed against the corrected endpoint shape captured by the AX-545 drift audit.

## Deployment Notes

- This correction is independent of Feature Support runtime behavior.
- It remains based on #1430 only to preserve the existing stacked PR and review history. After #1430 merges, GitHub can merge this into `main` normally.

## Stack PRs

1. [alchemyplatform/docs#1430](https://github.com/alchemyplatform/docs/pull/1430)
2. This PR

LINEAR TASK: https://linear.app/alchemyapi/issue/AX-545
