### PR TITLE
docs: add Robinhood Mainnet to internal ETH support for address activity webhooks

### DIFF
--- a/content/api-reference/data/webhooks/webhook-types/address-activity-webhook.mdx
+++ b/content/api-reference/data/webhooks/webhook-types/address-activity-webhook.mdx
@@ -32,7 +32,7 @@ There are three main types of transfers that are captured when receiving a `from
 <Warning>
 **Note on Internal Transfers**
 
-1. Internal transfers are currently only supported on Ethereum, Polygon, Arbitrum, Optimism, Base, BNB Chain, Avalanche, and Robinhood Mainnet. Support for other networks is a WIP!
+1. Internal transfers are currently only supported on Ethereum, Polygon, Arbitrum, Optimism, Base, BNB Chain, Avalanche, and Robinhood. Support for other networks is a WIP!
 2. Internal Transfers with the call type `delegatecall` are not supported on Alchemy. Although they have a value associated with them, they don't transfer a value. For details read the [Ethereum Yellow Paper](https://ethereum.github.io/yellowpaper/paper.pdf). Internal transfer miner rewards are also unsupported on Alchemy.
 </Warning>
 

--- a/content/api-reference/data/webhooks/webhook-types/address-activity-webhook.mdx
+++ b/content/api-reference/data/webhooks/webhook-types/address-activity-webhook.mdx
@@ -32,7 +32,7 @@ There are three main types of transfers that are captured when receiving a `from
 <Warning>
 **Note on Internal Transfers**
 
-1. Internal transfers are currently only supported on Ethereum, Polygon, Arbitrum, Optimism, Base, BNB Chain, and Avalanche. Support for other networks is a WIP!
+1. Internal transfers are currently only supported on Ethereum, Polygon, Arbitrum, Optimism, Base, BNB Chain, Avalanche, and Robinhood Mainnet. Support for other networks is a WIP!
 2. Internal Transfers with the call type `delegatecall` are not supported on Alchemy. Although they have a value associated with them, they don't transfer a value. For details read the [Ethereum Yellow Paper](https://ethereum.github.io/yellowpaper/paper.pdf). Internal transfer miner rewards are also unsupported on Alchemy.
 </Warning>
 


### PR DESCRIPTION
## Summary
- Adds Robinhood Mainnet to the list of networks that support Internal ETH transfers for [Address Activity webhooks](https://www.alchemy.com/docs/reference/address-activity-webhook).

## Details
Updated the "Note on Internal Transfers" callout in the Address Activity Webhook docs so Robinhood Mainnet is listed alongside Ethereum, Polygon, Arbitrum, Optimism, Base, BNB Chain, and Avalanche.

## Test plan
- [ ] Verify the rendered Address Activity Webhook page shows Robinhood Mainnet in the internal transfers support list.

Made with [Cursor](https://cursor.com)