### PR TITLE
docs: split Usage API into its own nav section

### DIFF
--- a/content/docs.yml
+++ b/content/docs.yml
@@ -2090,6 +2090,9 @@ navigation:
               - api: Admin API Endpoints
                 api-name: admin-api
                 flattened: true
+          - section: Usage API
+            hidden: true
+            contents:
               - api: Usage API Endpoints
                 api-name: usage-api
                 flattened: true

--- a/content/docs.yml
+++ b/content/docs.yml
@@ -2093,6 +2093,10 @@ navigation:
           - section: Usage API
             hidden: true
             contents:
+              - page: Overview
+                path: usage-api/overview.mdx
+              - page: Quickstart
+                path: usage-api/quickstart.mdx
               - api: Usage API Endpoints
                 api-name: usage-api
                 flattened: true

--- a/content/usage-api/overview.mdx
+++ b/content/usage-api/overview.mdx
@@ -1,0 +1,53 @@
+---
+title: Usage API Overview
+subtitle: Inspect compute unit usage and billing metrics for your account.
+slug: reference/usage-api/overview
+---
+
+The Usage API lets you programmatically inspect API usage for your Alchemy account. Use it to build dashboards, billing alerts, and internal reporting without exporting data from the Alchemy Dashboard.
+
+Usage data includes compute unit totals, estimated USD cost, billing period boundaries, and optional breakdowns by app, network, method, and request type.
+
+***
+
+## What you can do
+
+Use this API to:
+
+* Retrieve account usage summaries for the current billing period and recent rolling windows
+* Query usage time series with hourly or daily granularity
+* Filter by app, network, method, and request type
+* Group results by request type, app, network, or method
+
+Each request is authenticated and returns JSON responses.
+
+***
+
+## Authentication
+
+All requests must include credentials with Usage read permissions.
+
+You can authenticate with either:
+
+* An access key with **Usage** read permissions (`ADMIN_USAGE_READ`)
+* A dashboard user session token with `viewer`, `developer`, or `admin` role
+
+To create an access key:
+
+1. Go to the [security tab](https://dashboard.alchemy.com/settings/security?utm_source=docs&utm_medium=referral&utm_content=reference_usage-api_overview) in the Alchemy Dashboard
+2. Create a new access key
+3. Enable **Usage** with Read permissions
+
+***
+
+## Plan limits
+
+Time-series query ranges are limited by plan:
+
+| Plan | Maximum range |
+|---|---:|
+| Free | 1 day |
+| Pay as You Go | 7 days |
+| Longer ranges | [Contact sales](https://www.alchemy.com/contact-sales) |
+
+If you request a range longer than your plan supports, the API returns results for the allowed range.

--- a/content/usage-api/quickstart.mdx
+++ b/content/usage-api/quickstart.mdx
@@ -1,0 +1,137 @@
+---
+title: Usage API Quickstart
+subtitle: Query account usage summaries and time-series data with the Usage API.
+slug: reference/usage-api/quickstart
+---
+
+## Get started
+
+This guide walks through retrieving an account usage summary and querying usage over time.
+
+### Prerequisites
+
+* An access key with Usage **read** permissions
+  * Refer to the [overview authentication section](/docs/reference/usage-api/overview#authentication) for instructions to create an access key
+
+## Set up environment variables
+
+```bash
+export ALCHEMY_ADMIN_BASE_URL="https://admin-api.alchemy.com/v1"
+export ALCHEMY_ADMIN_ACCESS_KEY="YOUR_ACCESS_KEY_HERE"
+```
+
+Auth header:
+
+```bash
+export ALCHEMY_ADMIN_AUTH_HEADER="Authorization: Bearer $ALCHEMY_ADMIN_ACCESS_KEY"
+```
+
+## 1. Get usage summary
+
+Retrieve usage totals for the current billing period and recent rolling windows.
+
+```bash
+curl "$ALCHEMY_ADMIN_BASE_URL/usage/summary" \
+  -H "$ALCHEMY_ADMIN_AUTH_HEADER"
+```
+
+Example response:
+
+```json
+{
+  "data": {
+    "billingPeriod": {
+      "startTime": "2026-06-01T00:00:00Z",
+      "endTime": "2026-07-01T00:00:00Z"
+    },
+    "totals": {
+      "last7Days": {
+        "amount": "1250000",
+        "unit": "ALCHEMY_COMPUTE_UNIT",
+        "usd": "12.50"
+      },
+      "last30Days": {
+        "amount": "4800000",
+        "unit": "ALCHEMY_COMPUTE_UNIT",
+        "usd": "48.00"
+      },
+      "monthToDate": {
+        "amount": "3200000",
+        "unit": "ALCHEMY_COMPUTE_UNIT",
+        "usd": "32.00"
+      }
+    },
+    "usageLimit": {
+      "unit": "CU",
+      "limit": "10000000",
+      "used": "3200000",
+      "remaining": "6800000",
+      "percentUsed": 32
+    },
+    "freshness": {
+      "dataThrough": "2026-06-28T23:59:00Z",
+      "containsPartialToday": true,
+      "updateCadence": "minute"
+    }
+  }
+}
+```
+
+## 2. Get usage time series
+
+Query daily usage over a date range. You can optionally filter by app, network, method, or request type, and group results by one dimension.
+
+```bash
+curl -X POST "$ALCHEMY_ADMIN_BASE_URL/usage/time-series" \
+  -H "Content-Type: application/json" \
+  -H "$ALCHEMY_ADMIN_AUTH_HEADER" \
+  -d '{
+    "startTime": "2026-06-01T00:00:00Z",
+    "endTime": "2026-06-07T23:59:59Z",
+    "granularity": "day",
+    "products": ["SUPERNODE_CU"],
+    "metrics": ["amount", "usd"],
+    "groupBy": ["network"]
+  }'
+```
+
+Example response:
+
+```json
+{
+  "data": {
+    "query": {
+      "startTime": "2026-06-01T00:00:00Z",
+      "endTime": "2026-06-07T23:59:59Z",
+      "granularity": "day",
+      "products": ["SUPERNODE_CU"],
+      "metrics": ["amount", "usd"],
+      "groupBy": ["network"]
+    },
+    "freshness": {
+      "dataThrough": "2026-06-07T23:59:00Z",
+      "containsPartialToday": false,
+      "updateCadence": "minute"
+    },
+    "data": [
+      {
+        "startTime": "2026-06-01T00:00:00Z",
+        "endTime": "2026-06-02T00:00:00Z",
+        "isPartial": false,
+        "dimensions": {
+          "network": "eth-mainnet"
+        },
+        "amount": "450000",
+        "unit": "ALCHEMY_COMPUTE_UNIT",
+        "usd": "4.50"
+      }
+    ]
+  }
+}
+```
+
+## Next steps
+
+* See the [Get usage summary](/docs/tutorials/tools/usage-api/usage-api-endpoints/get-usage-summary) endpoint reference for response fields
+* See the [Get usage time series](/docs/tutorials/tools/usage-api/usage-api-endpoints/get-usage-time-series) endpoint reference for all request options
+* Use the [Alchemy CLI](/docs/alchemy-cli#usage) to query usage from the terminal without writing HTTP requests


### PR DESCRIPTION
## Summary
- Move the Usage API endpoints out from under the Admin API section in `content/docs.yml` so they render as a sibling section (still `hidden: true`) instead of nested under `admin-api/`.
- Spec (`usage-api` → `https://admin-api.alchemy.com/v1/usage/openapi.json`) already wired in `content/remote-specs.json`; two endpoints: `GET /v1/usage/summary` and `POST /v1/usage/time-series`.

## Test plan
- [ ] Preview the docs site and confirm the Usage API section renders separately from Admin API
- [ ] Confirm endpoint URLs land under a `usage-api` slug (not doubled under `admin-api/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)