### PR TITLE
Note DATA Network was formerly Story in quickstart + FAQ

### DIFF
--- a/content/api-reference/data-network/data-network-api-faq.mdx
+++ b/content/api-reference/data-network/data-network-api-faq.mdx
@@ -6,7 +6,7 @@ slug: reference/data-network-api-faq
 ---
 
 ## What is DATA Network?
-DATA Network is a purpose-built EVM-compatible blockchain that enables fast, transparent, and programmable management, licensing, and monetization of intellectual property onchain.
+DATA Network (formerly Story) is a purpose-built EVM-compatible blockchain that enables fast, transparent, and programmable management, licensing, and monetization of intellectual property onchain.
 
 ## What is the DATA Network API?
 

--- a/content/api-reference/data-network/data-network-api-quickstart.mdx
+++ b/content/api-reference/data-network/data-network-api-quickstart.mdx
@@ -10,7 +10,7 @@ slug: reference/data-network-api-quickstart
   <a href="https://dashboard.alchemy.com/signup">get started today</a>.
 </Tip>
 
-DATA Network is a purpose-built EVM-compatible blockchain that enables fast, transparent, and programmable management, licensing, and monetization of intellectual property onchain.
+DATA Network (formerly Story) is a purpose-built EVM-compatible blockchain that enables fast, transparent, and programmable management, licensing, and monetization of intellectual property onchain.
 
 The DATA Network API provides interaction with the DATA Network through a set of JSON-RPC methods. If you've worked with Ethereum's JSON-RPC APIs, you'll find the interface familiar.
 


### PR DESCRIPTION
## Summary
Story rebranded to **DATA Network** in June 2026 (chain-config #6136/#6152). Docs, dashboard, and the Admin API were all updated then, but no page mentions the former name "Story" — so anyone searching docs for "Story" (its name for the ~2 years before the rebrand) finds nothing, even though the chain has been public the whole time.

This surfaced when a customer (Redstone, Pylon #21656) asked why they couldn't find "Story" in the dashboard/docs — see internal Slack thread.

## Changes
Adds "(formerly Story)" to the two spots that introduce the chain, mirroring the existing **Gnosis Chain (formerly xDai)** pattern:
- `data-network-api-quickstart.mdx` — intro paragraph
- `data-network-api-faq.mdx` — "What is DATA Network?" answer

Sidebar/card titles are left as "DATA Network" (unchanged), matching how Gnosis/xDai and Sonic/Fantom are handled elsewhere in the nav. Display name and URLs are unaffected — this is purely a search/discoverability fix.

## Test plan
- [ ] Preview build renders both pages correctly
- [ ] Confirm search for "Story" now surfaces these pages