### PR TITLE
Make "getAccountInfoAtSlot" findable in docs search

### DIFF
--- a/content/api-reference/solana/account-archive.mdx
+++ b/content/api-reference/solana/account-archive.mdx
@@ -184,6 +184,10 @@ Everything the archive indexes is compressed, stored with at least 3 replicas fo
 
 Call `getAccountInfo` with the account's pubkey and a `slot` parameter in the config object: `getAccountInfo(pubkey, { "slot": S })`. The response is the standard `getAccountInfo` shape and returns the account's state as of slot `S`, the latest write at or before `S`.
 
+### Is there a getAccountInfoAtSlot method?
+
+No. There is no separate `getAccountInfoAtSlot` method; point-in-time reads are the `slot` parameter of the standard [`getAccountInfo`](/docs/chains/solana/solana-api-endpoints/get-account-info): `getAccountInfo(pubkey, { "slot": S })`. Any Solana JSON-RPC client can call it without changes.
+
 ### How do I get the full update history of a Solana account?
 
 Page with the cursor parameters. `getAccountInfo(pubkey, { "lastUpdateBeforeSlot": S })` returns the most recent write strictly before `S`, with the write's actual slot in `context.slot`; feed that slot back in as the next cursor to walk backward through every state transition. `firstUpdateAfterSlot` walks forward the same way.


### PR DESCRIPTION
## Summary

- Adds an FAQ entry to the Solana Account Archive guide: "Is there a getAccountInfoAtSlot method?" pointing to the `slot` parameter of the standard `getAccountInfo`.
- Docs search (Algolia) indexes the full body of MDX pages, so typing `getAccountInfoAtSlot` in the search box will now surface this page. Algolia's prefix matching cannot connect the longer query to the shorter `getAccountInfo` token on its own, and the indexer has no synonym/keyword mechanism — the literal string has to appear in indexed content.

## Notes

For a hit that lands directly on the `getAccountInfo` API reference page instead, the options are an Algolia one-way synonym (`getAccountInfoAtSlot` → `getAccountInfo`, configured in the Algolia dashboard, outside this repo) or adding the term to the method's description in the OpenRPC spec (visible on the reference page).

## Test plan

- [ ] After merge + reindex, search `getAccountInfoAtSlot` in the docs search box and confirm the Account Archive guide appears

Made with [Cursor](https://cursor.com)