### PR TITLE
docs(cli): add x402 Payments guide for third-party API payments

### DIFF
--- a/STYLE_RULES.md
+++ b/STYLE_RULES.md
@@ -285,6 +285,8 @@ Use consistent terms across docs, code comments, and examples.
 | ERC-20 | ERC20 |
 | ERC-721 | ERC721 |
 | ERC-4337 | ERC4337 |
+| x402 payments (the `alchemy x402` command group; third-party APIs) | "x402" alone for the command group |
+| x402 gateway auth (the `--x402` flag; Alchemy APIs) | "x402 auth", "x402 wallet auth" without the Alchemy scoping |
 
 Additional defaults:
 

--- a/content/docs.yml
+++ b/content/docs.yml
@@ -1846,11 +1846,13 @@ navigation:
             path: tutorials/build-with-ai/alchemy-cli.mdx
           - page: Agent Wallets
             path: tutorials/build-with-ai/agent-wallets.mdx
+          - page: x402 Payments
+            path: tutorials/build-with-ai/x402-payments.mdx
           - page: Alchemy MCP Server
             path: tutorials/build-with-ai/alchemy-mcp-server.mdx
           - page: Alchemy Claude Plugin
             path: tutorials/build-with-ai/alchemy-claude-plugin.mdx
-          - page: Agent Authentication and Payment
+          - page: Wallet Auth for Alchemy APIs
             path: tutorials/build-with-ai/alchemy-for-agents.mdx
         slug: getting-started
       - section: Tutorials

--- a/content/docs.yml
+++ b/content/docs.yml
@@ -1846,14 +1846,14 @@ navigation:
             path: tutorials/build-with-ai/alchemy-cli.mdx
           - page: Agent Wallets
             path: tutorials/build-with-ai/agent-wallets.mdx
-          - page: x402 Payments
+          - page: x402 payments
             path: tutorials/build-with-ai/x402-payments.mdx
+          - page: Wallet auth for Alchemy APIs
+            path: tutorials/build-with-ai/alchemy-for-agents.mdx
           - page: Alchemy MCP Server
             path: tutorials/build-with-ai/alchemy-mcp-server.mdx
           - page: Alchemy Claude Plugin
             path: tutorials/build-with-ai/alchemy-claude-plugin.mdx
-          - page: Wallet Auth for Alchemy APIs
-            path: tutorials/build-with-ai/alchemy-for-agents.mdx
         slug: getting-started
       - section: Tutorials
         contents:

--- a/content/tutorials/build-with-ai/agent-wallets.mdx
+++ b/content/tutorials/build-with-ai/agent-wallets.mdx
@@ -28,8 +28,9 @@ The session is approved in the Alchemy Dashboard, expires automatically, and can
     access from the CLI or Dashboard.
   </Card>
   <Card title="x402 payments" icon="coins">
-    Pay x402-enabled third-party APIs in USDC with the session signer: decoded
-    quotes, spend caps, and payment receipts. See [x402 Payments](docs/x402-payments).
+    Use the session signer to pay x402 v2 endpoints that offer a supported EVM
+    payment option. The CLI decodes quotes, enforces spend caps, and returns
+    payment receipts. See [x402 payments](docs/x402-payments).
   </Card>
 </CardGroup>
 
@@ -59,7 +60,7 @@ The session is approved in the Alchemy Dashboard, expires automatically, and can
 
     **x402 payments:** `alchemy x402 request` pays `402 Payment Required`
     quotes from third-party APIs in USDC with the session signer, via Circle
-    Gateway batched payments or direct EIP-3009 settlement. Requires
+    Gateway batched payments or direct exact settlement. Requires
     `--max-payment` in automation.
   </Accordion>
   <Accordion title="Session capabilities and limits">
@@ -284,6 +285,6 @@ alchemy --json --no-interactive wallet status --verify
 
 * [Alchemy CLI](docs/alchemy-cli)
 * [Alchemy CLI wallets and signing](docs/alchemy-cli#wallets-and-signing)
-* [x402 Payments](docs/x402-payments)
+* [x402 payments](docs/x402-payments)
 * [Alchemy Agent Skills](docs/alchemy-agent-skills)
 * [Alchemy Dashboard Agent Wallets](https://dashboard.alchemy.com/products/agent-wallet/evm-wallet)

--- a/content/tutorials/build-with-ai/agent-wallets.mdx
+++ b/content/tutorials/build-with-ai/agent-wallets.mdx
@@ -27,6 +27,10 @@ The session is approved in the Alchemy Dashboard, expires automatically, and can
     Approve sessions in the Dashboard, inspect the active session, and revoke
     access from the CLI or Dashboard.
   </Card>
+  <Card title="x402 payments" icon="coins">
+    Pay x402-enabled third-party APIs in USDC with the session signer: decoded
+    quotes, spend caps, and payment receipts. See [x402 Payments](docs/x402-payments).
+  </Card>
 </CardGroup>
 
 <AccordionGroup>
@@ -52,6 +56,11 @@ The session is approved in the Alchemy Dashboard, expires automatically, and can
 
     **Status:** `alchemy evm status` checks smart-wallet call IDs and EVM
     transaction hashes. `alchemy solana status` checks Solana signatures.
+
+    **x402 payments:** `alchemy x402 request` pays `402 Payment Required`
+    quotes from third-party APIs in USDC with the session signer, via Circle
+    Gateway batched payments or direct EIP-3009 settlement. Requires
+    `--max-payment` in automation.
   </Accordion>
   <Accordion title="Session capabilities and limits">
     A session can include `evm.signMessage`, `evm.signTypedData`,
@@ -215,7 +224,8 @@ alchemy --json --no-interactive wallet status --verify
           "swap_execute",
           "bridge_quote",
           "bridge_execute",
-          "status"
+          "status",
+          "x402_request"
         ],
         "sponsorshipFlags": ["--gas-sponsored", "--gas-policy-id <id>"],
         "directRawTransactionSigning": false,
@@ -231,6 +241,7 @@ alchemy --json --no-interactive wallet status --verify
         "Run balance, allowance, or quote checks before spending.",
         "Use --dry-run where available before broadcast.",
         "Treat sponsorship policies as fee controls, not wallet spend limits.",
+        "Set --max-payment on every x402 payment; non-interactive x402 payments fail without it.",
         "Disconnect or revoke the session after the workflow."
       ]
     }
