### PR TITLE
docs(wallets): document new v1.1.0 EIP-7702 delegation address

### DIFF
--- a/content/wallets/pages/smart-contracts/deployed-addresses.mdx
+++ b/content/wallets/pages/smart-contracts/deployed-addresses.mdx
@@ -11,24 +11,25 @@ The following tables list the deployed factory and account implementation contra
 | Version | Contract Name                 | Address                                      |
 | ------- | ----------------------------- | -------------------------------------------- |
 |         | **Implementation contracts**  |                                              |
-| v2.0.0  | SemiModularAccount7702        | `0x69007702764179f14F51cdce752f4f775d74E139` |
-| v2.0.0  | SemiModularAccountBytecode    | `0x000000000000c5A9089039570Dd36455b5C07383` |
-| v2.0.0  | SemiModularAccountStorageOnly | `0x0000000000006E2f9d80CaEc0Da6500f005EB25A` |
+| v1.0.0  | SemiModularAccount7702        | `0x69007702764179f14F51cdce752f4f775d74E139` |
+| v1.1.0  | SemiModularAccount7702        | `0x77021100bD87b7008E5E1989d0eB38555d0d0000` |
+| v1.0.0  | SemiModularAccountBytecode    | `0x000000000000c5A9089039570Dd36455b5C07383` |
+| v1.0.0  | SemiModularAccountStorageOnly | `0x0000000000006E2f9d80CaEc0Da6500f005EB25A` |
 | v2.0.0  | ExecutionInstallDelegate      | `0x0000000000008e6a39E03C7156e46b238C9E2036` |
 | v2.0.0  | ModularAccount                | `0x00000000000002377B26b1EdA7b0BC371C60DD4f` |
 |         | **Factory contracts**         |                                              |
 | v2.0.0  | AccountFactory                | `0x00000000000017c61b5bEe81050EC8eFc9c6fecd` |
 | v2.0.1  | WebAuthnFactory               | `0x55010E571dCf07e254994bfc88b9C1C8FAe31960` |
 |         | **Validation modules**        |                                              |
-| v2.0.0  | SingleSignerValidationModule  | `0x00000000000099DE0BF6fA90dEB851E2A2df7d83` |
-| v2.0.0  | WebAuthnValidationModule      | `0x0000000000001D9d34E07D9834274dF9ae575217` |
+| v1.0.0  | SingleSignerValidationModule  | `0x00000000000099DE0BF6fA90dEB851E2A2df7d83` |
+| v1.0.0  | WebAuthnValidationModule      | `0x0000000000001D9d34E07D9834274dF9ae575217` |
 |         | **Hook permission modules**   |                                              |
-| v2.0.1  | AllowlistModule               | `0x00000000003e826473a313e600b5b9b791f5a59a` |
-| v2.0.0  | NativeTokenLimitModule        | `0x00000000000001e541f0D090868FBe24b59Fbe06` |
-| v2.0.0  | PaymasterGuardModule          | `0x0000000000001aA7A7F7E29abe0be06c72FD42A1` |
-| v2.0.0  | TimeRangeModule               | `0x00000000000082B8e2012be914dFA4f62A0573eA` |
+| v1.0.0  | AllowlistModule               | `0x00000000003e826473a313e600b5b9b791f5a59a` |
+| v1.0.0  | NativeTokenLimitModule        | `0x00000000000001e541f0D090868FBe24b59Fbe06` |
+| v1.0.0  | PaymasterGuardModule          | `0x0000000000001aA7A7F7E29abe0be06c72FD42A1` |
+| v1.0.0  | TimeRangeModule               | `0x00000000000082B8e2012be914dFA4f62A0573eA` |
 
-[Source](https://github.com/alchemyplatform/modular-account/blob/develop/deployments/v2/Deployments.md)
+[Source](https://github.com/alchemyplatform/modular-account/blob/v2.0.2/deployments/v2/Deployments.md)
 
 ## LightAccount V2
 

--- a/content/wallets/pages/transactions/using-eip-7702/index.mdx
+++ b/content/wallets/pages/transactions/using-eip-7702/index.mdx
@@ -218,8 +218,10 @@ Call `requestAccount` with the desired `accountType`, then pass the returned add
 
   The `eip7702Auth` capability supports the interface defined in [ERC-7902](https://eips.ethereum.org/EIPS/eip-7902).
 
-  Currently, Wallet APIs only support delegation to the following contract:
-  `0x69007702764179f14F51cdce752f4f775d74E139` (Modular Account v2)
+  Wallet APIs support delegation to the following Modular Account v2 contracts:
+
+  * `0x69007702764179f14F51cdce752f4f775d74E139` (v1.0.0)
+  * `0x77021100bD87b7008E5E1989d0eB38555d0d0000` (v1.1.0)
 
   All other delegation addresses will be rejected.
 

--- a/content/wallets/pages/transactions/using-eip-7702/index.mdx
+++ b/content/wallets/pages/transactions/using-eip-7702/index.mdx
@@ -232,7 +232,7 @@ Call `requestAccount` with the desired `accountType`, then pass the returned add
   as defined in [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702#behavior).
 </Accordion>
 
-<Accordion title="EIP-7702 support on Monad">
+<Accordion title="EIP-7702 support on Monad" id="monad-support">
   Monad keeps a [minimum balance reserve on delegated
   accounts](https://docs.monad.xyz/developer-essentials/reserve-balance#eip-7702-delegated-accounts)
   as a safety measure, so [a 7702-delegated account can't dip below


### PR DESCRIPTION
## Description

Wallet APIs now accept a second EIP-7702 delegation address (SemiModularAccount7702 v1.1.0) in addition to the existing v1.0.0 default. This PR documents the new address and fixes several incorrect contract version labels on the deployed-addresses page.

## Related Issues

N/A

## Changes Made

- `using-eip-7702/index.mdx`: list both supported delegation contracts (v1.0.0 and v1.1.0) instead of only v1.0.0.
- `deployed-addresses.mdx`: add the new v1.1.0 `SemiModularAccount7702` address to the Modular Account V2 table.
- `deployed-addresses.mdx`: correct 6 rows that were labeled with the repo's overall release tag (e.g. v2.0.0) instead of each contract's own on-chain version — verified directly via `accountId()`/`moduleId()` calls against the deployed contracts.
- `deployed-addresses.mdx`: repoint the Modular Account V2 Source link at the `v2.0.2` tag, since the `develop` branch doesn't yet include the v1.1.0 entry.

## Testing

* [x] I have tested these changes locally
* [ ] I have run the validation scripts (`pnpm run validate`)
* [ ] I have checked that the documentation builds correctly