### PR TITLE
Hide Admin API Overview and Quickstart independently in nav

### DIFF
--- a/content/docs.yml
+++ b/content/docs.yml
@@ -2115,8 +2115,10 @@ navigation:
             contents:
               - page: Overview
                 path: admin-api/overview.mdx
+                hidden: true
               - page: Quickstart
                 path: admin-api/quickstart.mdx
+                hidden: true
               - section: Apps
                 hidden: true
                 url-path: admin-api/apps


### PR DESCRIPTION
## Description

The Admin API nesting IA was merged in #1525. This follow-up adds `hidden: true` on Overview and Quickstart so a Usage-only (or Apps-only) sidebar does not leak those prose pages when the parent Admin API section is revealed.

Pairs with OMGWINNING/docs-site#361, which reveals only the deepest hidden nav section.

## Changes Made

- Set `hidden: true` on Admin API Overview and Quickstart in `content/docs.yml`

## Testing

- [x] I have tested these changes locally
- [ ] Re-index content after merge so Redis picks up the new hidden flags

Created using the /git skill.
Co-Authored-By: Composer

Made with [Cursor](https://cursor.com)