### PR TITLE
Unhide Usage API and remove beta notice

### DIFF
--- a/content/admin-api/overview.mdx
+++ b/content/admin-api/overview.mdx
@@ -10,8 +10,6 @@ An App represents a single Alchemy project. You create an app, configure which n
 
 Usage data includes compute unit totals, estimated USD cost, billing period boundaries, and optional breakdowns by app, network, method, and request type.
 
-<Markdown src="usage-beta-notice.mdx" />
-
 ***
 
 ## What you can do
@@ -37,7 +35,7 @@ Each request is authenticated and returns JSON responses.
 All requests must include an access key. Grant only the permissions the caller needs:
 
 * **App Management** read or read and write, for apps and chains
-* **Usage** read (`ADMIN_USAGE_READ`), for Usage API endpoints (beta)
+* **Usage** read (`ADMIN_USAGE_READ`), for Usage API endpoints
 
 You can also authenticate usage requests with a dashboard user session token that has the `viewer`, `developer`, or `admin` role.
 

--- a/content/admin-api/quickstart.mdx
+++ b/content/admin-api/quickstart.mdx
@@ -11,7 +11,7 @@ This guide walks through creating an app, updating its configuration, and queryi
 ### Prerequisites
 
 * An access key with App Management **write** permissions
-  * Usage **read** permissions if you are following the beta Usage API steps
+  * Usage **read** permissions if you are following the Usage API steps
   * Refer to the [overview authentication section](/docs/reference/admin-api/overview#authentication) for instructions to create an access key
 
 ## Set up environment variables
@@ -166,8 +166,6 @@ curl -X PUT "$ALCHEMY_ADMIN_BASE_URL/apps/$APP_ID/ip-allowlist" \
 ```
 
 ## 5. Get usage summary
-
-<Markdown src="usage-beta-notice.mdx" />
 
 Retrieve usage totals for the current billing period and recent rolling windows.
 

--- a/content/admin-api/usage-beta-notice.mdx
+++ b/content/admin-api/usage-beta-notice.mdx
@@ -1,3 +1,0 @@
-<Callout intent="info">
-  The Usage API is in beta. Contact [Alchemy Support](mailto:support@alchemy.com) to request access. Endpoint availability and response schemas may change.
-</Callout>

--- a/content/docs.yml
+++ b/content/docs.yml
@@ -2165,7 +2165,6 @@ navigation:
                     skip-slug: true
                     flattened: true
               - section: Usage
-                hidden: true
                 url-path: admin-api/usage
                 contents:
                   - api: Usage


### PR DESCRIPTION
## Summary

Makes the Admin API **Usage** endpoints visible in the docs and removes the beta messaging around them.

- `content/docs.yml` — dropped `hidden: true` from the Usage nav section (endpoints are generated from the remote `usage-api` spec)
- Deleted `content/admin-api/usage-beta-notice.mdx` (the "in beta / contact support for access / schemas may change" callout) and its includes in the Admin API overview and quickstart
- Removed "(beta)" from the `ADMIN_USAGE_READ` permission bullet in the overview
- Reworded the quickstart prerequisite to drop "beta"

## Note for reviewers

The deleted notice also carried the access gate ("Contact Alchemy Support to request access"). If Usage API access is still request-gated, that's now undocumented — worth confirming before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)