### PR TITLE
docs: fix BSO typos and singular/plural usage

### DIFF
--- a/content/wallets/pages/transactions/sponsor-gas/bundler-sponsored-operations.mdx
+++ b/content/wallets/pages/transactions/sponsor-gas/bundler-sponsored-operations.mdx
@@ -1,7 +1,7 @@
 ---
 title: Bundler Sponsored Operations
 description: Advanced gas sponsorship, with faster confirmations and automatic retries.
-subtitle: Advanced gas sponsorship. BSO covers gas for your users' transactions with up to 30% faster execution and automatic retries built in.
+subtitle: Advanced gas sponsorship. BSOs cover gas for your users' transactions with up to 30% faster execution and automatic retries built in.
 slug: wallets/transactions/sponsor-gas/bundler-sponsored-operations
 ---
 
@@ -12,14 +12,14 @@ Bundler Sponsored Operations (BSO) are the advanced way to cover gas fees for yo
 ### Advanced sponsorship features
 
 * **Faster execution** — up to 30% faster execution vs. standard sponsorship. *Improvement varies by chain and network conditions.*
-* **Automatic retries** — transactions are retried automatically to handle gas fluctuation, with no extra integration work. Just tell us how much you're willing to spend per transaction and we will gaurunatee submission up to that limit. 
-* **No onchain contracts** — no dependncy on onchain paymaster infrastructure.
+* **Automatic retries** — transactions are retried automatically to handle gas fluctuation, with no extra integration work. Just tell us how much you're willing to spend per transaction and we will guarantee submission up to that limit. 
+* **No onchain contracts** — no dependency on onchain paymaster infrastructure.
 * **Multi-chain** — the same policy type works across every supported chain.
 * **Centralized control** — manage spend limits and rules from the dashboard.
 
 ## Supported chains
 
-BSO is supported on every chain where Alchemy offers gas sponsorship, except MegaETH.
+BSOs are supported on every chain where Alchemy offers gas sponsorship, except MegaETH.
 
 See the full [Wallet APIs supported chains](/docs/wallets/supported-chains) doc to confirm which chains qualify.
 
@@ -27,7 +27,7 @@ See the full [Wallet APIs supported chains](/docs/wallets/supported-chains) doc 
 
 Traditional ERC-4337 sponsorship relies on onchain paymaster contracts, which must be deployed on every network, add onchain verification overhead, and require per-chain balance management.
 
-BSO instead operates at the bundler level: it uses your Gas Manager policy to control spend and removes paymaster contract calls.
+BSOs instead operate at the bundler level: they use your Gas Manager policy to control spend and remove paymaster contract calls.
 
 ## How to use BSO sponsorship
 
@@ -83,7 +83,7 @@ See the [Bundler API Quickstart](/docs/reference/bundler-api-quickstart) for ful
 * Set the `x-alchemy-policy-id` header on the bundler transport (via `fetchOptions.headers`).
 * Zero out `maxFeePerGas`, `maxPriorityFeePerGas`, and `preVerificationGas` on the user operation. All three must be zero, the bundler treats that as the signal to cover gas under the BSO policy and fills in the actual values server-side.
 
-No `createPaymasterClient` is needed, BSO does not use a paymaster contract.
+No `createPaymasterClient` is needed, BSOs do not use a paymaster contract.
 
 ```ts
 import { createClient, type Hex } from "viem";

--- a/content/wallets/pages/transactions/sponsor-gas/index.mdx
+++ b/content/wallets/pages/transactions/sponsor-gas/index.mdx
@@ -67,6 +67,7 @@ and bills in fiat.
 
 Build more:
 
+* [Bundler Sponsored Operations](/docs/wallets/transactions/sponsor-gas/bundler-sponsored-operations) — advanced gas sponsorship with faster execution and automatic retries
 * [Pay gas with any token](/docs/wallets/transactions/pay-gas-with-any-token)
 * [Solana sponsorship](/docs/wallets/transactions/sponsor-gas/solana)
 


### PR DESCRIPTION
## Description

Fixes typos and inconsistent singular/plural usage of "BSO" on the newly added Bundler Sponsored Operations doc page, and links it from the sponsor-gas overview.

## Related Issues

N/A

## Changes Made

* Fixed typos "gaurunatee" → "guarantee" and "dependncy" → "dependency"
* Made "BSO is/covers/operates" consistently plural ("BSOs are/cover/operate") to match the acronym's plural expansion (Bundler Sponsored **Operations**)
* Added a link to the BSO page from the sponsor-gas overview's Next steps section

## Testing

* [x] I have tested these changes locally
* [ ] I have run the validation scripts (`pnpm run validate`)
* [ ] I have checked that the documentation builds correctly