### PR TITLE
Nest Admin API under Tools with split URLs and independent hiding

### DIFF
--- a/content/admin-api/DOCUMENTATION-PLAN.md
+++ b/content/admin-api/DOCUMENTATION-PLAN.md
@@ -1,0 +1,52 @@
+# Admin API documentation plan
+
+Internal planning doc. Not published on the docs site unless added to `docs.yml`.
+
+---
+
+## Target
+
+Admin API stays under **Tools & Resources → Tools**. Nested sections are Apps, Chains, and Usage. Nested sections do not have their own overview or quickstart.
+
+```
+Tools
+└── Admin API                         (hidden until GA)
+    ├── Overview                      /docs/reference/admin-api/overview
+    ├── Quickstart                    /docs/reference/admin-api/quickstart
+    ├── Apps                          /docs/admin-api/apps/{operation}
+    ├── Chains                        /docs/admin-api/chains/{operation}
+    └── Usage                         /docs/admin-api/usage/{operation}
+```
+
+## How URLs work
+
+Prose pages set `slug:` in frontmatter (`reference/admin-api/overview`). Endpoint pages inherit the parent section path. Each of Apps, Chains, and Usage uses `url-path` so endpoints do not pick up the Tools tab slug `tutorials`.
+
+## Visibility
+
+Each of Overview, Quickstart, Apps, Chains, and Usage can set `hidden: true` independently. Hidden pages still load by URL and stay out of search.
+
+Until a docs-site follow-up ships, a hidden URL does not show that section in the sidebar. The follow-up should show only the hidden section that contains the current URL (a Usage link shows Usage, not Apps).
+
+## External dependencies
+
+1. **Dashboard apps API** — OpenAPI tags `Apps` and `Chains` on the tsoa controllers, then deploy so `https://admin-api.alchemy.com/openapi.yaml` includes those tags. Docs `include-tags` filtering needs the tagged spec.
+2. **docs-site (follow-up)** — When the current URL sits inside a hidden section, show that section in the sidebar and keep other hidden sections hidden.
+
+## Related files
+
+| File | Role |
+|---|---|
+| `content/docs.yml` | Nav, visibility, api blocks |
+| `content/admin-api/*.mdx` | Admin API prose |
+| `content/remote-specs.json` | Remote OpenAPI sources |
+| `content/redirects.yml` | URL redirects |
+| `src/content-indexer/` | Builds paths and nav from `docs.yml` |
+
+## Changelog
+
+| Date | Notes |
+|---|---|
+| 2026-08-07 | Initial plan from IA discussion |
+| 2026-08-07 | Tightened for stakeholder review |
+| 2026-08-13 | Stay under Tools; split URL prefixes; nest Apps, Chains, Usage; docs-site sidebar filter is a follow-up |

--- a/content/admin-api/overview.mdx
+++ b/content/admin-api/overview.mdx
@@ -1,12 +1,14 @@
 ---
-title: App Management API Overview
-subtitle: Programmatically create, configure, and manage Alchemy apps.
+title: Admin API Overview
+subtitle: Programmatically manage Alchemy apps, networks, and usage.
 slug: reference/admin-api/overview
 ---
 
-The App Management API lets you programmatically create, configure, and manage Alchemy apps without using the Alchemy Dashboard. It is designed for automation, compliance, and enterprise workflows.
+The Admin API lets you manage Alchemy apps, list supported networks, and inspect compute unit usage without using the Alchemy Dashboard. Use it for automation, compliance, billing alerts, and enterprise workflows.
 
-An App represents a single Alchemy project. You create an app, configure which networks it can access, and optionally restrict usage via allowlists. All changes are applied immediately.
+An App represents a single Alchemy project. You create an app, configure which networks it can access, and optionally restrict usage via allowlists. All app changes are applied immediately.
+
+Usage data includes compute unit totals, estimated USD cost, billing period boundaries, and optional breakdowns by app, network, method, and request type.
 
 ***
 
@@ -19,18 +21,40 @@ Use this API to:
 * Manage network and allowlist settings
 * Retrieve app details
 * Query supported networks
+* Retrieve account usage summaries for the current billing period and recent rolling windows
+* Query usage time series with hourly or daily granularity
+* Filter usage by app, network, method, and request type
+* Group usage results by request type, app, network, or method
 
