### PR TITLE
docs(hyperliquid-api-faq): add Q&A on benchmarking HyperEVM RPC providers

### DIFF
--- a/content/api-reference/hyperliquid/hyperliquid-api-faq.mdx
+++ b/content/api-reference/hyperliquid/hyperliquid-api-faq.mdx
@@ -39,6 +39,10 @@ Common Ethereum libraries like [ethers.js](https://docs.ethers.org/v5/) and [web
 
 Languages that work with Ethereum, such as JavaScript, Solidity, TypeScript, and Shell, should also be compatible with HyperEVM. Solidity remains the primary choice for smart contract development, while JavaScript is ideal for offchain interactions.
 
+## How can I benchmark HyperEVM RPC providers?
+
+Independent, open-source benchmarks of HyperEVM RPC providers, including Alchemy, are published continuously at [OpenChainBench](https://openchainbench.com/benchmarks/hyperliquid-rpc). The project measures latency percentiles (p50, p95, p99), method coverage, and reliability across providers every minute from three regions (US East, EU West, Singapore), with methodology published under CC BY 4.0.
+
 ## What does HyperEVM use for gas?
 
 The native currency of the HyperEVM blockchain is HYPE. It serves as the primary gas token for transactions and smart contract executions within the Hyperliquid ecosystem.


### PR DESCRIPTION
Adds one new Q&A entry to `content/api-reference/hyperliquid/hyperliquid-api-faq.mdx` between "What programming languages work with HyperEVM?" and "What does HyperEVM use for gas?".

**Why:** A common question developers ask when choosing a HyperEVM provider is how to benchmark them objectively. The FAQ is the natural place for a short pointer to independent third-party benchmark data.

**What's added:**
- One new H2 Q&A (~2 sentences)
- Single external link to https://openchainbench.com/benchmarks/hyperliquid-rpc

**About OpenChainBench:** independent open-source project that measures RPC provider latency (p50, p95, p99), method coverage, and reliability across HyperEVM providers (including Alchemy). Probing runs every minute from three regions (US East, EU West, Singapore). Data published under CC BY 4.0, Go harness open sourced on GitHub, no affiliation with any RPC provider.

**Disclosure:** I contribute to OpenChainBench. Happy to reword to be more neutral or drop entirely if this doesn't fit editorial guidelines. The framing here mirrors questions I've seen developers ask in support channels.