### PR TITLE
Unhide Admin API Apps and Chains in nav

### DIFF
--- a/content/admin-api/overview.mdx
+++ b/content/admin-api/overview.mdx
@@ -10,6 +10,8 @@ An App represents a single Alchemy project. You create an app, configure which n
 
 Usage data includes compute unit totals, estimated USD cost, billing period boundaries, and optional breakdowns by app, network, method, and request type.
 
+<Markdown src="usage-beta-notice.mdx" />
+
 ***
 
 ## What you can do
@@ -35,7 +37,7 @@ Each request is authenticated and returns JSON responses.
 All requests must include an access key. Grant only the permissions the caller needs:
 
 * **App Management** read or read and write, for apps and chains
-* **Usage** read (`ADMIN_USAGE_READ`), for usage endpoints
+* **Usage** read (`ADMIN_USAGE_READ`), for Usage API endpoints (beta)
 
 You can also authenticate usage requests with a dashboard user session token that has the `viewer`, `developer`, or `admin` role.
 

--- a/content/admin-api/quickstart.mdx
+++ b/content/admin-api/quickstart.mdx
@@ -165,9 +165,9 @@ curl -X PUT "$ALCHEMY_ADMIN_BASE_URL/apps/$APP_ID/ip-allowlist" \
   }'
 ```
 
-<Markdown src="usage-beta-notice.mdx" />
-
 ## 5. Get usage summary
+
+<Markdown src="usage-beta-notice.mdx" />
 
 Retrieve usage totals for the current billing period and recent rolling windows.
 

--- a/content/admin-api/quickstart.mdx
+++ b/content/admin-api/quickstart.mdx
@@ -10,7 +10,8 @@ This guide walks through creating an app, updating its configuration, and queryi
 
 ### Prerequisites
 
-* An access key with App Management **write** permissions and Usage **read** permissions
+* An access key with App Management **write** permissions
+  * Usage **read** permissions if you are following the beta Usage API steps
   * Refer to the [overview authentication section](/docs/reference/admin-api/overview#authentication) for instructions to create an access key
 
 ## Set up environment variables
@@ -163,6 +164,8 @@ curl -X PUT "$ALCHEMY_ADMIN_BASE_URL/apps/$APP_ID/ip-allowlist" \
     ]
   }'
 ```
+
+<Markdown src="usage-beta-notice.mdx" />
 
 ## 5. Get usage summary
 

--- a/content/admin-api/usage-beta-notice.mdx
+++ b/content/admin-api/usage-beta-notice.mdx
@@ -1,0 +1,3 @@
+<Callout intent="info">
+  The Usage API is in beta. Contact [Alchemy Support](mailto:support@alchemy.com) to request access. Endpoint availability and response schemas may change.
+</Callout>

--- a/content/docs.yml
+++ b/content/docs.yml
@@ -2032,19 +2032,6 @@ navigation:
         contents:
           - page: Tools Quickstart
             path: tutorials/getting-started/dashboard/dashboard-tools-quickstart.mdx
-          - page: Sandbox
-            path: tutorials/getting-started/dashboard/alchemy-sandbox.mdx
-          - page: Alerts
-            path: tutorials/getting-started/developer-best-practices/dashboard-alerts.mdx
-          - page: Request Logs
-            path: tutorials/getting-started/dashboard/request-logs.mdx
-          - page: Roles
-            path: tutorials/getting-started/dashboard/dashboard-roles.mdx
-          - page: Dashboard Roles
-            path: tutorials/getting-started/dashboard/dashboard-team-roles.mdx
-            hidden: true
-          - page: Single Sign-On (SSO)
-            path: tutorials/getting-started/dashboard/dashboard-sso.mdx
           - section: Admin API
             contents:
               - page: Overview
@@ -2075,6 +2062,19 @@ navigation:
                     api-name: usage-api
                     skip-slug: true
                     flattened: true
+          - page: Sandbox
+            path: tutorials/getting-started/dashboard/alchemy-sandbox.mdx
+          - page: Alerts
+            path: tutorials/getting-started/developer-best-practices/dashboard-alerts.mdx
+          - page: Request Logs
+            path: tutorials/getting-started/dashboard/request-logs.mdx
+          - page: Roles
+            path: tutorials/getting-started/dashboard/dashboard-roles.mdx
+          - page: Dashboard Roles
+            path: tutorials/getting-started/dashboard/dashboard-team-roles.mdx
+            hidden: true
+          - page: Single Sign-On (SSO)
+            path: tutorials/getting-started/dashboard/dashboard-sso.mdx
           - section: Activity Log
             hidden: true
             contents:

--- a/content/docs.yml
+++ b/content/docs.yml
@@ -2046,14 +2046,12 @@ navigation:
           - page: Single Sign-On (SSO)
             path: tutorials/getting-started/dashboard/dashboard-sso.mdx
           - section: Admin API
-            hidden: true
             contents:
               - page: Overview
                 path: admin-api/overview.mdx
               - page: Quickstart
                 path: admin-api/quickstart.mdx
               - section: Apps
-                hidden: true
                 url-path: admin-api/apps
                 contents:
                   - api: Apps
@@ -2062,7 +2060,6 @@ navigation:
                     skip-slug: true
                     flattened: true
               - section: Chains
-                hidden: true
                 url-path: admin-api/chains
                 contents:
                   - api: Chains


### PR DESCRIPTION
## Summary
- Unhide the Admin API section plus Apps and Chains so they appear in Tools nav and search
- Leave Usage `hidden: true` until that surface is ready to launch

## Test plan
- [x] Confirm Tools → Admin API shows Overview, Quickstart, Apps, and Chains in the sidebar
- [x] Confirm Usage is not in the sidebar or search
- [x] Confirm Usage endpoint URLs still load directly
- [x] Confirm Apps and Chains endpoint pages render from the tagged OpenAPI spec


Made with [Cursor](https://cursor.com)