@@ -273,5 +284,6 @@ alchemy --json --no-interactive wallet status --verify
 
 * [Alchemy CLI](docs/alchemy-cli)
 * [Alchemy CLI wallets and signing](docs/alchemy-cli#wallets-and-signing)
+* [x402 Payments](docs/x402-payments)
 * [Alchemy Agent Skills](docs/alchemy-agent-skills)
 * [Alchemy Dashboard Agent Wallets](https://dashboard.alchemy.com/products/agent-wallet/evm-wallet)

--- a/content/tutorials/build-with-ai/alchemy-agent-skills.mdx
+++ b/content/tutorials/build-with-ai/alchemy-agent-skills.mdx
@@ -56,7 +56,7 @@ Your agent will walk you through wallet setup and handle the rest:
 
 Your wallet type only determines authentication and payment. Either wallet type can query any chain across [all networks Alchemy supports](docs/reference/node-supported-chains).
 
-For a full walkthrough of the authentication and payment flow, see [Agent Authentication and Payment](docs/alchemy-for-agents).
+For a full walkthrough of the authentication and payment flow, see [Wallet Auth for Alchemy APIs](docs/alchemy-for-agents). The agentic-gateway skill pays Alchemy for Alchemy API access; to have an agent pay third-party x402 APIs, use [x402 Payments](docs/x402-payments) in the CLI.
 
 ## How skills work
 
@@ -80,4 +80,5 @@ You can use both together: Skills for API knowledge and MCP for live data querie
 * [Alchemy Dashboard](https://dashboard.alchemy.com/)
 * [Alchemy MCP Server](docs/alchemy-mcp-server)
 * [Alchemy CLI](docs/alchemy-cli)
-* [Agent Authentication and Payment](docs/alchemy-for-agents)
+* [Wallet Auth for Alchemy APIs](docs/alchemy-for-agents)
+* [x402 Payments](docs/x402-payments)

--- a/content/tutorials/build-with-ai/alchemy-agent-skills.mdx
+++ b/content/tutorials/build-with-ai/alchemy-agent-skills.mdx
@@ -18,7 +18,7 @@ This installs two skills:
 | Skill | Auth method | Best for |
 |---|---|---|
 | `alchemy-api` | API key | You have an [Alchemy API key](https://dashboard.alchemy.com/) and you're building a server or dApp |
-| `agentic-gateway` | Wallet + x402 | Your agent needs to access Alchemy without an API key |
+| `agentic-gateway` | Wallet (x402 gateway auth) | Your agent needs to access Alchemy without an API key |
 
 After installation, your agent will ask which path you want before making any API requests.
 
@@ -56,7 +56,7 @@ Your agent will walk you through wallet setup and handle the rest:
 
 Your wallet type only determines authentication and payment. Either wallet type can query any chain across [all networks Alchemy supports](docs/reference/node-supported-chains).
 
-For a full walkthrough of the authentication and payment flow, see [Wallet Auth for Alchemy APIs](docs/alchemy-for-agents). The agentic-gateway skill pays Alchemy for Alchemy API access; to have an agent pay third-party x402 APIs, use [x402 Payments](docs/x402-payments) in the CLI.
+For a full walkthrough of the authentication and payment flow, see [Wallet auth for Alchemy APIs](docs/alchemy-for-agents). The agentic-gateway skill pays for access to Alchemy APIs; to have an agent pay x402 v2 endpoints that offer a supported EVM payment option, use [x402 payments](docs/x402-payments) in the CLI.
 
 ## How skills work
 
@@ -80,5 +80,5 @@ You can use both together: Skills for API knowledge and MCP for live data querie
 * [Alchemy Dashboard](https://dashboard.alchemy.com/)
 * [Alchemy MCP Server](docs/alchemy-mcp-server)
 * [Alchemy CLI](docs/alchemy-cli)
-* [Wallet Auth for Alchemy APIs](docs/alchemy-for-agents)
-* [x402 Payments](docs/x402-payments)
+* [Wallet auth for Alchemy APIs](docs/alchemy-for-agents)
+* [x402 payments](docs/x402-payments)

--- a/content/tutorials/build-with-ai/alchemy-cli.mdx
+++ b/content/tutorials/build-with-ai/alchemy-cli.mdx
@@ -9,7 +9,7 @@ The Alchemy CLI wraps Alchemy's node, Data API, wallet, transaction, webhook, an
 
 * Live query onchain data without writing a script
 * Send EVM transactions with an [Agent Wallet session](docs/agent-wallets) or local wallet
-* Pay x402-enabled third-party APIs in USDC with [x402 Payments](docs/x402-payments)
+* Pay compatible x402 v2 third-party APIs in USDC with [x402 payments](docs/x402-payments)
 * Run admin tasks like creating apps, rotating allowlists, and managing webhooks
 * Automate workflows in shell scripts, cron jobs, and CI pipelines
 
@@ -258,16 +258,16 @@ Bridge currently supports EVM mainnets. Use `alchemy evm swap` for same-chain to
 
 ### x402
 
-Use `alchemy x402` to call x402-enabled third-party APIs and pay `402 Payment Required` quotes in USDC, signed by your Agent Wallet session or a local key. See [x402 Payments](docs/x402-payments) for the full guide, payment schemes, and Circle Gateway funding.
+Use `alchemy x402` to call compatible x402 v2 third-party APIs and pay quotes that offer a supported EVM payment option, signed by your Agent Wallet session or a local key. See [x402 payments](docs/x402-payments) for the full guide, payment options, and Circle Gateway funding.
 
 <Note>
-  The `alchemy x402` command group pays third-party APIs. It is unrelated to the global `--x402` flag and `alchemy config set x402`, which authenticate to Alchemy's own APIs — see [Wallet Auth for Alchemy APIs](docs/alchemy-for-agents).
+  The `alchemy x402` command group pays third-party APIs. It is distinct from the global `--x402` flag and `alchemy config set x402`, which authenticate to Alchemy's own APIs — see [Wallet auth for Alchemy APIs](docs/alchemy-for-agents).
 </Note>
 
 | Command | Description |
 |---|---|
-| `alchemy x402 request <url>` | Make an HTTP request and pay an x402 quote in USDC. `--estimate` decodes the quote without paying. `--max-payment <usdc>` caps spend and is required for non-interactive payment. Supports curl-style `-X`, `-H`, `-d` (defaults the method to POST), `-o`, plus `--scheme gateway\|exact\|any` and `--signer session\|local`. |
-| `alchemy x402 balance` | Show Circle Gateway USDC balance per chain plus total, keyless. Supports `--address <addr>` and `--testnet`. |
+| `alchemy x402 request <url>` | Request a compatible x402 v2 endpoint. `--estimate` decodes the quote without paying; automated payment requires `--max-payment <usdc>`. See the full guide for HTTP, scheme, network, and signer flags. |
+| `alchemy x402 balance` | Show Circle Gateway USDC balance per chain plus total. No Alchemy API key is required; pass `--address <addr>` to query without a configured signer. Supports `--testnet`. |
 
 ```bash
 alchemy x402 request https://nano.blockrun.ai/api/v1/pm/matching-markets/pairs --estimate
@@ -446,7 +446,7 @@ alchemy completions fish > ~/.config/fish/completions/alchemy.fish
 
 * [Agent Skills](docs/alchemy-agent-skills)
 * [Agent Wallets](docs/agent-wallets)
-* [x402 Payments](docs/x402-payments)
+* [x402 payments](docs/x402-payments)
 * [Alchemy MCP Server](docs/alchemy-mcp-server)
-* [Wallet Auth for Alchemy APIs](docs/alchemy-for-agents)
+* [Wallet auth for Alchemy APIs](docs/alchemy-for-agents)
 * [Alchemy Dashboard](https://dashboard.alchemy.com/)

--- a/content/tutorials/build-with-ai/alchemy-cli.mdx
+++ b/content/tutorials/build-with-ai/alchemy-cli.mdx
@@ -9,6 +9,7 @@ The Alchemy CLI wraps Alchemy's node, Data API, wallet, transaction, webhook, an
 
 * Live query onchain data without writing a script
 * Send EVM transactions with an [Agent Wallet session](docs/agent-wallets) or local wallet
+* Pay x402-enabled third-party APIs in USDC with [x402 Payments](docs/x402-payments)
 * Run admin tasks like creating apps, rotating allowlists, and managing webhooks
 * Automate workflows in shell scripts, cron jobs, and CI pipelines
 
@@ -255,6 +256,25 @@ alchemy solana status <signature>
 
 Bridge currently supports EVM mainnets. Use `alchemy evm swap` for same-chain token exchanges.
 
+### x402
+
+Use `alchemy x402` to call x402-enabled third-party APIs and pay `402 Payment Required` quotes in USDC, signed by your Agent Wallet session or a local key. See [x402 Payments](docs/x402-payments) for the full guide, payment schemes, and Circle Gateway funding.
+
+<Note>
+  The `alchemy x402` command group pays third-party APIs. It is unrelated to the global `--x402` flag and `alchemy config set x402`, which authenticate to Alchemy's own APIs — see [Wallet Auth for Alchemy APIs](docs/alchemy-for-agents).
+</Note>
+
+| Command | Description |
+|---|---|
+| `alchemy x402 request <url>` | Make an HTTP request and pay an x402 quote in USDC. `--estimate` decodes the quote without paying. `--max-payment <usdc>` caps spend and is required for non-interactive payment. Supports curl-style `-X`, `-H`, `-d` (defaults the method to POST), `-o`, plus `--scheme gateway\|exact\|any` and `--signer session\|local`. |
+| `alchemy x402 balance` | Show Circle Gateway USDC balance per chain plus total, keyless. Supports `--address <addr>` and `--testnet`. |
+
+```bash
+alchemy x402 request https://nano.blockrun.ai/api/v1/pm/matching-markets/pairs --estimate
+```
+
+`-n, --network` filters which payment networks the CLI will pay on.
+
 ### Webhook (Notify)
 
 Requires a webhook API key. Pass `--webhook-api-key <key>` on the `webhook` command, set `ALCHEMY_WEBHOOK_API_KEY`, or run `alchemy config set webhook-api-key <key>`.
@@ -345,8 +365,8 @@ Filters are optional and combined with AND. `--group-by` accepts at most one dim
 | `alchemy config set webhook-api-key <key>` | Save the Notify webhook API key |
 | `alchemy config set network <id>` | Set the default network |
 | `alchemy config set verbose <true\|false>` | Set default verbose output |
-| `alchemy config set wallet-key-file <path>` | Set the local EVM wallet key file used for x402 wallet auth |
-| `alchemy config set x402 <true\|false>` | Enable or disable x402 wallet auth by default |
+| `alchemy config set wallet-key-file <path>` | Set the local EVM wallet key file used for x402 gateway auth to Alchemy APIs |
+| `alchemy config set x402 <true\|false>` | Enable or disable x402 gateway auth to Alchemy APIs by default |
 | `alchemy config set evm-gas-sponsored <true\|false>` | Enable or disable EVM gas sponsorship by default |
 | `alchemy config set evm-gas-policy-id <id>` | Save the EVM gas policy ID |
 | `alchemy config set solana-fee-sponsored <true\|false>` | Enable or disable Solana fee sponsorship by default |
@@ -375,8 +395,8 @@ These flags work on every command.
 |---|---|
 | `--api-key <key>` | API key for RPC and Data API requests (env: `ALCHEMY_API_KEY`) |
 | `-n, --network <id>` | Target network, defaults to `eth-mainnet` (env: `ALCHEMY_NETWORK`) |
-| `--x402` | Use x402 wallet-based gateway auth |
-| `--wallet-key-file <path>` | Path to an EVM wallet private key file for x402 |
+| `--x402` | Use x402 wallet-based gateway auth for Alchemy API requests |
+| `--wallet-key-file <path>` | Path to an EVM wallet private key file for x402 gateway auth |
 | `--solana-wallet-key-file <path>` | Path to a Solana wallet key file |
 | `--json` | Force JSON output (auto-enabled when piped) |
 | `-q, --quiet` | Suppress non-essential output |
@@ -426,6 +446,7 @@ alchemy completions fish > ~/.config/fish/completions/alchemy.fish
 
 * [Agent Skills](docs/alchemy-agent-skills)
 * [Agent Wallets](docs/agent-wallets)
+* [x402 Payments](docs/x402-payments)
 * [Alchemy MCP Server](docs/alchemy-mcp-server)
-* [Agent Authentication and Payment](docs/alchemy-for-agents)
+* [Wallet Auth for Alchemy APIs](docs/alchemy-for-agents)
 * [Alchemy Dashboard](https://dashboard.alchemy.com/)

--- a/content/tutorials/build-with-ai/alchemy-for-agents.mdx
+++ b/content/tutorials/build-with-ai/alchemy-for-agents.mdx
@@ -1,13 +1,17 @@
 ---
-title: Agent Authentication and Payment
-description: Authenticate your AI agent with an EVM wallet instead of an API key using SIWE. Your agent can pay with USDC through the x402 payment protocol.
-subtitle: Authenticate your AI agent with an EVM wallet instead of an API key using SIWE. Your agent can pay with USDC through the x402 payment protocol.
+title: Wallet Auth for Alchemy APIs
+description: Authenticate your AI agent to Alchemy APIs with an EVM wallet instead of an API key using SIWE, paying Alchemy in USDC through the x402 protocol.
+subtitle: Authenticate your AI agent to Alchemy APIs with an EVM wallet instead of an API key using SIWE, paying Alchemy in USDC through the x402 protocol.
 slug: docs/alchemy-for-agents
 ---
 
+<Note>
+  This page covers **x402 gateway auth** — using a wallet to authenticate and pay **Alchemy** for Alchemy API access. To pay arbitrary third-party x402 APIs from the CLI, see [x402 Payments](docs/x402-payments).
+</Note>
+
 ## How it works
 
-x402 wallet authentication in the Alchemy CLI uses two open standards today:
+x402 gateway auth to Alchemy APIs in the Alchemy CLI uses two open standards today:
 
 * **[SIWE (Sign-In With Ethereum)](https://eips.ethereum.org/EIPS/eip-4361):** Your agent authenticates by signing a message with an EVM wallet.
 * **[x402](https://www.x402.org/):** An open protocol for HTTP-native payments. When payment is required, the server responds with HTTP 402, the CLI signs the payment challenge with the same EVM wallet, and retries the request. Zero protocol fees.
@@ -43,10 +47,10 @@ These are the same APIs available with a standard API key. The only difference i
 | | EVM wallet | Solana wallet |
 |---|---|---|
 | **CLI use** | x402 gateway auth and EVM transaction signing | Solana transaction signing |
-| **Auth standard** | SIWE (EIP-4361) | Not used for x402 in the CLI today |
+| **Auth standard** | SIWE (EIP-4361) | Not used for x402 gateway auth in the CLI today |
 | **Signature** | secp256k1 | ed25519 |
-| **Payment** | USDC through x402 payment challenges | Not used for x402 in the CLI today |
-| **Queryable chains through x402** | [All supported networks](docs/reference/node-supported-chains) | Not applicable |
+| **Payment** | USDC payments to Alchemy through x402 gateway auth | Not used for x402 gateway auth in the CLI today |
+| **Queryable chains through x402 gateway auth** | [All supported networks](docs/reference/node-supported-chains) | Not applicable |
 
 ## Install as an agent skill
 
@@ -60,7 +64,7 @@ Your agent will walk you through wallet setup and handle authentication and paym
 
 ## Use it from the CLI
 
-The [Alchemy CLI](docs/alchemy-cli) ships the x402 flow built in. Create or import a local EVM wallet, opt into x402, and node and data commands can authenticate and pay from that wallet without an API key.
+The [Alchemy CLI](docs/alchemy-cli) ships the x402 gateway auth flow built in. Create or import a local EVM wallet, opt into x402 gateway auth, and node and data commands can authenticate and pay Alchemy from that wallet without an API key.
 
 ```bash
 alchemy wallet connect --mode local --chain evm
@@ -78,6 +82,7 @@ You can also point at an existing EVM private key file with `alchemy config set 
 
 ## Next steps
 
+* [x402 Payments (pay third-party APIs)](docs/x402-payments)
 * [agents.alchemy.com](https://agents.alchemy.com/)
 * [x402.org](https://www.x402.org/)
 * [EIP-4361: SIWE](https://eips.ethereum.org/EIPS/eip-4361)

--- a/content/tutorials/build-with-ai/alchemy-for-agents.mdx
+++ b/content/tutorials/build-with-ai/alchemy-for-agents.mdx
@@ -1,12 +1,12 @@
 ---
-title: Wallet Auth for Alchemy APIs
+title: Wallet auth for Alchemy APIs
 description: Authenticate your AI agent to Alchemy APIs with an EVM wallet instead of an API key using SIWE, paying Alchemy in USDC through the x402 protocol.
 subtitle: Authenticate your AI agent to Alchemy APIs with an EVM wallet instead of an API key using SIWE, paying Alchemy in USDC through the x402 protocol.
 slug: docs/alchemy-for-agents
 ---
 
 <Note>
-  This page covers **x402 gateway auth** — using a wallet to authenticate and pay **Alchemy** for Alchemy API access. To pay arbitrary third-party x402 APIs from the CLI, see [x402 Payments](docs/x402-payments).
+  This page covers **x402 gateway auth** — using a wallet to authenticate and pay for access to **Alchemy APIs**. To pay x402 v2 endpoints that offer a supported EVM payment option from the CLI, see [x402 payments](docs/x402-payments).
 </Note>
 
 ## How it works
@@ -26,7 +26,7 @@ When your agent needs to access Alchemy APIs without an API key, it handles the 
 2. **Authentication:** Your agent generates a signed SIWE token and includes it in every x402 gateway request.
 3. **Payment:** When payment is required, the server responds with HTTP 402, and your agent signs the requested USDC payment before retrying automatically.
 
-The x402 wallet only determines authentication and payment. Once authenticated, it can query any chain across [all networks Alchemy supports](docs/reference/node-supported-chains).
+The wallet used for x402 gateway auth only determines authentication and payment. Once authenticated, it can query any chain across [all networks Alchemy supports](docs/reference/node-supported-chains).
 
 ## What your agent can access
 
@@ -67,7 +67,7 @@ Your agent will walk you through wallet setup and handle authentication and paym
 The [Alchemy CLI](docs/alchemy-cli) ships the x402 gateway auth flow built in. Create or import a local EVM wallet, opt into x402 gateway auth, and node and data commands can authenticate and pay Alchemy from that wallet without an API key.
 
 ```bash
-alchemy wallet connect --mode local --chain evm
+alchemy wallet connect --mode local
 alchemy config set x402 true
 alchemy evm data balance vitalik.eth
 ```
@@ -82,7 +82,7 @@ You can also point at an existing EVM private key file with `alchemy config set 
 
 ## Next steps
 
-* [x402 Payments (pay third-party APIs)](docs/x402-payments)
+* [x402 payments (pay third-party APIs)](docs/x402-payments)
 * [agents.alchemy.com](https://agents.alchemy.com/)
 * [x402.org](https://www.x402.org/)
 * [EIP-4361: SIWE](https://eips.ethereum.org/EIPS/eip-4361)

--- a/content/tutorials/build-with-ai/alchemy-mcp-server.mdx
+++ b/content/tutorials/build-with-ai/alchemy-mcp-server.mdx
@@ -424,4 +424,4 @@ We support **100+ blockchains** including Ethereum, Base, Polygon, Arbitrum, Opt
 
 * [Agent Skills](docs/alchemy-agent-skills) teach your coding agent every Alchemy API at the source-code level
 * The [Alchemy CLI](docs/alchemy-cli) wraps the same APIs as a shell-friendly tool surface for live querying, admin work, and local automation
-* [Agent Authentication and Payment](docs/alchemy-for-agents) lets agents authenticate with a wallet instead of an API key
+* [Wallet Auth for Alchemy APIs](docs/alchemy-for-agents) lets agents authenticate with a wallet instead of an API key

--- a/content/tutorials/build-with-ai/alchemy-mcp-server.mdx
+++ b/content/tutorials/build-with-ai/alchemy-mcp-server.mdx
@@ -424,4 +424,4 @@ We support **100+ blockchains** including Ethereum, Base, Polygon, Arbitrum, Opt
 
 * [Agent Skills](docs/alchemy-agent-skills) teach your coding agent every Alchemy API at the source-code level
 * The [Alchemy CLI](docs/alchemy-cli) wraps the same APIs as a shell-friendly tool surface for live querying, admin work, and local automation
-* [Wallet Auth for Alchemy APIs](docs/alchemy-for-agents) lets agents authenticate with a wallet instead of an API key
+* [Wallet auth for Alchemy APIs](docs/alchemy-for-agents) lets agents authenticate with a wallet instead of an API key

--- a/content/tutorials/build-with-ai/overview.mdx
+++ b/content/tutorials/build-with-ai/overview.mdx
@@ -17,7 +17,7 @@ We ship four tools for building with AI on Alchemy. They're complementary, and m
 npx skills add alchemyplatform/skills --yes
 ```
 
-* Two skills included: `alchemy-api` (API key auth) and `agentic-gateway` (wallet-based x402 auth)
+* Two skills included: `alchemy-api` (API key auth) and `agentic-gateway` (x402 gateway auth)
 * Works with [Claude Code](https://www.anthropic.com/claude-code), [Codex](https://openai.com/index/codex/), [Cursor](https://cursor.com), [VS Code Copilot](https://code.visualstudio.com/docs/setup/copilot), and any agent that supports the [skills spec](https://agentskills.io)
 
 [Get started with Agent Skills →](docs/alchemy-agent-skills)
@@ -33,8 +33,8 @@ npm i -g @alchemy/cli@latest
 * Covers JSON-RPC nodes, Data APIs, Wallet APIs, Notify webhooks, and the Admin API across [100+ networks](docs/reference/node-supported-chains)
 * `--json --no-interactive` flags make every command machine-readable
 * Built-in `agent-prompt` command emits a complete usage spec for AI agents
-* Supports API key, access key, and x402 wallet authentication
-* Pays x402-enabled third-party APIs in USDC with [x402 Payments](docs/x402-payments) (`alchemy x402 request`)
+* Supports API key, access key, and x402 gateway auth for Alchemy APIs
+* Pays compatible x402 v2 third-party APIs in USDC with [x402 payments](docs/x402-payments) (`alchemy x402 request`)
 
 [Get started with the CLI →](docs/alchemy-cli)
 
@@ -62,7 +62,7 @@ Your agent can authenticate with a crypto wallet instead of an API key, purchasi
 
 [Learn about wallet auth for Alchemy APIs →](docs/alchemy-for-agents)
 
-To have your agent pay other services — any x402-enabled third-party API — use the CLI's [x402 Payments](docs/x402-payments) instead.
+To have your agent pay an x402 v2 endpoint that offers a supported EVM payment option, use the CLI's [x402 payments](docs/x402-payments) instead.
 
 ## Pick the right tool
 
@@ -73,8 +73,8 @@ To have your agent pay other services — any x402-enabled third-party API — u
 | Script a recurring job, cron, or CI step that calls Alchemy | [CLI](docs/alchemy-cli) |
 | Give a shell-driven agent a structured tool surface | [CLI](docs/alchemy-cli) with `--json --no-interactive` |
 | Let my IDE copilot query live onchain data during a conversation | [MCP Server](docs/alchemy-mcp-server) or [CLI](docs/alchemy-cli) |
-| Build an autonomous agent that authenticates with a wallet and pays Alchemy in USDC | [Wallet Auth for Alchemy APIs](docs/alchemy-for-agents) plus [Skills](docs/alchemy-agent-skills) or [CLI](docs/alchemy-cli) |
-| Pay any x402-enabled third-party API in USDC | [x402 Payments](docs/x402-payments) via the [CLI](docs/alchemy-cli) |
+| Build an autonomous agent that authenticates with a wallet and pays Alchemy in USDC | [Wallet auth for Alchemy APIs](docs/alchemy-for-agents) plus [Skills](docs/alchemy-agent-skills) or [CLI](docs/alchemy-cli) |
+| Pay a compatible x402 v2 third-party API in USDC | [x402 payments](docs/x402-payments) via the [CLI](docs/alchemy-cli) |
 | Give a coding agent both API knowledge and live data access | Agent Skills + MCP Server or CLI |
 
 These tools layer on top of each other. An agent using **Skills** to understand our APIs can shell out to the **CLI** for admin tasks, call the **MCP Server** for live data, use the **`agentic-gateway` skill** or `--x402` flag to operate without a pre-provisioned API key, and use `alchemy x402` to pay third-party APIs in USDC.

--- a/content/tutorials/build-with-ai/overview.mdx
+++ b/content/tutorials/build-with-ai/overview.mdx
@@ -34,6 +34,7 @@ npm i -g @alchemy/cli@latest
 * `--json --no-interactive` flags make every command machine-readable
 * Built-in `agent-prompt` command emits a complete usage spec for AI agents
 * Supports API key, access key, and x402 wallet authentication
+* Pays x402-enabled third-party APIs in USDC with [x402 Payments](docs/x402-payments) (`alchemy x402 request`)
 
 [Get started with the CLI →](docs/alchemy-cli)
 
@@ -51,15 +52,17 @@ claude mcp add alchemy --transport http https://mcp.alchemy.com/mcp
 
 [Get started with the MCP Server →](docs/alchemy-mcp-server)
 
-### Agent authentication and payment
+### Wallet auth for Alchemy APIs
 
-Your agent can authenticate with a crypto wallet instead of an API key, purchasing credits in USDC via the [x402 payment protocol](https://www.x402.org/). This is what the `agentic-gateway` skill teaches your agent automatically, and what the CLI uses when you pass `--x402`.
+Your agent can authenticate with a crypto wallet instead of an API key, purchasing Alchemy credits in USDC via the [x402 payment protocol](https://www.x402.org/). This is what the `agentic-gateway` skill teaches your agent automatically, and what the CLI uses when you pass `--x402`.
 
 * No API key required, supports authentication via [SIWE (Sign-In With Ethereum)](https://eips.ethereum.org/EIPS/eip-4361) and SIWS (Sign-In With Solana)
 * Supports payment via USDC on Base and Solana
 * Wallet type is independent of which chain you query
 
-[Learn about agent authentication and payment →](docs/alchemy-for-agents)
+[Learn about wallet auth for Alchemy APIs →](docs/alchemy-for-agents)
+
+To have your agent pay other services — any x402-enabled third-party API — use the CLI's [x402 Payments](docs/x402-payments) instead.
 
 ## Pick the right tool
 
@@ -70,10 +73,11 @@ Your agent can authenticate with a crypto wallet instead of an API key, purchasi
 | Script a recurring job, cron, or CI step that calls Alchemy | [CLI](docs/alchemy-cli) |
 | Give a shell-driven agent a structured tool surface | [CLI](docs/alchemy-cli) with `--json --no-interactive` |
 | Let my IDE copilot query live onchain data during a conversation | [MCP Server](docs/alchemy-mcp-server) or [CLI](docs/alchemy-cli) |
-| Build an autonomous agent that authenticates with a wallet and pays in USDC | [Agent Authentication and Payment](docs/alchemy-for-agents) plus [Skills](docs/alchemy-agent-skills) or [CLI](docs/alchemy-cli) |
+| Build an autonomous agent that authenticates with a wallet and pays Alchemy in USDC | [Wallet Auth for Alchemy APIs](docs/alchemy-for-agents) plus [Skills](docs/alchemy-agent-skills) or [CLI](docs/alchemy-cli) |
+| Pay any x402-enabled third-party API in USDC | [x402 Payments](docs/x402-payments) via the [CLI](docs/alchemy-cli) |
 | Give a coding agent both API knowledge and live data access | Agent Skills + MCP Server or CLI |
 
-These tools layer on top of each other. An agent using **Skills** to understand our APIs can shell out to the **CLI** for admin tasks, call the **MCP Server** for live data, and use the **`agentic-gateway` skill** or `--x402` flag to operate without a pre-provisioned API key.
+These tools layer on top of each other. An agent using **Skills** to understand our APIs can shell out to the **CLI** for admin tasks, call the **MCP Server** for live data, use the **`agentic-gateway` skill** or `--x402` flag to operate without a pre-provisioned API key, and use `alchemy x402` to pay third-party APIs in USDC.
 
 ## Supported AI tools
 

--- a/content/tutorials/build-with-ai/x402-payments.mdx
+++ b/content/tutorials/build-with-ai/x402-payments.mdx
@@ -5,7 +5,7 @@ subtitle: Pay compatible x402 v2 APIs in USDC from the Alchemy CLI. Decode 402 P
 slug: docs/x402-payments
 ---
 
-`alchemy x402 request <url>` is curl that can pay. When a compatible x402 v2 endpoint returns `402 Payment Required`, the CLI selects a supported EVM payment option and applies your spend cap or asks for confirmation. It signs with your [Agent Wallet session](docs/agent-wallets) or a local EVM wallet, retries the request once, and returns the resource with a payment receipt.
+`alchemy x402 request <url>` is curl that can pay. When a compatible x402 v2 endpoint returns `402 Payment Required`, the CLI selects a supported EVM payment option and applies your spend cap or asks for confirmation. It signs with your [Agent Wallet session](docs/agent-wallets), retries the request once, and returns the resource with a payment receipt.
 
 Automated capped payments support recognized USDC. In an uncapped interactive terminal, the CLI may also present another compatible `exact`-scheme asset for manual confirmation.
 
@@ -20,7 +20,7 @@ This command is available in `@alchemy/cli` 0.22.0 and later. Run `alchemy help 
 1. The CLI sends your request with no payment attached.
 2. If the resource is free, the server responds normally and the CLI returns it — nothing else happens.
 3. If payment is required, the server responds `402 Payment Required` with a machine-readable quote (price, network, and accepted payment schemes).
-4. The CLI checks your authorization (a spend cap or your confirmation), verifies the quote, and signs the selected payment with your Agent Wallet session or a local key.
+4. The CLI checks your authorization (a spend cap or your confirmation), verifies the quote, and signs the selected payment with your configured signer.
 5. The CLI retries the request with the signed payment attached and returns the resource along with a payment receipt.
 
 This is the open [x402 protocol](https://www.x402.org/). The CLI supports x402 v2 endpoints that offer compatible EVM `exact` payments, including Circle Gateway batched payments. It does not support x402 v1, Solana payment options, or other payment schemes.
@@ -29,7 +29,6 @@ This is the open [x402 protocol](https://www.x402.org/). The CLI supports x402 v
 
 * Install the CLI: `npm i -g @alchemy/cli@latest`
 * For session signing, run `alchemy auth` and connect an [Agent Wallet session](docs/agent-wallets) with `alchemy wallet connect --mode session`
-* For local signing, configure local wallets with `alchemy wallet connect --mode local` or use the [CLI wallet configuration](docs/alchemy-cli#wallets-and-signing) (`--wallet-key-file` or `ALCHEMY_WALLET_KEY`)
 * Fund the [payment path](#how-payment-schemes-work) the server offers. Capped payments use wallet-held USDC for direct settlement or a Gateway balance. An uncapped interactive quote for another asset requires that asset in the signing wallet.
 
 <Tip>

--- a/content/tutorials/build-with-ai/x402-payments.mdx
+++ b/content/tutorials/build-with-ai/x402-payments.mdx
@@ -1,40 +1,39 @@
 ---
-title: x402 Payments
-description: Pay any x402-enabled API in USDC from the Alchemy CLI. Decode 402 Payment Required quotes, set a spend cap, pay with an Agent Wallet session, and get a payment receipt.
-subtitle: Pay any x402-enabled API in USDC from the Alchemy CLI. Decode 402 Payment Required quotes, set a spend cap, pay with an Agent Wallet session, and get a payment receipt.
+title: x402 payments
+description: Pay compatible x402 v2 APIs in USDC from the Alchemy CLI. Decode 402 Payment Required quotes, set a spend cap, pay with an Agent Wallet session, and get a payment receipt.
+subtitle: Pay compatible x402 v2 APIs in USDC from the Alchemy CLI. Decode 402 Payment Required quotes, set a spend cap, pay with an Agent Wallet session, and get a payment receipt.
 slug: docs/x402-payments
 ---
 
-`alchemy x402 request <url>` is curl that can pay. It makes an HTTP request, and if the server responds `402 Payment Required`, the CLI decodes the payment quote, pays in USDC — signed by your [Agent Wallet session](docs/agent-wallets), with no private key or API key handled by the agent — retries the request, and returns the resource plus a payment receipt. It works against any server that speaks the x402 v2 protocol, not just Alchemy endpoints.
+`alchemy x402 request <url>` is curl that can pay. When a compatible x402 v2 endpoint returns `402 Payment Required`, the CLI selects a supported EVM payment option and applies your spend cap or asks for confirmation. It signs with your [Agent Wallet session](docs/agent-wallets) or a local EVM wallet, retries the request once, and returns the resource with a payment receipt.
 
-This guide reflects `@alchemy/cli` 0.22.0 and later, at the time of writing. Run `alchemy help x402` for the current command surface.
+Automated capped payments support recognized USDC. In an uncapped interactive terminal, the CLI may also present another compatible `exact`-scheme asset for manual confirmation.
+
+This command is available in `@alchemy/cli` 0.22.0 and later. Run `alchemy help x402` for the current command surface.
 
 <Note>
-  This page is about paying **third-party** x402-enabled APIs. It is not the global `--x402` flag or `alchemy config set x402`, which use **x402 gateway auth** to pay Alchemy for Alchemy API access — see [Wallet Auth for Alchemy APIs](docs/alchemy-for-agents).
+  This page is about paying compatible **third-party** x402 v2 APIs. It is not the global `--x402` flag or `alchemy config set x402`, which use **x402 gateway auth** to pay for access to Alchemy APIs — see [Wallet auth for Alchemy APIs](docs/alchemy-for-agents).
 </Note>
-
-```bash
-alchemy x402 request https://nano.blockrun.ai/api/v1/pm/matching-markets/pairs --estimate
-```
 
 ## How it works
 
 1. The CLI sends your request with no payment attached.
 2. If the resource is free, the server responds normally and the CLI returns it — nothing else happens.
 3. If payment is required, the server responds `402 Payment Required` with a machine-readable quote (price, network, and accepted payment schemes).
-4. The CLI checks your authorization (a spend cap or your confirmation), verifies the quote, and signs a USDC payment with your Agent Wallet session or a local key.
+4. The CLI checks your authorization (a spend cap or your confirmation), verifies the quote, and signs the selected payment with your Agent Wallet session or a local key.
 5. The CLI retries the request with the signed payment attached and returns the resource along with a payment receipt.
 
-This is the open [x402 protocol](https://www.x402.org/) — the CLI is a generic buyer for any compliant server, not just Alchemy's own APIs.
+This is the open [x402 protocol](https://www.x402.org/). The CLI supports x402 v2 endpoints that offer compatible EVM `exact` payments, including Circle Gateway batched payments. It does not support x402 v1, Solana payment options, or other payment schemes.
 
 ## Before you begin
 
-* Install the CLI and sign in: `npm i -g @alchemy/cli@latest` and `alchemy auth`
-* Connect an [Agent Wallet session](docs/agent-wallets) (`alchemy wallet connect --mode session`), or use a local EVM wallet with `--signer local`
-* USDC funding — how much depends on which [payment scheme](#how-payment-schemes-work) the server offers; see [funding Circle Gateway](#fund-circle-gateway-for-batched-payments) below
+* Install the CLI: `npm i -g @alchemy/cli@latest`
+* For session signing, run `alchemy auth` and connect an [Agent Wallet session](docs/agent-wallets) with `alchemy wallet connect --mode session`
+* For local signing, configure local wallets with `alchemy wallet connect --mode local` or use the [CLI wallet configuration](docs/alchemy-cli#wallets-and-signing) (`--wallet-key-file` or `ALCHEMY_WALLET_KEY`)
+* Fund the [payment path](#how-payment-schemes-work) the server offers. Capped payments use wallet-held USDC for direct settlement or a Gateway balance. An uncapped interactive quote for another asset requires that asset in the signing wallet.
 
 <Tip>
-  `--estimate` needs none of this. It decodes the quote and pays nothing, so it's the best first command to run against any x402 URL.
+  After installing the CLI, you can use `--estimate` without signing in, configuring a signer, or funding USDC. It decodes the quote and pays nothing, so it's the best first command to run against an unfamiliar x402 URL.
 </Tip>
 
 ## Decode a quote with --estimate
@@ -45,6 +44,8 @@ This is the open [x402 protocol](https://www.x402.org/) — the CLI is a generic
 alchemy x402 request https://nano.blockrun.ai/api/v1/pm/matching-markets/pairs --estimate
 ```
 
+An abbreviated human-readable result looks like:
+
 ```text
   Provider  nano.blockrun.ai
   Resource  Get all active exact-matched market pairs
@@ -54,7 +55,7 @@ alchemy x402 request https://nano.blockrun.ai/api/v1/pm/matching-markets/pairs -
   Decision  estimate only
 ```
 
-The price, scheme, and network are set by the server and may change — this is what BlockRun advertised at the time of writing.
+The full output also lists every payment option and why each one is eligible or excluded. The price, scheme, and network are set by the server and may change; this is what BlockRun advertised when this page was written.
 
 <Check>
   If you see a decoded quote, the CLI handled a live `402` end to end. Nothing was signed and nothing was spent.
@@ -64,11 +65,13 @@ The price, scheme, and network are set by the server and may change — this is 
 
 The CLI never pays on its own authority. Every payment needs an explicit authorization:
 
-* **Interactive terminal:** the CLI prints the quote and asks you to confirm before signing.
-* **Non-interactive runs** — scripts, `--json`, piped output, `--no-interactive`, or `-y/--yes` — require `--max-payment <usdc>`, a hard ceiling on what this invocation may spend. `--yes` without a cap fails by design:
+* **Any invocation with `--max-payment <usdc>`:** the cap authorizes a payment at or below that amount. The CLI does not ask for another confirmation.
+* **Interactive terminal without a cap:** the CLI prints the exact quote and asks you to confirm before signing.
+* **Non-interactive run without a cap** — a script, `--json`, piped output, or `--no-interactive` — exits without paying.
+* **Any non-estimate invocation with `-y/--yes`** also requires `--max-payment`. The cap already suppresses confirmation, so `--yes` does not authorize anything beyond it. `--yes` without a cap fails before the request is sent:
 
   ```bash
-  alchemy x402 request https://nano.blockrun.ai/api/v1/pm/matching-markets/pairs --yes
+  alchemy --json x402 request https://nano.blockrun.ai/api/v1/pm/matching-markets/pairs --yes
   ```
 
   ```json
@@ -81,33 +84,27 @@ The CLI never pays on its own authority. Every payment needs an explicit authori
   }
   ```
 
-A quote priced above your cap is never paid — the command exits with code `9` instead:
+A quote priced above your cap is not paid. For example, a `0.005` USDC quote with `--max-payment 0.004` exits with code `9` and reports:
 
-```json
-{
-  "error": {
-    "code": "PAYMENT_REQUIRED",
-    "message": "Payment of 0.005 USDC is required.",
-    "hint": "Re-run with --max-payment <usdc> to authorize payment non-interactively.",
-    "retryable": false
-  }
-}
+```text
+Cheapest acceptable option costs 0.005 USDC on eip155:137, above --max-payment 0.004.
 ```
 
-| Mode | What authorizes payment |
+| Invocation | What happens |
 |---|---|
-| Interactive terminal | A confirmation prompt showing the exact quote |
-| `--yes`, `--json`, `--no-interactive`, scripts | `--max-payment <usdc>` — required, a hard ceiling |
+| Any mode with `--max-payment <usdc>` | The cap authorizes payment without a confirmation prompt |
+| Interactive terminal without a cap | A prompt asks you to confirm the exact quote |
+| Non-interactive mode without a cap | The command exits without paying |
 
 <Warning>
-  These commands spend real USDC. Treat `--max-payment` as the authorization boundary, and set it to the smallest value that gets the job done.
+  Paid requests spend real assets. For automated USDC payments, treat `--max-payment` as the authorization boundary and set it to the smallest value that gets the job done. In an uncapped interactive terminal, verify any non-USDC asset before confirming.
 </Warning>
 
-The CLI also never pays twice for the same request — if a paid retry itself comes back `402`, the CLI stops rather than sign and send a second payment.
+The CLI issues at most one payment authorization per command. If the paid retry comes back `402`, it stops instead of signing a second payment.
 
 ## Make a paid request
 
-The commands below spend real USDC. The URLs are placeholders — replace them with the x402 endpoint you're actually calling.
+The payment step below can spend real USDC. The URLs are placeholders — replace them with the x402 endpoint you're actually calling.
 
 <Steps>
   <Step title="Check funding">
@@ -127,7 +124,7 @@ The commands below spend real USDC. The URLs are placeholders — replace them w
   </Step>
   <Step title="Pay with a cap">
     ```bash
-    alchemy x402 request https://api.example.com/paid-endpoint --max-payment 0.01
+    alchemy --json x402 request https://api.example.com/paid-endpoint --max-payment 0.01
     ```
 
     curl-style flags work the same way. `-d` sets the method to `POST` automatically when you don't pass `-X`:
@@ -140,20 +137,9 @@ The commands below spend real USDC. The URLs are placeholders — replace them w
       -o report.json
     ```
 
-    Passing `-X GET` (or `-X HEAD`) together with `-d` fails fast instead of sending a malformed request:
-
-    ```json
-    {
-      "error": {
-        "code": "INVALID_ARGS",
-        "message": "--data cannot be sent with a GET request. Use -X POST, or omit -X to default to POST when --data is set.",
-        "retryable": false
-      }
-    }
-    ```
   </Step>
   <Step title="Read the receipt">
-    A successful paid request returns the resource plus a receipt. In `--json` mode, `payment` carries every field:
+    A successful paid request returns the resource plus a receipt. This abridged, illustrative Gateway receipt uses placeholder addresses and a synthetic Gateway transfer ID:
 
     ```json
     {
@@ -171,17 +157,17 @@ The commands below spend real USDC. The URLs are placeholders — replace them w
         "amount": "5000",
         "amountUSDC": "0.005",
         "payTo": "0x6E007731870EDe419CfB31889Cd5C4493CEcb04c",
-        "payer": "0xYourSignerAddress",
-        "transaction": "0xillustrative-transaction-id",
+        "payer": "0x1111111111111111111111111111111111111111",
+        "transaction": "00000000-0000-4000-8000-000000000000",
         "settled": true,
-        "signerAddress": "0xYourSignerAddress",
+        "signerAddress": "0x1111111111111111111111111111111111111111",
         "signerKind": "session",
         "recovered": true
       }
     }
     ```
 
-    `settled` reflects whether the payment cleared: for Circle Gateway payments it may briefly be `null` if the server hasn't returned a settlement receipt yet, or `false` if settlement failed even though `status` is `200` — the resource is still delivered either way, since the payment was already accepted. `signerKind` tells you whether the session or a local key signed.
+    `settled` describes the settlement receipt, not the HTTP response. `null` means the server returned no decodable `PAYMENT-RESPONSE` header; the CLI does not poll for an update. `false` means the receipt reported a settlement failure, even if the provider returned the resource with HTTP `200`. `signerKind` tells you whether the session or a local key signed. The `transaction` value is scheme-dependent: Gateway uses a transfer ID, while direct exact settlement commonly returns an EVM transaction hash.
   </Step>
 </Steps>
 
@@ -195,45 +181,56 @@ The commands below spend real USDC. The URLs are placeholders — replace them w
 | `-o, --output <file>` | Write the response body to a file |
 | `--estimate` | Decode the payment quote without signing or paying |
 | `--max-payment <usdc>` | Maximum USDC to pay, e.g. `0.01`. Required for non-interactive payment. |
-| `-y, --yes` | Skip the confirmation prompt. Requires `--max-payment`. |
-| `--scheme <gateway\|exact\|any>` | Restrict to a payment scheme. Default `any` — cheapest eligible option wins. |
+| `-y, --yes` | Skip payment confirmation. Paid requests require `--max-payment`; the cap authorizes payment. |
+| `--scheme <gateway\|exact\|any>` | Filter payment options. `gateway` selects Circle Gateway-marked quotes, `exact` selects non-Gateway exact quotes, and `any` selects the cheapest eligible option. |
 | `--signer <session\|local>` | Override the active signer for this request |
 | `-n, --network <id>` | Filter which payment networks the CLI will pay on |
 
 Run `alchemy help x402 request` for the current flag surface.
 
+When you pass `-d/--data` without `-X`, the CLI uses `POST`. Combining `-d` with an explicit `-X GET` or `-X HEAD` fails before the request is sent.
+
 ## How payment schemes work
 
-A server can offer more than one way to pay. With `--scheme any` (the default), the CLI picks the cheapest eligible option — Circle Gateway wins ties. Force one scheme with `--scheme gateway` or `--scheme exact`.
+A server can offer more than one way to pay. Both paths below use the x402 protocol's `exact` scheme; the CLI recognizes Circle Gateway options by their Gateway marker. The `--scheme` flag filters between those options.
 
-| | Circle Gateway (`gateway`) | Exact (`exact`) |
+With `--scheme any` (the default), the CLI picks the cheapest eligible option and Circle Gateway wins ties. In estimate output, `eligible` only means an option passed the quote-selection filters; it does not guarantee payment creation will succeed. Confirm the selected network starts with `eip155:` because payment support is EVM-only. The CLI does not check balances before selection or fall back after a selected option fails. If Gateway is selected but unfunded, the server also offered a non-Gateway exact option, and your wallet holds the quoted asset on that network, retry with `--scheme exact`.
+
+| | Circle Gateway (`--scheme gateway`) | Direct exact (`--scheme exact`) |
 |---|---|---|
-| Settlement | Batched nanopayments through Circle Gateway | Direct EIP-3009 signed USDC transfer |
-| Funding source | A prior USDC deposit to Circle Gateway | USDC held in the signing wallet |
-| Gas for you | None | None — the server or facilitator settles the signed authorization |
+| Settlement | Batched nanopayments through Circle Gateway | EIP-3009 by default, or Permit2 when the server advertises it |
+| Funding source | A prefunded USDC balance in Circle Gateway | For capped payments, USDC held in the signing wallet; an uncapped interactive request uses the quoted asset |
+| Settlement gas | None | None; setting a Permit2 allowance may require gas unless the provider sponsors it |
 | Best for | Repeated micro-payments, down to fractions of a cent | One-off payments with no Gateway setup |
-| Prerequisite | A one-time Gateway deposit | USDC on the payment network |
+| Prerequisite | Deposit before paying and top up as needed | The quoted asset on the payment network; Permit2 may also require an existing allowance or provider-sponsored approval |
 
-Which schemes are eligible also depends on what the server offers and where you hold funds — see [Troubleshooting](#troubleshooting) if nothing is eligible.
+Which options are eligible depends on what the server offers and your `--scheme`, `--network`, asset, and spend-cap filters. Funding is checked later when the selected payment is created or settled.
 
 ## Fund Circle Gateway for batched payments
 
-Circle Gateway payments draw on a one-time USDC deposit you make to Circle Gateway, using [Circle's own deposit flow](https://developers.circle.com/gateway/nanopayments/howtos/x402-buyer) — the Alchemy CLI does not perform deposits.
+Circle Gateway payments draw on USDC you deposit in advance using [Circle's own deposit flow](https://developers.circle.com/gateway/nanopayments/howtos/x402-buyer) — the Alchemy CLI does not perform deposits. Top up the balance as needed.
 
 <Warning>
   Do not send USDC to the Circle Gateway contract with a plain ERC-20 transfer. Circle does not credit funds sent that way, and they cannot be recovered. Always deposit through Circle's Gateway deposit flow.
 </Warning>
 
-Check your balance any time — no wallet or API key required:
+No Alchemy API key is required to check Gateway balances. Without `--address`, the CLI uses your active signer's address:
 
 ```bash
 alchemy x402 balance
-alchemy x402 balance --address 0xYourAddress --testnet
 ```
+
+Pass `--address` to query without a configured signer. Add `--testnet` when you want to query the Gateway testnet instead:
+
+```bash
+alchemy --json x402 balance --address 0x1111111111111111111111111111111111111111
+```
+
+An abbreviated illustrative response looks like:
 
 ```json
 {
-  "address": "0xYourAddress",
+  "address": "0x1111111111111111111111111111111111111111",
   "environment": "mainnet",
   "token": "USDC",
   "balances": [
@@ -244,15 +241,21 @@ alchemy x402 balance --address 0xYourAddress --testnet
 }
 ```
 
-`--address` checks a specific depositor; without it, the CLI checks your active signer's address.
-
 ## Use it from agents and scripts
 
-Always pass `--json --no-interactive` and set `--max-payment` explicitly:
+Use `--json --no-interactive` for machine-readable automation. Estimates do not require a cap:
 
 ```bash
 alchemy --json --no-interactive x402 request https://nano.blockrun.ai/api/v1/pm/matching-markets/pairs --estimate
 ```
+
+Any request that may pay also requires an explicit `--max-payment`:
+
+```bash
+alchemy --json --no-interactive x402 request https://api.example.com/paid-endpoint --max-payment 0.01
+```
+
+An abbreviated estimate response looks like:
 
 ```json
 {
@@ -286,7 +289,7 @@ alchemy --json --no-interactive x402 request https://nano.blockrun.ai/api/v1/pm/
 ```
 
 <Accordion title="JSON envelope reference">
-  Every `x402 request` response — paid or not — shares one shape on stdout:
+  Every completed non-estimate `x402 request` response — paid or free — shares one shape on stdout:
 
   ```json
   {
@@ -304,40 +307,44 @@ alchemy --json --no-interactive x402 request https://nano.blockrun.ai/api/v1/pm/
   `payment` is `null` when no payment was required. When a payment was made, it carries `paid`, `scheme`, `gateway`, `network`, `asset`, `amount`, `amountUSDC`, `payTo`, `payer`, `transaction`, `settled`, `signerAddress`, `signerKind`, and `recovered` — see the [receipt example above](#make-a-paid-request). `--estimate` uses a different shape: `payment.required`, `payment.options` (every option the server offered, each annotated `eligible`), `payment.selected`, and `payment.cap`.
 </Accordion>
 
-Exit code **`9` (`PAYMENT_REQUIRED`)** means the target demanded payment the CLI wasn't authorized to make — no cap set non-interactively, or the quote exceeded `--max-payment`. Treat it as "raise the cap or ask a human," not something to retry blindly.
+Exit code **`9` (`PAYMENT_REQUIRED`)** covers x402 failures both before and after a payment authorization is created. Never retry it blindly; use the error message and [troubleshooting guidance](#troubleshooting) to determine whether a prior authorization may still settle.
 
 A few rules for agent code:
 
 * Estimate before paying anything you haven't seen priced before.
-* Always set `--max-payment` — it's the only thing standing between your agent and an unbounded spend.
+* Set `--max-payment` on every request that may pay. Estimates do not need one.
 * Read `payment.settled`, not just the HTTP status — a `200` can still carry `settled: false`.
-* Never loop on exit code `9`. Escalate or raise the cap deliberately.
+* Never retry exit code `9` blindly; follow the error message and confirm whether the prior authorization settled.
 
-Run `alchemy --json --no-interactive agent-prompt` for the full command tree and error catalog — it's the source of truth; this page doesn't duplicate it.
+For the current command tree and error catalog, run `alchemy --json --no-interactive agent-prompt`.
 
 ## Security and trust model
 
 * The spend cap or your interactive confirmation is the only thing that authorizes a payment. Nothing in a server's response can raise it.
 * Payment quotes from servers are **untrusted input**. The CLI validates a quote before ever signing against it.
 * Every payment signature is verified locally, before it's sent.
-* USDC is recognized only by known per-chain asset addresses — a quote naming an unrecognized asset is rejected rather than paid.
-* The CLI never pays twice for one request.
+* Capped payments recognize USDC only by known per-chain asset addresses. A quote naming an unrecognized asset is rejected when `--max-payment` is set.
+* Without a cap, an interactive terminal may present another `exact`-scheme asset in base units. Verify the asset contract and amount before confirming it.
+* The CLI issues only one payment authorization per request.
 * With `--signer session`, your Agent Wallet session signs the payment. No private key or API key is ever exposed to the agent — see [Agent Wallets](docs/agent-wallets).
 
 ## Troubleshooting
 
 <AccordionGroup>
-  <Accordion title="Exit code 9: payment required">
-    The server priced the request above what you authorized. Non-interactively, this means no `--max-payment` was set, or the quote exceeded it. Re-run with a higher `--max-payment`, or use `--estimate` to see the exact price first.
+  <Accordion title="Exit code 9 before payment">
+    Exit code `9` covers several pre-payment failures, including a missing or insufficient cap, an invalid quote, no eligible option, and signing or funding failures. Read the error message and correct that specific cause. Set or raise `--max-payment` only when the message explicitly identifies the cap.
+  </Accordion>
+  <Accordion title="Exit code 9 after authorization">
+    Some exit code `9` errors happen after a signed authorization was sent or released: a transport failure, another `402`, or a non-2xx paid response. The payment may still settle. Do not retry until you reconcile the payment with the provider or payment rail, or you could pay twice.
   </Accordion>
   <Accordion title="No eligible payment option">
-    The server didn't offer a scheme or network you allowed. Check the `options` array from `--estimate` for each option's `excludedBy` reason, try `--scheme any`, or remove a `-n/--network` filter.
+    The server didn't offer an option that passed the current scheme, network, asset, and cap filters. Check the `options` array from `--estimate` for each option's `excludedBy` reason, try `--scheme any`, or remove a `-n/--network` filter.
   </Accordion>
   <Accordion title="Circle Gateway balance too low">
-    Gateway payments need funds already deposited to Circle Gateway. Check `alchemy x402 balance` and [top up through Circle](#fund-circle-gateway-for-batched-payments) — never with a raw ERC-20 transfer.
+    Gateway payments need funds already deposited to Circle Gateway. Check `alchemy x402 balance` and [top up through Circle](#fund-circle-gateway-for-batched-payments) — never with a raw ERC-20 transfer. If the server also offers direct exact settlement and your wallet holds USDC on that network, retry with `--scheme exact`; the CLI does not fall back automatically.
   </Accordion>
   <Accordion title="Quote rejected as invalid">
-    A server response with a missing header, an unsupported x402 version, or an asset the CLI can't recognize as USDC is rejected before anything is signed. This is the CLI protecting your funds, not a bug.
+    Inspect the endpoint's x402 response. The CLI rejects missing payment headers, unsupported x402 versions, unsupported payment schemes, and unrecognized assets on capped requests before signing.
   </Accordion>
 </AccordionGroup>
 
@@ -345,6 +352,6 @@ Run `alchemy --json --no-interactive agent-prompt` for the full command tree and
 
 * [Agent Wallets](docs/agent-wallets)
 * [Alchemy CLI x402 reference](docs/alchemy-cli#x402)
-* [Wallet Auth for Alchemy APIs](docs/alchemy-for-agents) — the other x402: authenticating and paying Alchemy itself
+* [Wallet auth for Alchemy APIs](docs/alchemy-for-agents) — the other x402: authenticating and paying Alchemy itself
 * [x402.org](https://www.x402.org/)
 * [Circle Gateway documentation](https://developers.circle.com/gateway/nanopayments/howtos/x402-buyer)

--- a/content/tutorials/build-with-ai/x402-payments.mdx
+++ b/content/tutorials/build-with-ai/x402-payments.mdx
@@ -1,0 +1,350 @@
+---
+title: x402 Payments
+description: Pay any x402-enabled API in USDC from the Alchemy CLI. Decode 402 Payment Required quotes, set a spend cap, pay with an Agent Wallet session, and get a payment receipt.
+subtitle: Pay any x402-enabled API in USDC from the Alchemy CLI. Decode 402 Payment Required quotes, set a spend cap, pay with an Agent Wallet session, and get a payment receipt.
+slug: docs/x402-payments
+---
+
+`alchemy x402 request <url>` is curl that can pay. It makes an HTTP request, and if the server responds `402 Payment Required`, the CLI decodes the payment quote, pays in USDC — signed by your [Agent Wallet session](docs/agent-wallets), with no private key or API key handled by the agent — retries the request, and returns the resource plus a payment receipt. It works against any server that speaks the x402 v2 protocol, not just Alchemy endpoints.
+
+This guide reflects `@alchemy/cli` 0.22.0 and later, at the time of writing. Run `alchemy help x402` for the current command surface.
+
+<Note>
+  This page is about paying **third-party** x402-enabled APIs. It is not the global `--x402` flag or `alchemy config set x402`, which use **x402 gateway auth** to pay Alchemy for Alchemy API access — see [Wallet Auth for Alchemy APIs](docs/alchemy-for-agents).
+</Note>
+
+```bash
+alchemy x402 request https://nano.blockrun.ai/api/v1/pm/matching-markets/pairs --estimate
+```
+
+## How it works
+
+1. The CLI sends your request with no payment attached.
+2. If the resource is free, the server responds normally and the CLI returns it — nothing else happens.
+3. If payment is required, the server responds `402 Payment Required` with a machine-readable quote (price, network, and accepted payment schemes).
+4. The CLI checks your authorization (a spend cap or your confirmation), verifies the quote, and signs a USDC payment with your Agent Wallet session or a local key.
+5. The CLI retries the request with the signed payment attached and returns the resource along with a payment receipt.
+
+This is the open [x402 protocol](https://www.x402.org/) — the CLI is a generic buyer for any compliant server, not just Alchemy's own APIs.
+
+## Before you begin
+
+* Install the CLI and sign in: `npm i -g @alchemy/cli@latest` and `alchemy auth`
+* Connect an [Agent Wallet session](docs/agent-wallets) (`alchemy wallet connect --mode session`), or use a local EVM wallet with `--signer local`
+* USDC funding — how much depends on which [payment scheme](#how-payment-schemes-work) the server offers; see [funding Circle Gateway](#fund-circle-gateway-for-batched-payments) below
+
+<Tip>
+  `--estimate` needs none of this. It decodes the quote and pays nothing, so it's the best first command to run against any x402 URL.
+</Tip>
+
+## Decode a quote with --estimate
+
+`--estimate` sends the request, decodes the `402` quote, and prints it. It never signs or pays, so it's always free to run.
+
+```bash
+alchemy x402 request https://nano.blockrun.ai/api/v1/pm/matching-markets/pairs --estimate
+```
+
+```text
+  Provider  nano.blockrun.ai
+  Resource  Get all active exact-matched market pairs
+  Scheme    exact (Circle Gateway batched)
+  Network   eip155:137 (polygon-mainnet)
+  Amount    0.005 USDC
+  Decision  estimate only
+```
+
+The price, scheme, and network are set by the server and may change — this is what BlockRun advertised at the time of writing.
+
+<Check>
+  If you see a decoded quote, the CLI handled a live `402` end to end. Nothing was signed and nothing was spent.
+</Check>
+
+## Authorize payments: cap or confirm
+
+The CLI never pays on its own authority. Every payment needs an explicit authorization:
+
+* **Interactive terminal:** the CLI prints the quote and asks you to confirm before signing.
+* **Non-interactive runs** — scripts, `--json`, piped output, `--no-interactive`, or `-y/--yes` — require `--max-payment <usdc>`, a hard ceiling on what this invocation may spend. `--yes` without a cap fails by design:
+
+  ```bash
+  alchemy x402 request https://nano.blockrun.ai/api/v1/pm/matching-markets/pairs --yes
+  ```
+
+  ```json
+  {
+    "error": {
+      "code": "INVALID_ARGS",
+      "message": "--yes requires --max-payment <usdc> to set an explicit payment limit.",
+      "retryable": false
+    }
+  }
+  ```
+
+A quote priced above your cap is never paid — the command exits with code `9` instead:
+
+```json
+{
+  "error": {
+    "code": "PAYMENT_REQUIRED",
+    "message": "Payment of 0.005 USDC is required.",
+    "hint": "Re-run with --max-payment <usdc> to authorize payment non-interactively.",
+    "retryable": false
+  }
+}
+```
+
+| Mode | What authorizes payment |
+|---|---|
+| Interactive terminal | A confirmation prompt showing the exact quote |
+| `--yes`, `--json`, `--no-interactive`, scripts | `--max-payment <usdc>` — required, a hard ceiling |
+
+<Warning>
+  These commands spend real USDC. Treat `--max-payment` as the authorization boundary, and set it to the smallest value that gets the job done.
+</Warning>
+
+The CLI also never pays twice for the same request — if a paid retry itself comes back `402`, the CLI stops rather than sign and send a second payment.
+
+## Make a paid request
+
+The commands below spend real USDC. The URLs are placeholders — replace them with the x402 endpoint you're actually calling.
+
+<Steps>
+  <Step title="Check funding">
+    Confirm your signer and, for Circle Gateway payments, your Gateway balance:
+
+    ```bash
+    alchemy wallet status
+    alchemy x402 balance
+    ```
+  </Step>
+  <Step title="Estimate first">
+    Decode the quote before paying anything:
+
+    ```bash
+    alchemy x402 request https://api.example.com/paid-endpoint --estimate
+    ```
+  </Step>
+  <Step title="Pay with a cap">
+    ```bash
+    alchemy x402 request https://api.example.com/paid-endpoint --max-payment 0.01
+    ```
+
+    curl-style flags work the same way. `-d` sets the method to `POST` automatically when you don't pass `-X`:
+
+    ```bash
+    alchemy x402 request https://api.example.com/reports \
+      -H "content-type: application/json" \
+      -d '{"query":"latest"}' \
+      --max-payment 0.05 \
+      -o report.json
+    ```
+
+    Passing `-X GET` (or `-X HEAD`) together with `-d` fails fast instead of sending a malformed request:
+
+    ```json
+    {
+      "error": {
+        "code": "INVALID_ARGS",
+        "message": "--data cannot be sent with a GET request. Use -X POST, or omit -X to default to POST when --data is set.",
+        "retryable": false
+      }
+    }
+    ```
+  </Step>
+  <Step title="Read the receipt">
+    A successful paid request returns the resource plus a receipt. In `--json` mode, `payment` carries every field:
+
+    ```json
+    {
+      "url": "https://api.example.com/paid-endpoint",
+      "status": 200,
+      "ok": true,
+      "body": { "...": "the resource you paid for" },
+      "bodyEncoding": "json",
+      "payment": {
+        "paid": true,
+        "scheme": "exact",
+        "gateway": true,
+        "network": "eip155:137",
+        "asset": "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359",
+        "amount": "5000",
+        "amountUSDC": "0.005",
+        "payTo": "0x6E007731870EDe419CfB31889Cd5C4493CEcb04c",
+        "payer": "0xYourSignerAddress",
+        "transaction": "0xillustrative-transaction-id",
+        "settled": true,
+        "signerAddress": "0xYourSignerAddress",
+        "signerKind": "session",
+        "recovered": true
+      }
+    }
+    ```
+
+    `settled` reflects whether the payment cleared: for Circle Gateway payments it may briefly be `null` if the server hasn't returned a settlement receipt yet, or `false` if settlement failed even though `status` is `200` — the resource is still delivered either way, since the payment was already accepted. `signerKind` tells you whether the session or a local key signed.
+  </Step>
+</Steps>
+
+### Request flags
+
+| Flag | Description |
+|---|---|
+| `-X, --method <method>` | HTTP method. Defaults to `POST` when `--data` is set. |
+| `-H, --header <header>` | Request header as `"Name: value"`, repeatable |
+| `-d, --data <body>` | Request body |
+| `-o, --output <file>` | Write the response body to a file |
+| `--estimate` | Decode the payment quote without signing or paying |
+| `--max-payment <usdc>` | Maximum USDC to pay, e.g. `0.01`. Required for non-interactive payment. |
+| `-y, --yes` | Skip the confirmation prompt. Requires `--max-payment`. |
+| `--scheme <gateway\|exact\|any>` | Restrict to a payment scheme. Default `any` — cheapest eligible option wins. |
+| `--signer <session\|local>` | Override the active signer for this request |
+| `-n, --network <id>` | Filter which payment networks the CLI will pay on |
+
+Run `alchemy help x402 request` for the current flag surface.
+
+## How payment schemes work
+
+A server can offer more than one way to pay. With `--scheme any` (the default), the CLI picks the cheapest eligible option — Circle Gateway wins ties. Force one scheme with `--scheme gateway` or `--scheme exact`.
+
+| | Circle Gateway (`gateway`) | Exact (`exact`) |
+|---|---|---|
+| Settlement | Batched nanopayments through Circle Gateway | Direct EIP-3009 signed USDC transfer |
+| Funding source | A prior USDC deposit to Circle Gateway | USDC held in the signing wallet |
+| Gas for you | None | None — the server or facilitator settles the signed authorization |
+| Best for | Repeated micro-payments, down to fractions of a cent | One-off payments with no Gateway setup |
+| Prerequisite | A one-time Gateway deposit | USDC on the payment network |
+
+Which schemes are eligible also depends on what the server offers and where you hold funds — see [Troubleshooting](#troubleshooting) if nothing is eligible.
+
+## Fund Circle Gateway for batched payments
+
+Circle Gateway payments draw on a one-time USDC deposit you make to Circle Gateway, using [Circle's own deposit flow](https://developers.circle.com/gateway/nanopayments/howtos/x402-buyer) — the Alchemy CLI does not perform deposits.
+
+<Warning>
+  Do not send USDC to the Circle Gateway contract with a plain ERC-20 transfer. Circle does not credit funds sent that way, and they cannot be recovered. Always deposit through Circle's Gateway deposit flow.
+</Warning>
+
+Check your balance any time — no wallet or API key required:
+
+```bash
+alchemy x402 balance
+alchemy x402 balance --address 0xYourAddress --testnet
+```
+
+```json
+{
+  "address": "0xYourAddress",
+  "environment": "mainnet",
+  "token": "USDC",
+  "balances": [
+    { "chain": "base", "domain": 6, "balance": "0", "pendingBatch": "0" },
+    { "chain": "polygon", "domain": 7, "balance": "0", "pendingBatch": "0" }
+  ],
+  "totalAvailable": "0"
+}
+```
+
+`--address` checks a specific depositor; without it, the CLI checks your active signer's address.
+
+## Use it from agents and scripts
+
+Always pass `--json --no-interactive` and set `--max-payment` explicitly:
+
+```bash
+alchemy --json --no-interactive x402 request https://nano.blockrun.ai/api/v1/pm/matching-markets/pairs --estimate
+```
+
+```json
+{
+  "url": "https://nano.blockrun.ai/api/v1/pm/matching-markets/pairs",
+  "status": 402,
+  "payment": {
+    "required": true,
+    "x402Version": 2,
+    "resource": {
+      "url": "https://nano.blockrun.ai/api/v1/pm/matching-markets/pairs",
+      "description": "Get all active exact-matched market pairs",
+      "mimeType": "application/json"
+    },
+    "options": [
+      {
+        "scheme": "exact",
+        "network": "eip155:137",
+        "asset": "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359",
+        "amount": "5000",
+        "amountUSDC": "0.005",
+        "payTo": "0x6E007731870EDe419CfB31889Cd5C4493CEcb04c",
+        "maxTimeoutSeconds": 691200,
+        "gateway": true,
+        "eligible": true
+      }
+    ],
+    "selected": { "...": "same shape as the option above" },
+    "cap": null
+  }
+}
+```
+
+<Accordion title="JSON envelope reference">
+  Every `x402 request` response — paid or not — shares one shape on stdout:
+
+  ```json
+  {
+    "url": "string",
+    "status": 0,
+    "ok": true,
+    "headers": { "content-type": "application/json" },
+    "body": "parsed JSON, text, or null",
+    "bodyEncoding": "json | text | base64 | file | null",
+    "bodyBytes": 0,
+    "payment": null
+  }
+  ```
+
+  `payment` is `null` when no payment was required. When a payment was made, it carries `paid`, `scheme`, `gateway`, `network`, `asset`, `amount`, `amountUSDC`, `payTo`, `payer`, `transaction`, `settled`, `signerAddress`, `signerKind`, and `recovered` — see the [receipt example above](#make-a-paid-request). `--estimate` uses a different shape: `payment.required`, `payment.options` (every option the server offered, each annotated `eligible`), `payment.selected`, and `payment.cap`.
+</Accordion>
+
+Exit code **`9` (`PAYMENT_REQUIRED`)** means the target demanded payment the CLI wasn't authorized to make — no cap set non-interactively, or the quote exceeded `--max-payment`. Treat it as "raise the cap or ask a human," not something to retry blindly.
+
+A few rules for agent code:
+
+* Estimate before paying anything you haven't seen priced before.
+* Always set `--max-payment` — it's the only thing standing between your agent and an unbounded spend.
+* Read `payment.settled`, not just the HTTP status — a `200` can still carry `settled: false`.
+* Never loop on exit code `9`. Escalate or raise the cap deliberately.
+
+Run `alchemy --json --no-interactive agent-prompt` for the full command tree and error catalog — it's the source of truth; this page doesn't duplicate it.
+
+## Security and trust model
+
+* The spend cap or your interactive confirmation is the only thing that authorizes a payment. Nothing in a server's response can raise it.
+* Payment quotes from servers are **untrusted input**. The CLI validates a quote before ever signing against it.
+* Every payment signature is verified locally, before it's sent.
+* USDC is recognized only by known per-chain asset addresses — a quote naming an unrecognized asset is rejected rather than paid.
+* The CLI never pays twice for one request.
+* With `--signer session`, your Agent Wallet session signs the payment. No private key or API key is ever exposed to the agent — see [Agent Wallets](docs/agent-wallets).
+
+## Troubleshooting
+
+<AccordionGroup>
+  <Accordion title="Exit code 9: payment required">
+    The server priced the request above what you authorized. Non-interactively, this means no `--max-payment` was set, or the quote exceeded it. Re-run with a higher `--max-payment`, or use `--estimate` to see the exact price first.
+  </Accordion>
+  <Accordion title="No eligible payment option">
+    The server didn't offer a scheme or network you allowed. Check the `options` array from `--estimate` for each option's `excludedBy` reason, try `--scheme any`, or remove a `-n/--network` filter.
+  </Accordion>
+  <Accordion title="Circle Gateway balance too low">
+    Gateway payments need funds already deposited to Circle Gateway. Check `alchemy x402 balance` and [top up through Circle](#fund-circle-gateway-for-batched-payments) — never with a raw ERC-20 transfer.
+  </Accordion>
+  <Accordion title="Quote rejected as invalid">
+    A server response with a missing header, an unsupported x402 version, or an asset the CLI can't recognize as USDC is rejected before anything is signed. This is the CLI protecting your funds, not a bug.
+  </Accordion>
+</AccordionGroup>
+
+## Next steps
+
+* [Agent Wallets](docs/agent-wallets)
+* [Alchemy CLI x402 reference](docs/alchemy-cli#x402)
+* [Wallet Auth for Alchemy APIs](docs/alchemy-for-agents) — the other x402: authenticating and paying Alchemy itself
+* [x402.org](https://www.x402.org/)
+* [Circle Gateway documentation](https://developers.circle.com/gateway/nanopayments/howtos/x402-buyer)

--- a/lychee.toml
+++ b/lychee.toml
@@ -60,6 +60,7 @@ exclude = [
     ".*tenderly\\.co.*",             # Rate-limits crawlers with 429 (page loads fine in browser)
     ".*learnmeabitcoin\\.com.*",     # SSL certificate error for crawler clients (page loads fine in browser)
     ".*bscscan\\.com.*",             # Bot protection blocks crawlers with 403 (Etherscan-family explorer)
+    ".*nano\\.blockrun\\.ai.*",      # x402 example endpoint - intentionally returns HTTP 402 Payment Required
 
 ]
 

--- a/lychee.toml
+++ b/lychee.toml
@@ -60,7 +60,7 @@ exclude = [
     ".*tenderly\\.co.*",             # Rate-limits crawlers with 429 (page loads fine in browser)
     ".*learnmeabitcoin\\.com.*",     # SSL certificate error for crawler clients (page loads fine in browser)
     ".*bscscan\\.com.*",             # Bot protection blocks crawlers with 403 (Etherscan-family explorer)
-    ".*nano\\.blockrun\\.ai.*",      # x402 example endpoint - intentionally returns HTTP 402 Payment Required
+    "^https://nano\\.blockrun\\.ai/api/v1/pm/matching-markets/pairs$", # x402 example endpoint - intentionally returns HTTP 402 Payment Required
 
 ]
 


### PR DESCRIPTION
## Description

`@alchemy/cli` 0.22.0 shipped `alchemy x402 request <url>` and `alchemy x402 balance` — a generic x402 v2 buyer that pays third-party APIs in USDC, signed by the Agent Wallet session (Circle Gateway batched nanopayments or direct EIP-3009 settlement), with a spend-cap authorization model and JSON receipts for agents. The docs had zero coverage of this feature.

Complicating that: every existing "x402" mention in the docs (4 files, ~19 places) means something else entirely — authenticating and paying **Alchemy** for **Alchemy API** access via a local wallet key and SIWE (the `--x402` flag, `alchemy config set x402`, and the "Agent Authentication and Payment" page). This PR adds the new feature's docs and disambiguates the two meanings so they don't read as contradictory.

## Related Issues

Documents the CLI feature from [AX-610](https://linear.app/alchemyapi/issue/AX-610/add-external-x402-functionality-to-the-agent-wallet) (`OMGWINNING/alchemy-cli#112`, merged). No dedicated Linear ticket exists for this docs update.

## Changes Made

* **New page** `content/tutorials/build-with-ai/x402-payments.mdx` — how the x402 flow works, the cap-or-confirm authorization model, a paid-request walkthrough (`Steps`), the Gateway-vs-exact scheme comparison, Circle Gateway funding (with the "never send USDC via a raw ERC-20 transfer" footgun called out in a `Warning`), the JSON envelope for agents/scripts, the security/trust model, and troubleshooting. Registered in `content/docs.yml` under Build with AI → Getting Started, right after Agent Wallets.
* **Retitled** "Agent Authentication and Payment" → **"Wallet Auth for Alchemy APIs"** (`alchemy-for-agents.mdx`, same slug) and scoped its x402 wording to Alchemy API auth specifically, so its title no longer reads as owning the whole "agents paying for things" topic. Added a disambiguation `Note` linking to the new page.
* Added a `### x402` command-reference section to `alchemy-cli.mdx`, disambiguated the four existing `--x402`/`config set x402` rows ("...for Alchemy APIs"), and cross-linked the new page from `agent-wallets.mdx` (a new capability card, an accordion entry, and two additions to the machine-readable capability manifest JSON), `overview.mdx` (bullet, table row, layering sentence), and `alchemy-agent-skills.mdx`.
* Fixed a stale reference to the old page title in `alchemy-mcp-server.mdx` (outside the original scope, caught by a repo-wide sweep after the rename).
* Added two rows to the `STYLE_RULES.md` terminology table: "x402 payments" (third-party) vs. "x402 gateway auth" (Alchemy APIs) — the canonical phrases used consistently across all edited pages.
* Excluded `nano.blockrun.ai` (the guide's live example endpoint, which intentionally returns HTTP 402) from the `lychee.toml` link checker so the weekly link-check job doesn't flag it.

Every command, error message, and exit code in the new page was captured from a live `@alchemy/cli` 0.22.0 build rather than invented (see verification below). One thing that is **not** a live capture: the example payment receipt JSON uses illustrative `transaction`/`payer` values, since documenting this PR did not include making a real USDC payment — the field names are exact (from the CLI's shipped implementation), the values are placeholders.

## Testing

* \[x] I have tested these changes locally
* \[x] I have run the validation scripts (`pnpm run validate:docs-yml` passes; `pnpm run lint` — eslint/prettier/typecheck — passes with zero errors introduced by this change)
* \[ ] I have checked that the documentation builds correctly (no local dev server in this repo; awaiting the PR preview link)

Additional verification performed:
* Re-ran every command shown in the new page against a live `@alchemy/cli` 0.22.0 build: the BlockRun `--estimate` (both JSON and human-readable output), `x402 balance`, the non-interactive-without-`--max-payment` refusal (confirmed exit code `9`), `--yes` without a cap (confirmed exit code `2`), `-d` auto-POST vs. explicit `-X GET` + `-d` rejection, and `alchemy help x402` / `alchemy help x402 request` / `alchemy help x402 balance`.
* Considered a "practice on testnet" subsection (`testnet.blockrun.ai`) per the plan, but cut it — verified live that BlockRun's entire testnet `pm/*` namespace currently returns `503` ("Predexon integration is not configured"), an upstream issue, so I didn't want to ship an unverified money path.
* Swept the whole `content/` tree (`grep -rn "x402" content/`) after the edits — every remaining mention either says "gateway auth," says "payments," names the open protocol with an x402.org link, or is the new page's own nav entry.
* Swept the whole repo for the old page title ("Agent Authentication and Payment") — zero remaining references after the rename.
* Verified the Circle Gateway deposit docs link (`developers.circle.com/gateway/nanopayments/howtos/x402-buyer`) is current.

**Not included in this PR (by design, per repo convention):** the changelog bullet. Feature-docs PRs in this repo don't bundle the changelog entry — it goes through the separate weekly `content/changelog/YYYY-MM-DD.md` process. Suggested bullet for that PR, under `## Developer Experience` → `**Alchemy CLI**`:

> The CLI can now pay x402-enabled third-party APIs in USDC: `alchemy x402 request <url>` decodes 402 Payment Required quotes, enforces a spend cap (`--max-payment`), signs with your Agent Wallet session, and returns a payment receipt; `alchemy x402 balance` shows Circle Gateway balances. See the [x402 Payments docs](https://www.alchemy.com/docs/x402-payments).

Created using the /git skill.
Co-Authored-By: Claude Sonnet 5