-Each request is authenticated using an access key and returns JSON responses.
+Each request is authenticated and returns JSON responses.
 
 ***
 
 ## Authentication
 
-All requests must include an access key with App Management permissions.
+All requests must include an access key. Grant only the permissions the caller needs:
+
+* **App Management** read or read and write, for apps and chains
+* **Usage** read (`ADMIN_USAGE_READ`), for usage endpoints
+
+You can also authenticate usage requests with a dashboard user session token that has the `viewer`, `developer`, or `admin` role.
 
 To create an access key:
 
 1. Go to the [security tab](https://dashboard.alchemy.com/settings/security?utm_source=docs&utm_medium=referral&utm_content=reference_admin-api_overview) in the Alchemy Dashboard
 2. Create a new access key
-3. Enable App Management with Read & Write permissions
+3. Enable App Management and/or Usage with the permissions you need
 
+***
+
+## Plan limits
+
+Time-series query ranges are limited by plan:
+
+| Plan | Maximum range |
+|---|---:|
+| Free | 1 day |
+| Pay as You Go | 7 days |
+| Longer ranges | [Contact sales](https://www.alchemy.com/contact-sales) |
+
+If you request a range longer than your plan supports, the API returns results for the allowed range.

--- a/content/admin-api/quickstart.mdx
+++ b/content/admin-api/quickstart.mdx
@@ -1,41 +1,43 @@
 ---
 title: Admin API Quickstart
-subtitle: Create, configure, and manage an app using the Admin API.
+subtitle: Create an app and query usage with the Admin API.
 slug: reference/admin-api/quickstart
 ---
 
 ## Get started
 
-This guide walks through creating an app, retrieving its details, updating its configuration, and deleting it.
+This guide walks through creating an app, updating its configuration, and querying account usage.
 
 ### Prerequisites
 
-* An access key with App Management **write** permissions
-  * Refer to the overview authentication section for instructions to create an access key
+* An access key with App Management **write** permissions and Usage **read** permissions
+  * Refer to the [overview authentication section](/docs/reference/admin-api/overview#authentication) for instructions to create an access key
 
-## Set up Environment Variables
+## Set up environment variables
 
 ```bash
 export ALCHEMY_ADMIN_BASE_URL="https://admin-api.alchemy.com/v1"
 export ALCHEMY_ADMIN_ACCESS_KEY="YOUR_ACCESS_KEY_HERE"
 ```
 
-Auth Header
+Auth header:
 
 ```bash
 export ALCHEMY_ADMIN_AUTH_HEADER="Authorization: Bearer $ALCHEMY_ADMIN_ACCESS_KEY"
 ```
 
-## Get chain network options
+## 1. Get chain network options
 
-Use this endpoint to retrieve the list of supported networks and their identifiers. These values are required when configuring network allowlists.
+Retrieve the list of supported networks and their identifiers. These values are required when you configure network allowlists.
 
 ```bash
 curl "$ALCHEMY_ADMIN_BASE_URL/chains" \
   -H "$ALCHEMY_ADMIN_AUTH_HEADER"
 ```
 
-## 1. Create an app
+See the [List chains](/docs/admin-api/chains/list-chains) endpoint for response fields.
+
+## 2. Create an app
 
 Create a new app by providing a name, description, and supported networks.
 
@@ -79,7 +81,9 @@ Example response:
 }
 ```
 
-## 2. Get app info
+See the [Create app](/docs/admin-api/apps/create-app) endpoint for request options.
+
+## 3. Get app info
 
 Retrieve details for a single app using its `app_id`.
 
@@ -90,9 +94,7 @@ curl "$ALCHEMY_ADMIN_BASE_URL/apps/$APP_ID" \
   -H "$ALCHEMY_ADMIN_AUTH_HEADER"
 ```
 
-***
-
-## 3. Update app configuration
+## 4. Update app configuration
 
 App updates are split between **metadata updates** and **configuration updates**.
 
@@ -115,7 +117,7 @@ curl -X PATCH "$ALCHEMY_ADMIN_BASE_URL/apps/$APP_ID" \
 
 ### Update network allowlist (optional)
 
-Update the set of networks this app is allowed to access. Network values must come from the Chains endpoint. The networks provided will replace the current list.
+Update the set of networks this app is allowed to access. Network values must come from the Chains endpoint. The networks you provide replace the current list.
 
 ```bash
 APP_ID="app_123"
@@ -162,7 +164,115 @@ curl -X PUT "$ALCHEMY_ADMIN_BASE_URL/apps/$APP_ID/ip-allowlist" \
   }'
 ```
 
-## 4. Delete the app
+## 5. Get usage summary
+
+Retrieve usage totals for the current billing period and recent rolling windows.
+
+```bash
+curl "$ALCHEMY_ADMIN_BASE_URL/usage/summary" \
+  -H "$ALCHEMY_ADMIN_AUTH_HEADER"
+```
+
+Example response:
+
+```json
+{
+  "data": {
+    "billingPeriod": {
+      "startTime": "2026-06-01T00:00:00Z",
+      "endTime": "2026-07-01T00:00:00Z"
+    },
+    "totals": {
+      "last7Days": {
+        "amount": "1250000",
+        "unit": "ALCHEMY_COMPUTE_UNIT",
+        "usd": "12.50"
+      },
+      "last30Days": {
+        "amount": "4800000",
+        "unit": "ALCHEMY_COMPUTE_UNIT",
+        "usd": "48.00"
+      },
+      "monthToDate": {
+        "amount": "3200000",
+        "unit": "ALCHEMY_COMPUTE_UNIT",
+        "usd": "32.00"
+      }
+    },
+    "usageLimit": {
+      "unit": "CU",
+      "limit": "10000000",
+      "used": "3200000",
+      "remaining": "6800000",
+      "percentUsed": 32
+    },
+    "freshness": {
+      "dataThrough": "2026-06-28T23:59:00Z",
+      "containsPartialToday": true,
+      "updateCadence": "minute"
+    }
+  }
+}
+```
+
+See the [Get usage summary](/docs/admin-api/usage/get-usage-summary) endpoint for response fields.
+
+## 6. Get usage time series
+
+Query daily usage over a date range. You can optionally filter by app, network, method, or request type, and group results by one dimension.
+
+```bash
+curl -X POST "$ALCHEMY_ADMIN_BASE_URL/usage/time-series" \
+  -H "Content-Type: application/json" \
+  -H "$ALCHEMY_ADMIN_AUTH_HEADER" \
+  -d '{
+    "startTime": "2026-06-01T00:00:00Z",
+    "endTime": "2026-06-07T23:59:59Z",
+    "granularity": "day",
+    "products": ["SUPERNODE_CU"],
+    "metrics": ["amount", "usd"],
+    "groupBy": ["network"]
+  }'
+```
+
+Example response:
+
+```json
+{
+  "data": {
+    "query": {
+      "startTime": "2026-06-01T00:00:00Z",
+      "endTime": "2026-06-07T23:59:59Z",
+      "granularity": "day",
+      "products": ["SUPERNODE_CU"],
+      "metrics": ["amount", "usd"],
+      "groupBy": ["network"]
+    },
+    "freshness": {
+      "dataThrough": "2026-06-07T23:59:00Z",
+      "containsPartialToday": false,
+      "updateCadence": "minute"
+    },
+    "data": [
+      {
+        "startTime": "2026-06-01T00:00:00Z",
+        "endTime": "2026-06-02T00:00:00Z",
+        "isPartial": false,
+        "dimensions": {
+          "network": "eth-mainnet"
+        },
+        "amount": "450000",
+        "unit": "ALCHEMY_COMPUTE_UNIT",
+        "usd": "4.50"
+      }
+    ]
+  }
+}
+```
+
+See the [Get usage time series](/docs/admin-api/usage/get-usage-time-series) endpoint for request options.
+
+## 7. Delete the app
 
 Permanently delete an app. This action cannot be undone.
 
@@ -172,3 +282,7 @@ APP_ID="app_123"
 curl -X DELETE "$ALCHEMY_ADMIN_BASE_URL/apps/$APP_ID" \
   -H "$ALCHEMY_ADMIN_AUTH_HEADER"
 ```
+
+## Next steps
+
+* Use the [Alchemy CLI](/docs/alchemy-cli#usage) to query usage from the terminal without writing HTTP requests

--- a/content/docs-yml.schema.json
+++ b/content/docs-yml.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Alchemy docs.yml",
-  "description": "Navigation configuration for the Alchemy docs site. Allows only the options supported by the content indexer (src/content-indexer/types/docsYaml.ts), including Alchemy-specific extensions (skip-slug, flattened).",
+  "description": "Navigation configuration for the Alchemy docs site. Allows only the options supported by the content indexer (src/content-indexer/types/docsYaml.ts), including Alchemy-specific extensions (skip-slug, flattened, url-path, include-tags).",
   "type": "object",
   "additionalProperties": false,
   "required": ["navigation"],
@@ -121,6 +121,10 @@
           "description": "Alchemy extension: omit this section's slug from descendant URL paths.",
           "type": "boolean"
         },
+        "url-path": {
+          "description": "Alchemy extension: replace the inherited URL path for this section and its descendants. Do not include a /docs prefix.",
+          "type": "string"
+        },
         "hidden": {
           "description": "Hide this section and its contents from the sidebar and search indexing.",
           "type": "boolean"
@@ -172,6 +176,13 @@
         "flattened": {
           "description": "Alchemy extension: render endpoints as a flat list instead of grouped by spec hierarchy.",
           "type": "boolean"
+        },
+        "include-tags": {
+          "description": "Alchemy extension: keep only OpenAPI operations whose first tag is in this list.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     }

--- a/content/docs.yml
+++ b/content/docs.yml
@@ -2117,12 +2117,32 @@ navigation:
                 path: admin-api/overview.mdx
               - page: Quickstart
                 path: admin-api/quickstart.mdx
-              - api: Admin API Endpoints
-                api-name: admin-api
-                flattened: true
-              - api: Usage API Endpoints
-                api-name: usage-api
-                flattened: true
+              - section: Apps
+                hidden: true
+                url-path: admin-api/apps
+                contents:
+                  - api: Apps
+                    api-name: admin-api
+                    include-tags: [Apps]
+                    skip-slug: true
+                    flattened: true
+              - section: Chains
+                hidden: true
+                url-path: admin-api/chains
+                contents:
+                  - api: Chains
+                    api-name: admin-api
+                    include-tags: [Chains]
+                    skip-slug: true
+                    flattened: true
+              - section: Usage
+                hidden: true
+                url-path: admin-api/usage
+                contents:
+                  - api: Usage
+                    api-name: usage-api
+                    skip-slug: true
+                    flattened: true
           - section: Activity Log
             hidden: true
             contents:

--- a/content/docs.yml
+++ b/content/docs.yml
@@ -2115,8 +2115,10 @@ navigation:
             contents:
               - page: Overview
                 path: admin-api/overview.mdx
+                hidden: true
               - page: Quickstart
                 path: admin-api/quickstart.mdx
+                hidden: true
               - section: Apps
                 hidden: true
                 url-path: admin-api/apps

--- a/content/redirects.yml
+++ b/content/redirects.yml
@@ -2097,6 +2097,56 @@ redirects:
     destination: /docs/reference/nft-api-overview
     permanent: true
 
+  # Admin API URL realignment (Tools nav, /docs/admin-api/{apps|chains|usage}/... endpoints)
+  - source: /docs/reference/usage-api/overview
+    destination: /docs/reference/admin-api/overview
+    permanent: true
+  - source: /docs/reference/usage-api/quickstart
+    destination: /docs/reference/admin-api/quickstart
+    permanent: true
+  - source: /docs/tutorials/tools/usage-api/usage-api-endpoints/get-usage-summary
+    destination: /docs/admin-api/usage/get-usage-summary
+    permanent: true
+  - source: /docs/tutorials/tools/usage-api/usage-api-endpoints/get-usage-time-series
+    destination: /docs/admin-api/usage/get-usage-time-series
+    permanent: true
+  - source: /docs/tutorials/tools/admin-api/usage-api-endpoints/get-usage-summary
+    destination: /docs/admin-api/usage/get-usage-summary
+    permanent: true
+  - source: /docs/tutorials/tools/admin-api/usage-api-endpoints/get-usage-time-series
+    destination: /docs/admin-api/usage/get-usage-time-series
+    permanent: true
+  - source: /docs/tutorials/tools/admin-api/admin-api-endpoints/list-chains
+    destination: /docs/admin-api/chains/list-chains
+    permanent: true
+  - source: /docs/tutorials/tools/admin-api/admin-api-endpoints/list-apps
+    destination: /docs/admin-api/apps/list-apps
+    permanent: true
+  - source: /docs/tutorials/tools/admin-api/admin-api-endpoints/create-app
+    destination: /docs/admin-api/apps/create-app
+    permanent: true
+  - source: /docs/tutorials/tools/admin-api/admin-api-endpoints/get-app
+    destination: /docs/admin-api/apps/get-app
+    permanent: true
+  - source: /docs/tutorials/tools/admin-api/admin-api-endpoints/delete-app
+    destination: /docs/admin-api/apps/delete-app
+    permanent: true
+  - source: /docs/tutorials/tools/admin-api/admin-api-endpoints/patch-app
+    destination: /docs/admin-api/apps/patch-app
+    permanent: true
+  - source: /docs/tutorials/tools/admin-api/admin-api-endpoints/update-app-network-allowlist
+    destination: /docs/admin-api/apps/update-app-network-allowlist
+    permanent: true
+  - source: /docs/tutorials/tools/admin-api/admin-api-endpoints/update-app-address-allowlist
+    destination: /docs/admin-api/apps/update-app-address-allowlist
+    permanent: true
+  - source: /docs/tutorials/tools/admin-api/admin-api-endpoints/update-app-origin-allowlist
+    destination: /docs/admin-api/apps/update-app-origin-allowlist
+    permanent: true
+  - source: /docs/tutorials/tools/admin-api/admin-api-endpoints/update-app-ip-allowlist
+    destination: /docs/admin-api/apps/update-app-ip-allowlist
+    permanent: true
+
   # Dynamic Redirect MUST be at the end of the redirects list. This is because redirects are processed in order
   # and we want static redirects to take precedence over dynamic redirects.
   # ======================================= Dynamic Redirects ========================================

--- a/src/content-indexer/types/docsYaml.ts
+++ b/src/content-indexer/types/docsYaml.ts
@@ -14,6 +14,8 @@ export interface SectionConfig {
   hidden?: boolean;
   contents: NavigationItem[];
   path?: string; // Optional overview page
+  /** Full URL path override for this section and its children (no /docs prefix). */
+  "url-path"?: string;
 }
 
 export interface LinkConfig {
@@ -28,6 +30,8 @@ export interface ApiConfig {
   "skip-slug"?: boolean;
   hidden?: boolean;
   flattened?: boolean;
+  /** Keep only OpenAPI operations whose first tag is in this list. */
+  "include-tags"?: string[];
 }
 
 export interface ChangelogConfig {

--- a/src/content-indexer/visitors/__tests__/visit-api-reference.test.ts
+++ b/src/content-indexer/visitors/__tests__/visit-api-reference.test.ts
@@ -299,4 +299,52 @@ describe("visitApiReference", () => {
     // Should return array instead of wrapped in API section
     expect(Array.isArray(result.navItem)).toBe(true);
   });
+
+  test("should pass include-tags through to OpenAPI processing", () => {
+    const context = new ProcessingContext("docs");
+    const cache = new ContentCache();
+
+    cache.setSpec("admin-api", {
+      specType: "openapi",
+      spec: openApiSpecFactory({
+        paths: {
+          "/apps": {
+            get: {
+              operationId: "ListApps",
+              tags: ["Apps"],
+              responses: { "200": { description: "Success" } },
+            },
+          },
+          "/chains": {
+            get: {
+              operationId: "ListChains",
+              tags: ["Chains"],
+              responses: { "200": { description: "Success" } },
+            },
+          },
+        },
+      }),
+      specId: "alchemy/rest/admin-api.json",
+    });
+
+    const result = visitApiReference({
+      item: {
+        api: "Apps",
+        "api-name": "admin-api",
+        "skip-slug": true,
+        flattened: true,
+        "include-tags": ["Apps"],
+      },
+      parentPath: PathBuilder.init("admin-api/apps"),
+      tab: "get-started",
+      stripPathPrefix: undefined,
+      contentCache: cache,
+      context,
+      navigationAncestors: [],
+    });
+
+    expect(Object.keys(result.indexEntries)).toEqual([
+      "admin-api/apps/list-apps",
+    ]);
+  });
 });

--- a/src/content-indexer/visitors/__tests__/visit-section.test.ts
+++ b/src/content-indexer/visitors/__tests__/visit-section.test.ts
@@ -545,4 +545,36 @@ describe("visitSection", () => {
       expect(result.navItem.children[2].type).toBe("link");
     }
   });
+
+  test("should replace inherited path when url-path is set", () => {
+    const context = new ProcessingContext("docs");
+    const cache = new ContentCache();
+
+    const result = visitSection(
+      {
+        item: {
+          section: "Apps",
+          "url-path": "admin-api/apps",
+          contents: [
+            {
+              page: "Create app",
+              path: "content/admin-api/create-app.mdx",
+            },
+          ],
+        },
+        parentPath: PathBuilder.init("tutorials/tools/admin-api"),
+        tab: "get-started",
+        stripPathPrefix: undefined,
+        contentCache: cache,
+        context,
+        navigationAncestors: [],
+      },
+      visitNavigationItem,
+    );
+
+    expect(result.indexEntries["admin-api/apps/create-app"]).toBeDefined();
+    expect(
+      result.indexEntries["tutorials/tools/admin-api/apps/create-app"],
+    ).toBeUndefined();
+  });
 });

--- a/src/content-indexer/visitors/processors/__tests__/process-openapi.test.ts
+++ b/src/content-indexer/visitors/processors/__tests__/process-openapi.test.ts
@@ -456,4 +456,55 @@ describe("processOpenApiSpec", () => {
       expect(result.navItem.children[0].type).toBe("endpoint");
     }
   });
+
+  test("should keep only operations whose first tag is in includeTags", () => {
+    const context = new ProcessingContext("docs");
+
+    const result = processOpenApiSpec({
+      spec: openApiSpecFactory({
+        paths: {
+          "/apps": {
+            get: {
+              operationId: "ListApps",
+              tags: ["Apps"],
+              responses: { "200": { description: "Success" } },
+            },
+          },
+          "/chains": {
+            get: {
+              operationId: "ListChains",
+              tags: ["Chains"],
+              responses: { "200": { description: "Success" } },
+            },
+          },
+        },
+      }),
+      specId: "alchemy/rest/admin-api.json",
+      visitorConfig: {
+        item: { api: "Apps", "api-name": "admin-api" },
+        parentPath: PathBuilder.init(),
+        tab: "get-started",
+        stripPathPrefix: undefined,
+        contentCache: new ContentCache(),
+        context,
+        navigationAncestors: [],
+      },
+      apiPathBuilder: PathBuilder.init("admin-api/apps"),
+      apiTitle: "Apps",
+      isHidden: false,
+      isFlattened: true,
+      includeTags: ["Apps"],
+    });
+
+    expect(Object.keys(result.indexEntries)).toEqual([
+      "admin-api/apps/list-apps",
+    ]);
+    expect(result.indexEntries["admin-api/apps/list-chains"]).toBeUndefined();
+    expect(Array.isArray(result.navItem)).toBe(true);
+    if (Array.isArray(result.navItem)) {
+      expect(result.navItem).toHaveLength(1);
+      expect(result.navItem[0].type).toBe("endpoint");
+      expect(result.navItem[0].path).toBe("/admin-api/apps/list-apps");
+    }
+  });
 });

--- a/src/content-indexer/visitors/processors/process-openapi.ts
+++ b/src/content-indexer/visitors/processors/process-openapi.ts
@@ -32,6 +32,8 @@ export interface ProcessOpenApiConfig {
   apiTitle: string;
   isHidden: boolean;
   isFlattened: boolean;
+  /** When set, keep only operations whose first OpenAPI tag is in this list. */
+  includeTags?: string[];
 }
 
 interface BuildOpenApiIndexEntriesConfig {
@@ -182,11 +184,20 @@ export const processOpenApiSpec = ({
   apiTitle,
   isHidden,
   isFlattened,
+  includeTags,
 }: ProcessOpenApiConfig): VisitorResult => {
   const { tab, context, navigationAncestors } = visitorConfig;
 
   // Extract operations and build index entries
-  const operations = extractOpenApiOperations(spec.paths);
+  let operations = extractOpenApiOperations(spec.paths);
+  if (includeTags && includeTags.length > 0) {
+    const allowedTags = new Set(includeTags);
+    operations = operations
+      .filter((operation) => operation.tag && allowedTags.has(operation.tag))
+      // The yaml section already groups these endpoints, so drop the tag
+      // to avoid a duplicate URL segment and sidebar wrapper.
+      .map((operation) => ({ ...operation, tag: undefined }));
+  }
   const indexEntries = buildOpenApiIndexEntries({
     operations,
     apiPathBuilder,

--- a/src/content-indexer/visitors/visit-api-reference.ts
+++ b/src/content-indexer/visitors/visit-api-reference.ts
@@ -30,6 +30,7 @@ export const visitApiReference = (config: ApiVisitorConfig): VisitorResult => {
   const skipSlug = apiConfig["skip-slug"] ?? false;
   const isHidden = apiConfig.hidden || config.isAncestorHidden || false;
   const isFlattened = apiConfig.flattened ?? false;
+  const includeTags = apiConfig["include-tags"];
 
   // Build path for this API
   const apiPathBuilder = skipSlug
@@ -58,6 +59,7 @@ export const visitApiReference = (config: ApiVisitorConfig): VisitorResult => {
         apiTitle: apiConfig.api,
         isHidden,
         isFlattened,
+        includeTags,
       });
 
     case "openrpc":

--- a/src/content-indexer/visitors/visit-section.ts
+++ b/src/content-indexer/visitors/visit-section.ts
@@ -42,6 +42,7 @@ export const visitSection = (
   } = config;
   const sectionUrlSlug = sectionItem.slug ?? kebabCase(sectionItem.section);
   const skipSlug = sectionItem["skip-slug"] ?? false;
+  const urlPathSegments = sectionItem["url-path"]?.split("/").filter(Boolean);
 
   let sectionFullSlug: string[] | undefined;
   let sectionPath: string | undefined;
@@ -51,7 +52,7 @@ export const visitSection = (
   if (sectionItem.path) {
     const cached = contentCache.getMdxContent(sectionItem.path);
     const normalizedSlug = normalizeSlug(cached?.frontmatter.slug as string);
-    sectionFullSlug = normalizedSlug?.split("/");
+    sectionFullSlug = urlPathSegments ?? normalizedSlug?.split("/");
 
     const sectionPathBuilder = parentPath.apply({
       fullSlug: sectionFullSlug,
@@ -90,7 +91,7 @@ export const visitSection = (
 
   // Create path builder for children
   const childPathBuilder = parentPath.apply({
-    fullSlug: sectionFullSlug,
+    fullSlug: urlPathSegments ?? sectionFullSlug,
     urlSlug: sectionUrlSlug,
     skipUrlSlug: skipSlug,
   });


### PR DESCRIPTION
## Description

Restructure Admin API docs under Tools with stable endpoint URLs at `/docs/admin-api/{apps|chains|usage}/...`, independent `hidden` flags per section, and redirects from old paths. Also hide Overview and Quickstart on their own so a Usage-only sidebar does not leak those prose pages when the parent Admin API section is revealed.

This depends on the docs-site sidebar follow-up in OMGWINNING/docs-site for Usage-only / Apps-only sidebar behavior.

## Changes Made

- Add indexer support for `url-path` and `include-tags` so Apps, Chains, and Usage get separate URL prefixes from one OpenAPI spec
- Nest Apps, Chains, and Usage under Tools → Admin API in `docs.yml`
- Merge Usage prose into Admin API overview/quickstart; add redirects from old tutorial/reference URLs
- Set `hidden: true` on Overview and Quickstart independently (not only via parent section)
- Update Admin API documentation plan

## Testing

- [ ] I have tested these changes locally
- [ ] I have run the validation scripts (`pnpm run validate`)
- [ ] I have checked that the documentation builds correctly
- [x] Indexer tests updated for `url-path` and `include-tags`
- [ ] Confirm tagged admin-api spec is deployed before merging `include-tags` filtering

## Stack PRs

1. **alchemyplatform/docs** (this PR) — content, nav, indexer, redirects
2. **OMGWINNING/docs-site** — reveal only the deepest hidden nav section in sidebar

Merge docs-site after or with this PR so hidden Usage URLs get the correct sidebar.

Created using the /git skill.
Co-Authored-By: Composer

Made with [Cursor](https://cursor.com)