### PR TITLE
Document Admin API usage products and drop usd from time-series examples

### DIFF
--- a/content/admin-api/overview.mdx
+++ b/content/admin-api/overview.mdx
@@ -58,3 +58,30 @@ Time-series query ranges are limited by plan:
 | Longer ranges | [Contact sales](https://www.alchemy.com/contact-sales) |
 
 If you request a range longer than your plan supports, the API returns results for the allowed range.
+
+***
+
+## Time series products
+
+The `products` field on the time series endpoint selects which meter to query.
+
+If you omit `products`, the API uses `SUPERNODE_CU`. That meter is core RPC only. It does not include Enhanced APIs.
+
+You can pass more than one product when those products share a unit. A request cannot mix CU products with `SOLANA_GRPC_TB` or `SPONSORED_GAS`.
+
+For CU prices per method, see [Compute Units](/docs/reference/compute-units).
+
+| `products` value | What it measures | Unit |
+|---|---|---|
+| `SUPERNODE_CU` | Core RPC (default). Node methods, including `eth_*` and Solana JSON-RPC. | CU |
+| `SUPERNODE_ENHANCED_CU` | Enhanced APIs: NFT, Token, Transfers, Portfolio, and Prices. | CU |
+| `SOLANA_ARCHIVAL_CU` | Solana archival RPC. Historical Solana reads. | CU |
+| `BLAST_CU` | Blast RPC. | CU |
+| `SPONSORED_GAS` | Gas Manager sponsored transactions. | sponsored gas |
+| `SOLANA_GRPC_TB` | Solana Yellowstone gRPC streams. | TB |
+
+A dashboard-style CU query uses both core RPC and Enhanced APIs:
+
+```json
+"products": ["SUPERNODE_CU", "SUPERNODE_ENHANCED_CU"]
+```

--- a/content/admin-api/quickstart.mdx
+++ b/content/admin-api/quickstart.mdx
@@ -230,7 +230,7 @@ curl -X POST "$ALCHEMY_ADMIN_BASE_URL/usage/time-series" \
     "endTime": "2026-06-07T23:59:59Z",
     "granularity": "day",
     "products": ["SUPERNODE_CU"],
-    "metrics": ["amount", "usd"],
+    "metrics": ["amount"],
     "groupBy": ["network"]
   }'
 ```
@@ -245,7 +245,7 @@ Example response:
       "endTime": "2026-06-07T23:59:59Z",
       "granularity": "day",
       "products": ["SUPERNODE_CU"],
-      "metrics": ["amount", "usd"],
+      "metrics": ["amount"],
       "groupBy": ["network"]
     },
     "freshness": {
@@ -262,8 +262,7 @@ Example response:
           "network": "eth-mainnet"
         },
         "amount": "450000",
-        "unit": "ALCHEMY_COMPUTE_UNIT",
-        "usd": "4.50"
+        "unit": "ALCHEMY_COMPUTE_UNIT"
       }
     ]
   }

--- a/content/admin-api/quickstart.mdx
+++ b/content/admin-api/quickstart.mdx
@@ -221,6 +221,8 @@ See the [Get usage summary](/docs/admin-api/usage/get-usage-summary) endpoint fo
 
 Query daily usage over a date range. You can optionally filter by app, network, method, or request type, and group results by one dimension.
 
+The `products` values are listed in [Time series products](/docs/reference/admin-api/overview#time-series-products). If you omit `products`, the API uses `SUPERNODE_CU`.
+
 ```bash
 curl -X POST "$ALCHEMY_ADMIN_BASE_URL/usage/time-series" \
   -H "Content-Type: application/json" \


### PR DESCRIPTION
## Description

The Admin API quickstart still treated `usd` as a usage time-series metric. The Usage API dropped that metric, so the sample curl returns 400 and the sample response does not match the live payload.

Callers also had no map from time-series `products` names (`SUPERNODE_CU`, `SUPERNODE_ENHANCED_CU`, and the rest) to meters and units. This PR adds that table to the Admin API overview and links to it from the quickstart.

This follows the CLI docs fix in #1526 and the API change in OMGWINNING/dashboard#8380. Summary examples still include `usd` on totals, which remains valid.

The generated Get usage time series page cannot host this table. Companion OpenAPI descriptions in OMGWINNING/dashboard#8387 link to the overview table after usage-api deploy.

## Related Issues

LINEAR TASK: https://linear.app/alchemyapi/issue/DX-3525/remove-usd-cost-from-time-series-api

Companion OpenAPI enum docs: https://github.com/OMGWINNING/dashboard/pull/8387

## Changes Made

- Set the time-series request `metrics` example to `["amount"]` only
- Echo `["amount"]` in the sample query object
- Remove `usd` from time-series data points; those points return `amount` and `unit` only
- Add a Time series products table on the Admin API overview
- Link to that table from the quickstart time-series section

## Testing

- [x] Confirmed remaining `usd` fields in this file are on the usage **summary** totals, which still support that field
- [x] ESLint passed on `content/admin-api/overview.mdx` and `content/admin-api/quickstart.mdx`
- [ ] I have tested these changes locally
- [ ] I have run the validation scripts (`pnpm run validate`)
- [ ] I have checked that the documentation builds correctly

Created using the /git skill.
Co-Authored-By: Cursor Grok 4.6