### PR TITLE
docs: add Aptos gRPC API documentation

### DIFF
--- a/content/api-reference/aptos-grpc/overview.mdx
+++ b/content/api-reference/aptos-grpc/overview.mdx
@@ -1,0 +1,35 @@
+---
+title: Aptos gRPC overview
+description: High-performance transaction streaming for Aptos over gRPC
+slug: reference/aptos-grpc-overview
+---
+
+Aptos gRPC provides access to the Aptos Transaction Stream API (`aptos.indexer.v1`) using Protocol Buffers and gRPC. It streams complete, ordered transaction data in real time, making it the recommended way to build indexers, analytics pipelines, and any service that needs to process every transaction on chain.
+
+## Why Aptos gRPC?
+
+Aptos gRPC offers advantages over polling the REST API:
+
+* **Real-time push**: Transactions are streamed to your client as they are processed — no polling loop required
+* **Strongly typed**: Protocol Buffers provide strict typing and schema validation for every transaction field
+* **Efficient serialization**: Binary encoding reduces payload size compared to JSON
+* **Ordered and resumable**: Transactions arrive in version order, and streams can resume from any historical version
+* **Server-side filtering**: Optionally filter the stream so only matching transactions are delivered
+
+## Available services
+
+### [Transaction stream](/docs/reference/aptos-grpc-transaction-stream)
+
+Stream raw transactions through the `RawData` service.
+
+| gRPC method | REST equivalent |
+| --- | --- |
+| `GetTransactions` | `GET /v1/transactions` (paginated polling) |
+
+<Note>
+  gRPC server reflection is not supported on Alchemy endpoints. Clients must supply the Aptos proto definitions directly — see the [quickstart](/docs/reference/aptos-grpc-quickstart) for setup instructions.
+</Note>
+
+## Getting started
+
+Check out the [quickstart guide](/docs/reference/aptos-grpc-quickstart) to make your first gRPC call.

