### PR TITLE
docs: add Base Mainnet to internal transfer support (alchemy_getAssetTransfers)

### DIFF
--- a/src/openrpc/alchemy/transfers/transfers.yaml
+++ b/src/openrpc/alchemy/transfers/transfers.yaml
@@ -149,7 +149,7 @@ servers:
     name: Zora Sepolia
 methods:
   - name: alchemy_getAssetTransfers
-    description: The Transfers API allows you to easily fetch historical transactions for any address across Ethereum and supported L2s including Base, Polygon, Arbitrum, and Optimism (internal transfer data is only available on Ethereum Mainnet and Polygon Mainnet).
+    description: The Transfers API allows you to easily fetch historical transactions for any address across Ethereum and supported L2s including Base, Polygon, Arbitrum, and Optimism (internal transfer data is only available on Ethereum Mainnet, Polygon Mainnet, and Base Mainnet).
     x-compute-units: 120
     params:
       - name: assetTransferParams
@@ -174,7 +174,7 @@ methods:
               default: true
             category:
               type: array
-              description: "Array of transfer categories to include. Note: 'internal' category is not supported on Base, it is only available on Ethereum Mainnet and Polygon Mainnet."
+              description: "Array of transfer categories to include. Note: the 'internal' category is only available on Ethereum Mainnet, Polygon Mainnet, and Base Mainnet."
               items:
                 type: string
                 enum:


### PR DESCRIPTION
## What

Base now supports **internal transfers** in the Transfers API. This updates the `alchemy_getAssetTransfers` reference page to document that.

## Changes

In `src/openrpc/alchemy/transfers/transfers.yaml` (source for the [alchemy_getAssetTransfers](https://www.alchemy.com/docs/data/transfers-api/transfers-endpoints/alchemy-get-asset-transfers) page):

- **Method description** — internal transfer data is now documented as available on Ethereum Mainnet, Polygon Mainnet, **and Base Mainnet** (previously Ethereum + Polygon only).
- **`category` param note** — removed the "`internal` category is not supported on Base" caveat; the note now lists Ethereum Mainnet, Polygon Mainnet, and Base Mainnet as the chains where `internal` is available.

## Notes

Scoped to **Base Mainnet**, matching the existing mainnet-only framing for internal transfers on this page. The Address Activity Webhook page already lists Base (Mainnet, Sepolia) and is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
