### PR TITLE
DX-3264: Add hidden RBAC roles page

### DIFF
--- a/content/docs.yml
+++ b/content/docs.yml
@@ -1933,8 +1933,8 @@ navigation:
             path: tutorials/getting-started/dashboard/request-logs.mdx
           - page: Roles
             path: tutorials/getting-started/dashboard/dashboard-roles.mdx
-          - page: RBAC Roles
-            path: tutorials/getting-started/dashboard/dashboard-rbac-roles.mdx
+          - page: Dashboard Roles
+            path: tutorials/getting-started/dashboard/dashboard-team-roles.mdx
             hidden: true
           - page: Single Sign-On (SSO)
             path: tutorials/getting-started/dashboard/dashboard-sso.mdx

--- a/content/docs.yml
+++ b/content/docs.yml
@@ -1933,6 +1933,9 @@ navigation:
             path: tutorials/getting-started/dashboard/request-logs.mdx
           - page: Roles
             path: tutorials/getting-started/dashboard/dashboard-roles.mdx
+          - page: RBAC Roles
+            path: tutorials/getting-started/dashboard/dashboard-rbac-roles.mdx
+            hidden: true
           - page: Single Sign-On (SSO)
             path: tutorials/getting-started/dashboard/dashboard-sso.mdx
           - section: Admin API

