### PR TITLE
feat: rank chain API-overview pages first for chain-name search queries

### DIFF
--- a/src/content-indexer/collectors/algolia.ts
+++ b/src/content-indexer/collectors/algolia.ts
@@ -18,6 +18,7 @@ type AddRecordBaseParams = {
   description?: string;
   content: string;
   breadcrumbs: NavItem[];
+  pageRank?: number;
 };
 
 type AddGuideRecordParams = AddRecordBaseParams & {
@@ -65,6 +66,7 @@ export class AlgoliaCollector {
       title: params.title,
       content: params.content,
       breadcrumbs: breadcrumbTitles,
+      pageRank: params.pageRank ?? 0,
       ...(params.httpMethod && { httpMethod: params.httpMethod }),
       ...(params.description && { description: params.description }),
     });

--- a/src/content-indexer/indexers/changelog.ts
+++ b/src/content-indexer/indexers/changelog.ts
@@ -155,6 +155,7 @@ export const buildChangelogIndex = async (
         path: fullPath,
         pageType: "Changelog" as const,
         breadcrumbs: ["Changelog", date],
+        pageRank: 0,
       });
 
       return { route, pathIndexEntry, algoliaRecord };

--- a/src/content-indexer/types/algolia.ts
+++ b/src/content-indexer/types/algolia.ts
@@ -12,4 +12,5 @@ export interface AlgoliaRecord {
   breadcrumbs: string[]; // Navigation ancestry titles for context (e.g., ["NFT API", "NFT API Endpoints"])
   httpMethod?: string; // For API methods: "GET" | "POST" | etc.
   content: string; // MDX content or endpoint description
+  pageRank: number; // Custom-ranking signal (desc); 1 for chain API-overview pages, 0 otherwise
 }

--- a/src/content-indexer/uploaders/algolia.ts
+++ b/src/content-indexer/uploaders/algolia.ts
@@ -66,6 +66,11 @@ export const uploadToAlgolia = async (
   const truncatedRecords = records.map(truncateRecord);
 
   try {
+    await client.setSettings({
+      indexName,
+      indexSettings: { customRanking: ["desc(pageRank)"] },
+    });
+
     // 1. Delete all records with matching indexerType to ensure no orphaned records
     await client.deleteBy({
       indexName,

--- a/src/content-indexer/utils/__tests__/truncate-record.test.ts
+++ b/src/content-indexer/utils/__tests__/truncate-record.test.ts
@@ -14,6 +14,7 @@ describe("truncateRecord", () => {
       title: "Quickstart",
       content: "Short content",
       breadcrumbs: ["Guides"],
+      pageRank: 0,
     };
 
     const result = truncateRecord(record);
@@ -32,6 +33,7 @@ describe("truncateRecord", () => {
       title: "Large Page",
       content: largeContent,
       breadcrumbs: ["Guides"],
+      pageRank: 0,
     };
 
     const result = truncateRecord(record);
@@ -54,6 +56,7 @@ describe("truncateRecord", () => {
       content: largeContent,
       breadcrumbs: ["API", "Ethereum"],
       httpMethod: "POST",
+      pageRank: 0,
     };
 
     const result = truncateRecord(record);
@@ -74,6 +77,7 @@ describe("truncateRecord", () => {
       title: "Test",
       content: "Content",
       breadcrumbs: Array(50_000).fill("B"), // Many breadcrumbs = huge overhead
+      pageRank: 0,
     };
 
     expect(() => truncateRecord(record)).toThrow(
@@ -93,6 +97,7 @@ describe("truncateRecord", () => {
       title: "Large Page",
       content: largeContent,
       breadcrumbs: [],
+      pageRank: 0,
     };
 
     truncateRecord(record);
@@ -118,6 +123,7 @@ describe("truncateRecord", () => {
       title: "Title",
       content,
       breadcrumbs: [],
+      pageRank: 0,
     };
 
     const result = truncateRecord(record);

--- a/src/content-indexer/visitors/visit-page.ts
+++ b/src/content-indexer/visitors/visit-page.ts
@@ -72,6 +72,8 @@ export const visitPage = ({
   // Build Algolia record (if content available and not hidden)
   if (cached && !pageItem.hidden && !isAncestorHidden) {
     const title = cached.frontmatter.title || pageItem.page;
+    const isChainApiOverview =
+      tab === "chains" && /-api-overview\.mdx$/.test(pageItem.path);
     context.addAlgoliaRecord({
       pageType: "Guide",
       path: finalPath,
@@ -79,6 +81,7 @@ export const visitPage = ({
       content: cached.content,
       breadcrumbs: navigationAncestors, // Excludes current page
       description,
+      pageRank: isChainApiOverview ? 1 : 0,
     });
   }
 


### PR DESCRIPTION
## Summary
- Adds a `pageRank` custom-ranking signal on Algolia records, set to 1 for chain API-overview pages (`tab === "chains"` + `*-api-overview.mdx` path pattern) and 0 otherwise.
- Applies `customRanking: ["desc(pageRank)"]` via a partial `setSettings` call in the uploader, so ties in textual relevance are broken in favor of the chain's overview page.
- Threads `pageRank` through `AlgoliaCollector`/`AddRecordParams`, defaulting to 0 for existing callers (`visit-section.ts`, OpenAPI/OpenRPC processors, changelog indexer).

Verified locally: ran the indexer against a scratch branch-scoped Algolia index (`je-ax-593-test_alchemy_docs`), pointed a local docs-site checkout at it, and confirmed chain-name searches (Ethereum, Solana, Base, Bitcoin, etc.) now rank the chain's API Overview page first.

## Testing
- docs-site preview PR (points search at the scratch index so this is testable without local setup): https://github.com/OMGWINNING/docs-site/pull/347
- Live preview: https://docs-git-je-ax-593-search-ranking-preview-alchemy-dot-com.vercel.app/docs - search a chain's exact name (e.g. "Ethereum", "Solana", "Base", "Bitcoin") and confirm that chain's API Overview page ranks first.

Ticket: AX-593