### PR TITLE
Refuse preview indexing when --branch doesn't match the checkout

### DIFF
--- a/src/content-indexer/preview.ts
+++ b/src/content-indexer/preview.ts
@@ -83,9 +83,36 @@ const runTargetedGeneration = (changedFile?: string): void => {
   }
 };
 
+/**
+ * The indexer uploads the CURRENT checkout's content under `--branch`'s
+ * Redis keys. Running it while a different branch is checked out silently
+ * clobbers that branch's shared preview data, so refuse the mismatch.
+ * Detached HEAD is allowed: CI checks out merge refs while passing the PR's
+ * head branch name. Set PREVIEW_ALLOW_BRANCH_MISMATCH=1 to override.
+ */
+const assertBranchMatchesCheckout = (branch: string): void => {
+  if (process.env.PREVIEW_ALLOW_BRANCH_MISMATCH) {
+    return;
+  }
+  const checkedOut = execSync("git rev-parse --abbrev-ref HEAD", {
+    stdio: ["ignore", "pipe", "ignore"],
+  })
+    .toString()
+    .trim();
+  if (checkedOut !== "HEAD" && checkedOut !== branch) {
+    throw new Error(
+      `--branch=${branch} but this checkout is on '${checkedOut}'. ` +
+        "Indexing would overwrite that branch's shared preview data with " +
+        "this checkout's content. Check out the branch (or a worktree of " +
+        "it) first, or set PREVIEW_ALLOW_BRANCH_MISMATCH=1 to override.",
+    );
+  }
+};
+
 const main = async () => {
   try {
     const { branch, uploadFile, reindex, reindexFile } = parseArgs();
+    assertBranchMatchesCheckout(branch);
 
     // Mode: upload single file (fast path watcher)
     if (uploadFile) {


### PR DESCRIPTION
## Why

The preview indexer stamps the **current checkout's content** under whatever `--branch` it's given. Run it while a different branch is checked out — a stale `pnpm preview` watcher, a failed `cd` before the command, or a manual `--branch` flag — and it silently overwrites that branch's shared preview data. This has now clobbered a team-shared preview link three times (the nav-restructure mockup preview kept reverting to main's content while unrelated branches were being tested locally).

## What

`preview.ts` now fails fast when `--branch` doesn't match `git rev-parse --abbrev-ref HEAD`:

```
Error: --branch=nav-restructure-mockup but this checkout is on 'dx-3112-...'.
Indexing would overwrite that branch's shared preview data with this
checkout's content. Check out the branch (or a worktree of it) first, or
set PREVIEW_ALLOW_BRANCH_MISMATCH=1 to override.
```

- **Detached HEAD is allowed** — CI checks out the PR merge ref while passing `github.head_ref`, so the generate-preview job is unaffected (verified).
- `PREVIEW_ALLOW_BRANCH_MISMATCH=1` overrides for deliberate cases.
- Applies to all three modes (initial+watchers, `--reindex`, `--upload-file`), so stale watchers from a switched checkout also stop at the guard.

Tested: mismatch → guard error; matching branch → proceeds; detached HEAD → proceeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)