### PR TITLE
Remove retired V1 webhook / app-scope references from webhooks docs

### DIFF
--- a/content/api-reference/data/webhooks/webhooks-overview.mdx
+++ b/content/api-reference/data/webhooks/webhooks-overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: Webhooks Overview
-description: Monitor onchain activity in real time with Alchemy webhooks for address, mined transaction, and dropped transaction events.
+description: Monitor onchain activity in real time with Alchemy webhooks for address activity, custom, and NFT activity events.
 subtitle: Fast, consistent, and custom push notifications!
 slug: reference/webhooks-overview
 ---
@@ -34,7 +34,7 @@ Alchemy webhooks provide real-time notifications for primarily onchain data. The
   ![](https://alchemyapi-res.cloudinary.com/image/upload/v1764179964/docs/api-reference/alchemy-transact/transaction-simulation/523fb8a9a9d899921ee1046d0ff1b389967a9976d1c6112ebbbe071ddd1ef374-image.png)
 </Info>
 
-## V2 webhook
+## Webhook event object
 
 ### Field definitions
 
@@ -44,12 +44,12 @@ Alchemy webhooks provide real-time notifications for primarily onchain data. The
 | `id`        | ID of the event.                        | `whevt_ogrc5v64myey69ux`   |
 | `createdAt` | The timestamp when webhook was created. | `2021-12-07T03:52:45.899Z` |
 | `type`      | Webhook event type.                     | `TYPE_STRING`              |
-| `event`     | Object-mined transaction.               | `OBJECT`                   |
+| `event`     | The webhook event payload.              | `OBJECT`                   |
 
 ### Example
 
 <CodeGroup>
-  ```shell V2
+  ```shell
   {
    "webhookId": "wh_octjglnywaupz6th",
    "id": "whevt_ogrc5v64myey69ux",
@@ -60,30 +60,4 @@ Alchemy webhooks provide real-time notifications for primarily onchain data. The
   ```
 </CodeGroup>
 
-## V1 webhook event object
-
-### Field definitions
-
-| Field         | Description                                       | Value                      |
-| ------------- | ------------------------------------------------- | -------------------------- |
-| `app`         | Alchemy app name sending the transaction webhook. | `Demo`                     |
-| `network`     | Network for the webhook event.                    | `MAINNET`                  |
-| `webhookType` | The type of webhook.                              | `MINED_TRANSACTION`        |
-| `timestamp`   | Timestamp when the webhook was created.           | `2020-07-29T00:29:18.414Z` |
-| `event name`  | Webhook event type.                               | `OBJECT`                   |
-
 For full dependencies and more code examples, see the [webhook examples GitHub repo](https://github.com/alchemyplatform/webhook-examples).
-
-### Example response
-
-<CodeGroup>
-  ```shell v1
-  {
-    "app": "Demo", 
-    "network": "MAINNET",
-    "webhookType": "MINED_TRANSACTION",
-    "timestamp": "2020-07-29T00:29:18.414Z",
-    "event name": OBJECT
-  }
-  ```
-</CodeGroup>


### PR DESCRIPTION
## Summary
- Removes the "V1 webhook event object" section from the Webhooks Overview page, which documented `MINED_TRANSACTION`/`DROPPED_TRANSACTION` webhooks and their `app` field
- These webhook types (and their app-scoped tenancy model) were removed from prod in August 2025 — confirmed via the webhooks-service migration that deleted them from the DB and dropped the app-linked table
- The three webhook types actually live today (Address Activity, Custom/GraphQL, NFT Activity) are team-scoped, not app-scoped, and their delivery payloads carry no app field, so the old section implied a relationship that no longer holds
- Renamed "V2 webhook" → "Webhook event object" since there's no longer a V1 to distinguish it from, and cleaned up a stale "Object-mined transaction" field description left over from that era

## Test plan
- [ ] Docs site preview build renders the page correctly with the removed section