### PR TITLE
docs(wallets): reverse stale minContextSlot guidance on Solana sponsor-gas

### DIFF
--- a/content/wallets/pages/transactions/solana/api-request.mdx
+++ b/content/wallets/pages/transactions/solana/api-request.mdx
@@ -38,7 +38,7 @@ export interface AlchemyFeePayerResponse {
     estimatedFeeLamports: number;
     estimatedRentLamports: number;
     prefundLamports?: number; // omitted when no prefund simulation ran
-    simulationSlot?: number; // omitted when no prefund simulation ran
+    simulationSlot?: number; // slot the prefund simulation ran against, at `confirmed` commitment; omitted when no simulation ran
     usesDurableNonce: boolean;
     lastValidBlockHeight?: number; // omitted for durable-nonce transactions
   };

--- a/content/wallets/pages/transactions/solana/api-sign.mdx
+++ b/content/wallets/pages/transactions/solana/api-sign.mdx
@@ -11,7 +11,10 @@ const tx = VersionedTransaction.deserialize(
 
 tx.sign([keypair]);
 
-const signature = await connection.sendRawTransaction(tx.serialize());
+const signature = await connection.sendRawTransaction(tx.serialize(), {
+  // Explicit so preflight cannot fall back to the node default of `finalized`.
+  preflightCommitment: "confirmed",
+});
 ```
 
 ```ts title="config.ts"

--- a/content/wallets/pages/transactions/solana/sponsor-gas-solana.mdx
+++ b/content/wallets/pages/transactions/solana/sponsor-gas-solana.mdx
@@ -89,12 +89,11 @@ We support sponsoring rent for inner `SystemProgram.createAccount` calls. `Syste
 
 * Enable `prefundRent` only for flows that may create accounts through CPI.
 * Submit the returned transaction promptly from your backend after collecting signatures.
-* For extra protection against stale state, when the response includes `simulationSlot`, consider passing it as `minContextSlot` when submitting the transaction.
+* When sending quick subsequent transactions that depend on each other, call `sendTransaction` with `preflightCommitment: "confirmed"`, or with `skipPreflight: true` to skip preflight entirely. Preflight otherwise falls back to `finalized`, which trails the chain by roughly 13 seconds, so it will fail on state the earlier transaction just wrote.
 
 ### Notes
 
 * Simulation is not the same as execution. Account state can change between sponsorship and submission, and programs can take different CPI paths at execution time.
-  * `minContextSlot` reduces stale-state risk, but it does not guarantee identical execution.
   * If execution needs more lamports than the simulation predicted, the transaction will fail. If execution needs less, the extra SOL remains in the funded wallet and is still billed to your policy.
 * **Important:** Only use `prefundRent` for payloads you control or can validate. If an attacker can influence the transaction or the programs it invokes, they may be able to grief your policy by causing failed or unnecessarily expensive prefunds.
 * `prefundRent` is not transaction-shape-preserving. When prefunding is needed, the returned transaction includes an added top-level `SystemProgram.transfer` instruction before your program flow. Programs that inspect sibling instructions or depend on exact top-level instruction ordering can behave differently or fail.


### PR DESCRIPTION
## Description

The Solana sponsor-gas page told readers to pin their send to the paymaster's `simulationSlot` via `minContextSlot`. That is backwards: sponsorship simulates at `confirmed`, so the send is rejected with `MinContextSlotNotReached` whenever preflight resolves to a commitment that trails that slot — including the default `finalized` — which is worse than simulating against slightly stale state. This reverses the guidance to match OMGWINNING/wallet-server#728, which removed `minContextSlot` from `wallet_prepareCalls` / `wallet_sendPreparedCalls`.

## Related Issues

Docs follow-up to OMGWINNING/wallet-server#730; behavior fixed in OMGWINNING/wallet-server#728.

## Changes Made

- `sponsor-gas-solana.mdx`: drop the `minContextSlot` best practice and the stale "reduces stale-state risk" note; add guidance to use `preflightCommitment: "confirmed"` (or `skipPreflight: true`) for quick dependent back-to-back sends.
- `api-request.mdx`: `simulationSlot` comment now matches the `openrpc/paymaster.yaml` source of truth — the slot the prefund simulation ran against, at `confirmed` commitment.
- `api-sign.mdx`: the broadcast sample passes `preflightCommitment: "confirmed"` explicitly.
- `minContextSlot` no longer appears anywhere on the page or its snippets.

## Testing

Prose-and-snippet change only; no build or validation scripts were run. The `preflightCommitment` claim was verified against `@solana/web3.js` v1.98.4 `Connection.sendEncodedTransaction`, which resolves `options.preflightCommitment || this.commitment` and omits the field otherwise, leaving the node's `finalized` default to apply.

* [ ] I have tested these changes locally
* [ ] I have run the validation scripts (`pnpm run validate`)
* [ ] I have checked that the documentation builds correctly