### PR TITLE
docs: prioritize Solana DAS API v2 in navigation

### DIFF
--- a/content/docs.yml
+++ b/content/docs.yml
@@ -337,10 +337,10 @@ navigation:
             api-name: solana
           - page: Solana Account Archive
             path: api-reference/solana/account-archive.mdx
-          - link: Solana DAS APIs
-            href: /docs/reference/alchemy-das-apis-for-solana
           - link: Solana DAS APIs v2
             href: /docs/reference/alchemy-das-apis-for-solana-v2
+          - link: Solana DAS APIs
+            href: /docs/reference/alchemy-das-apis-for-solana
           - section: Solana Photon API
             path: >-
               api-reference/data/nft-api/alchemy-photon-apis-for-solana.mdx
@@ -1462,12 +1462,6 @@ navigation:
             path: api-reference/data/nft-api/nft-api-overview.mdx
           - page: NFT API Quickstart
             path: api-reference/data/nft-api/nft-api-quickstart.mdx
-          - section: Solana DAS API
-            path: >-
-              api-reference/data/nft-api/alchemy-das-apis-for-solana.mdx
-            contents:
-              - api: Solana DAS API Endpoints
-                api-name: solana-das
           - section: Solana DAS API v2
             path: >-
               api-reference/data/nft-api/alchemy-das-apis-for-solana-v2.mdx
@@ -1480,6 +1474,12 @@ navigation:
                 # v2 mdx landing page's hard-coded method links. Pin it so
                 # endpoint URLs stay stable.
                 slug: solana-das-api-v2-endpoints
+          - section: Solana DAS API
+            path: >-
+              api-reference/data/nft-api/alchemy-das-apis-for-solana.mdx
+            contents:
+              - api: Solana DAS API Endpoints
+                api-name: solana-das
           - section: NFT API Endpoints
             path: >-
               api-reference/data/nft-api/nft-api-endpoints.mdx


### PR DESCRIPTION
## Summary
Moves Solana DAS API v2 ahead of v1 in the Solana docs navigation.

## Why
DAS API v2 is already live and documented, but customers can encounter the older v1 API first. Prioritizing v2 improves discovery of its richer, Helius-compatible response format while keeping v1 fully available.

## Scope
Navigation ordering only; no API, URL, pricing, or documentation-content changes.

Also reorders the Data tab NFT API sidebar, which independently listed both DAS pages with v1 first.

## Test plan
- [ ] Confirm Solana (Chains) sidebar shows DAS APIs v2 before DAS APIs
- [ ] Confirm Data → NFT API sidebar shows Solana DAS API v2 before Solana DAS API
- [ ] Confirm v1 and v2 URLs still resolve:
  - https://www.alchemy.com/docs/reference/alchemy-das-apis-for-solana-v2
  - https://www.alchemy.com/docs/reference/alchemy-das-apis-for-solana
- [ ] Confirm labels and hrefs are unchanged