--- a/content/tutorials/getting-started/dashboard/activity-log-webhook-subscriptions.mdx
+++ b/content/tutorials/getting-started/dashboard/activity-log-webhook-subscriptions.mdx
@@ -17,7 +17,7 @@ Activity Log webhook subscriptions forward your team's [Activity Log](/docs/acti
 * Alchemy authenticates **to your endpoint** using the credential you configure on the subscription (a Bearer token, Basic auth, or a custom header). See [Authentication](#authentication).
 
 <Info>
-  Managing webhook subscriptions requires an **Admin** or **Owner** role on the team.
+  Managing webhook subscriptions requires **Admin** [access](/docs/dashboard-roles) on the team.
 </Info>
 
 ***

--- a/content/tutorials/getting-started/dashboard/activity-log.mdx
+++ b/content/tutorials/getting-started/dashboard/activity-log.mdx
@@ -24,7 +24,7 @@ It lives in the [Alchemy Dashboard](https://dashboard.alchemy.com/activity-log).
 2. Navigate to [Activity Log](https://dashboard.alchemy.com/activity-log).
 
 <Info>
-	Viewing the Activity Log requires an **Admin** or **Owner** [role](/docs/dashboard-roles) on the team. Members with a Viewer or Developer role won't see it.
+	Viewing the Activity Log requires **Admin** [access](/docs/dashboard-roles) on the team. Members with a Developer or Viewer role won't see it.
 </Info>
 
 ![](https://alchemyapi-res.cloudinary.com/image/upload/v1780953374/docs/activity-logs-2.png)

--- a/content/tutorials/getting-started/dashboard/dashboard-rbac-roles.mdx
+++ b/content/tutorials/getting-started/dashboard/dashboard-rbac-roles.mdx
@@ -1,0 +1,139 @@
+---
+title: Dashboard RBAC Roles
+description: Manage Admin, Developer, and Viewer roles and billing access in the Alchemy Dashboard.
+subtitle: Manage Admin, Developer, and Viewer roles and billing access in the Alchemy Dashboard.
+slug: docs/dashboard-rbac-roles
+---
+
+# Dashboard RBAC roles
+
+Role-based access control (RBAC) lets your team give each member the right level of access in the Alchemy Dashboard. Team roles control what a member can do across team settings, apps, API keys, webhooks, and activity logs.
+
+Billing access is managed separately from team roles. A member can have any team role and still be granted Billing access when they need to manage billing.
+
+![](https://alchemyapi-res.cloudinary.com/image/upload/v1785517933/docs/rbac-team_widmpq.png)
+
+***
+
+## Team roles
+
+Alchemy supports three team roles:
+
+| Role | Best for | Summary |
+| --- | --- | --- |
+| **Admin** | Team owners and administrators | Full dashboard access, including team settings, member management, role assignment, security settings, Activity Log, and all Developer capabilities. Billing access is still a separate setting. |
+| **Developer** | Engineers who build and operate apps | Can create and manage apps, app configuration, app webhooks, app logs, and API keys. Can't manage team members, roles, team security settings, Admin API keys, or Activity Log. |
+| **Viewer** | Teammates who need visibility without write access | Can view team settings, apps, app logs, and app configuration. Can't create, edit, or delete apps, and sensitive API keys are masked. |
+
+## Capabilities by role
+
+| Capability | Admin | Developer | Viewer |
+| --- | --- | --- | --- |
+| View team settings | ✓ | ✓ | ✓ |
+| Edit team settings, including team name | ✓ | — | — |
+| Invite members and remove members | ✓ | — | — |
+| Assign team roles and update Billing access | ✓ | — | — |
+| View apps | ✓ | ✓ | ✓ |
+| View app logs and app configuration | ✓ | ✓ | ✓ |
+| Create apps | ✓ | ✓ | — |
+| Edit app configuration, including allowlists and enabled networks | ✓ | ✓ | — |
+| Delete apps | ✓ | ✓ | — |
+| Manage app webhooks | ✓ | ✓ | — |
+| View unmasked API keys | ✓ | ✓ | — |
+| Rotate app API keys | ✓ | — | — |
+| Manage Admin API access keys and JWT public keys | ✓ | — | — |
+| View Activity Log | ✓ | — | — |
+| Manage Activity Log webhook subscriptions | ✓ | — | — |
+
+<Note>
+	Billing access is not shown in the table because it is not a team role permission. See [Billing access](#billing-access).
+</Note>
+
+***
+
+## Billing access
+
+Billing access controls whether a member can view and manage billing settings in the Dashboard. It is separate from the member's team role.
+
+Members with Billing access can open the Billing page and use billing-related controls such as plan changes, billing settings, invoices, payment details, and usage or spend controls. Members without Billing access see a restricted-access view if they open Billing.
+
+Admins can grant or remove Billing access when they invite a member or edit an existing member. A member with Billing access appears with a **Billing** badge in the team table.
+
+<Info>
+	When you invite or edit members under RBAC, assigning the Admin role does not automatically grant Billing access. Grant Billing access separately when an Admin, Developer, or Viewer needs billing permissions.
+</Info>
+
+***
+
+## Invite a member
+
+Admins can invite new team members from the Team page.
+
+1. Open the [Alchemy Dashboard](https://dashboard.alchemy.com).
+2. Go to **Team**.
+3. Click **Invite member**.
+4. Enter the member's email address.
+5. Select a **Team role**: **Admin**, **Developer**, or **Viewer**.
+6. Turn **Billing access** on if the member should be able to manage billing.
+7. Click **Invite member**.
+
+The invited member appears in the team table with an **Invited** badge until they accept the invitation. Admins can cancel a pending invitation from the same table.
+
+![](https://alchemyapi-res.cloudinary.com/image/upload/v1785518287/docs/team-invite_jzqdlu.png)
+
+***
+
+## Edit a member's role or billing access
+
+Admins can edit another member's access from the Team page.
+
+1. Go to **Team**.
+2. Find the member in the table.
+3. Click **Edit**.
+4. Change the member's **Team role**.
+5. Turn **Billing access** on or off.
+6. Click **Update member**.
+
+Admins can also remove a member from the edit modal by clicking **Remove teammate** and confirming the removal.
+
+<Note>
+	You can't change your own access. Ask another Admin to update your role or Billing access.
+</Note>
+
+***
+
+## Filter the team table
+
+Use the search and role filters at the top of the Team page to find members:
+
+* Search by member name or email.
+* Filter by **Admin**, **Developer**, or **Viewer**.
+* Filter by **Billing** to show members with Billing access.
+
+***
+
+## Access safeguards
+
+The Dashboard includes safeguards that help prevent accidental lockouts:
+
+* You can't change your own role or Billing access.
+* You can't change the role of the last Admin on the team.
+* You can't remove Billing access from the last member with Billing access.
+
+If you need to change access for the only Admin or the only member with Billing access, first grant the required access to another trusted teammate.
+
+***
+
+## Restricted views
+
+When you don't have access to a feature, the Dashboard may hide the feature, disable the action with a tooltip, mask sensitive values, or show a restricted-access view.
+
+For example:
+
+* Viewers can see apps and app configuration, but API keys are masked and editing controls are disabled.
+* Developers can manage apps and app webhooks, but can't open the Activity Log or manage team members.
+* Members without Billing access can't open the Billing page.
+
+If you need access to a restricted feature, ask a team Admin to update your role or Billing access.
+
+![](https://alchemyapi-res.cloudinary.com/image/upload/v1785518310/docs/rbac-denied_jczkrg.png)

--- a/content/tutorials/getting-started/dashboard/dashboard-roles.mdx
+++ b/content/tutorials/getting-started/dashboard/dashboard-roles.mdx
@@ -5,6 +5,8 @@ subtitle: Guide to explain the roles available on the Alchemy Dashboard
 slug: docs/dashboard-roles
 ---
 
+{/* TODO: Once RBAC is generally launched, replace this legacy roles page with the RBAC roles page at this same /docs/dashboard-roles URL. */}
+
 # Member roles in the Alchemy Dashboard
 
 The Alchemy Dashboard provides a default **Team** to manage your Alchemy apps. Here are the roles available in an Alchemy team, including role powers:

--- a/content/tutorials/getting-started/dashboard/dashboard-roles.mdx
+++ b/content/tutorials/getting-started/dashboard/dashboard-roles.mdx
@@ -5,7 +5,7 @@ subtitle: Guide to explain the roles available on the Alchemy Dashboard
 slug: docs/dashboard-roles
 ---
 
-{/* TODO: Once RBAC is generally launched, replace this legacy roles page with the RBAC roles page at this same /docs/dashboard-roles URL. */}
+{/* TODO: Once the new Dashboard Roles experience is generally launched, replace this legacy roles page with the new Dashboard Roles page at this same /docs/dashboard-roles URL. */}
 
 # Member roles in the Alchemy Dashboard
 

--- a/content/tutorials/getting-started/dashboard/dashboard-team-roles.mdx
+++ b/content/tutorials/getting-started/dashboard/dashboard-team-roles.mdx
@@ -22,7 +22,7 @@ Alchemy supports three team roles:
 | Role | Best for | Summary |
 | --- | --- | --- |
 | **Admin** | Team owners and administrators | Full dashboard access, including team settings, member management, role assignment, security settings, Activity Log, and all Developer capabilities. Billing access is still a separate setting. |
-| **Developer** | Engineers who build and operate apps | Can create and manage apps, app configuration, app webhooks, app logs, and API keys. Can't manage team members, roles, team security settings, Admin API keys, or Activity Log. |
+| **Developer** | Engineers who build and operate apps | Can create and manage apps, app configuration, app webhooks, app logs, and view unmasked API keys. Can't rotate API keys, manage team members, roles, team security settings, Admin API keys, or Activity Log. |
 | **Viewer** | Teammates who need visibility without write access | Can view team settings, apps, app logs, and app configuration. Can't create, edit, or delete apps, and sensitive API keys are masked. |
 
 ## Capabilities by role

--- a/content/tutorials/getting-started/dashboard/dashboard-team-roles.mdx
+++ b/content/tutorials/getting-started/dashboard/dashboard-team-roles.mdx
@@ -1,13 +1,13 @@
 ---
-title: Dashboard RBAC Roles
+title: Dashboard Roles
 description: Manage Admin, Developer, and Viewer roles and billing access in the Alchemy Dashboard.
 subtitle: Manage Admin, Developer, and Viewer roles and billing access in the Alchemy Dashboard.
-slug: docs/dashboard-rbac-roles
+slug: docs/dashboard-team-roles
 ---
 
-# Dashboard RBAC roles
+# Dashboard roles
 
-Role-based access control (RBAC) lets your team give each member the right level of access in the Alchemy Dashboard. Team roles control what a member can do across team settings, apps, API keys, webhooks, and activity logs.
+Dashboard roles let your team give each member the right level of access in the Alchemy Dashboard. Team roles control what a member can do across team settings, apps, API keys, webhooks, and activity logs.
 
 Billing access is managed separately from team roles. A member can have any team role and still be granted Billing access when they need to manage billing.
 
@@ -60,7 +60,7 @@ Members with Billing access can open the Billing page and use billing-related co
 Admins can grant or remove Billing access when they invite a member or edit an existing member. A member with Billing access appears with a **Billing** badge in the team table.
 
 <Info>
-	When you invite or edit members under RBAC, assigning the Admin role does not automatically grant Billing access. Grant Billing access separately when an Admin, Developer, or Viewer needs billing permissions.
+	When you invite or edit members, assigning the Admin role does not automatically grant Billing access. Grant Billing access separately when an Admin, Developer, or Viewer needs billing permissions.
 </Info>
 
 ***


### PR DESCRIPTION
## Description

Adds hidden end-user documentation for Dashboard RBAC roles while keeping the existing legacy `/docs/dashboard-roles` page visible for teams not yet on RBAC.

## Related Issues

Part of DX-3264

## Changes Made

- Added a hidden Dashboard RBAC roles page covering Admin, Developer, and Viewer roles, Billing access, capabilities, team-member workflows, safeguards, restricted views, and screenshots.
- Added the hidden RBAC page to `content/docs.yml` without linking to it from public docs pages.
- Added a TODO to the legacy Dashboard Roles page to replace it with the RBAC page at the same `/docs/dashboard-roles` slug after GA.
- Updated Activity Log docs to refer to Admin access while continuing to link to the existing roles page.

## Testing

- [x] `pnpm exec prettier --check content/docs.yml content/tutorials/getting-started/dashboard/dashboard-roles.mdx content/tutorials/getting-started/dashboard/dashboard-rbac-roles.mdx content/tutorials/getting-started/dashboard/activity-log.mdx content/tutorials/getting-started/dashboard/activity-log-webhook-subscriptions.mdx`
- [x] `pnpm run validate:docs-yml`
- [ ] Full `pnpm run validate` not run; changes are docs-navigation/content only.

Created using Codex.
Co-Authored-By: Codex