--- a/content/api-reference/aptos-grpc/quickstart.mdx
+++ b/content/api-reference/aptos-grpc/quickstart.mdx
@@ -1,0 +1,109 @@
+---
+title: Aptos gRPC quickstart
+description: Get started with the Aptos gRPC Transaction Stream API
+slug: reference/aptos-grpc-quickstart
+---
+
+import { Steps, Step } from "/snippets/interactive-steps.mdx";
+
+This guide walks you through streaming your first transactions over Aptos gRPC.
+
+## Prerequisites
+
+* An [Alchemy API key](https://dashboard.alchemy.com/signup)
+* A gRPC client library for your language ([grpcurl](https://github.com/fullstorydev/grpcurl) for CLI testing)
+* The [Aptos proto definitions](https://github.com/aptos-labs/aptos-core/tree/main/protos/proto) cloned locally (grpcurl requires the `.proto` files)
+
+## Endpoints
+
+| Network | Endpoint |
+| --- | --- |
+| Mainnet | `aptos-mainnet.g.alchemy.com:443` |
+| Testnet | `aptos-testnet.g.alchemy.com:443` |
+
+Authentication uses a Bearer token in the request header:
+
+```bash
+-H "Authorization: Bearer <YOUR_API_KEY>"
+```
+
+<Note>
+  gRPC server reflection is not supported. Always pass the proto files explicitly (`-import-path` and `-proto` with grpcurl, or compiled stubs in your client library). The relevant protos are `aptos/indexer/v1/raw_data.proto` and its imports (`aptos/indexer/v1/filter.proto`, `aptos/transaction/v1/transaction.proto`, `aptos/util/timestamp/timestamp.proto`).
+</Note>
+
+<Steps>
+<Step title="Get the proto definitions">
+
+The Transaction Stream API protos live in the `aptos-core` repository.
+
+```bash
+git clone --depth 1 https://github.com/aptos-labs/aptos-core.git
+cd aptos-core
+```
+
+The proto root is `protos/proto`; use it as the import path in the following steps.
+
+</Step>
+<Step title="Fetch a fixed batch of transactions">
+
+Request 5 transactions starting at a specific version. The server sends the transactions and closes the stream once the count is reached.
+
+```bash cURL
+grpcurl \
+  -H "Authorization: Bearer <YOUR_API_KEY>" \
+  -import-path protos/proto \
+  -proto aptos/indexer/v1/raw_data.proto \
+  -d '{
+    "starting_version": 100000000,
+    "transactions_count": 5
+  }' \
+  aptos-mainnet.g.alchemy.com:443 \
+  aptos.indexer.v1.RawData/GetTransactions
+```
+
+Each response message contains a batch of transactions plus the chain ID:
+
+```json
+{
+  "transactions": [
+    {
+      "timestamp": "2026-04-01T12:00:00Z",
+      "version": "100000000",
+      "info": { "...": "..." },
+      "type": "TRANSACTION_TYPE_USER",
+      "user": { "...": "..." }
+    }
+  ],
+  "chainId": "1"
+}
+```
+
+</Step>
+<Step title="Stream live transactions">
+
+Omit `transactions_count` to keep the stream open indefinitely. The server continuously pushes new transactions in version order as they are processed.
+
+```bash cURL
+grpcurl \
+  -H "Authorization: Bearer <YOUR_API_KEY>" \
+  -import-path protos/proto \
+  -proto aptos/indexer/v1/raw_data.proto \
+  -d '{
+    "starting_version": 100000000
+  }' \
+  aptos-mainnet.g.alchemy.com:443 \
+  aptos.indexer.v1.RawData/GetTransactions
+```
+
+</Step>
+<Step title="Resume from where you left off">
+
+Track the `version` of the last transaction you processed. If the stream disconnects, reconnect with `starting_version` set to that version plus one — transactions are strictly ordered by version, so you will not miss or duplicate data.
+
+</Step>
+</Steps>
+
+## Next steps
+
+* [Aptos gRPC overview](/docs/reference/aptos-grpc-overview) for the full service description
+* [Transaction stream](/docs/reference/aptos-grpc-transaction-stream) for detailed `RawData` service documentation

--- a/content/api-reference/aptos-grpc/transaction-stream.mdx
+++ b/content/api-reference/aptos-grpc/transaction-stream.mdx
@@ -1,0 +1,47 @@
+---
+title: Transaction stream
+description: Aptos gRPC RawData service API reference
+slug: reference/aptos-grpc-transaction-stream
+---
+
+The `RawData` service provides server-streaming access to complete Aptos transaction data.
+
+## GetTransactions
+
+Streams transactions in version order, starting from a given version. This is a server-streaming RPC: the server sends batches of transactions until the requested count is reached, or indefinitely if no count is set.
+
+**Request**:
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `starting_version` | uint64 | No | Version to start streaming from. If omitted, the stream starts at the latest version |
+| `transactions_count` | uint64 | No | Total number of transactions to return before closing the stream. If omitted, the stream stays open indefinitely |
+| `batch_size` | uint64 | No | Number of transactions per response message. If omitted, the server chooses a default |
+| `transaction_filter` | BooleanTransactionFilter | No | Server-side filter; only matching transactions are delivered |
+
+**Response** (stream):
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `transactions` | repeated Transaction | A batch of transactions in version order |
+| `chain_id` | uint64 | The chain ID of the network |
+| `processed_range` | ProcessedRange | First and last version covered by this response, useful when filtering |
+
+```bash cURL
+grpcurl \
+  -H "Authorization: Bearer <YOUR_API_KEY>" \
+  -import-path protos/proto \
+  -proto aptos/indexer/v1/raw_data.proto \
+  -d '{
+    "starting_version": 100000000,
+    "transactions_count": 100
+  }' \
+  aptos-mainnet.g.alchemy.com:443 \
+  aptos.indexer.v1.RawData/GetTransactions
+```
+
+Each `Transaction` message includes the transaction type (user, genesis, block metadata, state checkpoint, or validator), timestamp, version, transaction info with events and write-set changes, and the type-specific payload. See the [transaction proto](https://github.com/aptos-labs/aptos-core/blob/main/protos/proto/aptos/transaction/v1/transaction.proto) for the full schema.
+
+<Note>
+  This is a long-lived streaming connection. The server will continue sending transactions until the requested `transactions_count` is reached or the client disconnects. To resume after a disconnect, reconnect with `starting_version` set to the last processed version plus one.
+</Note>

--- a/content/docs.yml
+++ b/content/docs.yml
@@ -411,6 +411,21 @@ navigation:
           - api: Aptos API Endpoints
             api-name: aptos
             flattened: true
+          - section: Aptos gRPC
+            contents:
+              - section: Getting started
+                contents:
+                  - page: Overview
+                    path: api-reference/aptos-grpc/overview.mdx
+                  - page: Quickstart
+                    path: api-reference/aptos-grpc/quickstart.mdx
+                slug: getting-started
+              - section: API reference
+                contents:
+                  - page: Transaction stream
+                    path: api-reference/aptos-grpc/transaction-stream.mdx
+                slug: api-reference
+            slug: aptos-grpc
           - page: FAQ
             path: api-reference/aptos/aptos-api-faq.mdx
         slug: aptos


### PR DESCRIPTION
## Summary

- Adds dedicated documentation for the Aptos gRPC Transaction Stream API (`aptos.indexer.v1.RawData/GetTransactions`, server-streaming)
- Includes an overview with REST equivalent mapping, a quickstart guide (proto setup, fixed-batch fetch, live streaming, resume-after-disconnect), and a `RawData` service reference page
- Adds an Aptos gRPC section to docs navigation, nested under the Aptos chain section (same structure as Sui gRPC)

## Notes for reviewers

- gRPC server reflection is not supported through Alchemy endpoints, so the docs instruct clients to supply the `aptos-core` proto files explicitly — this is called out in both the overview and quickstart.
- The endpoints table lists both `aptos-mainnet` and `aptos-testnet`. Testnet is verified end-to-end in prod; please confirm mainnet indexer gRPC enablement status with node-ops before merging (it was still pending as of late July).

## Validation

- `pnpm run validate:docs-yml` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)