### PR TITLE
DX-3662: Document Growth and Scale 7-day Usage API lookback

### DIFF
--- a/content/admin-api/overview.mdx
+++ b/content/admin-api/overview.mdx
@@ -56,7 +56,7 @@ Time-series query ranges are limited by plan:
 | Plan | Maximum range |
 |---|---:|
 | Free | 1 day |
-| Pay as You Go | 7 days |
+| Pay as You Go, Growth, Scale | 7 days |
 | Longer ranges | [Contact sales](https://www.alchemy.com/contact-sales) |
 
 If you request a range longer than your plan supports, the API returns results for the allowed range.

--- a/content/tutorials/build-with-ai/alchemy-cli.mdx
+++ b/content/tutorials/build-with-ai/alchemy-cli.mdx
@@ -329,7 +329,7 @@ Usage time-series ranges are limited by plan:
 | Plan | Maximum range |
 |---|---:|
 | Free | 1 day |
-| Pay as You Go | 7 days |
+| Pay as You Go, Growth, Scale | 7 days |
 | Longer ranges | [Contact sales](https://www.alchemy.com/contact-sales) |
 
 If you request a range longer than your plan supports, the Usage API returns results for the allowed range. The CLI shows the requested and returned ranges when this happens.


### PR DESCRIPTION
## Description

Growth and Scale Usage API lookback is now 7 days, the same as Pay as You Go. The published plan-limits tables listed Free (1 day) and Pay as You Go (7 days) only, so those customers would see the Free window in the docs.

This PR adds Growth and Scale to the existing 7-day row. It does not add a new row.

## Related Issues

- https://linear.app/alchemyapi/issue/DX-3666/document-growth-and-scale-7-day-lookback-in-admin-api-overview
- https://linear.app/alchemyapi/issue/DX-3667/document-growth-and-scale-7-day-lookback-in-cli-usage-docs

Parent: https://linear.app/alchemyapi/issue/DX-3662/give-growth-and-scale-the-payg-7-day-usage-api-lookback

## Changes Made

- Admin API overview: add Growth and Scale to the 7-day plan-limits row
- Alchemy CLI usage docs: add Growth and Scale to the 7-day Usage time-series range row

## Testing

- [x] Table copy matches the API window change (Growth and Scale = 7 days)
- [ ] I have run the validation scripts (`pnpm run validate`) — not required; no OpenAPI/OpenRPC spec changes
- [x] MDX table syntax is unchanged except the plan-name cell

LINEAR TASK: https://linear.app/alchemyapi/issue/DX-3662/give-growth-and-scale-the-payg-7-day-usage-api-lookback

Created using the /git skill.
Co-Authored-By: Cursor Grok 4.6

Made with [Cursor](https://cursor.com)